### PR TITLE
Fixes CKV_AZURE_9 & CKV_AZURE_10 - Scan fails if protocol value doesn't match TCP

### DIFF
--- a/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
+++ b/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
@@ -36,7 +36,7 @@ class NSGRulePortAccessRestricted(BaseResourceCheck):
         for rule_conf in rule_confs:
             if 'access' in rule_conf and rule_conf['access'][0] == "Allow":
                 if 'direction' in rule_conf and rule_conf['direction'][0] == "Inbound":
-                    if 'protocol' in rule_conf and rule_conf['protocol'][0] == 'TCP':
+                    if 'protocol' in rule_conf and rule_conf['protocol'][0].upper() == 'TCP':
                         if 'destination_port_range' in rule_conf and self.is_port_in_range(rule_conf):
                             if 'source_address_prefix' in rule_conf and rule_conf['source_address_prefix'][0] in INTERNET_ADDRESSES:
                                 return CheckResult.FAILED


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Converting the protocol input to uppercase for `TCP` equality.

Here are some scan results used against the same code provided in the issue #601 

1. Failing scans 

```
terraform scan results:

Passed checks: 0, Failed checks: 2, Skipped checks: 0

Check: CKV_AZURE_9: "Ensure that RDP access is restricted from the internet"
	FAILED for resource: azurerm_network_security_group.network_security_group
	File: /main.tf:22-50
	Guide: https://docs.bridgecrew.io/docs/bc_azr_networking_2

		22 | resource "azurerm_network_security_group" "network_security_group" {
		23 |   name                = "${var.location_shortcode}-${var.application_name}-nsg"
		24 |   location            = azurerm_resource_group.resource_group.location
		25 |   resource_group_name = azurerm_resource_group.resource_group.name
		26 | 
		27 |   security_rule {
		28 |     name                       = "SSH"
		29 |     priority                   = 100
		30 |     direction                  = "Inbound"
		31 |     access                     = "Allow"
		32 |     protocol                   = "tcp"
		33 |     source_port_range          = "*"
		34 |     destination_port_range     = "22"
		35 |     source_address_prefix      = "*"
		36 |     destination_address_prefix = "*"
		37 |   }
		38 | 
		39 |   security_rule {
		40 |     name                       = "RDP"
		41 |     priority                   = 110
		42 |     direction                  = "Inbound"
		43 |     access                     = "Allow"
		44 |     protocol                   = "TcP"
		45 |     source_port_range          = "*"
		46 |     destination_port_range     = "3389"
		47 |     source_address_prefix      = "*"
		48 |     destination_address_prefix = "*"
		49 |   }
		50 | }


Check: CKV_AZURE_10: "Ensure that SSH access is restricted from the internet"
	FAILED for resource: azurerm_network_security_group.network_security_group
	File: /main.tf:22-50
	Guide: https://docs.bridgecrew.io/docs/bc_azr_networking_3

		22 | resource "azurerm_network_security_group" "network_security_group" {
		23 |   name                = "${var.location_shortcode}-${var.application_name}-nsg"
		24 |   location            = azurerm_resource_group.resource_group.location
		25 |   resource_group_name = azurerm_resource_group.resource_group.name
		26 | 
		27 |   security_rule {
		28 |     name                       = "SSH"
		29 |     priority                   = 100
		30 |     direction                  = "Inbound"
		31 |     access                     = "Allow"
		32 |     protocol                   = "tcp"
		33 |     source_port_range          = "*"
		34 |     destination_port_range     = "22"
		35 |     source_address_prefix      = "*"
		36 |     destination_address_prefix = "*"
		37 |   }
		38 | 
		39 |   security_rule {
		40 |     name                       = "RDP"
		41 |     priority                   = 110
		42 |     direction                  = "Inbound"
		43 |     access                     = "Allow"
		44 |     protocol                   = "TcP"
		45 |     source_port_range          = "*"
		46 |     destination_port_range     = "3389"
		47 |     source_address_prefix      = "*"
		48 |     destination_address_prefix = "*"
		49 |   }
		50 | }
```

2. Passing scans - 

```
terraform scan results:

Passed checks: 2, Failed checks: 0, Skipped checks: 0

Check: CKV_AZURE_9: "Ensure that RDP access is restricted from the internet"
	PASSED for resource: azurerm_network_security_group.network_security_group
	File: /main.tf:22-50
	Guide: https://docs.bridgecrew.io/docs/bc_azr_networking_2

Check: CKV_AZURE_10: "Ensure that SSH access is restricted from the internet"
	PASSED for resource: azurerm_network_security_group.network_security_group
	File: /main.tf:22-50
	Guide: https://docs.bridgecrew.io/docs/bc_azr_networking_3
```

3. Partial Failure

```
terraform scan results:

Passed checks: 1, Failed checks: 1, Skipped checks: 0

Check: CKV_AZURE_9: "Ensure that RDP access is restricted from the internet"
	PASSED for resource: azurerm_network_security_group.network_security_group
	File: /main.tf:22-50
	Guide: https://docs.bridgecrew.io/docs/bc_azr_networking_2

Check: CKV_AZURE_10: "Ensure that SSH access is restricted from the internet"
	FAILED for resource: azurerm_network_security_group.network_security_group
	File: /main.tf:22-50
	Guide: https://docs.bridgecrew.io/docs/bc_azr_networking_3

		22 | resource "azurerm_network_security_group" "network_security_group" {
		23 |   name                = "${var.location_shortcode}-${var.application_name}-nsg"
		24 |   location            = azurerm_resource_group.resource_group.location
		25 |   resource_group_name = azurerm_resource_group.resource_group.name
		26 | 
		27 |   security_rule {
		28 |     name                       = "SSH"
		29 |     priority                   = 100
		30 |     direction                  = "Inbound"
		31 |     access                     = "Allow"
		32 |     protocol                   = "tcp"
		33 |     source_port_range          = "*"
		34 |     destination_port_range     = "22"
		35 |     source_address_prefix      = "internet"
		36 |     destination_address_prefix = "*"
		37 |   }
		38 | 
		39 |   security_rule {
		40 |     name                       = "RDP"
		41 |     priority                   = 110
		42 |     direction                  = "Inbound"
		43 |     access                     = "Allow"
		44 |     protocol                   = "TcP"
		45 |     source_port_range          = "*"
		46 |     destination_port_range     = "3389"
		47 |     source_address_prefix      = "123.123.123.123/32"
		48 |     destination_address_prefix = "*"
		49 |   }
		50 | }
```