### PR TITLE
Fix checks not using force_list() when looping on policy_block['statement']

### DIFF
--- a/checkov/terraform/checks/resource/aws/IAMAdminPolicyDocument.py
+++ b/checkov/terraform/checks/resource/aws/IAMAdminPolicyDocument.py
@@ -1,5 +1,6 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.util.type_forcers import force_list
 import json
 
 
@@ -17,7 +18,7 @@ class IAMAdminPolicyDocument(BaseResourceCheck):
             try:
                 policy_block = json.loads(conf['policy'][0])
                 if 'Statement' in policy_block.keys():
-                    for statement in policy_block['Statement']:
+                    for statement in force_list(policy_block['Statement']):
                         if 'Action' in statement and \
                                 statement.get('Effect', ['Allow']) == 'Allow' and \
                                 '*' in statement.get('Action', ['']) and \

--- a/checkov/terraform/checks/resource/aws/IAMStarActionPolicyDocument.py
+++ b/checkov/terraform/checks/resource/aws/IAMStarActionPolicyDocument.py
@@ -1,5 +1,6 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.util.type_forcers import force_list
 import json
 
 
@@ -17,7 +18,7 @@ class IAMStarActionPolicyDocument(BaseResourceCheck):
             try:
                 policy_block = json.loads(conf['policy'][0])
                 if 'Statement' in policy_block.keys():
-                    for statement in policy_block['Statement']:
+                    for statement in force_list(policy_block['Statement']):
                         if 'Action' in statement and \
                                 statement.get('Effect', ['Allow']) == 'Allow' and \
                                 '*' in statement.get('Action', ['']):

--- a/checkov/terraform/checks/resource/aws/S3AllowsAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/S3AllowsAnyPrincipal.py
@@ -1,5 +1,6 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.util.type_forcers import force_list
 import json
 
 
@@ -18,7 +19,7 @@ class S3AllowsAnyPrincipal(BaseResourceCheck):
                 try:
                     policy_block = json.loads(conf['policy'][0])
                     if 'Statement' in policy_block.keys():
-                        for statement in policy_block['Statement']:
+                        for statement in force_list(policy_block['Statement']):
                             if statement['Effect'] == 'Deny':
                                 continue
                             if 'Principal' not in statement:


### PR DESCRIPTION
Statement may not always be a list.

Checks in this PR found via simple `grep -r "for statement in policy_block" .` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
