### PR TITLE
Ignore checkov-internal directories

### DIFF
--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 
 from checkov.runner_filter import RunnerFilter
 
-IGNORED_DIRECTORIES_ENV = os.getenv('CKV_IGNORED_DIRECTORIES', "node_modules,.terraform,.serverless")
+IGNORED_DIRECTORIES_ENV = os.getenv('CKV_IGNORED_DIRECTORIES', "node_modules,.terraform,.serverless,fixes,checkov_results")
 
 ignored_directories = IGNORED_DIRECTORIES_ENV.split(",")
 


### PR DESCRIPTION
ignore fixes and checkov_results directories while scanning
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
