### PR TITLE
Adding brew package for homebrew (OSX)

### DIFF
--- a/HomebrewFormula/checkov.rb
+++ b/HomebrewFormula/checkov.rb
@@ -1,11 +1,16 @@
 class Checkov < Formula
-  desc "Prevent cloud misconfigurations during build time - Terraform & Cloudformation static analysis"
+  include Language::Python::Virtualenv
+  desc "Prevent cloud misconfigurations during build time. Terraform & CFN static analysis"
   homepage "https://www.checkov.io/"
   url "https://github.com/bridgecrewio/checkov/archive/1.0.239.tar.gz"
   sha256 "7cca36f8fd6641dc46752581da5fe6aebb12361253644a9b2d5358bdda2959e5"
 
-  include Language::Python::Virtualenv
-  depends_on "python@3.8"
+  depends_on "python"
+
+  resource "importlib-metadata" do
+    url "https://files.pythonhosted.org/packages/b4/1b/baab42e3cd64c9d5caac25a9d6c054f8324cdc38975a44d600569f1f7158/importlib_metadata-1.6.0.tar.gz"
+    sha256 "34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
+  end
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/b8/e2/a3a86a67c3fc8249ed305fc7b7d290ebe5e4d46ad45573884761ef4dea7b/certifi-2020.4.5.1.tar.gz"
@@ -15,11 +20,6 @@ class Checkov < Formula
   resource "chardet" do
     url "https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz"
     sha256 "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
-  end
-
-  resource "checkov" do
-    url "https://files.pythonhosted.org/packages/1f/20/24ef945d1fe7b55967892ad88ef5ff901cb2c245ac30a63d4723324187c7/checkov-1.0.239.tar.gz"
-    sha256 "49c74488e4ab12c3d05fb4c36196a04d34917533a87b3ae70e16ce240d89fbed"
   end
 
   resource "colorama" do
@@ -101,6 +101,6 @@ class Checkov < Formula
     #
     # The installed folder is not in the path, so use the entire path to any
     # executables being tested: `system "#{bin}/program", "do", "something"`.
-    system "false"
+    system "#{bin}/checkov", "-h"
   end
 end

