### PR TITLE
Updating Kubernetes checks and runtime resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ a suppression can be inserted as a simple code annotation.
 
 #### Suppression comment format
 
-To skip a check on a given Terraform definition block, apply the following comment pattern inside it's scope:
+To skip a check on a given Terraform definition block or CloudFormation resource, apply the following comment pattern inside it's scope:
 
 `checkov:skip=<check_id>:<suppression_comment>`
 
@@ -128,6 +128,24 @@ Check: "S3 Bucket has an ACL defined which allows public access."
 ...
 ```
 
+To suppress checks in Kubernetes manifests, annotations are used with the following format:
+`checkov.io/skip#: <check_id>=<suppression_comment>`
+
+For example: 
+```bash
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mypod
+  annotations:
+    checkov.io/skip1: CKV_K8S_20=I don't care about Privilege Escalation :-O
+    checkov.io/skip2: CKV_K8S_14
+    checkov.io/skip3: CKV_K8S_11=I have not set CPU limits as I want BestEffort QoS
+spec:
+  containers:
+...
+```
+
 #### Logging
 For detailed logging to stdout setup the environment variable `LOG_LEVEL` to `DEBUG`. 
 
@@ -138,6 +156,8 @@ Default `LOGGING_LEVEL` value is `WARNING`.
 For Terraform compliance scanners check out [tfsec](https://github.com/liamg/tfsec), [Terrascan](https://github.com/cesar-rodriguez/terrascan) and [Terraform AWS Secure Baseline](https://github.com/nozaq/terraform-aws-secure-baseline).
 
 For CloudFormation scanning check out [cfripper](https://github.com/Skyscanner/cfripper/) and [cfn_nag](https://github.com/stelligent/cfn_nag).
+
+For Kubernetes scanning check out [kube-scan](https://github.com/octarinesec/kube-scan) and [Polaris](https://github.com/FairwindsOps/polaris)
 
 ## Contributing
 Contribution is welcomed! 

--- a/checkov/kubernetes/checks/DefaultNamespace.py
+++ b/checkov/kubernetes/checks/DefaultNamespace.py
@@ -7,6 +7,7 @@ class DefaultNamespace(BaseK8Check):
     def __init__(self):
         # CIS-1.5 5.7.4
         name = "The default namespace should not be used"
+        # default Service Account and Service/kubernetes are ignored
         id = "CKV_K8S_21"
         supported_kind = ['Pod', 'Deployment', 'DaemonSet', 'StatefulSet', 'ReplicaSet', 'ReplicationController', 'Job', 'CronJob', 'Service', 'Secret', 'ServiceAccount', 'Role', 'RoleBinding', 'ConfigMap', 'Ingress']
         categories = [CheckCategories.KUBERNETES]
@@ -23,6 +24,16 @@ class DefaultNamespace(BaseK8Check):
             if "namespace" in conf["metadata"]:
                 if conf["metadata"]["namespace"] != "default":
                     return CheckResult.PASSED
+                else:
+                    if conf["kind"] == "ServiceAccount" and conf["metadata"]["name"] == "default":
+                        return CheckResult.PASSED
+                    if conf["kind"] == "Service" and conf["metadata"]["name"] == "kubernetes":
+                       return CheckResult.PASSED
+            # If namespace not defined it is default -> Ignore default Service account and kubernetes service
+            if conf["kind"] == "ServiceAccount" and conf["metadata"]["name"] == "default":
+                return CheckResult.PASSED
+            if conf["kind"] == "Service" and conf["metadata"]["name"] == "kubernetes":
+                return CheckResult.PASSED
             return CheckResult.FAILED
         return CheckResult.FAILED
 

--- a/checkov/kubernetes/checks/ReadinessProbe.py
+++ b/checkov/kubernetes/checks/ReadinessProbe.py
@@ -17,10 +17,15 @@ class ReadinessProbe(BaseK8Check):
         return conf['parent']
 
     def scan_spec_conf(self, conf):
-        # Don't check Job/CronJob
+        # Don't check Job/CronJob (or Pods in runtime derived from Job/CronJob)
         if "parent" in conf:
             if "Job" in conf["parent"]:
                 return CheckResult.PASSED
+            if "parent_metadata" in conf:
+                if "ownerReferences" in conf["parent_metadata"]:
+                    for ref in conf["parent_metadata"]["ownerReferences"]:
+                        if ref["kind"] == "Job":
+                            return CheckResult.PASSED
         if "readinessProbe" not in conf:
             return CheckResult.FAILED
         return CheckResult.PASSED

--- a/kubernetes/checkov-cronjob.yaml
+++ b/kubernetes/checkov-cronjob.yaml
@@ -106,6 +106,7 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
+  - podsecuritypolicies
   verbs:
   - get
   - list
@@ -161,15 +162,27 @@ metadata:
   annotations:
     checkov.io/skip1: CKV_K8S_22=Checkov requires filesystem write access to dump resource definitions
     checkov.io/skip2: CKV_K8S_38=Service Account is required for read-only API access
+    checkov.io/skip3: CKV_K8S_14=Preferring latest rules every run - image pull always
+    checkov.io/skip4: CKV_K8S_43=Preferring latest rules every run - image pull always
 spec:
   # Minutes, Hours, Day of Month (1-31), Month (1-12), Day of Week (0-6)
   schedule: "0 * * * *"
   jobTemplate:
+    metadata:
+      annotations:
+        checkov.io/skip1: CKV_K8S_22=Checkov requires filesystem write access to dump resource definitions
+        checkov.io/skip2: CKV_K8S_38=Service Account is required for read-only API access
+        checkov.io/skip3: CKV_K8S_14=Preferring latest rules every run - image pull always
+        checkov.io/skip4: CKV_K8S_43=Preferring latest rules every run - image pull always
     spec:
       template:
         metadata:
           annotations:
             seccomp.security.alpha.kubernetes.io/pod: runtime/default
+            checkov.io/skip1: CKV_K8S_22=Checkov requires filesystem write access to dump resource definitions
+            checkov.io/skip2: CKV_K8S_38=Service Account is required for read-only API access
+            checkov.io/skip3: CKV_K8S_14=Preferring latest rules every run - image pull always
+            checkov.io/skip4: CKV_K8S_43=Preferring latest rules every run - image pull always
         spec:
           securityContext:
             runAsUser: 12000

--- a/kubernetes/checkov-job.yaml
+++ b/kubernetes/checkov-job.yaml
@@ -106,6 +106,7 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
+  - podsecuritypolicies
   verbs:
   - get
   - list
@@ -161,11 +162,17 @@ metadata:
   annotations:
     checkov.io/skip1: CKV_K8S_22=Checkov requires filesystem write access to dump resource definitions
     checkov.io/skip2: CKV_K8S_38=Service Account is required for read-only API access
+    checkov.io/skip3: CKV_K8S_14=Preferring latest rules every run - image pull always
+    checkov.io/skip4: CKV_K8S_43=Preferring latest rules every run - image pull always
 spec:
   template:
     metadata:
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
+        checkov.io/skip1: CKV_K8S_22=Checkov requires filesystem write access to dump resource definitions
+        checkov.io/skip2: CKV_K8S_38=Service Account is required for read-only API access
+        checkov.io/skip3: CKV_K8S_14=Preferring latest rules every run - image pull always
+        checkov.io/skip4: CKV_K8S_43=Preferring latest rules every run - image pull always
     spec:
       securityContext:
         runAsUser: 12000

--- a/tests/kubernetes/checks/example_DefaultNamespace/default-k8s-service-and-sa-PASSED2.yaml
+++ b/tests/kubernetes/checks/example_DefaultNamespace/default-k8s-service-and-sa-PASSED2.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: default
+secrets:
+  - name: default-token-tgp9r
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+secrets:
+  - name: default-token-tgp9r
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2020-05-26T15:59:43Z"
+  labels:
+    component: apiserver
+    provider: kubernetes
+  name: kubernetes
+  namespace: default
+  resourceVersion: "148"
+  selfLink: /api/v1/namespaces/default/services/kubernetes
+  uid: 288b4e4d-9706-4780-b594-39f1abd2a715
+spec:
+  clusterIP: 172.20.0.1
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 443
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2020-05-26T15:59:43Z"
+  labels:
+    component: apiserver
+    provider: kubernetes
+  name: kubernetes
+  resourceVersion: "148"
+  selfLink: /api/v1/namespaces/default/services/kubernetes
+  uid: 288b4e4d-9706-4780-b594-39f1abd2a715
+spec:
+  clusterIP: 172.20.0.1
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 443
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/tests/kubernetes/checks/example_LivenessReadiness/pod-from-job.yaml
+++ b/tests/kubernetes/checks/example_LivenessReadiness/pod-from-job.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    kubernetes.io/psp: eks.privileged
+    seccomp.security.alpha.kubernetes.io/pod: runtime/default
+  creationTimestamp: "2020-06-01T19:33:44Z"
+  generateName: checkov-
+  labels:
+    controller-uid: 8198b779-6e53-4fc0-bdbe-45b5caa9d216
+    job-name: checkov
+  name: checkov-b6z2b
+  namespace: checkov
+  ownerReferences:
+  - apiVersion: batch/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Job
+    name: checkov
+    uid: 8198b779-6e53-4fc0-bdbe-45b5caa9d216
+  resourceVersion: "1455453"
+  selfLink: /api/v1/namespaces/checkov/pods/checkov-b6z2b
+  uid: 118de7c1-3ad8-4f94-9cd7-fcdbd2e0ecd1
+spec:
+  containers:
+  - image: bridgecrew/checkov-k8s:latest
+    imagePullPolicy: Always
+    name: checkov
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 500m
+        memory: 128Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /etc/checkov
+      name: checkov-rt-secret
+      readOnly: true
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: checkov-token-tb8gh
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: ip-10-10-3-53.us-west-2.compute.internal
+  priority: 0
+  restartPolicy: Never
+  schedulerName: default-scheduler
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 12000
+  serviceAccount: checkov
+  serviceAccountName: checkov
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: checkov-rt-secret
+    secret:
+      defaultMode: 420
+      optional: true
+      secretName: checkov-rt-secret
+  - name: checkov-token-tb8gh
+    secret:
+      defaultMode: 420
+      secretName: checkov-token-tb8gh
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2020-06-01T19:33:44Z"
+    reason: PodCompleted
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2020-06-01T19:34:09Z"
+    reason: PodCompleted
+    status: "False"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2020-06-01T19:34:09Z"
+    reason: PodCompleted
+    status: "False"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2020-06-01T19:33:44Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: docker://cd7dc35bcfae60b95ad1c4e4fb11660bc47d1a8c7b073207a451c184cac1ff29
+    image: bridgecrew/checkov-k8s:latest
+    imageID: docker-pullable://bridgecrew/checkov-k8s@sha256:0340894435380b26300481f1de02bb5e6965cbd927ed08e9c9b0bbc6b564cf01
+    lastState: {}
+    name: checkov
+    ready: false
+    restartCount: 0
+    started: false
+    state:
+      terminated:
+        containerID: docker://cd7dc35bcfae60b95ad1c4e4fb11660bc47d1a8c7b073207a451c184cac1ff29
+        exitCode: 0
+        finishedAt: "2020-06-01T19:34:08Z"
+        reason: Completed
+        startedAt: "2020-06-01T19:33:48Z"
+  hostIP: 10.10.3.53
+  phase: Succeeded
+  podIP: 10.10.0.255
+  podIPs:
+  - ip: 10.10.0.255
+  qosClass: Guaranteed
+  startTime: "2020-06-01T19:33:44Z"

--- a/tests/kubernetes/checks/test_DefaultNamespace.py
+++ b/tests/kubernetes/checks/test_DefaultNamespace.py
@@ -16,7 +16,7 @@ class TestDefaultNamespace(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 5)
+        self.assertEqual(summary['passed'], 9)
         self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/kubernetes/checks/test_LivenessProbe.py
+++ b/tests/kubernetes/checks/test_LivenessProbe.py
@@ -17,7 +17,7 @@ class TestLivenessProbe(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/kubernetes/checks/test_ReadinessProbe.py
+++ b/tests/kubernetes/checks/test_ReadinessProbe.py
@@ -16,7 +16,7 @@ class TestReadinessProbe(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 1)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
* Updated readme for Kubernetes annotations
* Updated default namespace check to ignore default SA and kubernetes service
* Updated readiness probe to ignore runtime pods launched from jobs/cronjobs
* Updated k8s runtime job/cronjob spec

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
