### PR TITLE
Correct CKV_AWS_72 to match Action not Principal

### DIFF
--- a/checkov/terraform/checks/resource/aws/SQSPolicy.py
+++ b/checkov/terraform/checks/resource/aws/SQSPolicy.py
@@ -21,7 +21,7 @@ class SQSPolicy(BaseResourceCheck):
         """
         if "policy" in conf.keys():
             if is_json(conf["policy"][0]):
-                if json.loads(conf["policy"][0])['Statement'][0]['Principal'] == '*':
+                if json.loads(conf["policy"][0])['Statement'][0]['Action'] == '*':
                     return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/tests/terraform/checks/resource/aws/test_SQSPolicy.py
+++ b/tests/terraform/checks/resource/aws/test_SQSPolicy.py
@@ -22,7 +22,7 @@ class TestSQSPolicy(unittest.TestCase):
                         "Sid": "First",
                         "Effect": "Allow",
                         "Principal": "*",
-                        "Action": "sqs:SendMessage",
+                        "Action": "*",
                         "Resource": "${aws_sqs_queue.q.arn}",
                         "Condition": {
                             "ArnEquals": {


### PR DESCRIPTION
CKV_AWS_72 was created to fix issue #179 however, currently matches `principal` not `action`.
This PR corrects that mistake!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
