### PR TITLE
Add API Gateway access logs check

### DIFF
--- a/checkov/terraform/checks/resource/aws/APIGatewayAccessLogging.py
+++ b/checkov/terraform/checks/resource/aws/APIGatewayAccessLogging.py
@@ -1,0 +1,22 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.common.models.consts import ANY_VALUE
+
+
+class APIGatewayAccessLogging(BaseResourceValueCheck):
+
+    def __init__(self):
+        name = "Ensure API Gateway has Access Logging enabled"
+        id = "CKV_AWS_76"
+        supported_resources = ['aws_api_gateway_stage']
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "access_log_settings/[0]/destination_arn"
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = APIGatewayAccessLogging()

--- a/tests/terraform/checks/resource/aws/test_APIGatewayAccessLogging.py
+++ b/tests/terraform/checks/resource/aws/test_APIGatewayAccessLogging.py
@@ -1,0 +1,30 @@
+import unittest
+
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.aws.APIGatewayAccessLogging import check
+
+
+class TestAPIGatewayAccessLogs(unittest.TestCase):
+
+    def test_failure(self):
+        resource_conf = {
+            "rest_api_id": "Example",
+        }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        resource_conf = {
+            "rest_api_id": "Example",
+            "access_log_settings": [
+                {
+                    "destination_arn": "some-arn"
+                }
+            ],
+        }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Closes #186

this may be simplified to check just for `access_log_settings` but checking `destination_arn` argument under `access_log_settings` seems more future proof