### PR TITLE
Adding DNSSEC checks for Cloud DNS

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleCloudDNSKeySpecsRSASHA1.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudDNSKeySpecsRSASHA1.py
@@ -1,0 +1,33 @@
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+
+
+class GoogleCloudDNSKeySpecsRSASHA1(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure that RSASHA1 is not used for the zone-signing and key-signing keys in Cloud DNS DNSSEC"
+        id = "CKV_GCP_17"
+        supported_resources = ["google_dns_managed_zone"]
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        """
+            Looks for DNSSEC key algorithm at dns_managed_zone:
+            https://www.terraform.io/docs/providers/google/r/dns_managed_zone.html#algorithm
+        :param conf: dns_managed_zone configuration
+        :return: <CheckResult>
+        """
+        if "dnssec_config" in conf.keys():
+            dnssec_config = conf["dnssec_config"][0]
+
+            # default algo RSASHA256 as per the documentation:
+            # https://cloud.google.com/dns/docs/dnssec-advanced#advanced-signing-options
+            if "default_key_specs" in dnssec_config:
+                for default_key_specs in dnssec_config["default_key_specs"]:
+                    if "algorithm" in default_key_specs and default_key_specs["algorithm"] == ["rsasha1"]:
+                        return CheckResult.FAILED
+
+        return CheckResult.PASSED
+
+
+check = GoogleCloudDNSKeySpecsRSASHA1()

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudDNSSECEnabled.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudDNSSECEnabled.py
@@ -1,0 +1,28 @@
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+
+
+class GoogleCloudDNSSECEnabled(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure that DNSSEC is enabled for Cloud DNS"
+        id = "CKV_GCP_16"
+        supported_resources = ["google_dns_managed_zone"]
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        """
+            Looks for DNSSEC state at dns_managed_zone:
+            https://www.terraform.io/docs/providers/google/r/dns_managed_zone.html#state
+        :param conf: dns_managed_zone configuration
+        :return: <CheckResult>
+        """
+        if "dnssec_config" in conf.keys():
+            dnssec_config = conf["dnssec_config"][0]
+            if "state" in dnssec_config and dnssec_config["state"] != ["off"]:
+                return CheckResult.PASSED
+
+        return CheckResult.FAILED
+
+
+check = GoogleCloudDNSSECEnabled()

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudDNSKeySpecsRSASHA1.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudDNSKeySpecsRSASHA1.py
@@ -1,0 +1,65 @@
+import unittest
+
+from checkov.terraform.checks.resource.gcp.GoogleCloudDNSKeySpecsRSASHA1 import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestCloudDNSKeySpecsRSASHA1(unittest.TestCase):
+
+    def test_failure_zone_signing(self):
+        resource_conf = {"name": ["example-zone"],
+                         "dns_name": ["example-de13he3.com."],
+                         "description": ["Example DNS zone"],
+                         "dnssec_config": [{
+                             "state": ["on"],
+                             "default_key_specs": [
+                                 {"algorithm": ["rsasha1"], "key_type": ["zoneSigning"], "key_length": "1024"},
+                                 {"algorithm": ["rsasha256"], "key_type": ["keySigning"], "key_length": "2048"},
+                             ]
+                         }]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_key_signing(self):
+        resource_conf = {"name": ["example-zone"],
+                         "dns_name": ["example-de13he3.com."],
+                         "description": ["Example DNS zone"],
+                         "dnssec_config": [{
+                             "state": ["on"],
+                             "default_key_specs": [
+                                 {"algorithm": ["rsasha256"], "key_type": ["zoneSigning"], "key_length": "1024"},
+                                 {"algorithm": ["rsasha1"], "key_type": ["keySigning"], "key_length": "2048"},
+                             ]
+                         }]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        resource_conf = {"name": ["example-zone"],
+                         "dns_name": ["example-de13he3.com."],
+                         "description": ["Example DNS zone"],
+                         "dnssec_config": [{
+                             "state": ["on"],
+                             "default_key_specs": [
+                                 {"algorithm": ["rsasha256"], "key_type": ["zoneSigning"], "key_length": "1024"},
+                                 {"algorithm": ["rsasha256"], "key_type": ["keySigning"], "key_length": "2048"},
+                             ]
+                         }]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_default_config(self):
+        resource_conf = {"name": ["example-zone"],
+                         "dns_name": ["example-de13he3.com."],
+                         "description": ["Example DNS zone"],
+                         "dnssec_config": [{"state": ["on"]}]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudDNSSECEnabled.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudDNSSECEnabled.py
@@ -1,0 +1,37 @@
+import unittest
+
+from checkov.terraform.checks.resource.gcp.GoogleCloudDNSSECEnabled import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestCloudDNSSECEnabled(unittest.TestCase):
+
+    def test_failure_no_config(self):
+        resource_conf = {"name": ["example-zone"],
+                         "dns_name": ["example-de13he3.com."],
+                         "description": ["Example DNS zone"]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_wrong_config(self):
+        resource_conf = {"name": ["example-zone"],
+                         "dns_name": ["example-de13he3.com."],
+                         "description": ["Example DNS zone"],
+                         "dnssec_config": [{"state": ["off"]}]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        resource_conf = {"name": ["example-zone"],
+                         "dns_name": ["example-de13he3.com."],
+                         "description": ["Example DNS zone"],
+                         "dnssec_config": [{"state": ["on"]}]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I added a couple of new checks to ensure that DNSSEC is enabled in Cloud DNS and that the RSASHA1 algorithm is not used for the keys.

https://www.terraform.io/docs/providers/google/r/dns_managed_zone.html#state
https://www.terraform.io/docs/providers/google/r/dns_managed_zone.html#algorithm

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
