### PR TITLE
Image digest rule

### DIFF
--- a/checkov/common/util/banner.py
+++ b/checkov/common/util/banner.py
@@ -1,6 +1,6 @@
 from checkov.version import version
 
-banner = """
+banner = r"""
        _               _              
    ___| |__   ___  ___| | _______   __
   / __| '_ \ / _ \/ __| |/ / _ \ \ / /

--- a/checkov/kubernetes/checks/ImageDigest.py
+++ b/checkov/kubernetes/checks/ImageDigest.py
@@ -31,6 +31,6 @@ class ImageDigest(BaseK8Check):
             return CheckResult.PASSED if has_digest else CheckResult.FAILED
         else:
             return CheckResult.FAILED
-        return CheckResult.PASSED
+
 
 check = ImageDigest()

--- a/checkov/kubernetes/checks/ImageDigest.py
+++ b/checkov/kubernetes/checks/ImageDigest.py
@@ -1,0 +1,36 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.kubernetes.base_spec_check import BaseK8Check
+
+
+class ImageDigest(BaseK8Check):
+
+    def __init__(self):
+        """
+        The image specification should use a digest instead of a tag to make sure the container always uses the same
+        version of the image.
+        https://kubernetes.io/docs/concepts/configuration/overview/#container-images
+
+        An admission controller could be used to enforce the use of image digest
+        """
+        name = "Image should use digest"
+        id = "CKV_K8S_43"
+        # Location: container .image
+        supported_kind = ['containers', 'initContainers']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
+
+    def get_resource_id(self, conf):
+        return conf['parent']
+
+    def scan_spec_conf(self, conf):
+        if "image" in conf:
+
+            # The @ indicates there is a digest. It's technically possible to use a tag as well, but it doesn't make
+            # a difference. So, this @ is all we need to pass the check.
+            has_digest = '@' in conf["image"]
+            return CheckResult.PASSED if has_digest else CheckResult.FAILED
+        else:
+            return CheckResult.FAILED
+        return CheckResult.PASSED
+
+check = ImageDigest()

--- a/checkov/terraform/checks/resource/aws/IAMRoleAllowAssumeFromAccount.py
+++ b/checkov/terraform/checks/resource/aws/IAMRoleAllowAssumeFromAccount.py
@@ -20,7 +20,7 @@ class IAMRoleAllowAssumeFromAccount(BaseResourceCheck):
                 if 'Statement' in assume_role_block.keys():
                     if 'Principal' in assume_role_block['Statement'][0]:
                         if 'AWS' in assume_role_block['Statement'][0]['Principal']:
-                            account_access = re.compile('\d{12}|arn:aws:iam::\d{12}:root')
+                            account_access = re.compile(r'\d{12}|arn:aws:iam::\d{12}:root')
                             if re.match(account_access, assume_role_block['Statement'][0]['Principal']['AWS']):
                                 return CheckResult.FAILED
             except:

