### PR TITLE
added check and tests for docdb encryption for cloudformation

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/DocDBEncryption.py
+++ b/checkov/cloudformation/checks/resource/aws/DocDBEncryption.py
@@ -1,0 +1,16 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class DocDBEncryption(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure DocDB is encrypted at rest (default is unencrypted)"
+        id = "CKV_AWS_74"
+        supported_resources = ['AWS::DocDB::DBCluster']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'Properties/StorageEncrypted'
+
+check = DocDBEncryption()

--- a/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-FAILED.yaml
@@ -3,4 +3,6 @@ Resources:
   MyDocDB:
     Type: AWS::DocDB::DBCluster
     Properties:
+      MasterUsername: name
+      MasterUserPassword: password
       StorageEncrypted: false

--- a/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-FAILED.yaml
@@ -1,0 +1,6 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyDocDB:
+    Type: AWS::DocDB::DBCluster
+    Properties:
+      StorageEncrypted: false

--- a/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-PASSED.yaml
@@ -3,4 +3,6 @@ Resources:
   MyDocDB:
     Type: AWS::DocDB::DBCluster
     Properties:
+      MasterUsername: name
+      MasterUserPassword: password
       StorageEncrypted: true

--- a/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-PASSED.yaml
@@ -1,0 +1,6 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyDocDB:
+    Type: AWS::DocDB::DBCluster
+    Properties:
+      StorageEncrypted: true

--- a/tests/cloudformation/checks/resource/aws/test_DocDBEncryption.py
+++ b/tests/cloudformation/checks/resource/aws/test_DocDBEncryption.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.DocDBEncryption import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestDocDBEncryption(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_DocDBEncryption"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello,

First CF check I have added so I've tried to replicate based on some other similar checks.

To close issue https://github.com/bridgecrewio/checkov/issues/130 (see comments there).

This check corresponds with this terraform check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/DocDBEncryption.py and so I have replicated the type and description.

Notice that there are not many fields in the provided positive and negative tests data but this is because there are no required fields -  https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbcluster.html

2 more fields were added to test data based on CF lint failure from GH actions feedback.

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
