### PR TITLE
add checks for tiller server config

### DIFF
--- a/checkov/kubernetes/checks/Tiller.py
+++ b/checkov/kubernetes/checks/Tiller.py
@@ -16,20 +16,24 @@ class Tiller(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
+        return CheckResult.FAILED if self.is_tiller(conf) else CheckResult.PASSED
+
+    @staticmethod
+    def is_tiller(conf):
         if "image" in conf:
             conf_image = conf["image"]
             if isinstance(conf_image,str) and  "tiller" in conf_image:
-                    return CheckResult.FAILED
-        else:
-            return CheckResult.FAILED
+                    return True
+
         if "parent_metadata" in conf:
             if "labels" in conf["parent_metadata"]:
                 if "app" in conf["parent_metadata"]["labels"]:
                     if conf["parent_metadata"]["labels"]["app"] == "helm":
-                        return CheckResult.FAILED
+                        return True
                 elif "name" in conf["parent_metadata"]["labels"]:
                     if conf["parent_metadata"]["labels"]["name"] == "tiller":
-                        return CheckResult.FAILED
-        return CheckResult.PASSED
+                        return True
+
+        return False
 
 check = Tiller()

--- a/checkov/kubernetes/checks/TillerDeploymentListener.py
+++ b/checkov/kubernetes/checks/TillerDeploymentListener.py
@@ -18,9 +18,8 @@ class TillerDeploymentListener(BaseK8Check):
 
     def scan_spec_conf(self, conf):
 
-        # reuse the existing logic in case it ever changes.
-        is_tiller = Tiller().scan_spec_conf(conf) == CheckResult.FAILED
-
+        is_tiller = Tiller.is_tiller(conf)
+        
         if not is_tiller:
             return CheckResult.UNKNOWN
 

--- a/checkov/kubernetes/checks/TillerDeploymentListener.py
+++ b/checkov/kubernetes/checks/TillerDeploymentListener.py
@@ -6,7 +6,7 @@ from checkov.kubernetes.checks.Tiller import Tiller
 class TillerDeploymentListener(BaseK8Check):
 
     def __init__(self):
-        name = "Ensure that the Helm v2 Tiller Deployment is not accessible from within the cluster"
+        name = "Ensure the Tiller Deployment (Helm V2) is not accessible from within the cluster"
         id = "CKV_K8S_45"
         # Location: container .image
         supported_kind = ['containers', 'initContainers']

--- a/checkov/kubernetes/checks/TillerDeploymentListener.py
+++ b/checkov/kubernetes/checks/TillerDeploymentListener.py
@@ -6,7 +6,7 @@ from checkov.kubernetes.checks.Tiller import Tiller
 class TillerDeploymentListener(BaseK8Check):
 
     def __init__(self):
-        name = "Ensure that the Helm v2 Tiller Deployment does not listen across the cluster"
+        name = "Ensure that the Helm v2 Tiller Deployment is not accessible from within the cluster"
         id = "CKV_K8S_45"
         # Location: container .image
         supported_kind = ['containers', 'initContainers']

--- a/checkov/kubernetes/checks/TillerDeploymentListener.py
+++ b/checkov/kubernetes/checks/TillerDeploymentListener.py
@@ -1,0 +1,35 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.kubernetes.base_spec_check import BaseK8Check
+from checkov.kubernetes.checks.Tiller import Tiller
+
+
+class TillerDeploymentListener(BaseK8Check):
+
+    def __init__(self):
+        name = "Ensure that the Helm v2 Tiller Deployment does not listen across the cluster"
+        id = "CKV_K8S_45"
+        # Location: container .image
+        supported_kind = ['containers', 'initContainers']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
+
+    def get_resource_id(self, conf):
+        return f'{conf["parent"]} - {conf["name"]}'
+
+    def scan_spec_conf(self, conf):
+
+        # reuse the existing logic in case it ever changes.
+        is_tiller = Tiller().scan_spec_conf(conf) == CheckResult.FAILED
+
+        if not is_tiller:
+            return CheckResult.UNKNOWN
+
+        args = conf.get('args')
+        if args:
+            for arg in args:
+                if '--listen' in arg and ('localhost' in arg or '127.0.0.1' in arg):
+                    return CheckResult.PASSED
+
+        return CheckResult.FAILED
+
+check = TillerDeploymentListener()

--- a/checkov/kubernetes/checks/TillerService.py
+++ b/checkov/kubernetes/checks/TillerService.py
@@ -1,0 +1,43 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.kubernetes.base_spec_check import BaseK8Check
+
+
+class TillerService(BaseK8Check):
+
+    def __init__(self):
+        name = "Ensure that the Tiller Service (Helm v2) is deleted"
+        id = "CKV_K8S_44"
+        # Location: container .image
+        supported_kind = ['Service']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
+
+    def get_resource_id(self, conf):
+        if "namespace" in conf["metadata"]:
+            return "{}.{}.{}".format(conf["kind"], conf["metadata"]["name"], conf["metadata"]["namespace"])
+        else:
+            return "{}.{}.default".format(conf["kind"], conf["metadata"]["name"])
+
+    def scan_spec_conf(self, conf):
+
+        metadata = conf.get('metadata')
+        if metadata:
+            if 'name' in metadata and 'tiller' in str(metadata['name']).lower():
+                return CheckResult.FAILED
+            labels = metadata.get('labels')
+            if labels:
+                for v in labels.values():
+                    if 'tiller' in str(v).lower():
+                        return CheckResult.FAILED
+
+        spec = conf.get('spec')
+        if spec:
+            selector = spec.get('selector')
+            if selector:
+                for v in selector.values():
+                    if 'tiller' in str(v).lower():
+                        return CheckResult.FAILED
+
+        return CheckResult.UNKNOWN
+
+check = TillerService()

--- a/tests/kubernetes/checks/example_TillerDeploymentListener/nginx-deployment-UNKNOWN.yaml
+++ b/tests/kubernetes/checks/example_TillerDeploymentListener/nginx-deployment-UNKNOWN.yaml
@@ -1,0 +1,43 @@
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: my-nginx
+    labels:
+      app: nginx
+  spec:
+    replicas: 3
+    selector:
+      matchLabels:
+        app: nginx
+    template:
+      metadata:
+        labels:
+          app: nginx
+      spec:
+        containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+          - containerPort: 80
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: tiller
+    labels:
+      app: tiller
+  spec:
+    replicas: 3
+    selector:
+      matchLabels:
+        app: nginx
+    template:
+      metadata:
+        labels:
+          app: nginx
+      spec:
+        containers:
+        - name: tiller
+          image: nginx:1.14.2
+          ports:
+          - containerPort: 80

--- a/tests/kubernetes/checks/example_TillerDeploymentListener/tiller-deployment_FAILED.json
+++ b/tests/kubernetes/checks/example_TillerDeploymentListener/tiller-deployment_FAILED.json
@@ -1,0 +1,68 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "Deployment",
+  "metadata": {
+    "creationTimestamp": null,
+    "labels": {
+      "app": "helm",
+      "name": "tiller"
+    },
+    "name": "tiller-deploy",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "strategy": {},
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "helm",
+          "name": "tiller"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "env": [
+              {
+                "name": "TILLER_NAMESPACE",
+                "value": "kube-system"
+              },
+              {
+                "name": "TILLER_HISTORY_MAX",
+                "value": "0"
+              }
+            ],
+            "image": "gcr.io/kubernetes-helm/tiller:v2.8.0",
+            "imagePullPolicy": "IfNotPresent",
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/liveness",
+                "port": 44135
+              },
+              "initialDelaySeconds": 1,
+              "timeoutSeconds": 1
+            },
+            "name": "tiller",
+            "ports": [
+              {
+                "containerPort": 44134,
+                "name": "tiller"
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/readiness",
+                "port": 44135
+              },
+              "initialDelaySeconds": 1,
+              "timeoutSeconds": 1
+            },
+            "resources": {}
+          }
+        ]
+      }
+    }
+  },
+  "status": {}
+}

