### PR TITLE
Fix ElasticsearchNodeToNodeEncryption check

### DIFF
--- a/checkov/terraform/checks/resource/aws/ElasticsearchNodeToNodeEncryption.py
+++ b/checkov/terraform/checks/resource/aws/ElasticsearchNodeToNodeEncryption.py
@@ -22,10 +22,10 @@ class ElasticsearchNodeToNodeEncryption(BaseResourceCheck):
             if isinstance(cluster_config, dict):
                 if "instance_count" not in cluster_config:
                     return CheckResult.PASSED
-                instance_count = cluster_config["instance_count"][0]
+                instance_count = cluster_config["instance_count"]
                 if isinstance(instance_count, int):
                     if instance_count > 1:
-                        if "node_to_node_encryption" in conf.keys() and conf["node_to_node_encryption"][0]["enabled"][0]:
+                        if "node_to_node_encryption" in conf.keys() and conf["node_to_node_encryption"][0]["enabled"]:
                                 return CheckResult.PASSED
                         else:
                             return CheckResult.FAILED

--- a/tests/terraform/checks/resource/aws/test_ElasticsearchNodeToNodeEncryption.py
+++ b/tests/terraform/checks/resource/aws/test_ElasticsearchNodeToNodeEncryption.py
@@ -45,14 +45,14 @@ class TestElasticsearchNodeToNodeEncryption(unittest.TestCase):
                  'volume_size': ['${var.ebs_volume_size}'], 'volume_type': ['${var.ebs_volume_type}'],
                  'iops': ['${var.ebs_iops}']}],
                          'encrypt_at_rest': [{'enabled': [False], 'kms_key_id': ['${var.encrypt_at_rest_kms_key_id}']}],
-                         'cluster_config': [{'instance_count': [3], 'instance_type': ['${var.instance_type}'],
+                         'cluster_config': [{'instance_count': 3, 'instance_type': ['${var.instance_type}'],
                                              'dedicated_master_enabled': ['${var.dedicated_master_enabled}'],
                                              'dedicated_master_count': ['${var.dedicated_master_count}'],
                                              'dedicated_master_type': ['${var.dedicated_master_type}'],
                                              'zone_awareness_enabled': ['${var.zone_awareness_enabled}'],
                                              'zone_awareness_config': [
                                                  {'availability_zone_count': ['${var.availability_zone_count}']}]}],
-                         'node_to_node_encryption': [{'enabled': [False]}], 'vpc_options': [
+                         'node_to_node_encryption': [{'enabled': False}], 'vpc_options': [
                 {'security_group_ids': [['${join("",aws_security_group.default.*.id)}']],
                  'subnet_ids': ['${var.subnet_ids}']}], 'snapshot_options': [
                 {'automated_snapshot_start_hour': ['${var.automated_snapshot_start_hour}']}],
@@ -76,7 +76,7 @@ class TestElasticsearchNodeToNodeEncryption(unittest.TestCase):
                  'volume_size': ['${var.ebs_volume_size}'], 'volume_type': ['${var.ebs_volume_type}'],
                  'iops': ['${var.ebs_iops}']}],
                          'encrypt_at_rest': [{'enabled': [False], 'kms_key_id': ['${var.encrypt_at_rest_kms_key_id}']}],
-                         'cluster_config': [{'instance_count': [3], 'instance_type': ['${var.instance_type}'],
+                         'cluster_config': [{'instance_count': 3, 'instance_type': ['${var.instance_type}'],
                                              'dedicated_master_enabled': ['${var.dedicated_master_enabled}'],
                                              'dedicated_master_count': ['${var.dedicated_master_count}'],
                                              'dedicated_master_type': ['${var.dedicated_master_type}'],
@@ -107,14 +107,14 @@ class TestElasticsearchNodeToNodeEncryption(unittest.TestCase):
                  'volume_size': ['${var.ebs_volume_size}'], 'volume_type': ['${var.ebs_volume_type}'],
                  'iops': ['${var.ebs_iops}']}],
                          'encrypt_at_rest': [{'enabled': [True], 'kms_key_id': ['${var.encrypt_at_rest_kms_key_id}']}],
-                         'cluster_config': [{'instance_count': [3], 'instance_type': ['${var.instance_type}'],
+                         'cluster_config': [{'instance_count': 3, 'instance_type': ['${var.instance_type}'],
                                              'dedicated_master_enabled': ['${var.dedicated_master_enabled}'],
                                              'dedicated_master_count': ['${var.dedicated_master_count}'],
                                              'dedicated_master_type': ['${var.dedicated_master_type}'],
                                              'zone_awareness_enabled': ['${var.zone_awareness_enabled}'],
                                              'zone_awareness_config': [
                                                  {'availability_zone_count': ['${var.availability_zone_count}']}]}],
-                         'node_to_node_encryption': [{'enabled': [True]}], 'vpc_options': [
+                         'node_to_node_encryption': [{'enabled': True}], 'vpc_options': [
                 {'security_group_ids': [['${join("",aws_security_group.default.*.id)}']],
                  'subnet_ids': ['${var.subnet_ids}']}], 'snapshot_options': [
                 {'automated_snapshot_start_hour': ['${var.automated_snapshot_start_hour}']}],
@@ -138,14 +138,14 @@ class TestElasticsearchNodeToNodeEncryption(unittest.TestCase):
                  'volume_size': ['${var.ebs_volume_size}'], 'volume_type': ['${var.ebs_volume_type}'],
                  'iops': ['${var.ebs_iops}']}],
                          'encrypt_at_rest': [{'enabled': [True], 'kms_key_id': ['${var.encrypt_at_rest_kms_key_id}']}],
-                         'cluster_config': [{'instance_count': [1], 'instance_type': ['${var.instance_type}'],
+                         'cluster_config': [{'instance_count': 1, 'instance_type': ['${var.instance_type}'],
                                              'dedicated_master_enabled': ['${var.dedicated_master_enabled}'],
                                              'dedicated_master_count': ['${var.dedicated_master_count}'],
                                              'dedicated_master_type': ['${var.dedicated_master_type}'],
                                              'zone_awareness_enabled': ['${var.zone_awareness_enabled}'],
                                              'zone_awareness_config': [
                                                  {'availability_zone_count': ['${var.availability_zone_count}']}]}],
-                         'node_to_node_encryption': [{'enabled': [False]}], 'vpc_options': [
+                         'node_to_node_encryption': [{'enabled': False}], 'vpc_options': [
                 {'security_group_ids': [['${join("",aws_security_group.default.*.id)}']],
                  'subnet_ids': ['${var.subnet_ids}']}], 'snapshot_options': [
                 {'automated_snapshot_start_hour': ['${var.automated_snapshot_start_hour}']}],


### PR DESCRIPTION
Fix ElasticsearchNodeToNodeEncryption check - wrong access to instance_count and node_to_node_encryption

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
