### PR TITLE
support multiple statements IAM policies

### DIFF
--- a/checkov/terraform/checks/data/aws/StarActionPolicyDocument.py
+++ b/checkov/terraform/checks/data/aws/StarActionPolicyDocument.py
@@ -19,7 +19,7 @@ class StarActionPolicyDocument(BaseDataCheck):
         """
         key = 'statement'
         if key in conf.keys():
-            for statement in conf['statement']:
+            for statement in conf[key]:
                 if 'actions' in statement and '*' in statement['actions'][0] and statement.get('effect', ['Allow'])[0] == 'Allow':
                     return CheckResult.FAILED
         return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/aws/IAMAdminPolicyDocument.py
+++ b/checkov/terraform/checks/resource/aws/IAMAdminPolicyDocument.py
@@ -17,13 +17,13 @@ class IAMAdminPolicyDocument(BaseResourceCheck):
             try:
                 policy_block = json.loads(conf['policy'][0])
                 if 'Statement' in policy_block.keys():
-                        if 'Action' in policy_block['Statement'][0] and \
-                                policy_block['Statement'][0].get('Effect', ['Allow']) == 'Allow' and \
-                                policy_block['Statement'][0]['Action'][0] == "*" and \
-                                'Resource' in policy_block['Statement'][0] and \
-                                policy_block['Statement'][0]['Resource'] == '*':
+                    for statement in policy_block['Statement']:
+                        if 'Action' in statement and \
+                                statement.get('Effect', ['Allow']) == 'Allow' and \
+                                '*' in statement.get('Action', ['']) and \
+                                '*' in statement.get('Resource', ['']):
                             return CheckResult.FAILED
-            except: # nosec
+            except:  # nosec
                 pass
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/aws/IAMStarActionPolicyDocument.py
+++ b/checkov/terraform/checks/resource/aws/IAMStarActionPolicyDocument.py
@@ -17,9 +17,10 @@ class IAMStarActionPolicyDocument(BaseResourceCheck):
             try:
                 policy_block = json.loads(conf['policy'][0])
                 if 'Statement' in policy_block.keys():
-                        if 'Action' in policy_block['Statement'][0] and \
-                                policy_block['Statement'][0].get('Effect', ['Allow']) == 'Allow' and \
-                                policy_block['Statement'][0]['Action'][0] == "*":
+                    for statement in policy_block['Statement']:
+                        if 'Action' in statement and \
+                                statement.get('Effect', ['Allow']) == 'Allow' and \
+                                '*' in statement.get('Action', ['']):
                             return CheckResult.FAILED
             except: # nosec
                 pass

--- a/tests/terraform/checks/resource/aws/test_IAMAdminPolicyDocument.py
+++ b/tests/terraform/checks/resource/aws/test_IAMAdminPolicyDocument.py
@@ -26,6 +26,17 @@ class TestAdminPolicyDocument(unittest.TestCase):
         scan_result = check.scan_entity_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_multiple_statements(self):
+        resource_conf = {'name': ['test'], 'user': ['${aws_iam_user.lb.name}'],
+                         'policy': [
+                             '{"Version":"2012-10-17","Statement":[{"Sid":"SqsAllow","Effect":"Allow","Action":['
+                             '"sqs:GetQueueAttributes","sqs:GetQueueUrl","sqs:ListDeadLetterSourceQueues",'
+                             '"sqs:ListQueues","sqs:ReceiveMessage","sqs:SendMessage","sqs:SendMessageBatch"],'
+                             '"Resource":"*"},{"Sid":"ALL","Effect":"Allow","Action":["*"],"Resource":["*"]}]} '
+                             ]}
+        scan_result = check.scan_entity_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/terraform/checks/resource/aws/test_IAMStarActionPolicyDocument.py
+++ b/tests/terraform/checks/resource/aws/test_IAMStarActionPolicyDocument.py
@@ -26,6 +26,16 @@ class TestAdminPolicyDocument(unittest.TestCase):
         scan_result = check.scan_entity_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_multiple_statements(self):
+        resource_conf = {'name': ['test'], 'user': ['${aws_iam_user.lb.name}'],
+                         'policy': [
+                             '{"Version":"2012-10-17","Statement":[{"Sid":"SqsAllow","Effect":"Allow","Action":['
+                             '"sqs:GetQueueAttributes","sqs:GetQueueUrl","sqs:ListDeadLetterSourceQueues",'
+                             '"sqs:ListQueues","sqs:ReceiveMessage","sqs:SendMessage","sqs:SendMessageBatch"],'
+                             '"Resource":"*"},{"Sid":"ALL","Effect":"Allow","Action":["*"],"Resource":["${var.my_resource_arn}"]}]}'
+                         ]}
+        scan_result = check.scan_entity_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Scan all statements of an IAM policy document, instead of only the first one
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Resolves #443 
