### PR TITLE
edit git releases message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,13 +61,13 @@ jobs:
           git pull
           pipenv run python ./checkov/common/util/docs_generator.py >> $scansdoc
 
-          git commit -m "update resource scans doc" $scansdoc || echo "No changes to commit"
+          git commit --reuse-message=HEAD@{1} $scansdoc || echo "No changes to commit"
 
           ## update python version
           echo "version = '$new_tag'" > 'checkov/version.py'
           echo "checkov==$new_tag" > 'kubernetes/requirements.txt'
 
-          git commit -m "bump version to '$new_tag'" checkov/version.py kubernetes/requirements.txt HomebrewFormula/checkov.rb || echo "No changes to commit"
+          git commit --reuse-message=HEAD@{1} checkov/version.py kubernetes/requirements.txt HomebrewFormula/checkov.rb || echo "No changes to commit"
           git push origin
           git tag $new_tag
           git push origin $new_tag
@@ -117,7 +117,7 @@ jobs:
           pipenv run pip install checkov -U
           git pull
           pipenv run poet -f checkov > HomebrewFormula/checkov.rb
-          git commit -m "update brew formula" HomebrewFormula/checkov.rb || echo "No brew changes to commit"
+          git commit --reuse-message=HEAD@{1} HomebrewFormula/checkov.rb || echo "No brew changes to commit"
           git push origin
   update-bridgecrew-projects:
     needs: publish-package

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
           git config --local user.name "GitHub Action"
           pipenv run python -m coverage_badge -o coverage.svg -f
           git add coverage.svg
-          git commit -m "Update coverage" coverage.svg || echo "No changes to commit"
+          git commit --reuse-message=HEAD@{1} coverage.svg || echo "No changes to commit"
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:


### PR DESCRIPTION
Github actions creates commit messages that makes it hard to track release changes. instead we will use the HEAD branch last commit as a message to make it easy tracking each release change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
