### PR TITLE
Decrease docker image size and improve cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.8-slim-buster
 
+RUN apt-get update && apt install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip install -U checkov
-RUN apt-get update
-RUN apt install -y git
 
 ENTRYPOINT ["checkov"]


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Followed some best practices for dockerfiles and improved the size (around 17MB on my machine) and it also should be better in terms of layers and caching them.