--- a/tests/kubernetes/checks/example_TillerDeploymentListener/tiller-deployment_FAILED_WRONGARG.yaml
+++ b/tests/kubernetes/checks/example_TillerDeploymentListener/tiller-deployment_FAILED_WRONGARG.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tiller
+  labels:
+    app: tiller
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: helm
+      name: tiller
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: helm
+        name: tiller
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --listen=0.0.0.0:44134
+        env:
+        - name: TILLER_NAMESPACE
+          value: kube-system
+        - name: TILLER_HISTORY_MAX
+          value: "0"
+        image: gcr.io/kubernetes-helm/tiller:v2.16.9
+        name: tiller
+        ports:
+        - containerPort: 44134
+          name: tiller
+          protocol: TCP
+        - containerPort: 44135
+          name: http
+          protocol: TCP

--- a/tests/kubernetes/checks/example_TillerDeploymentListener/tiller-deployment_PASSED_LOCALHOST.json
+++ b/tests/kubernetes/checks/example_TillerDeploymentListener/tiller-deployment_PASSED_LOCALHOST.json
@@ -1,0 +1,69 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "Deployment",
+  "metadata": {
+    "creationTimestamp": null,
+    "labels": {
+      "app": "helm",
+      "name": "tiller"
+    },
+    "name": "tiller-deploy",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "strategy": {},
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "helm",
+          "name": "tiller"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "args": ["--listen=localhost:12345"],
+            "env": [
+              {
+                "name": "TILLER_NAMESPACE",
+                "value": "kube-system"
+              },
+              {
+                "name": "TILLER_HISTORY_MAX",
+                "value": "0"
+              }
+            ],
+            "image": "gcr.io/kubernetes-helm/tiller:v2.8.0",
+            "imagePullPolicy": "IfNotPresent",
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/liveness",
+                "port": 44135
+              },
+              "initialDelaySeconds": 1,
+              "timeoutSeconds": 1
+            },
+            "name": "tiller",
+            "ports": [
+              {
+                "containerPort": 44134,
+                "name": "tiller"
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/readiness",
+                "port": 44135
+              },
+              "initialDelaySeconds": 1,
+              "timeoutSeconds": 1
+            },
+            "resources": {}
+          }
+        ]
+      }
+    }
+  },
+  "status": {}
+}

