### PR TITLE
Check for ec2 instances with public IPs

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ALBListenerHTTPS.py
+++ b/checkov/cloudformation/checks/resource/aws/ALBListenerHTTPS.py
@@ -20,13 +20,17 @@ class ALBListenerHTTPS(BaseResourceCheck):
 
         if 'Properties' in conf.keys():
             if 'Protocol' in conf['Properties'].keys():
-                if conf['Properties']['Protocol'] == 'HTTPS' or conf['Properties']['Protocol'] == 'TLS':
+                if conf['Properties']['Protocol'] in ('HTTPS', 'TLS'):
                     return CheckResult.PASSED
                 else:
-                    if 'DefaultActions' in conf['Properties'].keys():
-                        if conf['Properties']['DefaultActions'][0]['Type'] == 'redirect':
-                            if conf['Properties']['DefaultActions'][0]['RedirectConfig']['Protocol'] == "HTTPS":
-                                return CheckResult.PASSED
+                    if (
+                        'DefaultActions' in conf['Properties'].keys()
+                        and
+                        conf['Properties']['DefaultActions'][0]['Type'] == 'redirect'
+                        and
+                        conf['Properties']['DefaultActions'][0]['RedirectConfig']['Protocol'] == "HTTPS"
+                    ):
+                        return CheckResult.PASSED
         return CheckResult.FAILED
 
 check = ALBListenerHTTPS()

--- a/checkov/terraform/checks/resource/aws/EC2PublicIP.py
+++ b/checkov/terraform/checks/resource/aws/EC2PublicIP.py
@@ -1,0 +1,49 @@
+from checkov.common.models.enums import (
+    CheckCategories,
+    CheckResult,
+)
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class EC2PublicIP(BaseResourceCheck):
+
+    def __init__(self):
+        name = "EC2 instance should not have public IP."
+        id = "CKV_AWS_88"
+        categories = [CheckCategories.NETWORKING]
+        supported_resources = ['aws_instance', 'aws_launch_template']
+        super().__init__(
+            name=name,
+            id=id,
+            categories=categories,
+            supported_resources=supported_resources,
+        )
+
+    def scan_resource_conf(self, conf):
+        """
+        Looks for if associate_public_ip_address is set
+            https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#associate_public_ip_address
+            or
+            https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template#associate_public_ip_address
+
+        :param conf: dict of supported resource configuration
+        :return: <CheckResult>
+        """
+        # For aws_instance
+        if 'associate_public_ip_address' in conf.keys():
+            if conf['associate_public_ip_address'] == [True]:
+                return CheckResult.FAILED
+
+        # For aws_launch_template
+        if (
+            'network_interfaces' in conf.keys()
+            and
+            conf['network_interfaces'][0].get('associate_public_ip_address') == [True]
+        ):
+            return CheckResult.FAILED
+
+        # Note: checkov does not know, so we default to PASSED
+        # There is no default value for associate_public_ip_address, it depends on the subnet
+        return CheckResult.PASSED
+
+check = EC2PublicIP()

--- a/checkov/terraform/checks/resource/aws/IMDSv1Disabled.py
+++ b/checkov/terraform/checks/resource/aws/IMDSv1Disabled.py
@@ -37,15 +37,13 @@ class IMDSv1Disabled(BaseResourceCheck):
             return CheckResult.FAILED
 
         metadata_options = conf['metadata_options'][0]
-        return (
-            CheckResult.PASSED if
-            (
-                metadata_options.get("http_tokens") == ["required"]
-                or
-                metadata_options.get("http_endpoint") == ["disabled"]
-            )
-            else CheckResult.FAILED
-        )
+        if (
+            metadata_options.get("http_tokens") == ["required"]
+            or
+            metadata_options.get("http_endpoint") == ["disabled"]
+        ):
+            return CheckResult.PASSED
+        return CheckResult.FAILED
 
 
 check = IMDSv1Disabled()

--- a/tests/terraform/checks/resource/aws/test_EC2PublicIP.py
+++ b/tests/terraform/checks/resource/aws/test_EC2PublicIP.py
@@ -1,0 +1,75 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.aws.EC2PublicIP import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestEC2PublicIP(unittest.TestCase):
+
+    def test_pass_defaults_aws_instance(self):
+        hcl_res = hcl2.loads("""
+            resource "aws_instance" "test" {
+            }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_instance']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_pass_defaults_aws_launch_template(self):
+        hcl_res = hcl2.loads("""
+            resource "aws_launch_template" "test" {
+            }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_launch_template']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_failure_aws_instance(self):
+        hcl_res = hcl2.loads("""
+            resource "aws_instance" "test" {
+                associate_public_ip_address = true
+            }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_instance']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_aws_launch_template(self):
+        hcl_res = hcl2.loads("""
+            resource "aws_launch_template" "test" {
+                network_interfaces {
+                    associate_public_ip_address = true
+                }
+            }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_launch_template']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_aws_launch_template(self):
+        hcl_res = hcl2.loads("""
+            resource "aws_launch_template" "test" {
+                network_interfaces {
+                    associate_public_ip_address = false
+                }
+            }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_launch_template']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_aws_instance(self):
+        hcl_res = hcl2.loads("""
+            resource "aws_instance" "test" {
+                associate_public_ip_address = false
+            }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_instance']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
From @0xdabbad00's [AWS Security Maturity Roadmap](https://summitroute.com/downloads/aws_security_maturity_roadmap-Summit_Route.pdf):
```
Resources such as EC2s and S3 buckets should not be publicly accessible, but instead should have an ELB or
CloudFront in front them. This has a number of benefits including being able to make use of AWS Shield
(DDoS protection), AWS WAF, and a more standardized means of logging access. This has operations
improvements such as an ability to scale and reduced latency.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
