### PR TITLE
Adding check for BigQuery datasets not being anonymously or publicly accessible

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleBigQueryDatasetPublicACL.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleBigQueryDatasetPublicACL.py
@@ -1,0 +1,34 @@
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+
+
+class GoogleBigQueryDatasetPublicACL(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure that BigQuery datasets are not anonymously or publicly accessible"
+        id = "CKV_GCP_15"
+        supported_resources = ["google_bigquery_dataset"]
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        """
+            Looks for ACL configuration at bigquery_dataset:
+            https://www.terraform.io/docs/providers/google/r/bigquery_dataset.html#access
+        :param conf: bigquery_dataset configuration
+        :return: <CheckResult>
+        """
+        if "access" in conf.keys():
+            for access in conf["access"]:
+                if "special_group" in access:
+                    if access["special_group"] in [["allAuthenticatedUsers"], ["allUsers"]]:
+                        return CheckResult.FAILED
+
+                # access block with only the role key found in the statefile
+                # when manually adding "allUsers" to the dataset
+                elif not any(key in access for key in ["user_by_email", "group_by_email", "domain", "view"]):
+                    return CheckResult.FAILED
+
+        return CheckResult.PASSED
+
+
+check = GoogleBigQueryDatasetPublicACL()

--- a/tests/terraform/checks/resource/gcp/test_GoogleBigQueryDatasetPublicACL.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleBigQueryDatasetPublicACL.py
@@ -1,0 +1,56 @@
+import unittest
+
+from checkov.terraform.checks.resource.gcp.GoogleBigQueryDatasetPublicACL import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestBigQueryDatasetPublicACL(unittest.TestCase):
+
+    def test_failure_special_group(self):
+        resource_conf = {"dataset_id": ["example_dataset"],
+                         "friendly_name": ["test"],
+                         "description": ["This is a test description"],
+                         "location": ["EU"],
+                         "default_table_expiration_ms": [3600000],
+                         "access": [{"role": ["READER"], "special_group": ["allAuthenticatedUsers"]}]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_all_users(self):
+        resource_conf = {"dataset_id": ["example_dataset"],
+                         "friendly_name": ["test"],
+                         "description": ["This is a test description"],
+                         "location": ["EU"],
+                         "default_table_expiration_ms": [3600000],
+                         "access": [{"role": ["VIEWER"], "special_group": ["projectReaders"]},
+                                    {"role": ["READER"]}]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_special_group(self):
+        resource_conf = {"dataset_id": ["example_dataset"],
+                         "friendly_name": ["test"],
+                         "description": ["This is a test description"],
+                         "location": ["EU"],
+                         "default_table_expiration_ms": [3600000],
+                         "access": [{"role": ["READER"], "special_group": ["projectReaders"]}]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success(self):
+        resource_conf = {"dataset_id": ["example_dataset"],
+                         "friendly_name": ["test"],
+                         "description": ["This is a test description"],
+                         "location": ["EU"],
+                         "default_table_expiration_ms": [3600000],
+                         "access": [{"role": ["EDITOR"], "user_by_email": ["foo@bar.com"]}]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
First time contributing to Checkov 😄 

I added a new check to ensure that BigQuery datasets are not anonymously or publicly accessible.

https://www.terraform.io/docs/providers/google/r/bigquery_dataset.html#access

The `allowAuthenticatedUsers` _special_group_ works with the APIs, but the `allUsers` doesn't... After trying to add that group via CLI, I noticed that the Terraform statefile contains an `access` block with just the role defined, so I figured it's considered "all users".

The check is then also verifying if there's a user, group, domain or view in the access block.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
