### PR TITLE
sort checks in the same framework by number

### DIFF
--- a/checkov/common/util/docs_generator.py
+++ b/checkov/common/util/docs_generator.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from functools import cmp_to_key
 
 from tabulate import tabulate
 
@@ -9,6 +10,25 @@ from checkov.cloudformation.checks.resource.registry import cfn_registry as cfn_
 from checkov.kubernetes.registry import registry as k8_registry
 from checkov.serverless.registry import sls_registry
 from checkov.arm.registry import arm_registry
+
+
+def check_compare(c1, c2):
+    c1: str = c1[0]
+    c2: str = c2[0]
+
+    c1_index = c1.rindex('_')
+    c2_index = c2.rindex('_')
+
+    c1_prefix = c1[0:c1_index]
+    c1_number = int(c1[c1_index + 1:])
+
+    c2_prefix = c2[0:c2_index]
+    c2_number = int(c2[c2_index + 1:])
+
+    if c1_prefix == c2_prefix:
+        return c1_number - c2_number
+    else:
+        return -1 if c1 < c2 else 1
 
 
 def print_checks(framework="all"):
@@ -47,7 +67,7 @@ def get_checks(framework="all"):
         for key in arm_registry.checks.keys():
             for check in arm_registry.checks[key]:
                 printable_checks_list.append([check.id, "resource", key, check.name, "arm"])
-    return sorted(printable_checks_list, key=lambda x: x[0])
+    return sorted(printable_checks_list, key=cmp_to_key(check_compare))
 
 if __name__ == '__main__':
     print_checks()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Adds sorting when listing checks, so, e.g., `CKV_ABC_2` appears before `CKV_ABC_10`