### PR TITLE
Feature/speed up context building

### DIFF
--- a/checkov/terraform/context_parsers/base_parser.py
+++ b/checkov/terraform/context_parsers/base_parser.py
@@ -130,7 +130,7 @@ class BaseContextParser(ABC):
             for line_num, line in potential_block_start_lines:
                 line_tokens = [x.replace('"', "") for x in line.split()]
                 if self._is_block_signature(line_num, line_tokens, entity_context_path):
-                    print(f'created context for {" ".join(entity_context_path)}')
+                    logging.debug(f'created context for {" ".join(entity_context_path)}')
                     start_line = line_num
                     end_line = self._compute_definition_end_line(line_num)
                     dpath.new(self.context, entity_context_path + ["start_line"], start_line)

--- a/checkov/terraform/context_parsers/base_parser.py
+++ b/checkov/terraform/context_parsers/base_parser.py
@@ -1,14 +1,16 @@
 import logging
 import re
-import dpath.util
 from abc import ABC, abstractmethod
-from checkov.terraform.context_parsers.registry import parser_registry
-from checkov.common.models.enums import ContextCategories
 from itertools import islice
+
+import dpath.util
+
 from checkov.common.comment.enum import COMMENT_REGEX
+from checkov.common.models.enums import ContextCategories
+from checkov.terraform.context_parsers.registry import parser_registry
+
 OPEN_CURLY = '{'
 CLOSE_CURLY = '}'
-TERRAFORM_OBJ_BLOCK_TYPES = ['module', 'resource', 'data']
 
 
 class BaseContextParser(ABC):
@@ -122,8 +124,7 @@ class BaseContextParser(ABC):
         :return: Enriched block context
         """
         parsed_file_lines = self._filter_file_lines()
-        potential_block_start_lines = [(ind, line) for (ind, line) in parsed_file_lines
-                                       if any(block_type for block_type in TERRAFORM_OBJ_BLOCK_TYPES if line.startswith(block_type))]
+        potential_block_start_lines = [(ind, line) for (ind, line) in parsed_file_lines if line.startswith(self.get_block_type())]
         for i, entity_block in enumerate(definition_blocks):
             entity_context_path = self.get_entity_context_path(entity_block)
             for line_num, line in potential_block_start_lines:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Speed up context building by looking for starting lines only in lines starting with the correct block type (and not through all the lines in the file), and if a lines was found remove it from the collection to shorten the lookup time.