### PR TITLE
CKV_AZURE_33 queue logging and account kind

### DIFF
--- a/checkov/terraform/checks/resource/azure/StorageAccountLoggingQueueServiceEnabled.py
+++ b/checkov/terraform/checks/resource/azure/StorageAccountLoggingQueueServiceEnabled.py
@@ -11,6 +11,9 @@ class StorageAccountLoggingQueueServiceEnabled(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
+        if 'account_kind' in conf and (conf['account_kind'][0] != 'Storage' or conf['account_kind'][0] != 'StorageV2'):
+            # queue_properties block doesn't apply for other account kind
+            return CheckResult.PASSED
         if 'queue_properties' in conf and 'logging' in conf['queue_properties'][0]:
             logging = conf['queue_properties'][0]['logging'][0]
             if logging['delete'][0] and logging['write'][0] and logging['read'][0]:

--- a/tests/terraform/checks/resource/azure/test_StorageAccountLoggingQueueServiceEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_StorageAccountLoggingQueueServiceEnabled.py
@@ -57,6 +57,21 @@ class TestStorageAccountLoggingQueueServiceEnabled(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_success_blobstorage(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_storage_account" "example" {
+              name                     = "example"
+              resource_group_name      = data.azurerm_resource_group.example.name
+              location                 = data.azurerm_resource_group.example.location
+              account_tier             = "Standard"
+              account_replication_type = "LRS"
+              account_kind             = "BlobStorage"
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
I'm checking my Azure Storage account with Ckeckov.
The account kind is *BlobStorage*, the rule *CKV_AZURE_33* should not apply in this case.

## Terraform code :
```hcl
resource "azurerm_storage_account" "ingestion" {
  #checkov:skip=CKV_AZURE_3:skip for bug test
  #checkov:skip=CKV_AZURE_35:skip for bug test
  name                     = "stocheckov"
  resource_group_name      = "rg-checkov-test"
  location                 = "checkov"
  account_kind             = "BlobStorage"
  account_tier             = "Standard"
  account_replication_type = "LRS"
}
```

## Step to reproduce
```
checkov -d . --framework terraform --output cli --quiet

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

by bridgecrew.io | version: 1.0.397

terraform scan results:

Passed checks: 1, Failed checks: 1, Skipped checks: 2

Check: CKV_AZURE_33: "Ensure Storage logging is enabled for Queue service for read, write and delete requests"
	FAILED for resource: azurerm_storage_account.ingestion
	File: /azurerm_storage_account.tf:2-11

		2  | resource "azurerm_storage_account" "ingestion" {
		3  |   #checkov:skip=CKV_AZURE_3:skip for bug test
		4  |   #checkov:skip=CKV_AZURE_35:skip for bug test
		5  |   name                     = "stocheckov"
		6  |   resource_group_name      = "rg-checkov-test"
		7  |   location                 = "checkov"
		8  |   account_kind             = "BlobStorage"
		9  |   account_tier             = "Standard"
		10 |   account_replication_type = "LRS"
		11 | }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
