### PR TITLE
handle environment value as int instead of string.

### DIFF
--- a/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -18,14 +18,14 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
         if 'environment' in conf.keys():
             if isinstance(conf['environment'][0], dict):
                 if 'variables' in conf['environment'][0]:
-                    if type (conf['environment'][0]['variables']) is not list:
+                    if not isinstance(conf['environment'][0]['variables'], list):
                         conf['environment'][0]['variables'] = [conf['environment'][0]['variables']]
-                    if type(conf['environment'][0]['variables'][0]) is dict:
+                    if isinstance(conf['environment'][0]['variables'][0], dict):
                         # variables can be a string, which in this case it points to a variable
                         for values in list(conf['environment'][0]['variables'][0].values()):
-                            if type(values) is not list:
+                            if not isinstance(values, list):
                                 values = [values]
-                            for value in list(filter(lambda value: type(value) is str, values)):
+                            for value in list(filter(lambda value: isinstance(value, str), values)):
                                     if re.match(access_key_pattern, value) or re.match(secret_key_pattern, value):
                                         return CheckResult.FAILED
         return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -16,18 +16,19 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
 
     def scan_resource_conf(self, conf):
         if 'environment' in conf.keys():
-            if 'variables' in conf['environment'][0]:
-                if type (conf['environment'][0]['variables']) is not list:
-                    conf['environment'][0]['variables'] = [conf['environment'][0]['variables']]
-                if type(conf['environment'][0]['variables'][0]) is dict:
-                    # variables can be a string, which in this case it points to a variable
-                    for values in list(conf['environment'][0]['variables'][0].values()):
-                        if type(values) is not list:
-                            values = [values]
-                        for value in values:
-                            if isinstance(value, str):
-                                if re.match(access_key_pattern, value) or re.match(secret_key_pattern, value):
-                                    return CheckResult.FAILED
+            if isinstance(conf['environment'][0], dict):
+                if 'variables' in conf['environment'][0]:
+                    if type (conf['environment'][0]['variables']) is not list:
+                        conf['environment'][0]['variables'] = [conf['environment'][0]['variables']]
+                    if type(conf['environment'][0]['variables'][0]) is dict:
+                        # variables can be a string, which in this case it points to a variable
+                        for values in list(conf['environment'][0]['variables'][0].values()):
+                            if type(values) is not list:
+                                values = [values]
+                            for value in values:
+                                if isinstance(value, str):
+                                    if re.match(access_key_pattern, value) or re.match(secret_key_pattern, value):
+                                        return CheckResult.FAILED
         return CheckResult.PASSED
 
 

--- a/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -25,8 +25,7 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
                         for values in list(conf['environment'][0]['variables'][0].values()):
                             if type(values) is not list:
                                 values = [values]
-                            for value in values:
-                                if isinstance(value, str):
+                            for value in list(filter(lambda value: type(value) is str, values)):
                                     if re.match(access_key_pattern, value) or re.match(secret_key_pattern, value):
                                         return CheckResult.FAILED
         return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -25,8 +25,9 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
                         if type(values) is not list:
                             values = [values]
                         for value in values:
-                            if re.match(access_key_pattern, value) or re.match(secret_key_pattern, value):
-                                return CheckResult.FAILED
+                            if isinstance(value, str):
+                                if re.match(access_key_pattern, value) or re.match(secret_key_pattern, value):
+                                    return CheckResult.FAILED
         return CheckResult.PASSED
 
 

--- a/tests/terraform/runner/resources/example/example.tf
+++ b/tests/terraform/runner/resources/example/example.tf
@@ -770,6 +770,29 @@ resource "aws_lambda_function" "environment and variables with '= {' example" {
   }
 }
 
+resource "aws_lambda_function" "dynamic environment that appears as string example" {
+  function_name = var.name
+  filename = "${path.module}/lambda_function.zip"
+  role = aws_iam_role.this.arn
+  handler = var.handler
+  runtime = var.runtime
+  memory_size = var.memory_size
+  timeout = var.timeout
+  layers = var.layers
+  description = var.description
+  reserved_concurrent_executions = var.reserved_concurrent_executions
+  publish = var.publish
+  kms_key_arn = var.kms_key_arn
+
+  dynamic "environment" {
+    for_each = length(var.environment_variables) > 0 ? [
+      true] : []
+
+    content {
+      variables = var.environment_variables
+    }
+  }
+}
 resource "aws_s3_bucket" "versioning as string example" {
   bucket = "${var.bucket}"
   region = "${var.region}"


### PR DESCRIPTION
the tf example for an error (delete_after):

  environment {
    variables = {
      es_endpoint  = var.es_endpoint
      index        = 'all'
      delete_after = 15
      index_format = var.index_format
      sns_arn      = var.sns_arn
    }
  }

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
