### PR TITLE
Doc update for issue #561

### DIFF
--- a/checkov/main.py
+++ b/checkov/main.py
@@ -88,7 +88,7 @@ def add_parser_args(parser):
     parser.add_argument('-v', '--version',
                         help='version', action='store_true')
     parser.add_argument('-d', '--directory', action='append',
-                        help='IaC root directory (can not be used together with --file). Can be repeated')
+                        help='IaC root directory (can not be used together with --file).')
     parser.add_argument('-f', '--file', action='append',
                         help='IaC file(can not be used together with --directory)')
     parser.add_argument('--external-checks-dir', action='append',

--- a/docs/1.Introduction/Getting Started.md
+++ b/docs/1.Introduction/Getting Started.md
@@ -25,7 +25,7 @@ checkov -d /user/tf
   -v, --version         version
   -d DIRECTORY, --directory DIRECTORY
                         IaC root directory (can not be used together with
-                        --file). Can be repeated
+                        --file).
   -f FILE, --file FILE  IaC file(can not be used together with --directory)
   --external-checks-dir EXTERNAL_CHECKS_DIR
                         Directory for custom checks to be loaded. Can be


### PR DESCRIPTION
Removed "can be repeated" for `-d` / `--directory` options from docs and CLI help.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
