### PR TITLE
Serverless sub-cf template unit test

### DIFF
--- a/checkov/serverless/parsers/context_parser.py
+++ b/checkov/serverless/parsers/context_parser.py
@@ -1,4 +1,4 @@
-from checkov.cloudformation.parser.node import dict_node, list_node
+from checkov.cloudformation.parser.node import dict_node, list_node, str_node
 from checkov.serverless.parsers.parser import FUNCTIONS_TOKEN, PROVIDER_TOKEN, IAM_ROLE_STATEMENTS_TOKEN, \
     ENVIRONMENT_TOKEN
 from checkov.cloudformation.context_parser import ContextParser as CfnContextParser
@@ -17,6 +17,7 @@ class ContextParser(object):
         self.sls_template_lines = sls_template_lines
         self.provider_conf = sls_template[PROVIDER_TOKEN]
         self.functions_conf = sls_template[FUNCTIONS_TOKEN]
+        self.provider_type = self._infer_provider_type()
 
     def extract_function_code_lines(self, sls_function):
         find_lines_result_list = list(CfnContextParser.find_lines(sls_function, '__startline__'))
@@ -36,14 +37,21 @@ class ContextParser(object):
         :param sls_function_name: scanned function
         :return: None
         """
-        for enriched_attribute in self.ENRICHED_ATTRIBUTES:
-            if self.provider_conf.get(enriched_attribute):
-                provider_attribute = self.provider_conf.get(enriched_attribute)
-                template_function = self.functions_conf[sls_function_name]
-                if template_function.get(enriched_attribute):
-                    if isinstance(template_function[enriched_attribute], list_node):
-                        template_function[enriched_attribute].extend(provider_attribute)
-                    if isinstance(template_function[enriched_attribute], dict_node):
-                        template_function[enriched_attribute].update(provider_attribute)
-                else:
-                    template_function[enriched_attribute] = provider_attribute
+        if isinstance(self.provider_conf, dict_node):
+            for enriched_attribute in self.ENRICHED_ATTRIBUTES:
+                if self.provider_conf.get(enriched_attribute):
+                    provider_attribute = self.provider_conf.get(enriched_attribute)
+                    template_function = self.functions_conf[sls_function_name]
+                    if template_function.get(enriched_attribute):
+                        if isinstance(template_function[enriched_attribute], list_node):
+                            template_function[enriched_attribute].extend(provider_attribute)
+                        if isinstance(template_function[enriched_attribute], dict_node):
+                            template_function[enriched_attribute].update(provider_attribute)
+                    else:
+                        template_function[enriched_attribute] = provider_attribute
+
+    def _infer_provider_type(self):
+        if isinstance(self.provider_conf, dict_node):
+            return self.provider_conf.get('name')
+        if isinstance(self.provider_conf, str_node):
+            return self.provider_conf

--- a/checkov/serverless/parsers/parser.py
+++ b/checkov/serverless/parsers/parser.py
@@ -11,6 +11,7 @@ CFN_RESOURCES_TOKEN = 'resources'
 PROVIDER_TOKEN = 'provider'
 FUNCTIONS_TOKEN = 'functions'
 ENVIRONMENT_TOKEN = 'environment'
+SUPPORTED_PROVIDERS = ['aws']
 
 
 def parse(filename):
@@ -43,8 +44,8 @@ def parse(filename):
 
 def is_checked_sls_template(template):
     if template.__contains__('provider'):
-        # support AWS provider serverless templates
-        if template['provider'].get('name').lower() == 'aws':
+        if template['provider'].get('name').lower() in SUPPORTED_PROVIDERS or \
+                template['provider'] in SUPPORTED_PROVIDERS:
             if template_contains_cfn_resources(template) or template_contains_key(template, FUNCTIONS_TOKEN):
                 return True
     return False

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -95,7 +95,7 @@ class Runner(BaseRunner):
                             variable_evaluations = {}
                             sls_context_parser.enrich_function_with_provider(sls_function_name)
                             results = sls_registry.scan(sls_file, {'function': sls_function,
-                                                                   'provider_type': sls_context_parser.provider_conf.get('name')},
+                                                                   'provider_type': sls_context_parser.provider_type},
                                                         skipped_checks, runner_filter)
                             for check, check_result in results.items():
                                 record = Record(check_id=check.id, check_name=check.name, check_result=check_result,

--- a/tests/serverless/checks/aws/example_S3PublicACLRead/S3PublicACLRead-FAILED/serverless.yml
+++ b/tests/serverless/checks/aws/example_S3PublicACLRead/S3PublicACLRead-FAILED/serverless.yml
@@ -1,0 +1,29 @@
+service: usersCrud
+provider: aws
+
+functions:
+  myFunc:
+    name: myFunc
+    tags:
+      RESOURCE: lambda
+      PUBLIC: false
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - "lambda:InvokeFunction"
+        Resource:
+          - "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:invokedLambda"
+    handler: Handler.handle
+    timeout: 600
+    memorySize: 320
+
+resources: # CloudFormation template syntax
+  Resources:
+    S3BucketPublicRead:
+      Type: AWS::S3::Bucket
+      Properties:
+        AccessControl: PublicRead
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256

--- a/tests/serverless/checks/aws/example_S3PublicACLRead/S3PublicACLRead-PASSED/serverless.yml
+++ b/tests/serverless/checks/aws/example_S3PublicACLRead/S3PublicACLRead-PASSED/serverless.yml
@@ -1,0 +1,30 @@
+service: usersCrud
+provider:
+  name: aws
+
+functions:
+  myFunc:
+    name: myFunc
+    tags:
+      RESOURCE: lambda
+      PUBLIC: false
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - "lambda:InvokeFunction"
+        Resource:
+          - "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:invokedLambda"
+    handler: Handler.handle
+    timeout: 600
+    memorySize: 320
+
+resources: # CloudFormation template syntax
+  Resources:
+    S3BucketPublicRead:
+      Type: AWS::S3::Bucket
+      Properties:
+        AccessControl: Private
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256

--- a/tests/serverless/checks/aws/test_S3PublicACLRead.py
+++ b/tests/serverless/checks/aws/test_S3PublicACLRead.py
@@ -1,23 +1,23 @@
 import os
 import unittest
 
-from checkov.serverless.checks.aws.AWSCredentials import check
+from checkov.cloudformation.checks.resource.aws.S3PublicACLRead import check
 from checkov.serverless.runner import Runner
 from checkov.runner_filter import RunnerFilter
 
 
-class TestAWSCredentials(unittest.TestCase):
+class TestS3PublicACLRead(unittest.TestCase):
 
     def test_summary(self):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_AWSCredentials"
+        test_files_dir = current_dir + "/example_S3PublicACLRead"
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['failed'], 1)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
- Unit test CF sub-template found in serverless files
- Support the direct provider name syntax, infer the provider type in context parser
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
