### PR TITLE
allow external checks to be set using -c

### DIFF
--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -24,13 +24,9 @@ class RunnerFilter(object):
         self.external_check_ids.add(check_id)
 
     def should_run_check(self, check_id):
-        if check_id in self.external_check_ids:
-            pass        # enabled unless skipped
-        elif self.checks:
-            if check_id in self.checks:
-                return True
-            else:
-                return False
-        if self.skip_checks and check_id in self.skip_checks:
-            return False
+        if self.checks:
+            return check_id in self.checks
+        elif self.skip_checks:
+            return check_id not in self.skip_checks
+
         return True

--- a/tests/common/test_runner_filter.py
+++ b/tests/common/test_runner_filter.py
@@ -45,7 +45,7 @@ class TestRunnerFilter(unittest.TestCase):
     def test_should_run_external2(self):
         instance = RunnerFilter(checks=["CHECK_1"], skip_checks=["CHECK_2"])
         instance.notify_external_check("EXT_CHECK_999")
-        self.assertTrue(instance.should_run_check("EXT_CHECK_999"))
+        self.assertFalse(instance.should_run_check("EXT_CHECK_999"))
 
     def test_should_run_external3(self):
         instance = RunnerFilter(checks=["EXT_CHECK_999"])


### PR DESCRIPTION
This PR allows the `-c` flag to work with external checks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
