### PR TITLE
CloudFormation parsing bugfix

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/SecurityGroupUnrestrictedIngress22.py
+++ b/checkov/cloudformation/checks/resource/aws/SecurityGroupUnrestrictedIngress22.py
@@ -3,6 +3,7 @@ from checkov.cloudformation.checks.resource.base_resource_check import BaseResou
 
 PORT = 22
 
+
 class SecurityGroupUnrestrictedIngress22(BaseResourceCheck):
     def __init__(self):
         name = "Ensure no security groups allow ingress from 0.0.0.0:0 to port %d" % PORT
@@ -29,11 +30,13 @@ class SecurityGroupUnrestrictedIngress22(BaseResourceCheck):
                 rules.append(conf['Properties'])
 
         for rule in rules:
-            if int(rule['FromPort']) == int(PORT) and int(rule['ToPort']) == int(PORT):
-                if 'CidrIp' in rule.keys() and rule['CidrIp'] == '0.0.0.0/0':
-                    return CheckResult.FAILED
-                elif 'CidrIpv6' in rule.keys() and rule['CidrIpv6'] == '::/0':
-                    return CheckResult.FAILED
+            if rule.__contains__('FromPort') and rule.__contains__('ToPort'):
+                if isinstance(rule['FromPort'], int) and isinstance(rule['ToPort'], int):
+                    if int(rule['FromPort']) == int(PORT) and int(rule['ToPort']) == int(PORT):
+                        if 'CidrIp' in rule.keys() and rule['CidrIp'] == '0.0.0.0/0':
+                            return CheckResult.FAILED
+                        elif 'CidrIpv6' in rule.keys() and rule['CidrIpv6'] == '::/0':
+                            return CheckResult.FAILED
         return CheckResult.PASSED
 
 

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -40,6 +40,10 @@ class Runner:
             relative_file_path = f'/{os.path.relpath(file, os.path.commonprefix((root_folder, file)))}'
             (definitions[relative_file_path], definitions_raw[relative_file_path]) = parse(file)
 
+        # Filter out empty files that have not been parsed successfully, and filter out non-CF template files
+        definitions = {k: v for k, v in definitions.items() if v and v.__contains__("Resources")}
+        definitions_raw = {k: v for k, v in definitions_raw.items() if k in definitions.keys()}
+
         for cf_file in definitions.keys():
             if not 'Resources' in definitions[cf_file].keys():
                 continue


### PR DESCRIPTION
fixed the filtering of non-cf template files, and support only primitive values of security group port check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