--- a/tests/kubernetes/checks/example_TillerDeploymentListener/tiller-deployment_PASSED_LOOPBACK.json
+++ b/tests/kubernetes/checks/example_TillerDeploymentListener/tiller-deployment_PASSED_LOOPBACK.json
@@ -1,0 +1,69 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "Deployment",
+  "metadata": {
+    "creationTimestamp": null,
+    "labels": {
+      "app": "helm",
+      "name": "tiller"
+    },
+    "name": "tiller-deploy",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "strategy": {},
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "helm",
+          "name": "tiller"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "args": ["--listen=127.0.0.1:12345"],
+            "env": [
+              {
+                "name": "TILLER_NAMESPACE",
+                "value": "kube-system"
+              },
+              {
+                "name": "TILLER_HISTORY_MAX",
+                "value": "0"
+              }
+            ],
+            "image": "gcr.io/kubernetes-helm/tiller:v2.8.0",
+            "imagePullPolicy": "IfNotPresent",
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/liveness",
+                "port": 44135
+              },
+              "initialDelaySeconds": 1,
+              "timeoutSeconds": 1
+            },
+            "name": "tiller",
+            "ports": [
+              {
+                "containerPort": 44134,
+                "name": "tiller"
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/readiness",
+                "port": 44135
+              },
+              "initialDelaySeconds": 1,
+              "timeoutSeconds": 1
+            },
+            "resources": {}
+          }
+        ]
+      }
+    }
+  },
+  "status": {}
+}

--- a/tests/kubernetes/checks/example_TillerService/tiller-services.yaml
+++ b/tests/kubernetes/checks/example_TillerService/tiller-services.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      service: flask-svc
+    name: flask-svc
+  spec:
+    clusterIP: 10.103.37.236
+    externalTrafficPolicy: Cluster
+    ports:
+    - nodePort: 32061
+      port: 5000
+      protocol: TCP
+      targetPort: 5000
+    selector:
+      app: hello-flask
+    sessionAffinity: None
+    type: NodePort
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  # This one fails because it finds the label.
+  kind: Service
+  metadata:
+    labels:
+      app: helm
+      name: tiller
+    name: tiller-deploy
+    namespace: kube-system
+  spec:
+    clusterIP: 10.99.167.51
+    ports:
+    - name: tiller
+      port: 44134
+      protocol: TCP
+      targetPort: tiller
+    selector:
+      app: helm
+      name: tiller
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  # This one fails because it finds the selector.
+  kind: Service
+  metadata:
+    name: tiller-deploy
+    namespace: kube-system
+  spec:
+    clusterIP: 10.99.167.51
+    ports:
+    - name: tiller
+      port: 44134
+      protocol: TCP
+      targetPort: tiller
+    selector:
+      app: helm
+      name: tiller
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/tests/kubernetes/checks/test_TillerDeploymentListener.py
+++ b/tests/kubernetes/checks/test_TillerDeploymentListener.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.kubernetes.checks.TillerDeploymentListener import check
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestTillerDeploymentListener(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_TillerDeploymentListener"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/kubernetes/checks/test_TillerService.py
+++ b/tests/kubernetes/checks/test_TillerService.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.kubernetes.checks.TillerService import check
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestTillerService(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_TillerService"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 0)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This adds two checks for limiting the exposure of a Tiller deployment when using Helm v2:

1. Make sure there is not a service
2. Make sure the deployment only listens on localhost. This still allows authenticated client connections to be proxied in, but prevents requests from within the cluster.

Taken from: https://engineering.bitnami.com/articles/helm-security.html