### PR TITLE
[Add] Terraform Code Alignment in console output

### DIFF
--- a/checkov/terraform/output/record.py
+++ b/checkov/terraform/output/record.py
@@ -34,11 +34,17 @@ class Record():
         return any([stripped_expression in line for (_, line) in self.code_block])
 
     @staticmethod
-    def _code_line_string(line_num, line):
-        if '#' in line:
-            return "\t\t" + Fore.WHITE + str(line_num) + ' | ' + line
-        else:
-            return "\t\t" + Fore.WHITE + str(line_num) + ' | ' + Fore.YELLOW + line
+    def _code_line_string(code_block):
+        string_block = ''
+        last_line_number, _ = code_block[-1]
+
+        for (line_num, line) in code_block:
+            spaces = ' ' * (len(str(last_line_number)) - len(str(line_num)))
+            if '#' in line:
+                string_block += "\t\t" + Fore.WHITE + str(line_num) + spaces + ' | ' + line
+            else:
+                string_block += "\t\t" + Fore.WHITE + str(line_num) + spaces + ' | ' + Fore.YELLOW + line
+        return string_block
 
     def __str__(self):
         status = ''
@@ -61,7 +67,7 @@ class Record():
             "magenta")
         if self.code_block:
             code_lines = "{}\n".format("".join(
-                [self._code_line_string(line_num, line) for (line_num, line) in self.code_block]))
+                [self._code_line_string(self.code_block)]))
         if self.evaluations:
             for (var_name, evaluations) in self.evaluations.items():
                 var_file = evaluations['var_file']


### PR DESCRIPTION
This adds formatting to align the printing of terraform when output to console.

### Original
```bash
Check: CKV_AWS_21: "Ensure all data stored in the S3 bucket have versioning enabled"
	FAILED for resource: aws_s3_bucket.default
	File: /s3:91-102
		91 | resource "aws_s3_bucket" "default" {
		92 |   bucket = lower(random_id.s3_bucket.b64_url)
		93 |   acl    = "private"
		94 |
		95 |   tags = merge(
		96 |     local.default_tags,
		97 |     {
		98 |       Name        = "GitHub Webhook Listener"
		99 |       Environment = "prod"
		100 |     }
		101 |   )
		102 | }
```
### Fix
```bash
Check: CKV_AWS_21: "Ensure all data stored in the S3 bucket have versioning enabled"
	FAILED for resource: aws_s3_bucket.default
	File: /s3:91-102
		91  | resource "aws_s3_bucket" "default" {
		92  |   bucket = lower(random_id.s3_bucket.b64_url)
		93  |   acl    = "private"
		94  |
		95  |   tags = merge(
		96  |     local.default_tags,
		97  |     {
		98  |       Name        = "GitHub Webhook Listener"
		99  |       Environment = "prod"
		100 |     }
		101 |   )
		102 | }