### PR TITLE
Cloudformation SecurityGroupDescription key incorrect

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/SecurityGroupRuleDescription.py
+++ b/checkov/cloudformation/checks/resource/aws/SecurityGroupRuleDescription.py
@@ -30,7 +30,7 @@ class SecurityGroupRuleDescription(BaseResourceCheck):
                 return CheckResult.PASSED
 
         elif conf['Type'] == 'AWS::EC2::SecurityGroupIngress' or conf['Type'] == 'AWS::EC2::SecurityGroupEgress':
-            if 'Properties' in conf.keys() and 'Description' in conf['Properties']:
+            if 'Properties' in conf.keys() and 'GroupDescription' in conf['Properties']:
                 return CheckResult.PASSED
 
         return CheckResult.FAILED


### PR DESCRIPTION
Checkov check_CKV_AWS_23 failing due to 

Type: AWS::EC2::SecurityGroup
Properties: 
  Description: String

but should be

Type: AWS::EC2::SecurityGroup
Properties: 
  GroupDescription: String

from https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html

Updated as per documentation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
