### PR TITLE
Exclude NLBs from CKV_AWS_2 HTTPS check

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ALBListenerHTTPS.py
+++ b/checkov/cloudformation/checks/resource/aws/ALBListenerHTTPS.py
@@ -20,7 +20,7 @@ class ALBListenerHTTPS(BaseResourceCheck):
 
         if 'Properties' in conf.keys():
             if 'Protocol' in conf['Properties'].keys():
-                if conf['Properties']['Protocol'] in ('HTTPS', 'TLS'):
+                if conf['Properties']['Protocol'] in ('HTTPS', 'TLS', 'TCP', 'UDP'):
                     return CheckResult.PASSED
                 else:
                     if (

--- a/checkov/cloudformation/checks/resource/aws/ALBListenerHTTPS.py
+++ b/checkov/cloudformation/checks/resource/aws/ALBListenerHTTPS.py
@@ -20,7 +20,7 @@ class ALBListenerHTTPS(BaseResourceCheck):
 
         if 'Properties' in conf.keys():
             if 'Protocol' in conf['Properties'].keys():
-                if conf['Properties']['Protocol'] in ('HTTPS', 'TLS', 'TCP', 'UDP'):
+                if conf['Properties']['Protocol'] in ('HTTPS', 'TLS', 'TCP', 'UDP', 'TCP_UDP'):
                     return CheckResult.PASSED
                 else:
                     if (

--- a/checkov/terraform/checks/resource/aws/ALBListenerHTTPS.py
+++ b/checkov/terraform/checks/resource/aws/ALBListenerHTTPS.py
@@ -23,6 +23,10 @@ class ALBListenerHTTPS(BaseResourceCheck):
                 conf[key] == ["HTTPS"]
                 or
                 conf[key] == ["TLS"]
+                or
+                conf[key] == ["TCP"]
+                or
+                conf[key] == ["UDP"]
             ):
                 return CheckResult.PASSED
             elif conf[key] == ["HTTP"]:

--- a/checkov/terraform/checks/resource/aws/ALBListenerHTTPS.py
+++ b/checkov/terraform/checks/resource/aws/ALBListenerHTTPS.py
@@ -19,17 +19,7 @@ class ALBListenerHTTPS(BaseResourceCheck):
         """
         key = 'protocol'
         if key in conf.keys():
-            if (
-                conf[key] == ["HTTPS"]
-                or
-                conf[key] == ["TLS"]
-                or
-                conf[key] == ["TCP"]
-                or
-                conf[key] == ["UDP"]
-                or
-                conf[key] == ["TCP_UDP"]
-            ):
+            if conf[key] in (["HTTPS"], ["TLS"], ["TCP"], ["UDP"], ["TCP_UDP"]):
                 return CheckResult.PASSED
             elif conf[key] == ["HTTP"]:
                 if 'default_action' in conf.keys():

--- a/checkov/terraform/checks/resource/aws/ALBListenerHTTPS.py
+++ b/checkov/terraform/checks/resource/aws/ALBListenerHTTPS.py
@@ -27,6 +27,8 @@ class ALBListenerHTTPS(BaseResourceCheck):
                 conf[key] == ["TCP"]
                 or
                 conf[key] == ["UDP"]
+                or
+                conf[key] == ["TCP_UDP"]
             ):
                 return CheckResult.PASSED
             elif conf[key] == ["HTTP"]:

--- a/tests/cloudformation/checks/resource/aws/example_ALBListener/ALBListenerHTTPS-PASSED-TCP.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ALBListener/ALBListenerHTTPS-PASSED-TCP.yaml
@@ -1,0 +1,67 @@
+Description: >
+  This template deploys an NLB with TLS termination
+Parameters:
+  VPC:
+    Type: AWS::EC2::VPC::Id
+    Description: Choose which VPC the Application Load Balancer should be deployed to
+
+  Subnets:
+    Description: Choose a minimum of 2 subnets the ALB should be deployed to
+    Type: List<AWS::EC2::Subnet::Id>
+
+Resources:
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: CheckovTest
+      Type: 'network'
+      Subnets: !Ref Subnets
+  
+  ListenerHTTPS:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      Certificates:
+        - CertificateArn: !Ref Certificate
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 22
+      Protocol: TCP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref DefaultTargetGroup
+
+  ### NOTE - Stack will remain in CREATE_IN_PROGRESS until you validate the certificate!
+  Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: example.com
+      DomainValidationOptions:
+        - DomainName: example.com
+          ValidationDomain: example.com
+
+  ListenerCert:
+    Type: AWS::ElasticLoadBalancingV2::ListenerCertificate
+    Properties: 
+      Certificates: 
+        - CertificateArn: !Ref Certificate
+      ListenerArn: !Ref ListenerHTTPS
+
+  # We define a default target group here, as this is a mandatory Parameters
+  # when creating an Application Load Balancer Listener. This is not used, instead
+  # a target group is created per-service in each service template (../services/*)
+  DefaultTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: checkov-default
+      VpcId: !Ref VPC
+      Port: 22
+      Protocol: TCP
+
+Outputs:
+  LoadBalancer:
+    Description: A reference to the Application Load Balancer
+    Value: !Ref LoadBalancer
+
+  LoadBalancerUrl:
+    Description: The URL of the ALB
+    Value: !GetAtt LoadBalancer.DNSName
+

--- a/tests/cloudformation/checks/resource/aws/example_ALBListener/ALBListenerHTTPS-PASSED-TCP_UDP.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ALBListener/ALBListenerHTTPS-PASSED-TCP_UDP.yaml
@@ -1,0 +1,67 @@
+Description: >
+  This template deploys an NLB with TLS termination
+Parameters:
+  VPC:
+    Type: AWS::EC2::VPC::Id
+    Description: Choose which VPC the Application Load Balancer should be deployed to
+
+  Subnets:
+    Description: Choose a minimum of 2 subnets the ALB should be deployed to
+    Type: List<AWS::EC2::Subnet::Id>
+
+Resources:
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: CheckovTest
+      Type: 'network'
+      Subnets: !Ref Subnets
+  
+  ListenerHTTPS:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      Certificates:
+        - CertificateArn: !Ref Certificate
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 53
+      Protocol: TCP_UDP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref DefaultTargetGroup
+
+  ### NOTE - Stack will remain in CREATE_IN_PROGRESS until you validate the certificate!
+  Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: example.com
+      DomainValidationOptions:
+        - DomainName: example.com
+          ValidationDomain: example.com
+
+  ListenerCert:
+    Type: AWS::ElasticLoadBalancingV2::ListenerCertificate
+    Properties: 
+      Certificates: 
+        - CertificateArn: !Ref Certificate
+      ListenerArn: !Ref ListenerHTTPS
+
+  # We define a default target group here, as this is a mandatory Parameters
+  # when creating an Application Load Balancer Listener. This is not used, instead
+  # a target group is created per-service in each service template (../services/*)
+  DefaultTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: checkov-default
+      VpcId: !Ref VPC
+      Port: 53
+      Protocol: TCP_UDP
+
+Outputs:
+  LoadBalancer:
+    Description: A reference to the Application Load Balancer
+    Value: !Ref LoadBalancer
+
+  LoadBalancerUrl:
+    Description: The URL of the ALB
+    Value: !GetAtt LoadBalancer.DNSName
+

--- a/tests/cloudformation/checks/resource/aws/example_ALBListener/ALBListenerHTTPS-PASSED-UDP.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ALBListener/ALBListenerHTTPS-PASSED-UDP.yaml
@@ -1,0 +1,67 @@
+Description: >
+  This template deploys an NLB with TLS termination
+Parameters:
+  VPC:
+    Type: AWS::EC2::VPC::Id
+    Description: Choose which VPC the Application Load Balancer should be deployed to
+
+  Subnets:
+    Description: Choose a minimum of 2 subnets the ALB should be deployed to
+    Type: List<AWS::EC2::Subnet::Id>
+
+Resources:
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: CheckovTest
+      Type: 'network'
+      Subnets: !Ref Subnets
+  
+  ListenerHTTPS:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      Certificates:
+        - CertificateArn: !Ref Certificate
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 53
+      Protocol: UDP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref DefaultTargetGroup
+
+  ### NOTE - Stack will remain in CREATE_IN_PROGRESS until you validate the certificate!
+  Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: example.com
+      DomainValidationOptions:
+        - DomainName: example.com
+          ValidationDomain: example.com
+
+  ListenerCert:
+    Type: AWS::ElasticLoadBalancingV2::ListenerCertificate
+    Properties: 
+      Certificates: 
+        - CertificateArn: !Ref Certificate
+      ListenerArn: !Ref ListenerHTTPS
+
+  # We define a default target group here, as this is a mandatory Parameters
+  # when creating an Application Load Balancer Listener. This is not used, instead
+  # a target group is created per-service in each service template (../services/*)
+  DefaultTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: checkov-default
+      VpcId: !Ref VPC
+      Port: 53
+      Protocol: UDP
+
+Outputs:
+  LoadBalancer:
+    Description: A reference to the Application Load Balancer
+    Value: !Ref LoadBalancer
+
+  LoadBalancerUrl:
+    Description: The URL of the ALB
+    Value: !GetAtt LoadBalancer.DNSName
+

--- a/tests/cloudformation/checks/resource/aws/test_ALBListenerHTTPS.py
+++ b/tests/cloudformation/checks/resource/aws/test_ALBListenerHTTPS.py
@@ -16,7 +16,7 @@ class TestALBListenerHTTPS(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 4)
+        self.assertEqual(summary['passed'], 6)
         self.assertEqual(summary['failed'], 1)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/cloudformation/checks/resource/aws/test_ALBListenerHTTPS.py
+++ b/tests/cloudformation/checks/resource/aws/test_ALBListenerHTTPS.py
@@ -16,7 +16,7 @@ class TestALBListenerHTTPS(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 6)
+        self.assertEqual(summary['passed'], 7)
         self.assertEqual(summary['failed'], 1)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/terraform/checks/resource/aws/test_ALBListenerHTTPS.py
+++ b/tests/terraform/checks/resource/aws/test_ALBListenerHTTPS.py
@@ -32,6 +32,12 @@ class TestALBListenerHTTPS(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_nlb_tcp_udp_success(self):
+        resource_conf = {'load_balancer_arn': ['${aws_lb.front_end.arn}'], 'port': ['53'], 'protocol': ['TCP_UDP']}
+
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
     def test_failure(self):
         resource_conf = {'load_balancer_arn': ['${aws_lb.front_end.arn}'], 'port': ['80'], 'protocol': ['HTTP']}
         scan_result = check.scan_resource_conf(conf=resource_conf)

--- a/tests/terraform/checks/resource/aws/test_ALBListenerHTTPS.py
+++ b/tests/terraform/checks/resource/aws/test_ALBListenerHTTPS.py
@@ -20,6 +20,18 @@ class TestALBListenerHTTPS(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_nlb_tcp_success(self):
+        resource_conf = {'load_balancer_arn': ['${aws_lb.front_end.arn}'], 'port': ['22'], 'protocol': ['TCP']}
+
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_nlb_udp_success(self):
+        resource_conf = {'load_balancer_arn': ['${aws_lb.front_end.arn}'], 'port': ['53'], 'protocol': ['UDP']}
+
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
     def test_failure(self):
         resource_conf = {'load_balancer_arn': ['${aws_lb.front_end.arn}'], 'port': ['80'], 'protocol': ['HTTP']}
         scan_result = check.scan_resource_conf(conf=resource_conf)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Closes #424 

CloudFormation config may need to be verified too - I haven't worked with it before (I'm more of a TF dude).

I wanted to add protocols to exclude from the check, as opposed to only checking for `HTTP` so that we don't miss any new protocols supported by the ALB. If new protocols supported by ALB are added then we would miss them in this check.