### PR TITLE
Make IDs of k8s and terraform providers unique

### DIFF
--- a/checkov/kubernetes/checks/AllowPrivilegeEscalation.py
+++ b/checkov/kubernetes/checks/AllowPrivilegeEscalation.py
@@ -19,7 +19,7 @@ class AllowPrivilegeEscalation(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "securityContext" in conf:
@@ -31,5 +31,6 @@ class AllowPrivilegeEscalation(BaseK8Check):
         else:
             return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = AllowPrivilegeEscalation()

--- a/checkov/kubernetes/checks/AllowedCapabilities.py
+++ b/checkov/kubernetes/checks/AllowedCapabilities.py
@@ -16,7 +16,7 @@ class AllowedCapabilities(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "securityContext" in conf:
@@ -25,5 +25,6 @@ class AllowedCapabilities(BaseK8Check):
                     if conf["securityContext"]["capabilities"]["add"]:
                         return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = AllowedCapabilities()

--- a/checkov/kubernetes/checks/AllowedCapabilitiesSysAdmin.py
+++ b/checkov/kubernetes/checks/AllowedCapabilitiesSysAdmin.py
@@ -15,7 +15,7 @@ class AllowedCapabilitiesSysAdmin(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "securityContext" in conf:
@@ -24,5 +24,6 @@ class AllowedCapabilitiesSysAdmin(BaseK8Check):
                     if "SYS_ADMIN" in conf["securityContext"]["capabilities"]["add"]:
                         return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = AllowedCapabilitiesSysAdmin()

--- a/checkov/kubernetes/checks/CPULimits.py
+++ b/checkov/kubernetes/checks/CPULimits.py
@@ -13,7 +13,7 @@ class CPULimits(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-            return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "resources" in conf:
@@ -25,5 +25,6 @@ class CPULimits(BaseK8Check):
         else:
             return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = CPULimits()

--- a/checkov/kubernetes/checks/CPURequests.py
+++ b/checkov/kubernetes/checks/CPURequests.py
@@ -13,7 +13,7 @@ class CPURequests(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "resources" in conf:
@@ -25,5 +25,6 @@ class CPURequests(BaseK8Check):
         else:
             return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = CPURequests()

--- a/checkov/kubernetes/checks/ContainerSecurityContext.py
+++ b/checkov/kubernetes/checks/ContainerSecurityContext.py
@@ -16,12 +16,13 @@ class ContainerSecurityContext(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "securityContext" in conf:
             if conf["securityContext"]:
                     return CheckResult.PASSED
         return CheckResult.FAILED
+
 
 check = ContainerSecurityContext()

--- a/checkov/kubernetes/checks/DropCapabilities.py
+++ b/checkov/kubernetes/checks/DropCapabilities.py
@@ -16,7 +16,7 @@ class DropCapabilities(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "securityContext" in conf:
@@ -26,5 +26,6 @@ class DropCapabilities(BaseK8Check):
                         if "ALL" in d or "NET_RAW" in d:
                             return CheckResult.PASSED
         return CheckResult.FAILED
+
 
 check = DropCapabilities()

--- a/checkov/kubernetes/checks/HostPort.py
+++ b/checkov/kubernetes/checks/HostPort.py
@@ -21,7 +21,7 @@ class HostPort(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "ports" in conf:
@@ -29,5 +29,6 @@ class HostPort(BaseK8Check):
                 if "hostPort" in port:
                     return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = HostPort()

--- a/checkov/kubernetes/checks/ImageDigest.py
+++ b/checkov/kubernetes/checks/ImageDigest.py
@@ -20,7 +20,7 @@ class ImageDigest(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "image" in conf:

--- a/checkov/kubernetes/checks/ImagePullPolicyAlways.py
+++ b/checkov/kubernetes/checks/ImagePullPolicyAlways.py
@@ -23,7 +23,7 @@ class ImagePullPolicyAlways(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "image" in conf:
@@ -49,5 +49,6 @@ class ImagePullPolicyAlways(BaseK8Check):
         else:
             return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = ImagePullPolicyAlways()

--- a/checkov/kubernetes/checks/ImageTagFixed.py
+++ b/checkov/kubernetes/checks/ImageTagFixed.py
@@ -21,7 +21,7 @@ class ImageTagFixed(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "image" in conf:

--- a/checkov/kubernetes/checks/KubernetesDashboard.py
+++ b/checkov/kubernetes/checks/KubernetesDashboard.py
@@ -13,7 +13,7 @@ class KubernetesDashboard(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "image" in conf:

--- a/checkov/kubernetes/checks/LivenessProbe.py
+++ b/checkov/kubernetes/checks/LivenessProbe.py
@@ -14,7 +14,7 @@ class LivenessProbe(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         # Don't check Job/CronJob
@@ -24,5 +24,6 @@ class LivenessProbe(BaseK8Check):
         if "livenessProbe" not in conf:
             return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = LivenessProbe()

--- a/checkov/kubernetes/checks/MemoryLimits.py
+++ b/checkov/kubernetes/checks/MemoryLimits.py
@@ -13,7 +13,7 @@ class MemoryLimits(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "resources" in conf:
@@ -25,5 +25,6 @@ class MemoryLimits(BaseK8Check):
         else:
             return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = MemoryLimits()

--- a/checkov/kubernetes/checks/MemoryRequests.py
+++ b/checkov/kubernetes/checks/MemoryRequests.py
@@ -13,7 +13,7 @@ class MemoryRequests(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "resources" in conf:
@@ -25,5 +25,6 @@ class MemoryRequests(BaseK8Check):
         else:
             return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = MemoryRequests()

--- a/checkov/kubernetes/checks/MinimizeCapabilities.py
+++ b/checkov/kubernetes/checks/MinimizeCapabilities.py
@@ -14,7 +14,7 @@ class MinimizeCapabilities(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "securityContext" in conf:
@@ -24,5 +24,6 @@ class MinimizeCapabilities(BaseK8Check):
                         if "ALL" in d:
                             return CheckResult.PASSED
         return CheckResult.FAILED
+
 
 check = MinimizeCapabilities()

--- a/checkov/kubernetes/checks/PrivilegedContainers.py
+++ b/checkov/kubernetes/checks/PrivilegedContainers.py
@@ -15,7 +15,7 @@ class PrivilegedContainers(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "securityContext" in conf:
@@ -23,5 +23,6 @@ class PrivilegedContainers(BaseK8Check):
                 if conf["securityContext"]["privileged"]:
                     return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = PrivilegedContainers()

--- a/checkov/kubernetes/checks/ReadOnlyFilesystem.py
+++ b/checkov/kubernetes/checks/ReadOnlyFilesystem.py
@@ -13,7 +13,7 @@ class ReadOnlyFilesystem(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "securityContext" in conf:
@@ -21,5 +21,6 @@ class ReadOnlyFilesystem(BaseK8Check):
                 if conf["securityContext"]["readOnlyRootFilesystem"]:
                     return CheckResult.PASSED
         return CheckResult.FAILED
+
 
 check = ReadOnlyFilesystem()

--- a/checkov/kubernetes/checks/ReadinessProbe.py
+++ b/checkov/kubernetes/checks/ReadinessProbe.py
@@ -14,7 +14,7 @@ class ReadinessProbe(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-        return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         # Don't check Job/CronJob (or Pods in runtime derived from Job/CronJob)
@@ -29,5 +29,6 @@ class ReadinessProbe(BaseK8Check):
         if "readinessProbe" not in conf:
             return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = ReadinessProbe()

--- a/checkov/kubernetes/checks/Secrets.py
+++ b/checkov/kubernetes/checks/Secrets.py
@@ -14,7 +14,7 @@ class Secrets(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-            return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "env" in conf:

--- a/checkov/kubernetes/checks/Tiller.py
+++ b/checkov/kubernetes/checks/Tiller.py
@@ -13,7 +13,7 @@ class Tiller(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def get_resource_id(self, conf):
-            return conf['parent']
+        return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
         if "image" in conf:

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -158,7 +158,6 @@ class Runner(BaseRunner):
                                         check_class=check.__class__.__module__)
                         report.add_record(record=record)
 
-
         return report
 
 

--- a/checkov/terraform/context_parsers/base_parser.py
+++ b/checkov/terraform/context_parsers/base_parser.py
@@ -34,9 +34,10 @@ class BaseContextParser(ABC):
         """
         raise NotImplementedError
 
-    def _is_block_signature(self, line_tokens, entity_context_path):
+    def _is_block_signature(self, line_num, line_tokens, entity_context_path):
         """
         Determine if the given tokenized line token is the entity signature line
+        :param line_num: The line number in the file
         :param line_tokens: list of line tokens
         :param entity_context_path: the entity's path in the context parser
         :return: True/False
@@ -124,7 +125,7 @@ class BaseContextParser(ABC):
             entity_context_path = self.get_entity_context_path(entity_block)
             for line_num, line in parsed_file_lines:
                 line_tokens = [x.replace('"', "") for x in line.split()]
-                if self._is_block_signature(line_tokens, entity_context_path):
+                if self._is_block_signature(line_num, line_tokens, entity_context_path):
                     start_line = line_num
                     end_line = self._compute_definition_end_line(line_num)
                     dpath.new(self.context, entity_context_path + ["start_line"], start_line)

--- a/checkov/terraform/context_parsers/parsers/provider_context_parser.py
+++ b/checkov/terraform/context_parsers/parsers/provider_context_parser.py
@@ -1,3 +1,5 @@
+import hcl2
+
 from checkov.terraform.context_parsers.base_parser import BaseContextParser
 
 
@@ -8,7 +10,19 @@ class ProviderContextParser(BaseContextParser):
 
     def get_entity_context_path(self, entity_block):
         entity_type = next(iter(entity_block))
-        return [entity_type]
+        return [entity_type] + entity_block[entity_type].get('alias', ['default'])
+
+    def _is_block_signature(self, line_num, line_tokens, entity_context_path):
+        # Ignore the alias as it is not part of the signature
+        is_provider = super()._is_block_signature(line_num, line_tokens, entity_context_path[0:-1])
+        if not is_provider:
+            return False
+
+        end_line = self._compute_definition_end_line(line_num)
+        provider_type = entity_context_path[0]
+        provider_obj = hcl2.loads("\n".join(map(lambda obj: obj[1], self.file_lines[line_num - 1:end_line])))['provider'][0]
+        alias = provider_obj[provider_type].get('alias', ['default'])
+        return super()._is_block_signature(line_num, line_tokens + alias, entity_context_path)
 
 
 parser = ProviderContextParser()

--- a/tests/terraform/runner/resources/many_providers/main.tf
+++ b/tests/terraform/runner/resources/many_providers/main.tf
@@ -1,0 +1,78 @@
+provider "aws" {
+  region     = "ap-northeast-1"
+  alias      = "ap-northeast-1"
+}
+
+provider "aws" {
+  region     = "ap-northeast-2"
+  alias      = "ap-northeast-2"
+}
+
+provider "aws" {
+  region     = "ap-south-1"
+  alias      = "ap-south-1"
+}
+
+provider "aws" {
+  region     = "ap-southeast-1"
+  alias      = "ap-southeast-1"
+}
+
+provider "aws" {
+  region     = "ap-southeast-2"
+  alias      = "ap-southeast-2"
+}
+
+provider "aws" {
+  region     = "ca-central-1"
+  alias      = "ca-central-1"
+}
+
+provider "aws" {
+  region     = "eu-central-1"
+  alias      = "eu-central-1"
+}
+
+provider "aws" {
+  region     = "eu-north-1"
+  alias      = "eu-north-1"
+}
+
+provider "aws" {
+  region     = "eu-west-1"
+  alias      = "eu-west-1"
+}
+
+provider "aws" {
+  region     = "eu-west-2"
+  alias      = "eu-west-2"
+}
+
+provider "aws" {
+  region     = "eu-west-3"
+  alias      = "eu-west-3"
+}
+
+provider "aws" {
+  region     = "sa-east-1"
+  alias      = "sa-east-1"
+}
+
+provider "aws" {
+  region     = "us-east-1"
+}
+
+provider "aws" {
+  region     = "us-east-2"
+  alias      = "us-east-2"
+}
+
+provider "aws" {
+  region     = "us-west-1"
+  alias      = "us-west-1"
+}
+
+provider "aws" {
+  region     = "us-west-2"
+  alias      = "us-west-2"
+}

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -154,6 +154,15 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(dpath.get(runner.tf_definitions[tf_file], 'resource/0/aws_db_instance/test_db/multi_az/0'),
                          False)
 
+    def test_provider_uniqueness(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/resources/many_providers"
+        tf_file = f"{valid_dir_path}/main.tf"
+        runner = Runner()
+        result = runner.run(root_folder=valid_dir_path, external_checks_dir=None, runner_filter=RunnerFilter(checks='CKV_AWS_41'))
+        self.assertEqual(len(result.passed_checks), 16)
+        self.assertIn('aws.default', map(lambda record: record.resource, result.passed_checks))
+
     def tearDown(self):
         parser_registry.definitions_context = {}
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR adds:
1. Uniqueness to kubernetes resources.
2. Uses provider aliases for uniqueness in terraform providers through the context parser.