### PR TITLE
Add authenticated-read to set of "public" ACL values for s3 buckets

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/S3PublicACLRead.py
+++ b/checkov/cloudformation/checks/resource/aws/S3PublicACLRead.py
@@ -11,7 +11,7 @@ class S3AccessLogs(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if conf.get('Properties') and conf['Properties'].get('AccessControl') in ['PublicReadWrite', 'PublicRead']:
+        if conf.get('Properties') and conf['Properties'].get('AccessControl') in ['PublicReadWrite', 'PublicRead', 'AuthenticatedRead']:
             return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/aws/S3PublicACLRead.py
+++ b/checkov/terraform/checks/resource/aws/S3PublicACLRead.py
@@ -14,7 +14,7 @@ class S3PublicACLRead(BaseResourceNegativeValueCheck):
         return 'acl'
 
     def get_forbidden_values(self):
-        return ["public-read", "public-read-write", "website"]
+        return ["public-read", "public-read-write", "website", "authenticated-read"]
 
 
 check = S3PublicACLRead()

--- a/tests/cloudformation/checks/resource/aws/test_S3BlockPublicACLs.py
+++ b/tests/cloudformation/checks/resource/aws/test_S3BlockPublicACLs.py
@@ -3,6 +3,7 @@ import unittest
 
 from checkov.cloudformation.checks.resource.aws.S3BlockPublicACLs import check
 from checkov.cloudformation.runner import Runner
+from checkov.common.models.enums import CheckResult
 from checkov.runner_filter import RunnerFilter
 
 
@@ -20,6 +21,16 @@ class TestS3BlockPublicACLs(unittest.TestCase):
         self.assertEqual(summary['failed'], 5)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
+
+    def test_failure_auth_read(self):
+        resource_conf = {
+            "Type": "AWS::S3::Bucket",
+            "Properties": {
+                "AccessControl": "AuthenticatedRead"
+            }
+        }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
 
 
 if __name__ == '__main__':

--- a/tests/terraform/checks/resource/aws/test_S3PublicACLRead.py
+++ b/tests/terraform/checks/resource/aws/test_S3PublicACLRead.py
@@ -16,6 +16,16 @@ class TestS3PublicACL(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_auth_read(self):
+        resource_conf = {"region": ["us-west-2"],
+                         "bucket": ["my_bucket"],
+                         "acl": ["authenticated-read"],
+                         "force_destroy": [True],
+                         "tags": [{"Name": "my-bucket"}],
+                         }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_success(self):
         resource_conf = {"region": ["us-west-2"],
                          "bucket": ["my_bucket"],


### PR DESCRIPTION
Fixes: #596

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
