### PR TITLE
Support suppressions by Bridgecrew IDs as well as Checkov IDs

### DIFF
--- a/checkov/common/bridgecrew/platform_key.py
+++ b/checkov/common/bridgecrew/platform_key.py
@@ -6,15 +6,17 @@ home = str(Path.home())
 bridgecrew_dir = "{}/.bridgecrew".format(home)
 bridgecrew_file = "{}/credentials".format(bridgecrew_dir)
 
+
 def persist_key(key):
     if not os.path.exists(bridgecrew_dir):
         os.makedirs(bridgecrew_dir)
-    with open(bridgecrew_file,"w") as f:
+    with open(bridgecrew_file, "w") as f:
         f.write(key)
+
 
 def read_key():
     key = None
     if os.path.exists(bridgecrew_file):
-        with open(bridgecrew_file,"r") as f:
+        with open(bridgecrew_file, "r") as f:
             key = f.readline()
     return key

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -25,11 +25,12 @@ class RunnerRegistry(object):
     def extract_entity_details(self, entity):
         raise NotImplementedError()
 
-    def run(self, root_folder=None, external_checks_dir=None, files=None, guidelines={}, collect_skip_comments=True):
+    def run(self, root_folder=None, external_checks_dir=None, files=None, guidelines=None, collect_skip_comments=True):
         for runner in self.runners:
             scan_report = runner.run(root_folder, external_checks_dir=external_checks_dir, files=files,
                                      runner_filter=self.runner_filter, collect_skip_comments=collect_skip_comments)
-            RunnerRegistry.enrich_report_with_guidelines(scan_report, guidelines)
+            if guidelines:
+                RunnerRegistry.enrich_report_with_guidelines(scan_report, guidelines)
             self.scan_reports.append(scan_report)
         return self.scan_reports
 

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from checkov.arm.runner import Runner as arm_runner
 from checkov.cloudformation.runner import Runner as cfn_runner
-from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
+from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.goget.github.get_git import GitGetter
 from checkov.common.runners.runner_registry import RunnerRegistry, OUTPUT_CHOICES
 from checkov.common.util.banner import banner as checkov_banner
@@ -25,12 +25,10 @@ outer_registry = None
 logging_init()
 
 
-
 def run(banner=checkov_banner):
     parser = argparse.ArgumentParser(description='Infrastructure as code static analysis')
     add_parser_args(parser)
     args = parser.parse_args()
-    bc_integration = BcPlatformIntegration()
     runner_filter = RunnerFilter(framework=args.framework, checks=args.check, skip_checks=args.skip_check)
     if outer_registry:
         runner_registry = outer_registry

--- a/tests/terraform/context_parsers/mock_tf_files/mock.tf
+++ b/tests/terraform/context_parsers/mock_tf_files/mock.tf
@@ -1,5 +1,6 @@
 mock "mock_type" "mock_name" {
 # checkov:skip=CKV_AWS_19:aa
 # checkov:skip=CKV_AWS_20
+# bridgecrew:skip=BC_AWS_IAM_5:some-comment
  foo = "bar"
 }

--- a/tests/terraform/context_parsers/test_base_parser.py
+++ b/tests/terraform/context_parsers/test_base_parser.py
@@ -1,8 +1,8 @@
+import os
 import unittest
 
-from tests.terraform.context_parsers.mock_context_parser import MockContextParser
 from checkov.terraform.context_parsers.registry import parser_registry
-import os
+from tests.terraform.context_parsers.mock_context_parser import MockContextParser
 
 mock_tf_file = os.path.dirname(os.path.realpath(__file__)) + '/mock_tf_files/mock.tf'
 mock_definition = (mock_tf_file, {'mock': [
@@ -20,9 +20,11 @@ class TestBaseParser(unittest.TestCase):
         mock_parser = MockContextParser()
         parser_registry.register(mock_parser)
         definition_context = parser_registry.enrich_definitions_context(mock_definition)
-        self.assertIsNotNone(definition_context[mock_tf_file]['mock']['mock_type']['mock_name'].get('skipped_checks'))
-        self.assertEqual(len(definition_context[mock_tf_file]['mock']['mock_type']['mock_name'].get('skipped_checks')),
-                         2)
+        skipped_checks = definition_context[mock_tf_file]['mock']['mock_type']['mock_name'].get('skipped_checks')
+        self.assertIsNotNone(skipped_checks)
+        self.assertEqual(len(skipped_checks), 3)
+        # Ensure checkov IDs are mapped to BC IDs
+        self.assertEqual(skipped_checks[2]['id'], 'CKV_AWS_15')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Turn BcPlatformIntegration into a singelton imported from anywhere
2. Ingest the new `idMapping` field to allow suppression by BC IDs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
