### PR TITLE
Edge case handling in CKV_GCP_18

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GKEPublicControlPlane.py
+++ b/checkov/terraform/checks/resource/gcp/GKEPublicControlPlane.py
@@ -20,7 +20,7 @@ class GKEPublicControlPlane(BaseResourceCheck):
         if 'master_authorized_networks_config' in conf.keys():
             if isinstance(conf['master_authorized_networks_config'][0], dict) and 'cidr_blocks' in conf['master_authorized_networks_config'][0]:
                 for cidr_block_conf in conf['master_authorized_networks_config'][0]['cidr_blocks']:
-                    if '0.0.0.0/0' in cidr_block_conf['cidr_block']:
+                    if type(cidr_block_conf) is dict and '0.0.0.0/0' in cidr_block_conf['cidr_block']:
                         return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/gcp/GKEPublicControlPlane.py
+++ b/checkov/terraform/checks/resource/gcp/GKEPublicControlPlane.py
@@ -20,7 +20,7 @@ class GKEPublicControlPlane(BaseResourceCheck):
         if 'master_authorized_networks_config' in conf.keys():
             if isinstance(conf['master_authorized_networks_config'][0], dict) and 'cidr_blocks' in conf['master_authorized_networks_config'][0]:
                 for cidr_block_conf in conf['master_authorized_networks_config'][0]['cidr_blocks']:
-                    if type(cidr_block_conf) is dict and '0.0.0.0/0' in cidr_block_conf['cidr_block']:
+                    if isinstance(cidr_block_conf, dict) and '0.0.0.0/0' in cidr_block_conf['cidr_block']:
                         return CheckResult.FAILED
         return CheckResult.PASSED
 


### PR DESCRIPTION
Handle a case where cidr_block_conf's value is a string (local block).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
