### PR TITLE
Fix bug with kubernetes scanner failing if containers or initContainers

### DIFF
--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -96,14 +96,15 @@ class Runner(BaseRunner):
                         else:
                             namespace = "default"
                         containerDef["containers"] = containers.pop()
-                        for cd in containerDef["containers"]:
-                            i = containerDef["containers"].index(cd)
-                            containerDef["containers"][i]["apiVersion"] = entity_conf["apiVersion"]
-                            containerDef["containers"][i]["kind"] = type
-                            containerDef["containers"][i]["parent"] = "{}.{}.{} (container {})".format(
-                                entity_conf["kind"], entity_conf["metadata"]["name"], namespace, str(i))
-                            containerDef["containers"][i]["parent_metadata"] = entity_conf["metadata"]
-                        definitions[k8_file].extend(containerDef["containers"])
+                        if containerDef["containers"] is not None:
+                            for cd in containerDef["containers"]:
+                                i = containerDef["containers"].index(cd)
+                                containerDef["containers"][i]["apiVersion"] = entity_conf["apiVersion"]
+                                containerDef["containers"][i]["kind"] = type
+                                containerDef["containers"][i]["parent"] = "{}.{}.{} (container {})".format(
+                                    entity_conf["kind"], entity_conf["metadata"]["name"], namespace, str(i))
+                                containerDef["containers"][i]["parent_metadata"] = entity_conf["metadata"]
+                            definitions[k8_file].extend(containerDef["containers"])
 
                 # Run for each definition included added container definitions
                 for i in range(len(definitions[k8_file])):


### PR DESCRIPTION
This corrects a scan issue if containers or initContainers is empty in a Kubernetes manifest

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
