### PR TITLE
Cloudformation RDS check parity

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/RDSEncryption.py
+++ b/checkov/cloudformation/checks/resource/aws/RDSEncryption.py
@@ -1,0 +1,26 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class RDSEncryption(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure all data stored in the RDS is securely encrypted at rest"
+        id = "CKV_AWS_16"
+        supported_resources = ['AWS::RDS::DBInstance']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        """
+            Looks for encryption configuration on RDS instance:
+            https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html
+        :param conf: AWS::RDS::DBInstance configuration
+        :return: <CheckResult>
+        """
+        if 'Properties' in conf.keys():
+            if 'StorageEncrypted' in conf['Properties'].keys():
+                if conf['Properties']['StorageEncrypted'] == True:
+                    return CheckResult.PASSED
+        return CheckResult.FAILED
+
+check = RDSEncryption()

--- a/checkov/cloudformation/checks/resource/aws/RDSPubliclyAccessible.py
+++ b/checkov/cloudformation/checks/resource/aws/RDSPubliclyAccessible.py
@@ -1,0 +1,26 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class RDSPubliclyAccessible(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure all data stored in the RDS bucket is not public accessible"
+        id = "CKV_AWS_17"
+        supported_resources = ['AWS::RDS::DBInstance']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        """
+            Looks for publicy accessible configuration on RDS instance:
+            https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html
+        :param conf: AWS::RDS::DBInstance configuration
+        :return: <CheckResult>
+        """
+        if 'Properties' in conf.keys():
+            if 'PubliclyAccessible' in conf['Properties'].keys():
+                if conf['Properties']['PubliclyAccessible'] == True:
+                    return CheckResult.FAILED
+        return CheckResult.PASSED
+
+check = RDSPubliclyAccessible()

--- a/tests/cloudformation/checks/resource/aws/example_RDSEncryption/RDSEncryption-FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSEncryption/RDSEncryption-FAIL.yaml
@@ -1,0 +1,10 @@
+Resources:
+  MyDB:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: 'mydb'
+      DBInstanceClass: 't3.micro'
+      AllocatedStorage: 5
+      Engine: 'mysql'
+      MasterUsername: 'master'
+      MasterUserPassword: 'password'

--- a/tests/cloudformation/checks/resource/aws/example_RDSEncryption/RDSEncryption-FAILED-2.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSEncryption/RDSEncryption-FAILED-2.yaml
@@ -1,0 +1,11 @@
+Resources:
+  MyDB:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: 'mydb'
+      DBInstanceClass: 't3.micro'
+      AllocatedStorage: 5
+      Engine: 'mysql'
+      MasterUsername: 'master'
+      MasterUserPassword: 'password'
+      StorageEncrypted: false

--- a/tests/cloudformation/checks/resource/aws/example_RDSEncryption/RDSEncryption-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSEncryption/RDSEncryption-PASSED.yaml
@@ -1,0 +1,11 @@
+Resources:
+  MyDB:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: 'mydb'
+      DBInstanceClass: 't3.micro'
+      AllocatedStorage: 5
+      Engine: 'mysql'
+      MasterUsername: 'master'
+      MasterUserPassword: 'password'
+      StorageEncrypted: true

--- a/tests/cloudformation/checks/resource/aws/example_RDSPubliclyAccessible/RDSPubliclyAccessible-FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSPubliclyAccessible/RDSPubliclyAccessible-FAIL.yaml
@@ -1,0 +1,11 @@
+Resources:
+  MyDB:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: 'mydb'
+      DBInstanceClass: 't3.micro'
+      AllocatedStorage: 5
+      Engine: 'mysql'
+      MasterUsername: 'master'
+      MasterUserPassword: 'password'
+      PubliclyAccessible: true

--- a/tests/cloudformation/checks/resource/aws/example_RDSPubliclyAccessible/RDSPubliclyAccessible-PASSED-2.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSPubliclyAccessible/RDSPubliclyAccessible-PASSED-2.yaml
@@ -1,0 +1,11 @@
+Resources:
+  MyDB:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: 'mydb'
+      DBInstanceClass: 't3.micro'
+      AllocatedStorage: 5
+      Engine: 'mysql'
+      MasterUsername: 'master'
+      MasterUserPassword: 'password'
+      PubliclyAccessible: false

--- a/tests/cloudformation/checks/resource/aws/example_RDSPubliclyAccessible/RDSPubliclyAccessible-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSPubliclyAccessible/RDSPubliclyAccessible-PASSED.yaml
@@ -1,0 +1,10 @@
+Resources:
+  MyDB:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: 'mydb'
+      DBInstanceClass: 't3.micro'
+      AllocatedStorage: 5
+      Engine: 'mysql'
+      MasterUsername: 'master'
+      MasterUserPassword: 'password'

--- a/tests/cloudformation/checks/resource/aws/test_RDSEncryption.py
+++ b/tests/cloudformation/checks/resource/aws/test_RDSEncryption.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.RDSEncryption import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestRDSEncryption(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_RDSEncryption"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_RDSPubliclyAccessible.py
+++ b/tests/cloudformation/checks/resource/aws/test_RDSPubliclyAccessible.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.RDSPubliclyAccessible import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestRDSPubliclyAccessible(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_RDSPubliclyAccessible"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds equivalent RDS checks for Cloudformation as Terraform has.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
