### PR TITLE
fix skipped repo-id format check

### DIFF
--- a/checkov/main.py
+++ b/checkov/main.py
@@ -37,8 +37,8 @@ def run(banner=checkov_banner):
     if args.bc_api_key:
         if args.repo_id is None:
             parser.error("--repo-id argument is required when using --bc-api-key")
-            if len(args.repo_id.split('/')) != 2:
-                parser.error("--repo-id argument format should be 'organization/repository_name' E.g "
+        if len(args.repo_id.split('/')) != 2:
+            parser.error("--repo-id argument format should be 'organization/repository_name' E.g "
                              "bridgecrewio/checkov")
         bc_integration.setup_bridgecrew_credentials(bc_api_key=args.bc_api_key, repo_id=args.repo_id)
 


### PR DESCRIPTION
Fixes the validation that makes sure the repo-id has a slash. It got skipped before, causing the creation of invalid "integrations" in BC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
