### PR TITLE
check - test - Document DB Encryption in transit not disabled - Terraform

### DIFF
--- a/checkov/terraform/checks/resource/aws/DocDBTLS.py
+++ b/checkov/terraform/checks/resource/aws/DocDBTLS.py
@@ -1,0 +1,23 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+
+
+class DocDBTLS(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure DocDB TLS is not disabled"
+        id = "CKV_AWS_90"
+        supported_resources = ['aws_docdb_cluster_parameter_group']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'parameter' in conf:
+            for elem in conf["parameter"]:
+                if elem["name"][0] == "tls" and elem["value"][0] == "disabled":
+                    return CheckResult.FAILED
+        else:
+            return CheckResult.PASSED
+        return CheckResult.PASSED
+
+
+check = DocDBTLS()

--- a/tests/terraform/checks/resource/aws/test_DocDBTLS.py
+++ b/tests/terraform/checks/resource/aws/test_DocDBTLS.py
@@ -1,0 +1,63 @@
+import unittest
+
+import hcl2
+
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.aws.DocDBTLS import check
+
+
+class TestDocDBTLS(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+                resource "aws_docdb_cluster_parameter_group" "test" {
+                  family      = "docdb3.6"
+                  name        = "test"
+                  description = "docdb cluster parameter group"
+
+                  parameter {
+                    name  = "tls"
+                    value = "disabled"
+                  }
+
+                  parameter {
+                    name  = "other-param"
+                    value = "enabled"
+                  }
+                }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_docdb_cluster_parameter_group']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_no_parameters(self):
+        hcl_res = hcl2.loads("""
+                resource "aws_docdb_cluster_parameter_group" "test" {
+                  family      = "docdb3.6"
+                  name        = "test"
+                  description = "docdb cluster parameter group"
+                }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_docdb_cluster_parameter_group']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_with_parameters(self):
+        hcl_res = hcl2.loads("""
+                resource "aws_docdb_cluster_parameter_group" "test" {
+                  family      = "docdb3.6"
+                  name        = "test"
+                  description = "docdb cluster parameter group"
+
+                  parameter {
+                    name  = "tls"
+                    value = "enabled"
+                  }
+                }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_docdb_cluster_parameter_group']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello, first time adding a check to this project but i've tried to follow the helper documentation and i've found it very useful thus far!

This change is the terraform check implementation and unit tests for ensuring DocumentDB does not have in-flight encryption disabled.

Issue: https://github.com/bridgecrewio/checkov/issues/165

As mentioned in the issue the DocDB default is to have tls enabled, so in this check we just need to check that an explicit disable is not found for the configuration.

Provider doc for the configuration: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_parameter_group

The type was a bit confusing for me so I verified through the provider code to ensure it was a Type Set and I used the hcl2 library to ensure that the test data was input correctly as I saw from some of the other tests.
https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_docdb_cluster_parameter_group.go
https://www.terraform.io/docs/extend/schemas/schema-types.html#typeset

EDIT: type list and type set

Note that the 'parameter' option is optional but if it is used the 'name' and 'value' are then required.

Please let me know if anything needs adjusting :) Great project.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
