### PR TITLE
fix aws_iam_policy_document check type

### DIFF
--- a/checkov/terraform/checks/data/aws/AdminPolicyDocument.py
+++ b/checkov/terraform/checks/data/aws/AdminPolicyDocument.py
@@ -1,16 +1,16 @@
+from checkov.terraform.checks.data.base_check import BaseDataCheck
 from checkov.terraform.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_check import BaseResourceCheck
 
 
-class AdminPolicyDocument(BaseResourceCheck):
+class AdminPolicyDocument(BaseDataCheck):
     def __init__(self):
         name = "Ensure IAM policies that allow full \"*-*\" administrative privileges are not created"
         id = "CKV_AWS_1"
-        supported_resource = ['aws_iam_policy_document']
+        supported_data = ['aws_iam_policy_document']
         categories = [CheckCategories.GENERAL_SECURITY]
-        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resource)
+        super().__init__(name=name, id=id, categories=categories, supported_data=supported_data)
 
-    def scan_resource_conf(self, conf):
+    def scan_data_conf(self, conf):
         """
             validates iam policy document
             https://learn.hashicorp.com/terraform/aws/iam-policy

--- a/tests/terraform/checks/data/aws/test_AdminPolicyDocument.py
+++ b/tests/terraform/checks/data/aws/test_AdminPolicyDocument.py
@@ -1,6 +1,6 @@
 import unittest
 
-from checkov.terraform.checks.resource.aws.AdminPolicyDocument import check
+from checkov.terraform.checks.data.aws.AdminPolicyDocument import check
 from checkov.terraform.models.enums import CheckResult
 
 
@@ -13,7 +13,7 @@ class TestAdminPolicyDocument(unittest.TestCase):
                 "resources": ["arn:aws:s3:::my_corporate_bucket/*"]
             }]
         }
-        scan_result = check.scan_resource_conf(conf=resource_conf)
+        scan_result = check.scan_data_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
     def test_failure(self):
@@ -23,7 +23,7 @@ class TestAdminPolicyDocument(unittest.TestCase):
                 "resources": ["*"]
             }]
         }
-        scan_result = check.scan_resource_conf(conf=resource_conf)
+        scan_result = check.scan_data_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
 


### PR DESCRIPTION
aws_iam_policy_document is a `data` entity, not a `resource`