### PR TITLE
Base resource value checks enhancements

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,18 +18,18 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:9b5d0d3e2a0374fa6786d7e42f42c25b69695b449b816823be46875af9c32e05",
-                "sha256:a9518f580f18b9ca5638be0d7eb90651cceb0fff3524739488763f6dcade1caf"
+                "sha256:b81a6296134aec4d48319e5d25e47c2abcea2cd13ddd160f95b692e56c6ab9b7",
+                "sha256:c347350521e8138a42b7c877bb87ba32842405d7bc7fd86b29745abc60b9e83d"
             ],
             "index": "pypi",
-            "version": "==1.13.7"
+            "version": "==1.13.8"
         },
         "botocore": {
             "hashes": [
-                "sha256:48f68a27825632b5567796f5e6f46889971d9e48908ba9fdfc319cf78ffe1e91",
-                "sha256:7cd876e6186e845c3667fdcbfd73756f09761c2d5695dfba64b00a08195e7c1f"
+                "sha256:68eb83d97a8ecdbf271c17989280bc9a533269d4ee983d2ef80289e2333042da",
+                "sha256:8263bba760c3f24aeb0651936b24798ba8a172828afdccf8bee5ca6d5d7c4b9c"
             ],
-            "version": "==1.16.7"
+            "version": "==1.16.8"
         },
         "colorama": {
             "hashes": [
@@ -62,10 +62,10 @@
         },
         "jmespath": {
             "hashes": [
-                "sha256:695cb76fa78a10663425d5b73ddc5714eb711157e52704d69be03b1a02ba4fec",
-                "sha256:cca55c8d153173e21baa59983015ad0daf603f9cb799904ff057bfb8ff8dc2d9"
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "version": "==0.9.5"
+            "version": "==0.10.0"
         },
         "junit-xml": {
             "hashes": [

--- a/checkov/common/models/consts.py
+++ b/checkov/common/models/consts.py
@@ -1,1 +1,2 @@
 SUPPORTED_FILE_EXTENSIONS = [".tf", ".yml", ".yaml", ".json", ".template"]
+ANY_VALUE = ["CKV_ANY"]

--- a/checkov/common/models/consts.py
+++ b/checkov/common/models/consts.py
@@ -1,2 +1,2 @@
 SUPPORTED_FILE_EXTENSIONS = [".tf", ".yml", ".yaml", ".json", ".template"]
-ANY_VALUE = ["CKV_ANY"]
+ANY_VALUE = "CKV_ANY"

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -56,8 +56,8 @@ def run(banner=checkov_banner):
                         default='master')
     args = parser.parse_args()
     bc_integration = BcPlatformIntegration()
-    runner_filter = RunnerFilter(framework=args.framework,checks=args.check,skip_checks=args.skip_check)
-    runner_registry = RunnerRegistry(banner,runner_filter, tf_runner(), cfn_runner(),k8_runner())
+    runner_filter = RunnerFilter(framework=args.framework, checks=args.check, skip_checks=args.skip_check)
+    runner_registry = RunnerRegistry(banner, runner_filter, tf_runner(), cfn_runner(), k8_runner())
     if args.version:
         print(version)
         return

--- a/checkov/terraform/checks/resource/aws/LaunchConfigurationEBSEncryption.py
+++ b/checkov/terraform/checks/resource/aws/LaunchConfigurationEBSEncryption.py
@@ -1,14 +1,17 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class LaunchConfigurationEBSEncryption(BaseResourceCheck):
+class LaunchConfigurationEBSEncryption(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure all data stored in the Launch configuration EBS is securely encrypted "
         id = "CKV_AWS_8"
-        supported_resources = ['aws_launch_configuration','aws_instance']
+        supported_resources = ['aws_launch_configuration', 'aws_instance']
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "*_block_device/[0]/encrypted"
 
     def scan_resource_conf(self, conf):
         """

--- a/checkov/terraform/checks/resource/aws/S3Encryption.py
+++ b/checkov/terraform/checks/resource/aws/S3Encryption.py
@@ -1,8 +1,8 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class S3Encryption(BaseResourceCheck):
+class S3Encryption(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure all data stored in the S3 bucket is securely encrypted at rest"
         id = "CKV_AWS_19"
@@ -10,29 +10,15 @@ class S3Encryption(BaseResourceCheck):
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        """
-            Looks for encryption configuration at aws_s3_bucket:
-            https://www.terraform.io/docs/providers/aws/r/s3_bucket.html
-        :param conf: aws_s3_bucket configuration
-        :return: <CheckResult>
-        """
-        if 'server_side_encryption_configuration' in conf.keys():
-            sse_block = conf['server_side_encryption_configuration']
-            if type(sse_block[0]) is not dict:
-                # all non-dict sse_blocks will return as PASSED
-                return CheckResult.PASSED
-            if 'rule' in sse_block[0].keys():
-                rule_block = sse_block[0]['rule']
-                if isinstance(rule_block, dict):
-                    rule_block = [rule_block]
-                if 'apply_server_side_encryption_by_default' in rule_block[0].keys():
-                    encryption_block = rule_block[0]['apply_server_side_encryption_by_default']
-                    if isinstance(encryption_block, dict):
-                        encryption_block = [encryption_block]
-                    if 'sse_algorithm' in encryption_block[0].keys():
-                        return CheckResult.PASSED
-        return CheckResult.FAILED
+    def get_inspected_key(self):
+        return 'server_side_encryption_configuration/[0]/rule/[0]/' \
+               'apply_server_side_encryption_by_default/[0]/sse_algorithm'
+
+    def get_expected_value(self):
+        return 'AES256'
+
+    def get_expected_values(self):
+        return [self.get_expected_value(), 'aws:kms']
 
 
 check = S3Encryption()

--- a/checkov/terraform/checks/resource/aws/SQSQueueEncryption.py
+++ b/checkov/terraform/checks/resource/aws/SQSQueueEncryption.py
@@ -1,26 +1,24 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.common.models.consts import ANY_VALUE
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class SQSQueueEncryption(BaseResourceCheck):
+class SQSQueueEncryption(BaseResourceValueCheck):
     def __init__(self):
-        name = "Ensure all data stored in the SQS queue  is encrypted"
+        name = "Ensure all data stored in the SQS queue is encrypted"
         id = "CKV_AWS_27"
         supported_resources = ['aws_sqs_queue']
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        """
-            Looks for encryption configuration at aws_sqs_queue:
-            https://www.terraform.io/docs/providers/aws/r/sqs_queue.html
-        :param conf: aws_s3_bucket configuration
-        :return: <CheckResult>
-        """
-        if 'kms_master_key_id' in conf.keys():
-            if conf['kms_master_key_id']:
-                return CheckResult.PASSED
-        return CheckResult.FAILED
+    def get_inspected_key(self):
+        return 'kms_master_key_id'
+
+    def get_expected_values(self):
+        return [ANY_VALUE]
+
+    def get_expected_value(self):
+        return 'alias/aws/sqs'
 
 
 check = SQSQueueEncryption()

--- a/checkov/terraform/checks/resource/base_resource_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_value_check.py
@@ -41,7 +41,7 @@ class BaseResourceValueCheck(BaseResourceCheck):
         inspected_key = self.get_inspected_key()
         expected_values = self.get_expected_values()
         if dpath.search(conf, inspected_key) != {}:
-            if expected_values == [ANY_VALUE]:
+            if ANY_VALUE in expected_values:
                 # Key is found on the configuration - if it accepts any value, the check is PASSED
                 return CheckResult.PASSED
             value = dpath.get(conf, inspected_key)
@@ -86,7 +86,6 @@ class BaseResourceValueCheck(BaseResourceCheck):
 
     def get_expected_value(self):
         """
-
-        :return:
+        Returns the default expected value, governed by provider best practices
         """
         return True

--- a/checkov/terraform/checks/resource/base_resource_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_value_check.py
@@ -1,29 +1,92 @@
 from abc import abstractmethod
-
-import dpath
-
+import dpath.util
+import re
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.common.models.enums import CheckResult
+from checkov.common.models.consts import ANY_VALUE
+
+VARIABLE_DEPENDANT_REGEX = r'(?:local|var)\.[^\s]+'
 
 
 class BaseResourceValueCheck(BaseResourceCheck):
     def __init__(self, name, id, categories, supported_resources):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
+    @staticmethod
+    def _filter_key_path(path):
+        """
+        Filter an attribute path to contain only named attributes
+        :param path: valid JSONPath of an attribute
+        :return: JSONPath path to contain only named attributes
+        """
+        return [x for x in path.split("/") if not re.search(r'\[?\d+\]?', x)]
+
+    @staticmethod
+    def _is_variable_dependant(value):
+        if isinstance(value, str) and re.match(VARIABLE_DEPENDANT_REGEX, value):
+            return True
+        return False
+
+    @staticmethod
+    def _is_nesting_key(inspected_attributes, key):
+        """
+        Resolves whether a key is a subset of the inspected nesting attributes
+        :param inspected_attributes: list of nesting attributes
+        :param key: JSONPath key of an attribute
+        :return: True/False
+        """
+        return any([x in key for x in inspected_attributes])
+
     def scan_resource_conf(self, conf):
         inspected_key = self.get_inspected_key()
-        if dpath.util.search(conf, inspected_key) != {}:
-            value = dpath.util.get(conf, inspected_key)
-            if isinstance(value, bool):
-                value = [value]
-            if value[0] == self.get_expected_value():
+        expected_values = self.get_expected_values()
+        if dpath.search(conf, inspected_key) != {}:
+            if expected_values == [ANY_VALUE]:
+                # Key is found on the configuration - if it accepts any value, the check is PASSED
                 return CheckResult.PASSED
+            value = dpath.get(conf, inspected_key)
+            if isinstance(value, list) and len(value) == 1:
+                value = value[0]
+            if self._is_variable_dependant(value):
+                # If the tested attribute is variable-dependant, then result is PASSED
+                return CheckResult.PASSED
+            if value in expected_values:
+                return CheckResult.PASSED
+        else:
+            # Look for the configuration in a bottom-up fashion
+            inspected_attributes = self._filter_key_path(inspected_key)
+            for attribute in reversed(inspected_attributes):
+                for sub_key, sub_conf in dpath.search(conf, f'**/{attribute}', yielded=True):
+                    filtered_sub_key = self._filter_key_path(sub_key)
+                    if self._is_nesting_key(inspected_attributes, filtered_sub_key):
+                        if isinstance(sub_conf, list) and len(sub_conf) == 1:
+                            sub_conf = sub_conf[0]
+                        if sub_conf in self.get_expected_values():
+                            return CheckResult.PASSED
+                        if self._is_variable_dependant(sub_conf):
+                            # If the tested attribute is variable-dependant, then result is PASSED
+                            return CheckResult.PASSED
+
         return CheckResult.FAILED
 
     @abstractmethod
     def get_inspected_key(self):
-        raise NotImplemented()
+        """
+        :return: JSONPath syntax path of the checked attribute
+        """
+        raise NotImplementedError()
+
+    def get_expected_values(self):
+        """
+        Override the method with the list of acceptable values if the check has more than one possible expected value, given
+        the inspected key
+        :return: List of expected values, defaults to a list of the expected value
+        """
+        return [self.get_expected_value()]
 
     def get_expected_value(self):
-        # default expected value. can be override by derived class
+        """
+
+        :return:
+        """
         return True


### PR DESCRIPTION
- Support of hierarchy on `BaseResourceValueCheck` checks, in order to support non-root attribute checks
- Support of multiple expected values
- Support of a default expected value, according to best practices
- Identify attributes which are variable dependant, and mark these resources as `PASSED` under the check
- Incorporation of `CKV_ANY` value,  in the case the check looks for any value for the inspected key
- Conversion of `S3Encryption`, `LaunchConfigurationEBSEncryption` and `SQSQueueEncryption` to implement the  `BaseResourceValueCheck` class

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
