### PR TITLE
conversion of BaseResourceAttributeValue checks

### DIFF
--- a/checkov/terraform/checks/resource/aws/EKSPublicAccess.py
+++ b/checkov/terraform/checks/resource/aws/EKSPublicAccess.py
@@ -1,8 +1,8 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
 
 
-class EKSPublicAccess(BaseResourceCheck):
+class EKSPublicAccess(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure Amazon EKS public endpoint disabled"
         id = "CKV_AWS_39"
@@ -10,23 +10,11 @@ class EKSPublicAccess(BaseResourceCheck):
         categories = [CheckCategories.KUBERNETES]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        """
-            Looks for endpoint_public_access disabled at aws_eks_cluster:
-            https://www.terraform.io/docs/providers/aws/r/eks_cluster.html
-        :param conf: aws_eks_cluster configuration
-        :return: <CheckResult>
-        """
-        if "vpc_config" in conf.keys():
-            if "endpoint_public_access" in conf["vpc_config"][0].keys():
-                if not conf["vpc_config"][0]["endpoint_public_access"][0]:
-                    return CheckResult.PASSED
-                else:
-                    return CheckResult.FAILED
-            else:
-                return CheckResult.FAILED
-        else:
-            return CheckResult.UNKNOWN
+    def get_inspected_key(self):
+        return 'vpc_config/[0]/endpoint_public_access/[0]/endpoint_public_access'
+
+    def get_expected_value(self):
+        return False
 
 
 check = EKSPublicAccess()

--- a/checkov/terraform/checks/resource/aws/EKSSecretsEncryption.py
+++ b/checkov/terraform/checks/resource/aws/EKSSecretsEncryption.py
@@ -11,7 +11,7 @@ class EKSSecretsEncryption(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):
-        return "encryption_config/[0]/resources/[0]/resources"
+        return "encryption_config/[0]/resources"
 
     def get_expected_value(self):
         return ["secrets"]

--- a/checkov/terraform/checks/resource/aws/EKSSecretsEncryption.py
+++ b/checkov/terraform/checks/resource/aws/EKSSecretsEncryption.py
@@ -1,8 +1,8 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
 
 
-class EKSSecretsEncryption(BaseResourceCheck):
+class EKSSecretsEncryption(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure EKS Cluster has Secrets Encryption Enabled"
         id = "CKV_AWS_58"
@@ -10,12 +10,11 @@ class EKSSecretsEncryption(BaseResourceCheck):
         categories = [CheckCategories.KUBERNETES]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        if "encryption_config" in conf.keys() and "resources" in conf["encryption_config"][0] and \
-                "secrets" in conf["encryption_config"][0]["resources"][0]:
-            return CheckResult.PASSED
-        else:
-            return CheckResult.FAILED
+    def get_inspected_key(self):
+        return "encryption_config/[0]/resources/[0]/resources"
+
+    def get_expected_value(self):
+        return ["secrets"]
 
 
 check = EKSSecretsEncryption()

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyExpiration.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyExpiration.py
@@ -1,9 +1,9 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.util.type_forcers import force_int
 
 
-class PasswordPolicyExpiration(BaseResourceCheck):
+class PasswordPolicyExpiration(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure IAM password policy expires passwords within 90 days or less"
         id = "CKV_AWS_9"
@@ -11,17 +11,23 @@ class PasswordPolicyExpiration(BaseResourceCheck):
         categories = [CheckCategories.IAM]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
+    def get_inspected_key(self):
+        return 'max_password_age'
+
+    def get_expected_value(self):
+        return 90
+
     def scan_resource_conf(self, conf):
         """
-            validates iam password policy
-            https://www.terraform.io/docs/providers/aws/r/iam_account_password_policy.html
+        validates iam password policy
+        https://www.terraform.io/docs/providers/aws/r/iam_account_password_policy.html
         :param conf: aws_iam_account_password_policy configuration
         :return: <CheckResult>
         """
         key = 'max_password_age'
         if key in conf.keys():
             max_age = force_int(conf[key][0])
-            if max_age and max_age <= 90:
+            if max_age and 0 < max_age <= 90:
                 return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyLength.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyLength.py
@@ -1,15 +1,21 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.util.type_forcers import force_int
 
 
-class PasswordPolicyLength(BaseResourceCheck):
+class PasswordPolicyLength(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure IAM password policy requires minimum length of 14 or greater"
         id = "CKV_AWS_10"
         supported_resources = ['aws_iam_account_password_policy']
         categories = [CheckCategories.IAM]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'minimum_password_length'
+
+    def get_expected_value(self):
+        return 14
 
     def scan_resource_conf(self, conf):
         """

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyLowercaseLetter.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyLowercaseLetter.py
@@ -1,8 +1,8 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class PasswordPolicyLowercaseLetter(BaseResourceCheck):
+class PasswordPolicyLowercaseLetter(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure IAM password policy requires at least one lowercase letter"
         id = "CKV_AWS_11"
@@ -10,18 +10,8 @@ class PasswordPolicyLowercaseLetter(BaseResourceCheck):
         categories = [CheckCategories.IAM]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        """
-            validates iam password policy
-            https://www.terraform.io/docs/providers/aws/r/iam_account_password_policy.html
-        :param conf: aws_iam_account_password_policy configuration
-        :return: <CheckResult>
-        """
-        key = 'require_lowercase_characters'
-        if key in conf.keys():
-            if conf[key][0]:
-                return CheckResult.PASSED
-        return CheckResult.FAILED
+    def get_inspected_key(self):
+        return 'require_lowercase_characters'
 
 
 check = PasswordPolicyLowercaseLetter()

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyNumber.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyNumber.py
@@ -1,8 +1,8 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class PasswordPolicyNumber(BaseResourceCheck):
+class PasswordPolicyNumber(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure IAM password policy requires at least one number"
         id = "CKV_AWS_12"
@@ -10,18 +10,8 @@ class PasswordPolicyNumber(BaseResourceCheck):
         categories = [CheckCategories.IAM]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        """
-            validates iam password policy
-            https://www.terraform.io/docs/providers/aws/r/iam_account_password_policy.html
-        :param conf: aws_iam_account_password_policy configuration
-        :return: <CheckResult>
-        """
-        key = 'require_numbers'
-        if key in conf.keys():
-            if conf[key][0]:
-                return CheckResult.PASSED
-        return CheckResult.FAILED
+    def get_inspected_key(self):
+        return 'require_numbers'
 
 
 check = PasswordPolicyNumber()

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyReuse.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyReuse.py
@@ -1,15 +1,21 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.util.type_forcers import force_int
 
 
-class PasswordPolicyReuse(BaseResourceCheck):
+class PasswordPolicyReuse(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure IAM password policy prevents password reuse"
         id = "CKV_AWS_13"
         supported_resources = ['aws_iam_account_password_policy']
         categories = [CheckCategories.IAM]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'password_reuse_prevention'
+
+    def get_expected_value(self):
+        return 24
 
     def scan_resource_conf(self, conf):
         """

--- a/checkov/terraform/checks/resource/aws/PasswordPolicySymbol.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicySymbol.py
@@ -1,8 +1,8 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class PasswordPolicySymbol(BaseResourceCheck):
+class PasswordPolicySymbol(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure IAM password policy requires at least one symbol"
         id = "CKV_AWS_14"
@@ -10,18 +10,8 @@ class PasswordPolicySymbol(BaseResourceCheck):
         categories = [CheckCategories.IAM]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        """
-            validates iam password policy
-            https://www.terraform.io/docs/providers/aws/r/iam_account_password_policy.html
-        :param conf: aws_iam_account_password_policy configuration
-        :return: <CheckResult>
-        """
-        key = 'require_symbols'
-        if key in conf.keys():
-            if conf[key][0]:
-                return CheckResult.PASSED
-        return CheckResult.FAILED
+    def get_inspected_key(self):
+        return 'require_symbols'
 
 
 check = PasswordPolicySymbol()

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyUppercaseLetter.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyUppercaseLetter.py
@@ -1,8 +1,8 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class PasswordPolicyUppcaseLetter(BaseResourceCheck):
+class PasswordPolicyUppcaseLetter(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure IAM password policy requires at least one uppercase letter"
         id = "CKV_AWS_15"
@@ -10,18 +10,8 @@ class PasswordPolicyUppcaseLetter(BaseResourceCheck):
         categories = [CheckCategories.IAM]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        """
-            validates iam password policy
-            https://www.terraform.io/docs/providers/aws/r/iam_account_password_policy.html
-        :param conf: aws_iam_account_password_policy configuration
-        :return: <CheckResult>
-        """
-        key = 'require_uppercase_characters'
-        if key in conf.keys():
-            if conf[key][0]:
-                return CheckResult.PASSED
-        return CheckResult.FAILED
+    def get_inspected_key(self):
+        return 'require_uppercase_characters'
 
 
 check = PasswordPolicyUppcaseLetter()

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudDNSSECEnabled.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudDNSSECEnabled.py
@@ -1,8 +1,13 @@
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
-from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
 
 
-class GoogleCloudDNSSECEnabled(BaseResourceCheck):
+class GoogleCloudDNSSECEnabled(BaseResourceValueCheck):
+    """
+    Looks for DNSSEC state at dns_managed_zone:
+    https://www.terraform.io/docs/providers/google/r/dns_managed_zone.html#state
+    """
+
     def __init__(self):
         name = "Ensure that DNSSEC is enabled for Cloud DNS"
         id = "CKV_GCP_16"
@@ -10,19 +15,14 @@ class GoogleCloudDNSSECEnabled(BaseResourceCheck):
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        """
-            Looks for DNSSEC state at dns_managed_zone:
-            https://www.terraform.io/docs/providers/google/r/dns_managed_zone.html#state
-        :param conf: dns_managed_zone configuration
-        :return: <CheckResult>
-        """
-        if "dnssec_config" in conf.keys():
-            dnssec_config = conf["dnssec_config"][0]
-            if "state" in dnssec_config and dnssec_config["state"] != ["off"]:
-                return CheckResult.PASSED
+    def get_inspected_key(self):
+        return "dnssec_config/[0]/state"
 
-        return CheckResult.FAILED
+    def get_expected_value(self):
+        return "on"
+
+    def get_expected_values(self):
+        return [self.get_expected_value(), "transfer"]
 
 
 check = GoogleCloudDNSSECEnabled()

--- a/checkov/terraform/checks/resource/gcp/GoogleKMSRotationPeriod.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleKMSRotationPeriod.py
@@ -1,18 +1,25 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 # rotation_period time unit is seconds
 ONE_DAY = 24 * 60 * 60
 NINETY_DAYS = 90 * ONE_DAY
 
 
-class GoogleKMSKeyRotationPeriod(BaseResourceCheck):
+class GoogleKMSKeyRotationPeriod(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure KMS encryption keys are rotated within a period of 90 days"
         id = "CKV_GCP_43"
         supported_resources = ['google_kms_crypto_key']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'rotation_period'
+
+    def get_expected_value(self):
+        # 90 days in seconds
+        return "7776000s"
 
     def scan_resource_conf(self, conf):
         if 'rotation_period' in conf.keys():


### PR DESCRIPTION
Converted the following checks to implement `BaseResourceValueCheck`
- aws/EKSPublicAccess.py
- aws/EKSSecretsEncryption.py
- aws/PasswordPolicyExpiration.py
- aws/PasswordPolicyLength.py
- aws/PasswordPolicyLowercaseLetter.py
- aws/PasswordPolicyNumber.py
- aws/PasswordPolicyReuse.py
- aws/PasswordPolicySymbol.py
- aws/PasswordPolicyUppercaseLetter.py
- gcp/GoogleCloudDNSSECEnabled.py
- gcp/GoogleKMSRotationPeriod.py

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