--- a/tests/kubernetes/checks/example_ImageDigest/imageWithTagAndDigest-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ImageDigest/imageWithTagAndDigest-PASSED.yaml
@@ -1,0 +1,188 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-hs
+  labels:
+    app: kafka
+spec:
+  ports:
+  - port: 9093
+    name: server
+  clusterIP: None
+  selector:
+    app: kafka
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kafka-pdb
+spec:
+  selector:
+    matchLabels:
+      app: kafka
+  maxUnavailable: 1
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: kafka
+spec:
+  serviceName: kafka-hs
+  replicas: 5
+  podManagementPolicy: Parallel
+  updateStrategy:
+      type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values: 
+                    - kafka
+              topologyKey: "kubernetes.io/hostname"
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+             - weight: 1
+               podAffinityTerm:
+                 labelSelector:
+                    matchExpressions:
+                      - key: "app"
+                        operator: In
+                        values: 
+                        - zk
+                 topologyKey: "kubernetes.io/hostname"
+      terminationGracePeriodSeconds: 300
+      containers:
+      - name: k8skafka
+        imagePullPolicy: Always
+        image: gcr.io/google_containers/kubernetes-kafka:1.0-10.2.1@sha256:123456
+        resources:
+          requests:
+            memory: "12Gi"
+            cpu: 4
+        ports:
+        - containerPort: 9093
+          name: server
+        command:
+        - sh
+        - -c
+        - "exec kafka-server-start.sh /opt/kafka/config/server.properties --override broker.id=${HOSTNAME##*-} \
+          --override listeners=PLAINTEXT://:9093 \
+          --override zookeeper.connect=zk-cs.default.svc.cluster.local:2181 \
+          --override log.dir=/var/lib/kafka \
+          --override auto.create.topics.enable=true \
+          --override auto.leader.rebalance.enable=true \
+          --override background.threads=10 \
+          --override compression.type=producer \
+          --override delete.topic.enable=false \
+          --override leader.imbalance.check.interval.seconds=300 \
+          --override leader.imbalance.per.broker.percentage=10 \
+          --override log.flush.interval.messages=9223372036854775807 \
+          --override log.flush.offset.checkpoint.interval.ms=60000 \
+          --override log.flush.scheduler.interval.ms=9223372036854775807 \
+          --override log.retention.bytes=-1 \
+          --override log.retention.hours=168 \
+          --override log.roll.hours=168 \
+          --override log.roll.jitter.hours=0 \
+          --override log.segment.bytes=1073741824 \
+          --override log.segment.delete.delay.ms=60000 \
+          --override message.max.bytes=1000012 \
+          --override min.insync.replicas=1 \
+          --override num.io.threads=8 \
+          --override num.network.threads=3 \
+          --override num.recovery.threads.per.data.dir=1 \
+          --override num.replica.fetchers=1 \
+          --override offset.metadata.max.bytes=4096 \
+          --override offsets.commit.required.acks=-1 \
+          --override offsets.commit.timeout.ms=5000 \
+          --override offsets.load.buffer.size=5242880 \
+          --override offsets.retention.check.interval.ms=600000 \
+          --override offsets.retention.minutes=1440 \
+          --override offsets.topic.compression.codec=0 \
+          --override offsets.topic.num.partitions=50 \
+          --override offsets.topic.replication.factor=3 \
+          --override offsets.topic.segment.bytes=104857600 \
+          --override queued.max.requests=500 \
+          --override quota.consumer.default=9223372036854775807 \
+          --override quota.producer.default=9223372036854775807 \
+          --override replica.fetch.min.bytes=1 \
+          --override replica.fetch.wait.max.ms=500 \
+          --override replica.high.watermark.checkpoint.interval.ms=5000 \
+          --override replica.lag.time.max.ms=10000 \
+          --override replica.socket.receive.buffer.bytes=65536 \
+          --override replica.socket.timeout.ms=30000 \
+          --override request.timeout.ms=30000 \
+          --override socket.receive.buffer.bytes=102400 \
+          --override socket.request.max.bytes=104857600 \
+          --override socket.send.buffer.bytes=102400 \
+          --override unclean.leader.election.enable=true \
+          --override zookeeper.session.timeout.ms=6000 \
+          --override zookeeper.set.acl=false \
+          --override broker.id.generation.enable=true \
+          --override connections.max.idle.ms=600000 \
+          --override controlled.shutdown.enable=true \
+          --override controlled.shutdown.max.retries=3 \
+          --override controlled.shutdown.retry.backoff.ms=5000 \
+          --override controller.socket.timeout.ms=30000 \
+          --override default.replication.factor=1 \
+          --override fetch.purgatory.purge.interval.requests=1000 \
+          --override group.max.session.timeout.ms=300000 \
+          --override group.min.session.timeout.ms=6000 \
+          --override inter.broker.protocol.version=0.10.2-IV0 \
+          --override log.cleaner.backoff.ms=15000 \
+          --override log.cleaner.dedupe.buffer.size=134217728 \
+          --override log.cleaner.delete.retention.ms=86400000 \
+          --override log.cleaner.enable=true \
+          --override log.cleaner.io.buffer.load.factor=0.9 \
+          --override log.cleaner.io.buffer.size=524288 \
+          --override log.cleaner.io.max.bytes.per.second=1.7976931348623157E308 \
+          --override log.cleaner.min.cleanable.ratio=0.5 \
+          --override log.cleaner.min.compaction.lag.ms=0 \
+          --override log.cleaner.threads=1 \
+          --override log.cleanup.policy=delete \
+          --override log.index.interval.bytes=4096 \
+          --override log.index.size.max.bytes=10485760 \
+          --override log.message.timestamp.difference.max.ms=9223372036854775807 \
+          --override log.message.timestamp.type=CreateTime \
+          --override log.preallocate=false \
+          --override log.retention.check.interval.ms=300000 \
+          --override max.connections.per.ip=2147483647 \
+          --override num.partitions=1 \
+          --override producer.purgatory.purge.interval.requests=1000 \
+          --override replica.fetch.backoff.ms=1000 \
+          --override replica.fetch.max.bytes=1048576 \
+          --override replica.fetch.response.max.bytes=10485760 \
+          --override reserved.broker.max.id=1000 "
+        env:
+        - name: KAFKA_HEAP_OPTS
+          value : "-Xmx2G -Xms2G"
+        - name: KAFKA_OPTS
+          value: "-Dlogging.level=INFO"
+        volumeMounts:
+        - name: datadir
+          mountPath: /var/lib/kafka
+        readinessProbe:
+          exec:
+           command: 
+            - sh 
+            - -c 
+            - "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server=localhost:9093"
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi

