### PR TITLE
Fix ACL checks - separate read and write permissions

### DIFF
--- a/checkov/terraform/checks/resource/aws/S3PublicACLRead.py
+++ b/checkov/terraform/checks/resource/aws/S3PublicACLRead.py
@@ -1,0 +1,27 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class S3PublicACLRead(BaseResourceCheck):
+    def __init__(self):
+        name = "S3 Bucket has an ACL defined which allows public READ access."
+        id = "CKV_AWS_20"
+        supported_resources = ['aws_s3_bucket']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        """
+            Looks for ACL configuration at aws_s3_bucket:
+            https://www.terraform.io/docs/providers/aws/r/s3_bucket.html
+        :param conf: aws_s3_bucket configuration
+        :return: <CheckResult>
+        """
+        if 'acl' in conf.keys():
+            acl_block = conf['acl']
+            if acl_block in [["public-read"], ["public-read-write"], ["website"]]:
+                return CheckResult.FAILED
+        return CheckResult.PASSED
+
+
+check = S3PublicACLRead()

--- a/checkov/terraform/checks/resource/aws/S3PublicACLWRITE.py
+++ b/checkov/terraform/checks/resource/aws/S3PublicACLWRITE.py
@@ -2,10 +2,10 @@ from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
 
-class S3PublicACL(BaseResourceCheck):
+class S3PublicACLWrite(BaseResourceCheck):
     def __init__(self):
-        name = "S3 Bucket has an ACL defined which allows public access."
-        id = "CKV_AWS_20"
+        name = "S3 Bucket has an ACL defined which allows public WRITE access."
+        id = "CKV_AWS_57"
         supported_resources = ['aws_s3_bucket']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
@@ -19,9 +19,9 @@ class S3PublicACL(BaseResourceCheck):
         """
         if 'acl' in conf.keys():
             acl_block = conf['acl']
-            if acl_block in [["public-read"],["public-read-write"],["website"]]:
+            if acl_block[0] == "public-read-write":
                 return CheckResult.FAILED
         return CheckResult.PASSED
 
 
-check = S3PublicACL()
+check = S3PublicACLWrite()

--- a/tests/terraform/checks/resource/aws/test_S3PublicACLRead.py
+++ b/tests/terraform/checks/resource/aws/test_S3PublicACLRead.py
@@ -1,0 +1,30 @@
+import unittest
+
+from checkov.terraform.checks.resource.aws.S3PublicACLRead import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestS3PublicACL(unittest.TestCase):
+
+    def test_failure(self):
+        resource_conf = {"region": ["us-west-2"],
+                         "bucket": ["my_bucket"],
+                         "acl": ["public-read"],
+                         "force_destroy": [True],
+                         "tags": [{"Name": "my-bucket"}],
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        resource_conf = {"region": ["us-west-2"],
+                         "bucket": ["my_bucket"],
+                         "force_destroy": [True],
+                         "tags": [{"Name": "my-bucket"}]
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_S3PublicACLWrite.py
+++ b/tests/terraform/checks/resource/aws/test_S3PublicACLWrite.py
@@ -1,15 +1,15 @@
 import unittest
 
-from checkov.terraform.checks.resource.aws.S3PublicACL import check
+from checkov.terraform.checks.resource.aws.S3PublicACLWRITE import check
 from checkov.common.models.enums import CheckResult
 
 
-class TestS3PublicACL(unittest.TestCase):
+class TestS3PublicACLWrite(unittest.TestCase):
 
     def test_failure(self):
         resource_conf = {"region": ["us-west-2"],
                          "bucket": ["my_bucket"],
-                         "acl": ["public-read"],
+                         "acl": ["public-read-write"],
                          "force_destroy": [True],
                          "tags": [{"Name": "my-bucket"}],
                          }
@@ -17,6 +17,16 @@ class TestS3PublicACL(unittest.TestCase):
         self.assertEqual(CheckResult.FAILED, scan_result)
 
     def test_success(self):
+        resource_conf = {"region": ["us-west-2"],
+                         "bucket": ["my_bucket"],
+                         "acl": ["public-read"],
+                         "force_destroy": [True],
+                         "tags": [{"Name": "my-bucket"}],
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success2(self):
         resource_conf = {"region": ["us-west-2"],
                          "bucket": ["my_bucket"],
                          "force_destroy": [True],


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Separate read access and write access as they should be looked at differently - no bucket should have public write access, unlike public read for websites, for example