### PR TITLE
add check for aws_security_group_rule resource

### DIFF
--- a/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
@@ -7,7 +7,7 @@ from checkov.common.util.type_forcers import force_int
 class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
     def __init__(self, check_id, port):
         name = "Ensure no security groups allow ingress from 0.0.0.0:0 to port %d" % port
-        supported_resources = ['aws_security_group']
+        supported_resources = ['aws_security_group', 'aws_security_group_rule']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=check_id, categories=categories, supported_resources=supported_resources)
         self.port = port
@@ -16,25 +16,37 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
         """
             Looks for configuration at security group ingress rules :
             https://www.terraform.io/docs/providers/aws/r/security_group.html
+            https://www.terraform.io/docs/providers/aws/r/security_group_rule.html
         :param conf: aws_security_group configuration
         :return: <CheckResult>
         """
-        if 'ingress' in conf:
+        if 'ingress' in conf:  # This means it's an ingress rule defined in the SG resource.
             ingress_conf = conf['ingress']
             for ingress_rule in ingress_conf:
                 ingress_rules = force_list(ingress_rule)
                 for rule in ingress_rules:
                     if isinstance(rule, dict):
-                        from_port = force_int(force_list(rule['from_port'])[0])
-                        to_port = force_int(force_list(rule['to_port'])[0])
+                        if self.contains_violation(rule):
+                            return CheckResult.FAILED
 
-                        if from_port is not None and to_port is not None and from_port <= self.port <= to_port:
-                            # It's not clear whether these can ever be a type other
-                            # than an empty list but just in case…
-                            cidr_blocks = force_list(rule.get('cidr_blocks', [[]])[0])
-                            security_groups = rule.get('security_groups', [])
+            return CheckResult.PASSED
 
-                            if "0.0.0.0/0" in cidr_blocks and not security_groups:
-                                return CheckResult.FAILED
+        if 'type' in conf:  # This means it's an SG_rule resource.
+            type = force_list(conf['type'])[0]
+            if type != 'ingress':
+                return CheckResult.UNKNOWN
+            else:
+                return CheckResult.FAILED if self.contains_violation(conf) else CheckResult.PASSED
 
-        return CheckResult.PASSED
+        return CheckResult.UNKNOWN
+
+    def contains_violation(self, conf):
+        from_port = force_int(force_list(conf['from_port'])[0])
+        to_port = force_int(force_list(conf['to_port'])[0])
+
+        if from_port is not None and to_port is not None and (from_port <= self.port <= to_port):
+            cidr_blocks = force_list(conf.get('cidr_blocks', [[]])[0])
+            if "0.0.0.0/0" in cidr_blocks:
+                return True
+
+        return False

--- a/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngress22.py
+++ b/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngress22.py
@@ -18,7 +18,7 @@ resource "aws_security_group" "bar-sg" {
     from_port = 22
     to_port   = 22
     protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["192.168.0.0/16", "0.0.0.0/0"]
     description = "foo"
   }
 
@@ -34,7 +34,33 @@ resource "aws_security_group" "bar-sg" {
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-    def test_success(self):
+    def test_success_different_port(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port = 222
+    to_port   = 222
+    protocol  = "tcp"
+    cidr_blocks = ["192.168.0.0/16", "0.0.0.0/0"]
+    description = "foo"
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}  
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_no_cidr(self):
         hcl_res = hcl2.loads("""
 resource "aws_security_group" "bar-sg" {
   name   = "sg-bar"
@@ -45,6 +71,86 @@ resource "aws_security_group" "bar-sg" {
     to_port   = 22
     protocol  = "tcp"
     security_groups = [aws_security_group.foo-sg.id]
+    description = "foo"
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_cidr(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = ["192.168.0.0/16"]
+    description = "foo"
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_failure_combined_ingress(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    security_groups = [aws_security_group.foo-sg.id]
+    cidr_blocks = ["192.168.0.0/16", "0.0.0.0/0"]
+    description = "foo"
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_combined_ingress(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    security_groups = [aws_security_group.foo-sg.id]
+    cidr_blocks = ["192.168.0.0/16"]
     description = "foo"
   }
 
@@ -82,6 +188,95 @@ resource "aws_security_group" "inline_rules" {
         conf = hcl_res['resource'][0]['aws_security_group']['inline_rules']
         result = check.scan_resource_conf(conf)
         self.assertEqual(result, CheckResult.FAILED)
+
+    def test_failure_separate_rule_cidr(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_security_group_rule" "ingress" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["192.168.0.0/16", "0.0.0.0/0"]
+  security_group_id = aws_security_group.bar-sg.id
+}
+        """)
+
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+
+        resource_conf = hcl_res['resource'][1]['aws_security_group_rule']['ingress']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_pass_separate_rule_cidr(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group_rule" "ingress" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["192.168.0.0/16"]
+  security_group_id = aws_security_group.bar-sg.id
+}
+        """)
+
+        resource_conf = hcl_res['resource'][0]['aws_security_group_rule']['ingress']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_unknown_separate_rule_egress(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group_rule" "ingress" {
+  type              = "egress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.bar-sg.id
+}
+        """)
+
+        resource_conf = hcl_res['resource'][0]['aws_security_group_rule']['ingress']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+
+    def test_pass_separate_rule_source_sg(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group_rule" "ingress" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  source_security_group_id       = "sg-123456"
+  security_group_id = aws_security_group.bar-sg.id
+}
+        """)
+
+        resource_conf = hcl_res['resource'][0]['aws_security_group_rule']['ingress']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_pass_separate_rule_different_port(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group_rule" "ingress" {
+  type              = "ingress"
+  from_port         = 222
+  to_port           = 222
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.bar-sg.id
+}
+        """)
+
+        resource_conf = hcl_res['resource'][0]['aws_security_group_rule']['ingress']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR makes two main changes:

1. 

Modify the AWS SG ingress check to work for ingress rules specified within the aws_security_group resource as well as standalone aws_security_group_rule resources. It also modifies the return values to UNKNOWN for SGs that do not define any ingress blocks, to prevent the root SG object from passing the check even if its separate rule fails the check.

For example, the following resources will result in one FAIL check and zero PASS:

```
resource "aws_security_group" "bar-sg" {
  name   = "sg-bar"
  vpc_id = aws_vpc.main.id
}

resource "aws_security_group_rule" "ingress" {
  type              = "ingress"
  from_port         = 22
  to_port           = 22
  protocol          = "tcp"
  cidr_blocks       = ["192.168.0.0/16", "0.0.0.0/0"]
  security_group_id = aws_security_group.bar-sg.id
}
```

2. 

Fix a bug in the ingress block checking logic that would cause a check to pass any time a source security group was defined.

The following terraform resource is valid and gets created in AWS, but did not fail the check as expected:
```
resource "aws_security_group" "bar-sg" {
  name   = "mysg"
  vpc_id = "vpc-013e69f5146412c46"

  ingress {
    from_port = 22
    to_port   = 22
    protocol  = "tcp"
    security_groups = ["sg-0346cfeab178a2d01"]
    cidr_blocks       = ["0.0.0.0/0"]
    description = "foo"
  }

  egress {
    from_port = 0
    to_port   = 0
    protocol  = "-1"
    cidr_blocks = ["0.0.0.0/0"]
  }
}
```