--- a/tests/kubernetes/checks/example_ImageDigest/job-ImageTagLatest-FAILED.yaml
+++ b/tests/kubernetes/checks/example_ImageDigest/job-ImageTagLatest-FAILED.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: countdown
+spec:
+  template:
+    metadata:
+      name: countdown
+    spec:
+      containers:
+      - name: counter
+        image: centos:latest
+        command:
+         - "bin/bash"
+         - "-c"
+         - "for i in 9 8 7 6 5 4 3 2 1 ; do echo $i ; done"
+      restartPolicy: Never

--- a/tests/kubernetes/checks/example_ImageDigest/kafka-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ImageDigest/kafka-PASSED.yaml
@@ -1,0 +1,188 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-hs
+  labels:
+    app: kafka
+spec:
+  ports:
+  - port: 9093
+    name: server
+  clusterIP: None
+  selector:
+    app: kafka
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kafka-pdb
+spec:
+  selector:
+    matchLabels:
+      app: kafka
+  maxUnavailable: 1
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: kafka
+spec:
+  serviceName: kafka-hs
+  replicas: 5
+  podManagementPolicy: Parallel
+  updateStrategy:
+      type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values: 
+                    - kafka
+              topologyKey: "kubernetes.io/hostname"
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+             - weight: 1
+               podAffinityTerm:
+                 labelSelector:
+                    matchExpressions:
+                      - key: "app"
+                        operator: In
+                        values: 
+                        - zk
+                 topologyKey: "kubernetes.io/hostname"
+      terminationGracePeriodSeconds: 300
+      containers:
+      - name: k8skafka
+        imagePullPolicy: Always
+        image: gcr.io/google_containers/kubernetes-kafka@sha256:123456
+        resources:
+          requests:
+            memory: "12Gi"
+            cpu: 4
+        ports:
+        - containerPort: 9093
+          name: server
+        command:
+        - sh
+        - -c
+        - "exec kafka-server-start.sh /opt/kafka/config/server.properties --override broker.id=${HOSTNAME##*-} \
+          --override listeners=PLAINTEXT://:9093 \
+          --override zookeeper.connect=zk-cs.default.svc.cluster.local:2181 \
+          --override log.dir=/var/lib/kafka \
+          --override auto.create.topics.enable=true \
+          --override auto.leader.rebalance.enable=true \
+          --override background.threads=10 \
+          --override compression.type=producer \
+          --override delete.topic.enable=false \
+          --override leader.imbalance.check.interval.seconds=300 \
+          --override leader.imbalance.per.broker.percentage=10 \
+          --override log.flush.interval.messages=9223372036854775807 \
+          --override log.flush.offset.checkpoint.interval.ms=60000 \
+          --override log.flush.scheduler.interval.ms=9223372036854775807 \
+          --override log.retention.bytes=-1 \
+          --override log.retention.hours=168 \
+          --override log.roll.hours=168 \
+          --override log.roll.jitter.hours=0 \
+          --override log.segment.bytes=1073741824 \
+          --override log.segment.delete.delay.ms=60000 \
+          --override message.max.bytes=1000012 \
+          --override min.insync.replicas=1 \
+          --override num.io.threads=8 \
+          --override num.network.threads=3 \
+          --override num.recovery.threads.per.data.dir=1 \
+          --override num.replica.fetchers=1 \
+          --override offset.metadata.max.bytes=4096 \
+          --override offsets.commit.required.acks=-1 \
+          --override offsets.commit.timeout.ms=5000 \
+          --override offsets.load.buffer.size=5242880 \
+          --override offsets.retention.check.interval.ms=600000 \
+          --override offsets.retention.minutes=1440 \
+          --override offsets.topic.compression.codec=0 \
+          --override offsets.topic.num.partitions=50 \
+          --override offsets.topic.replication.factor=3 \
+          --override offsets.topic.segment.bytes=104857600 \
+          --override queued.max.requests=500 \
+          --override quota.consumer.default=9223372036854775807 \
+          --override quota.producer.default=9223372036854775807 \
+          --override replica.fetch.min.bytes=1 \
+          --override replica.fetch.wait.max.ms=500 \
+          --override replica.high.watermark.checkpoint.interval.ms=5000 \
+          --override replica.lag.time.max.ms=10000 \
+          --override replica.socket.receive.buffer.bytes=65536 \
+          --override replica.socket.timeout.ms=30000 \
+          --override request.timeout.ms=30000 \
+          --override socket.receive.buffer.bytes=102400 \
+          --override socket.request.max.bytes=104857600 \
+          --override socket.send.buffer.bytes=102400 \
+          --override unclean.leader.election.enable=true \
+          --override zookeeper.session.timeout.ms=6000 \
+          --override zookeeper.set.acl=false \
+          --override broker.id.generation.enable=true \
+          --override connections.max.idle.ms=600000 \
+          --override controlled.shutdown.enable=true \
+          --override controlled.shutdown.max.retries=3 \
+          --override controlled.shutdown.retry.backoff.ms=5000 \
+          --override controller.socket.timeout.ms=30000 \
+          --override default.replication.factor=1 \
+          --override fetch.purgatory.purge.interval.requests=1000 \
+          --override group.max.session.timeout.ms=300000 \
+          --override group.min.session.timeout.ms=6000 \
+          --override inter.broker.protocol.version=0.10.2-IV0 \
+          --override log.cleaner.backoff.ms=15000 \
+          --override log.cleaner.dedupe.buffer.size=134217728 \
+          --override log.cleaner.delete.retention.ms=86400000 \
+          --override log.cleaner.enable=true \
+          --override log.cleaner.io.buffer.load.factor=0.9 \
+          --override log.cleaner.io.buffer.size=524288 \
+          --override log.cleaner.io.max.bytes.per.second=1.7976931348623157E308 \
+          --override log.cleaner.min.cleanable.ratio=0.5 \
+          --override log.cleaner.min.compaction.lag.ms=0 \
+          --override log.cleaner.threads=1 \
+          --override log.cleanup.policy=delete \
+          --override log.index.interval.bytes=4096 \
+          --override log.index.size.max.bytes=10485760 \
+          --override log.message.timestamp.difference.max.ms=9223372036854775807 \
+          --override log.message.timestamp.type=CreateTime \
+          --override log.preallocate=false \
+          --override log.retention.check.interval.ms=300000 \
+          --override max.connections.per.ip=2147483647 \
+          --override num.partitions=1 \
+          --override producer.purgatory.purge.interval.requests=1000 \
+          --override replica.fetch.backoff.ms=1000 \
+          --override replica.fetch.max.bytes=1048576 \
+          --override replica.fetch.response.max.bytes=10485760 \
+          --override reserved.broker.max.id=1000 "
+        env:
+        - name: KAFKA_HEAP_OPTS
+          value : "-Xmx2G -Xms2G"
+        - name: KAFKA_OPTS
+          value: "-Dlogging.level=INFO"
+        volumeMounts:
+        - name: datadir
+          mountPath: /var/lib/kafka
+        readinessProbe:
+          exec:
+           command: 
+            - sh 
+            - -c 
+            - "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server=localhost:9093"
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi

