### PR TITLE
fix: security_groups in aws_security_group rule not supported

### DIFF
--- a/checkov/terraform/checks/resource/aws/SecurityGroupUnrestrictedIngress22.py
+++ b/checkov/terraform/checks/resource/aws/SecurityGroupUnrestrictedIngress22.py
@@ -22,9 +22,10 @@ class SecurityGroupUnrestrictedIngress22(BaseResourceCheck):
         if 'ingress' in conf.keys():
             ingress_conf = conf['ingress']
             for rule in ingress_conf:
-                if rule['from_port'] == [PORT] and rule['to_port'] == [PORT] and rule['cidr_blocks'] == [[
-                    "0.0.0.0/0"]] and 'self' not in rule.keys() and 'security_groups' not in rule.keys():
-                    return CheckResult.FAILED
+                if rule['from_port'] == [PORT] and rule['to_port'] == [PORT]:
+                    if 'cidr_blocks' in rule.keys():
+                        if rule['cidr_blocks'] == [["0.0.0.0/0"]] and 'security_groups' not in rule.keys():
+                            return CheckResult.FAILED
 
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/aws/SecurityGroupUnrestrictedIngress3389.py
+++ b/checkov/terraform/checks/resource/aws/SecurityGroupUnrestrictedIngress3389.py
@@ -22,9 +22,11 @@ class SecurityGroupUnrestrictedIngress3389(BaseResourceCheck):
         if 'ingress' in conf.keys():
             ingress_conf = conf['ingress']
             for rule in ingress_conf:
-                if rule['from_port'] == [PORT] and rule['to_port'] == [PORT] and rule['cidr_blocks'] == [
-                    ["0.0.0.0/0"]] and 'self' not in rule.keys() and 'security_groups' not in rule.keys():
-                    return CheckResult.FAILED
+                if rule['from_port'] == [PORT] and rule['to_port'] == [PORT]:
+                    if 'cidr_blocks' in rule.keys():
+                        if rule['cidr_blocks'] == [["0.0.0.0/0"]] and 'security_groups' not in rule.keys():
+                            return CheckResult.FAILED
+
 
         return CheckResult.PASSED
 

--- a/tests/terraform/runner/resources/example/example.tf
+++ b/tests/terraform/runner/resources/example/example.tf
@@ -125,3 +125,26 @@ resource "aws_iam_account_password_policy" "password-policy" {
   require_symbols                = true
   allow_users_to_change_password = true
 }
+
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    security_groups = [
+    aws_security_group.foo-sg.id]
+    description = "foo"
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = [
+    "0.0.0.0/0"]
+  }
+
+}


### PR DESCRIPTION
fix #38 referencing a security_group instead of cidr_block in a secuity group rule causes an exception