### PR TITLE
Make supported_resources deprecated

### DIFF
--- a/checkov/terraform/checks/module/base_module_check.py
+++ b/checkov/terraform/checks/module/base_module_check.py
@@ -5,7 +5,20 @@ from checkov.terraform.checks.module.registry import module_registry
 
 
 class BaseModuleCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_resources):
+    def __init__(self, name, id, categories, supported_resources=None):
+        """
+        Base class for terraform module call related checks.
+
+        :param name: an error message that is shown, when the check failed.
+        :param id: the id of the check
+        :param categories: categories of the check
+        :param supported_resources: DEPRECATED the resources that this check applies to.
+
+            This is deprecated because there is only one resource type that is valid for
+            checks that extend this class.
+        """
+        if supported_resources is None:
+            supported_resources = ['module']
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_resources,
                          block_type="module")
         self.supported_resources = supported_resources

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -199,6 +199,39 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(len(result.passed_checks), 1)
         self.assertIn('module.some-module', map(lambda record: record.resource, result.passed_checks))
 
+    def test_terraform_module_checks_are_performed_even_if_supported_resources_is_omitted(self):
+        check_name = "TF_M_2"
+
+        from checkov.common.models.enums import CheckResult
+        from checkov.terraform.checks.module.base_module_check import BaseModuleCheck
+        from checkov.terraform.checks.module.registry import module_registry
+
+        class ModuleCheck(BaseModuleCheck):
+
+            def __init__(self):
+                name = "Test check"
+                id = check_name
+                categories = []
+                super().__init__(name=name, id=id, categories=categories)
+
+            def scan_module_conf(self, conf):
+                return CheckResult.PASSED
+
+        check = ModuleCheck()
+
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = os.path.join(current_dir, "resources/valid_tf_only_module_usage")
+        runner = Runner()
+        result = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(checks=check_name))
+
+        # unregister check
+        for resource in check.supported_resources:
+            module_registry.checks[resource].remove(check)
+
+        self.assertEqual(len(result.passed_checks), 1)
+        self.assertIn('module.some-module', map(lambda record: record.resource, result.passed_checks))
+
     def test_typed_terraform_resource_checks_are_performed(self):
         test_self = self
         check_name = "TF_M_2"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

There is only one way to use `supported_resources` and that is setting it to `['module']`. To reduce confusion when using the base class, it is now deprecated and set automatically.