--- a/HomebrewFormula/checkov.rb
+++ b/HomebrewFormula/checkov.rb
@@ -1,0 +1,106 @@
+class Checkov < Formula
+  desc "Prevent cloud misconfigurations during build time - Terraform & Cloudformation static analysis"
+  homepage "https://www.checkov.io/"
+  url "https://github.com/bridgecrewio/checkov/archive/1.0.239.tar.gz"
+  sha256 "7cca36f8fd6641dc46752581da5fe6aebb12361253644a9b2d5358bdda2959e5"
+
+  include Language::Python::Virtualenv
+  depends_on "python@3.8"
+
+  resource "certifi" do
+    url "https://files.pythonhosted.org/packages/b8/e2/a3a86a67c3fc8249ed305fc7b7d290ebe5e4d46ad45573884761ef4dea7b/certifi-2020.4.5.1.tar.gz"
+    sha256 "51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+  end
+
+  resource "chardet" do
+    url "https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz"
+    sha256 "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+  end
+
+  resource "checkov" do
+    url "https://files.pythonhosted.org/packages/1f/20/24ef945d1fe7b55967892ad88ef5ff901cb2c245ac30a63d4723324187c7/checkov-1.0.239.tar.gz"
+    sha256 "49c74488e4ab12c3d05fb4c36196a04d34917533a87b3ae70e16ce240d89fbed"
+  end
+
+  resource "colorama" do
+    url "https://files.pythonhosted.org/packages/82/75/f2a4c0c94c85e2693c229142eb448840fba0f9230111faa889d1f541d12d/colorama-0.4.3.tar.gz"
+    sha256 "e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+  end
+
+  resource "docopt" do
+    url "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz"
+    sha256 "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+  end
+
+  resource "dpath" do
+    url "https://files.pythonhosted.org/packages/88/b2/abc5803f37a2ea1045d68765acfcb4ec166bc9e08c3ba451c53af29a73f2/dpath-1.5.0.tar.gz"
+    sha256 "496615b4ea84236d18e0d286122de74869a60e0f87e2c7ec6787ff286c48361b"
+  end
+
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/ad/13/eb56951b6f7950cadb579ca166e448ba77f9d24efc03edd7e55fa57d04b7/idna-2.8.tar.gz"
+    sha256 "c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"
+  end
+
+  resource "junit-xml" do
+    url "https://files.pythonhosted.org/packages/a6/2a/f8d5aab80bb31fcc789d0f2b34b49f08bd6121cd8798d2e37f416df2b9f8/junit-xml-1.8.tar.gz"
+    sha256 "602f1c480a19d64edb452bf7632f76b5f2cb92c1938c6e071dcda8ff9541dc21"
+  end
+
+  resource "lark-parser" do
+    url "https://files.pythonhosted.org/packages/34/b8/aa7d6cf2d5efdd2fcd85cf39b33584fe12a0f7086ed451176ceb7fb510eb/lark-parser-0.7.8.tar.gz"
+    sha256 "26215ebb157e6fb2ee74319aa4445b9f3b7e456e26be215ce19fdaaa901c20a4"
+  end
+
+  resource "python-hcl2" do
+    url "https://files.pythonhosted.org/packages/2f/93/193808a0d4dd5d47397b4a5e3ba038c79d5fc51c93bb5610bb0f7d49c7bf/python-hcl2-0.2.0.tar.gz"
+    sha256 "845a30af9b151625e2449cb9835e5ebc9181b2cb086de38f8d57d4e1e1b516a7"
+  end
+
+  resource "PyYAML" do
+    url "https://files.pythonhosted.org/packages/8d/c9/e5be955a117a1ac548cdd31e37e8fd7b02ce987f9655f5c7563c656d5dcb/PyYAML-5.2.tar.gz"
+    sha256 "c0ee8eca2c582d29c3c2ec6e2c4f703d1b7f1fb10bc72317355a746057e7346c"
+  end
+
+  resource "requests" do
+    url "https://files.pythonhosted.org/packages/01/62/ddcf76d1d19885e8579acb1b1df26a852b03472c0e46d2b959a714c90608/requests-2.22.0.tar.gz"
+    sha256 "11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/94/3e/edcf6fef41d89187df7e38e868b2dd2182677922b600e880baad7749c865/six-1.13.0.tar.gz"
+    sha256 "30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+  end
+
+  resource "tabulate" do
+    url "https://files.pythonhosted.org/packages/c4/41/523f6a05e6dc3329a5660f6a81254c6cd87e5cfb5b7482bae3391d86ec3a/tabulate-0.8.6.tar.gz"
+    sha256 "5470cc6687a091c7042cee89b2946d9235fe9f6d49c193a4ae2ac7bf386737c8"
+  end
+
+  resource "termcolor" do
+    url "https://files.pythonhosted.org/packages/8a/48/a76be51647d0eb9f10e2a4511bf3ffb8cc1e6b14e9e4fab46173aa79f981/termcolor-1.1.0.tar.gz"
+    sha256 "1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"
+  end
+
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/ad/fc/54d62fa4fc6e675678f9519e677dfc29b8964278d75333cf142892caf015/urllib3-1.25.7.tar.gz"
+    sha256 "f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! For Homebrew/homebrew-core
+    # this will need to be a test that verifies the functionality of the
+    # software. Run the test with `brew test checkov`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Scheduled scan result in Jenkins
 ```sh
 pip install checkov
 ```
+or using homebrew (MacOS only)
+```sh
+brew tap bridgecrewio/checkov https://github.com/bridgecrewio/checkov
+brew update
+brew install checkov
+```
 
 ### Configure an input folder
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR adds the ability to install checkov using homebrew on OSX (as requested in #218)
Once merged into master, OSX users should execute:

> $ brew tap bridgecrewio/checkov https://github.com/bridgecrewio/checkov
> $ brew update
> $ brew install checkov

On each release, the formula should be updated to reflect the latest release