--- a/tests/kubernetes/checks/example_ImageDigest/storm-zookeeper-FAILED.json
+++ b/tests/kubernetes/checks/example_ImageDigest/storm-zookeeper-FAILED.json
@@ -1,0 +1,28 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "zookeeper",
+    "labels": {
+      "name": "zookeeper"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "zookeeper",
+        "image": "mattf/zookeeper",
+        "ports": [
+          {
+            "containerPort": 2181
+          }
+        ],
+        "resources": {
+          "limits": {
+            "cpu": "100m"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/kubernetes/checks/example_ImagePullPolicy/imageWithDigest-PullPolicyAlways-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ImagePullPolicy/imageWithDigest-PullPolicyAlways-PASSED.yaml
@@ -1,0 +1,118 @@
+# Source: https://kubernetes.io/docs/tutorials/stateful-application/cassandra/
+# https://github.com/kubernetes/examples/tree/master/cassandra
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: cassandra
+  name: cassandra
+spec:
+  clusterIP: None
+  ports:
+  - port: 9042
+  selector:
+    app: cassandra
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cassandra
+  labels:
+    app: cassandra
+spec:
+  serviceName: cassandra
+  replicas: 3
+  selector:
+    matchLabels:
+      app: cassandra
+  template:
+    metadata:
+      labels:
+        app: cassandra
+    spec:
+      terminationGracePeriodSeconds: 1800
+      containers:
+      - name: cassandra
+        image: gcr.io/google-samples/cassandra@sha256:123456
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 7000
+          name: intra-node
+        - containerPort: 7001
+          name: tls-intra-node
+        - containerPort: 7199
+          name: jmx
+        - containerPort: 9042
+          name: cql
+        resources:
+          limits:
+            cpu: "500m"
+            memory: 1Gi
+          requests:
+            cpu: "500m"
+            memory: 1Gi
+        securityContext:
+          capabilities:
+            add:
+              - IPC_LOCK
+        lifecycle:
+          preStop:
+            exec:
+              command: 
+              - /bin/sh
+              - -c
+              - nodetool drain
+        env:
+          - name: MAX_HEAP_SIZE
+            value: 512M
+          - name: HEAP_NEWSIZE
+            value: 100M
+          - name: CASSANDRA_SEEDS
+            value: "cassandra-0.cassandra.default.svc.cluster.local"
+          - name: CASSANDRA_CLUSTER_NAME
+            value: "K8Demo"
+          - name: CASSANDRA_DC
+            value: "DC1-K8Demo"
+          - name: CASSANDRA_RACK
+            value: "Rack1-K8Demo"
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /ready-probe.sh
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        # These volume mounts are persistent. They are like inline claims,
+        # but not exactly because the names need to match exactly one of
+        # the stateful pod volumes.
+        volumeMounts:
+        - name: cassandra-data
+          mountPath: /cassandra_data
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above.
+  # do not use these in production until ssd GCEPersistentDisk or other ssd pd
+  volumeClaimTemplates:
+  - metadata:
+      name: cassandra-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: fast
+      resources:
+        requests:
+          storage: 1Gi
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast
+provisioner: k8s.io/minikube-hostpath
+parameters:
+  type: pd-ssd
+
+

--- a/tests/kubernetes/checks/example_ImageTagFixed/imageWithDigest-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ImageTagFixed/imageWithDigest-PASSED.yaml
@@ -1,0 +1,188 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-hs
+  labels:
+    app: kafka
+spec:
+  ports:
+  - port: 9093
+    name: server
+  clusterIP: None
+  selector:
+    app: kafka
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kafka-pdb
+spec:
+  selector:
+    matchLabels:
+      app: kafka
+  maxUnavailable: 1
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: kafka
+spec:
+  serviceName: kafka-hs
+  replicas: 5
+  podManagementPolicy: Parallel
+  updateStrategy:
+      type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values: 
+                    - kafka
+              topologyKey: "kubernetes.io/hostname"
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+             - weight: 1
+               podAffinityTerm:
+                 labelSelector:
+                    matchExpressions:
+                      - key: "app"
+                        operator: In
+                        values: 
+                        - zk
+                 topologyKey: "kubernetes.io/hostname"
+      terminationGracePeriodSeconds: 300
+      containers:
+      - name: k8skafka
+        imagePullPolicy: Always
+        image: gcr.io/google_containers/kubernetes-kafka:1.0-10.2.1@sha256:123456
+        resources:
+          requests:
+            memory: "12Gi"
+            cpu: 4
+        ports:
+        - containerPort: 9093
+          name: server
+        command:
+        - sh
+        - -c
+        - "exec kafka-server-start.sh /opt/kafka/config/server.properties --override broker.id=${HOSTNAME##*-} \
+          --override listeners=PLAINTEXT://:9093 \
+          --override zookeeper.connect=zk-cs.default.svc.cluster.local:2181 \
+          --override log.dir=/var/lib/kafka \
+          --override auto.create.topics.enable=true \
+          --override auto.leader.rebalance.enable=true \
+          --override background.threads=10 \
+          --override compression.type=producer \
+          --override delete.topic.enable=false \
+          --override leader.imbalance.check.interval.seconds=300 \
+          --override leader.imbalance.per.broker.percentage=10 \
+          --override log.flush.interval.messages=9223372036854775807 \
+          --override log.flush.offset.checkpoint.interval.ms=60000 \
+          --override log.flush.scheduler.interval.ms=9223372036854775807 \
+          --override log.retention.bytes=-1 \
+          --override log.retention.hours=168 \
+          --override log.roll.hours=168 \
+          --override log.roll.jitter.hours=0 \
+          --override log.segment.bytes=1073741824 \
+          --override log.segment.delete.delay.ms=60000 \
+          --override message.max.bytes=1000012 \
+          --override min.insync.replicas=1 \
+          --override num.io.threads=8 \
+          --override num.network.threads=3 \
+          --override num.recovery.threads.per.data.dir=1 \
+          --override num.replica.fetchers=1 \
+          --override offset.metadata.max.bytes=4096 \
+          --override offsets.commit.required.acks=-1 \
+          --override offsets.commit.timeout.ms=5000 \
+          --override offsets.load.buffer.size=5242880 \
+          --override offsets.retention.check.interval.ms=600000 \
+          --override offsets.retention.minutes=1440 \
+          --override offsets.topic.compression.codec=0 \
+          --override offsets.topic.num.partitions=50 \
+          --override offsets.topic.replication.factor=3 \
+          --override offsets.topic.segment.bytes=104857600 \
+          --override queued.max.requests=500 \
+          --override quota.consumer.default=9223372036854775807 \
+          --override quota.producer.default=9223372036854775807 \
+          --override replica.fetch.min.bytes=1 \
+          --override replica.fetch.wait.max.ms=500 \
+          --override replica.high.watermark.checkpoint.interval.ms=5000 \
+          --override replica.lag.time.max.ms=10000 \
+          --override replica.socket.receive.buffer.bytes=65536 \
+          --override replica.socket.timeout.ms=30000 \
+          --override request.timeout.ms=30000 \
+          --override socket.receive.buffer.bytes=102400 \
+          --override socket.request.max.bytes=104857600 \
+          --override socket.send.buffer.bytes=102400 \
+          --override unclean.leader.election.enable=true \
+          --override zookeeper.session.timeout.ms=6000 \
+          --override zookeeper.set.acl=false \
+          --override broker.id.generation.enable=true \
+          --override connections.max.idle.ms=600000 \
+          --override controlled.shutdown.enable=true \
+          --override controlled.shutdown.max.retries=3 \
+          --override controlled.shutdown.retry.backoff.ms=5000 \
+          --override controller.socket.timeout.ms=30000 \
+          --override default.replication.factor=1 \
+          --override fetch.purgatory.purge.interval.requests=1000 \
+          --override group.max.session.timeout.ms=300000 \
+          --override group.min.session.timeout.ms=6000 \
+          --override inter.broker.protocol.version=0.10.2-IV0 \
+          --override log.cleaner.backoff.ms=15000 \
+          --override log.cleaner.dedupe.buffer.size=134217728 \
+          --override log.cleaner.delete.retention.ms=86400000 \
+          --override log.cleaner.enable=true \
+          --override log.cleaner.io.buffer.load.factor=0.9 \
+          --override log.cleaner.io.buffer.size=524288 \
+          --override log.cleaner.io.max.bytes.per.second=1.7976931348623157E308 \
+          --override log.cleaner.min.cleanable.ratio=0.5 \
+          --override log.cleaner.min.compaction.lag.ms=0 \
+          --override log.cleaner.threads=1 \
+          --override log.cleanup.policy=delete \
+          --override log.index.interval.bytes=4096 \
+          --override log.index.size.max.bytes=10485760 \
+          --override log.message.timestamp.difference.max.ms=9223372036854775807 \
+          --override log.message.timestamp.type=CreateTime \
+          --override log.preallocate=false \
+          --override log.retention.check.interval.ms=300000 \
+          --override max.connections.per.ip=2147483647 \
+          --override num.partitions=1 \
+          --override producer.purgatory.purge.interval.requests=1000 \
+          --override replica.fetch.backoff.ms=1000 \
+          --override replica.fetch.max.bytes=1048576 \
+          --override replica.fetch.response.max.bytes=10485760 \
+          --override reserved.broker.max.id=1000 "
+        env:
+        - name: KAFKA_HEAP_OPTS
+          value : "-Xmx2G -Xms2G"
+        - name: KAFKA_OPTS
+          value: "-Dlogging.level=INFO"
+        volumeMounts:
+        - name: datadir
+          mountPath: /var/lib/kafka
+        readinessProbe:
+          exec:
+           command: 
+            - sh 
+            - -c 
+            - "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server=localhost:9093"
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi

--- a/tests/kubernetes/checks/test_ImageDigest.py
+++ b/tests/kubernetes/checks/test_ImageDigest.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.kubernetes.checks.ImagePullPolicyAlways import check
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestImageDigest(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ImageDigest"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/kubernetes/checks/test_ImageDigest.py
+++ b/tests/kubernetes/checks/test_ImageDigest.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from checkov.kubernetes.checks.ImagePullPolicyAlways import check
+from checkov.kubernetes.checks.ImageDigest import check
 from checkov.kubernetes.runner import Runner
 from checkov.runner_filter import RunnerFilter
 

--- a/tests/kubernetes/checks/test_ImagePullPolicyAlways.py
+++ b/tests/kubernetes/checks/test_ImagePullPolicyAlways.py
@@ -16,7 +16,7 @@ class TestImagePullPolicyAlways(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 3)
+        self.assertEqual(summary['passed'], 4)
         self.assertEqual(summary['failed'], 3)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/kubernetes/checks/test_ImageTagFixed.py
+++ b/tests/kubernetes/checks/test_ImageTagFixed.py
@@ -16,7 +16,7 @@ class TestImageTagFixed(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/terraform/evaluation/test_base_variable_evaluation.py
+++ b/tests/terraform/evaluation/test_base_variable_evaluation.py
@@ -49,9 +49,9 @@ class TestBaseVariableEvaluation(unittest.TestCase):
         definition_type1, var_name1 = 'locals', 'dummy'
         definition_type2, var_name2 = 'variable', 'customer_name'
         self.assertEqual(BaseVariableEvaluation._generate_evaluation_regex(definition_type1, var_name1),
-                         "((?:\$\{)?local[.]dummy(?:\})?)")
+                         r"((?:\$\{)?local[.]dummy(?:\})?)")
         self.assertEqual(BaseVariableEvaluation._generate_evaluation_regex(definition_type2, var_name2),
-                         "((?:\$\{)?var[.]customer_name(?:\})?)")
+                         r"((?:\$\{)?var[.]customer_name(?:\})?)")
 
     def tearDown(self):
         parser_registry.definitions_context = {}


### PR DESCRIPTION
This PR adds a rule for checking whether a container image is specified with a digest, as is best practice. It ignores whether a tag is present or not, because it technically doesn't matter (the digest will always be used, and the tag will be ignored).

It also adds tests for the fixes in https://github.com/bridgecrewio/checkov/pull/278.

Finally, it also cleans up some tests to eliminate warnings in test output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

