### PR TITLE
Handle digests in image names for image pull checks

### DIFF
--- a/checkov/kubernetes/checks/ImagePullPolicyAlways.py
+++ b/checkov/kubernetes/checks/ImagePullPolicyAlways.py
@@ -24,11 +24,17 @@ class ImagePullPolicyAlways(BaseK8Check):
 
     def scan_spec_conf(self, conf):
         if "image" in conf:
+            
+            # Remove the digest, if present
+            image_val = conf["image"]
+            if '@' in image_val:
+                image_val = image_val[0:image_val.index('@')]
+
             # Split on :
-            if ":" in conf["image"]:
-                (image, tag) = conf["image"].split(':')
+            if ":" in image_val:
+                (image, tag) = image_val.split(':')
             else:
-                image = conf["image"]
+                image = image_val
                 tag = ""
             if "imagePullPolicy" not in conf:
                 if tag == "latest" or tag == "":

--- a/checkov/kubernetes/checks/ImageTagFixed.py
+++ b/checkov/kubernetes/checks/ImageTagFixed.py
@@ -22,11 +22,17 @@ class ImageTagFixed(BaseK8Check):
 
     def scan_spec_conf(self, conf):
         if "image" in conf:
+
+            # Remove the digest, if present
+            image_val = conf["image"]
+            if '@' in image_val:
+                image_val = image_val[0:image_val.index('@')]
+
             # Split on :
-            if ":" in conf["image"]:
-                (image, tag) = conf["image"].split(':')
+            if ":" in image_val:
+                (image, tag) = image_val.split(':')
             else:
-                image = conf["image"]
+                image = image_val
                 tag = ""
             if tag == "latest" or tag == "":
                 return CheckResult.FAILED


### PR DESCRIPTION
The image checks fail if the image has a digest (e.g., `repo/image:tag@sha256:12345`), because splitting on `:` returns three values.

This fixes that by removing the digest if it's present.