### PR TITLE
Add new check: Redshift cluster should not be publicly available [terraform]

### DIFF
--- a/checkov/terraform/checks/resource/aws/RedshitClusterPubliclyAvailable.py
+++ b/checkov/terraform/checks/resource/aws/RedshitClusterPubliclyAvailable.py
@@ -1,0 +1,21 @@
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+
+
+class RedshiftClusterPubliclyAccessible(BaseResourceNegativeValueCheck):
+    def __init__(self):
+        name = "Redshift cluster should not be publicly accessible"
+        id = "CKV_AWS_87"
+        supported_resources = ['redshift_cluster']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'publicly_accessible'
+
+    def get_forbidden_values(self):
+        return [True]
+
+
+check = RedshiftClusterPubliclyAccessible()

--- a/tests/terraform/checks/resource/aws/test_RedshiftClusterPubliclyAccessible.py
+++ b/tests/terraform/checks/resource/aws/test_RedshiftClusterPubliclyAccessible.py
@@ -1,0 +1,42 @@
+import unittest
+import hcl2
+
+from checkov.terraform.checks.resource.aws.RDSPubliclyAccessible import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestRedshitClusterPubliclyAccessible(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+          resource "aws_redshift_cluster" "public" {
+            cluster_identifier  = "tf-redshift-cluster"
+            database_name       = "mydb"
+            master_username     = "foo"
+            master_password     = "Mustbe8characters"
+            node_type           = "dc1.large"
+            publicly_accessible = true
+          }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_redshift_cluster']['public']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+          resource "aws_redshift_cluster" "private" {
+            cluster_identifier  = "tf-redshift-cluster"
+            database_name       = "mydb"
+            master_username     = "foo"
+            master_password     = "Mustbe8characters"
+            node_type           = "dc1.large"
+            publicly_accessible = false
+          }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_redshift_cluster']['private']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi,

 I based this on the `RDSPubliclyAccessible.py` check but there is one issue that I cannot understand. When it comes to `redshift_cluster` documentation states that `publicly_available` is set to true by default. So I would like to make sure that if someone creates a reasource and does not specify this option Checkov should still fail, as the cluster will be available publicly. 

Based on the `RDSPubliclyAccessible.py` tests, it should fail the check, but I'm probably missing something.

Closes https://github.com/bridgecrewio/checkov/issues/162

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
