### PR TITLE
chore(docker): adding a docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python
+
+RUN pip install checkov
+
+ENTRYPOINT ["checkov"]


### PR DESCRIPTION
The resulting image can be used by mounting the terraform files at a location and directing checkov to scan that location:
$ docker container run -v /host/path/tf:/tf <image> -d /tf

The entry point can also be overridden to bash for other uses, such as CI commands:
$ docker container run -i -v /host/path/tf:/tf --entrypoint=/bin/bash <image>