### PR TITLE
Update broken link in documentation.md

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -9,7 +9,7 @@ Checkov is a static code analysis tool for infrastructure-as-code.
 Checkov is written in Python and aims to simplify and increase the adoption of security and compliance best practices that prevent common cloud misconfigurations. Its scans adhere and implement common industry standards such as the Center for Internet Security (CIS) Amazon Web Services (AWS) Foundations Benchmark.
 
 
-See how to [install and get Checkov up and running](1.Introduction/Getting%20Started.md).
+See how to [install and get Checkov up and running](1.Introduction/Getting%20Started.html).
 
 Next [learn how to customize and add policies](1.Introduction/Policies.md).
 


### PR DESCRIPTION
`Introduction/Getting%20Started.md` does not have a redirect setup to `Introduction/Getting%20Started.html`.  Changed link to point directly to html.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
