### PR TITLE
python-hcl2 package version update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "idna==2.8",
         "junit-xml==1.8",
         "lark-parser==0.7.8",
-        "python-hcl2==0.2.0",
+        "python-hcl2==0.2.5",
         "pyyaml==5.2",
         "requests==2.22.0",
         "six==1.13.0",


### PR DESCRIPTION
updated python-hcl2 package version from 0.2.0 to 0.2.5. 
Solves #223 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
