### PR TITLE
CKV_AZURE_44 Enforce a minimum required version of Transport Layer Security (TLS) for requests to a storage account

### DIFF
--- a/checkov/terraform/checks/resource/azure/StorageAccountMinimumTlsVersion.py
+++ b/checkov/terraform/checks/resource/azure/StorageAccountMinimumTlsVersion.py
@@ -1,0 +1,26 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class StorageAccountMinimumTlsVersion(BaseResourceCheck):
+    """
+        Looks for min_tls_version configuration at azurerm_storage_account to be set to TLS1_2
+        https://www.terraform.io/docs/providers/azurerm/r/storage_account.html#min_tls_version
+        :param conf: azurerm_storage_account configuration
+        :return: <CheckResult>
+    """
+    def __init__(self):
+        name = "Ensure Storage Account is using the latest version of TLS encryption"
+        id = "CKV_AZURE_44"
+        supported_resources = ['azurerm_storage_account']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'min_tls_version' in conf:
+            if conf['min_tls_version'][0] == 'TLS1_2':
+                return CheckResult.PASSED
+        return CheckResult.FAILED
+
+
+check = StorageAccountMinimumTlsVersion()

--- a/checkov/terraform/checks/resource/azure/StorageAccountMinimumTlsVersion.py
+++ b/checkov/terraform/checks/resource/azure/StorageAccountMinimumTlsVersion.py
@@ -17,10 +17,10 @@ class StorageAccountMinimumTlsVersion(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if 'min_tls_version' in conf:
-            if conf['min_tls_version'][0] == 'TLS1_2':
-                return CheckResult.PASSED
-        return CheckResult.FAILED
+        if 'min_tls_version' not in conf or \
+                conf['min_tls_version'][0] == 'TLS1_0' or conf['min_tls_version'][0] == 'TLS1_1':
+            return CheckResult.FAILED
+        return CheckResult.PASSED
 
 
 check = StorageAccountMinimumTlsVersion()

--- a/tests/terraform/checks/resource/azure/test_StorageAccountMinimumTlsVersion.py
+++ b/tests/terraform/checks/resource/azure/test_StorageAccountMinimumTlsVersion.py
@@ -8,7 +8,7 @@ from checkov.terraform.checks.resource.azure.StorageAccountMinimumTlsVersion imp
 
 class TestAppServiceMinTLSVersion(unittest.TestCase):
 
-    def test_failure(self):
+    def test_failure_option_not_present(self):
         hcl_res = hcl2.loads("""
             resource "azurerm_storage_account" "example" {
               name                     = "example"
@@ -27,7 +27,47 @@ class TestAppServiceMinTLSVersion(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-    def test_success(self):
+    def test_failure_insecure_option_present_tls10(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_storage_account" "example" {
+              name                     = "example"
+              resource_group_name      = data.azurerm_resource_group.example.name
+              location                 = data.azurerm_resource_group.example.location
+              account_tier             = "Standard"
+              account_replication_type = "GRS"
+              min_tls_version          = "TLS1_0"
+              network_rules {
+                default_action             = "Allow"
+                ip_rules                   = ["100.0.0.1"]
+                virtual_network_subnet_ids = [azurerm_subnet.example.id]
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_insecure_option_present_tls11(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_storage_account" "example" {
+              name                     = "example"
+              resource_group_name      = data.azurerm_resource_group.example.name
+              location                 = data.azurerm_resource_group.example.location
+              account_tier             = "Standard"
+              account_replication_type = "GRS"
+              min_tls_version          = "TLS1_1"
+              network_rules {
+                default_action             = "Allow"
+                ip_rules                   = ["100.0.0.1"]
+                virtual_network_subnet_ids = [azurerm_subnet.example.id]
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_secure_option_present(self):
         hcl_res = hcl2.loads("""
             resource "azurerm_storage_account" "example" {
               name                     = "example"
@@ -36,6 +76,26 @@ class TestAppServiceMinTLSVersion(unittest.TestCase):
               account_tier             = "Standard"
               account_replication_type = "GRS"
               min_tls_version          = "TLS1_2"
+              network_rules {
+                default_action             = "Allow"
+                ip_rules                   = ["100.0.0.1"]
+                virtual_network_subnet_ids = [azurerm_subnet.example.id]
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_future_option_present(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_storage_account" "example" {
+              name                     = "example"
+              resource_group_name      = data.azurerm_resource_group.example.name
+              location                 = data.azurerm_resource_group.example.location
+              account_tier             = "Standard"
+              account_replication_type = "GRS"
+              min_tls_version          = "TLS1_3"
               network_rules {
                 default_action             = "Allow"
                 ip_rules                   = ["100.0.0.1"]

--- a/tests/terraform/checks/resource/azure/test_StorageAccountMinimumTlsVersion.py
+++ b/tests/terraform/checks/resource/azure/test_StorageAccountMinimumTlsVersion.py
@@ -1,0 +1,52 @@
+import unittest
+
+import hcl2
+
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.azure.StorageAccountMinimumTlsVersion import check
+
+
+class TestAppServiceMinTLSVersion(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_storage_account" "example" {
+              name                     = "example"
+              resource_group_name      = data.azurerm_resource_group.example.name
+              location                 = data.azurerm_resource_group.example.location
+              account_tier             = "Standard"
+              account_replication_type = "GRS"
+              network_rules {
+                default_action             = "Allow"
+                ip_rules                   = ["100.0.0.1"]
+                virtual_network_subnet_ids = [azurerm_subnet.example.id]
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_storage_account" "example" {
+              name                     = "example"
+              resource_group_name      = data.azurerm_resource_group.example.name
+              location                 = data.azurerm_resource_group.example.location
+              account_tier             = "Standard"
+              account_replication_type = "GRS"
+              min_tls_version          = "TLS1_2"
+              network_rules {
+                default_action             = "Allow"
+                ip_rules                   = ["100.0.0.1"]
+                virtual_network_subnet_ids = [azurerm_subnet.example.id]
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add new scan rule to make sure storage accounts use the latest TLS version.

Reference: https://docs.microsoft.com/en-us/azure/storage/common/transport-layer-security-configure-minimum-version?tabs=portal


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
