### PR TITLE
Support of suppress comment in skipped checks

### DIFF
--- a/checkov/terraform/checks/resource/base_check.py
+++ b/checkov/terraform/checks/resource/base_check.py
@@ -17,17 +17,24 @@ class BaseResourceCheck(ABC):
         self.logger = logging.getLogger("{}".format(self.__module__))
         resource_registry.register(self)
 
-    def run(self, scanned_file, resource_configuration, resource_name, resource_type, skip=False):
-        if skip:
-            result = CheckResult.SKIPPED
+    def run(self, scanned_file, resource_configuration, resource_name, resource_type, skip_info):
+        check_result={}
+        if skip_info:
+            check_result['result'] = CheckResult.SKIPPED
+            check_result['suppress_comment'] = skip_info['suppress_comment']
+            message = "File {}, Resource \"{}.{}\" check \"{}\" Result: {}, Suppression comment: {} ".format(
+                scanned_file, resource_type,
+                resource_name,
+                self.name,
+                check_result, check_result['suppress_comment'])
         else:
-            result = self.scan_resource_conf(resource_configuration)
-        message = "File {}, Resource \"{}.{}\" check \"{}\" Result: {} ".format(scanned_file, resource_type,
-                                                                                resource_name,
-                                                                                self.name,
-                                                                                result)
+            check_result['result'] = self.scan_resource_conf(resource_configuration)
+            message = "File {}, Resource \"{}.{}\" check \"{}\" Result: {} ".format(scanned_file, resource_type,
+                                                                                    resource_name,
+                                                                                    self.name,
+                                                                                    check_result)
         self.logger.debug(message)
-        return result
+        return check_result
 
     @abstractmethod
     def scan_resource_conf(self, conf):

--- a/checkov/terraform/checks/resource/registry.py
+++ b/checkov/terraform/checks/resource/registry.py
@@ -1,6 +1,5 @@
 import logging
 
-
 class Registry:
     checks = {}
 
@@ -24,14 +23,16 @@ class Registry:
         results = {}
         checks = self.get_checks(resource)
         for check in checks:
-            skip = False
+            skip_info = {}
             if skipped_checks:
-                skip = check.id in skipped_checks
+                if check.id in [x['id'] for x in skipped_checks]:
+                    skip_info = [x for x in skipped_checks if x['id'] == check.id][0]
             resource_name = list(resource_conf.keys())[0]
             resource_conf_def = resource_conf[resource_name]
             self.logger.debug("Running check: {} on file {}".format(check.name, scanned_file))
             result = check.run(scanned_file=scanned_file, resource_configuration=resource_conf_def,
-                               resource_name=resource_name, resource_type=resource, skip=skip)
+                               resource_name=resource_name, resource_type=resource, skip_info=skip_info)
+
             results[check] = result
         return results
 

--- a/checkov/terraform/output/record.py
+++ b/checkov/terraform/output/record.py
@@ -36,15 +36,17 @@ class Record():
     def __str__(self):
         status = ''
         status_color = "white"
-        if self.check_result == CheckResult.PASSED:
+        if self.check_result['result'] == CheckResult.PASSED:
             status = CheckResult.PASSED.name
             status_color = "green"
-        elif self.check_result == CheckResult.FAILED:
+        elif self.check_result['result'] == CheckResult.FAILED:
             status = CheckResult.FAILED.name
             status_color = "red"
-        elif self.check_result == CheckResult.SKIPPED:
+        elif self.check_result['result'] == CheckResult.SKIPPED:
             status = CheckResult.SKIPPED.name
             status_color = 'blue'
+            suppress_comment = "\tSuppress comment: {}\n".format(self.check_result['suppress_comment'])
+
         check_message = colored("Check: \"{}\"\n".format(self.check_name), "white")
         file_details = colored(
             "\tFile: {}:{}\n\n".format(self.file_path, "-".join([str(x) for x in self.file_line_range])),
@@ -52,8 +54,10 @@ class Record():
         code_lines = "{}\n".format("".join(
             [self._code_line_string(line_num, line) for (line_num, line) in self.code_block]))
         status_message = colored("\t{} for resource: {}\n".format(status, self.resource), status_color)
-
-        if self.check_result == CheckResult.FAILED:
+        if self.check_result['result'] == CheckResult.FAILED:
             return check_message + status_message + file_details + code_lines
+
+        if self.check_result['result'] == CheckResult.SKIPPED:
+            return check_message + status_message + suppress_comment + file_details
         else:
             return check_message + status_message + file_details

--- a/checkov/terraform/output/report.py
+++ b/checkov/terraform/output/report.py
@@ -26,11 +26,11 @@ class Report:
             self.parsing_errors.append(file)
 
     def add_record(self, record):
-        if record.check_result == CheckResult.PASSED:
+        if record.check_result['result'] == CheckResult.PASSED:
             self.passed_checks.append(record)
-        if record.check_result == CheckResult.FAILED:
+        if record.check_result['result'] == CheckResult.FAILED:
             self.failed_checks.append(record)
-        if record.check_result == CheckResult.SKIPPED:
+        if record.check_result['result'] == CheckResult.SKIPPED:
             self.skipped_checks.append(record)
 
     def get_summary(self):
@@ -95,12 +95,14 @@ class Report:
 
             test_name = "{} {}".format(check_name, record.resource)
             test_case = TestCase(name=test_name, file=record.file_path, classname=record.check_class)
-            if record.check_result == CheckResult.FAILED:
+            if record.check_result['result'] == CheckResult.FAILED:
                 test_case.add_failure_info(
                     "Resource \"{}\" failed in check \"{}\"".format(record.resource, check_name))
-            if record.check_result == CheckResult.SKIPPED:
+            if record.check_result['result'] == CheckResult.SKIPPED:
                 test_case.add_skipped_info(
-                    "Resource \"{}\" skipped in check \"{}\"".format(record.resource, check_name))
+                    "Resource \"{}\" skipped in check \"{}\"\n Suppress comment: {}".format(record.resource, check_name,
+                                                                                            record.check_result[
+                                                                                                'suppress_comment']))
             test_cases[check_name].append(test_case)
         for key in test_cases.keys():
             test_suites.append(


### PR DESCRIPTION
Redesigned the skip check comment format to the following:
`# checkov:skip:<check-Id>:<suppress-comment>`

- Support an optional suppression comment
- Comment is limited to one skipped check in a line

Illustration:
<img width="832" alt="Screen Shot 2019-12-16 at 13 05 01" src="https://user-images.githubusercontent.com/10135538/70902470-87978180-2005-11ea-967b-1fe16861fe3b.png">

<img width="585" alt="Screen Shot 2019-12-16 at 13 05 30" src="https://user-images.githubusercontent.com/10135538/70902491-967e3400-2005-11ea-9e55-7d8a7a1dde71.png">
