### PR TITLE
Add case insensitivity to Azure SG rule values

### DIFF
--- a/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
+++ b/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
@@ -38,7 +38,7 @@ class NSGRulePortAccessRestricted(BaseResourceCheck):
             if not isinstance(rule_conf, dict):
                 return CheckResult.UNKNOWN
             if 'access' in rule_conf and rule_conf['access'][0].lower() == "allow":
-                if 'direction' in rule_conf and rule_conf['direction'][0].lower() == "inbound":  # case sensitivy, protocol can be *
+                if 'direction' in rule_conf and rule_conf['direction'][0].lower() == "inbound":
                     if 'protocol' in rule_conf and rule_conf['protocol'][0].lower() in ['tcp', '*']:
                         if 'destination_port_range' in rule_conf and self.is_port_in_range(rule_conf):
                             if 'source_address_prefix' in rule_conf and rule_conf['source_address_prefix'][0].lower() in INTERNET_ADDRESSES:

--- a/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
+++ b/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
@@ -29,7 +29,7 @@ class NSGRulePortAccessRestricted(BaseResourceCheck):
     def scan_resource_conf(self, conf):
         if "dynamic" in conf:
             return CheckResult.UNKNOWN
-            
+
         rule_confs = [conf]
         if 'security_rule' in conf:
             rule_confs = conf['security_rule']
@@ -37,11 +37,11 @@ class NSGRulePortAccessRestricted(BaseResourceCheck):
         for rule_conf in rule_confs:
             if not isinstance(rule_conf, dict):
                 return CheckResult.UNKNOWN
-            if 'access' in rule_conf and rule_conf['access'][0] == "Allow":
-                if 'direction' in rule_conf and rule_conf['direction'][0] == "Inbound":
-                    if 'protocol' in rule_conf and rule_conf['protocol'][0].upper() == 'TCP':
+            if 'access' in rule_conf and rule_conf['access'][0].lower() == "allow":
+                if 'direction' in rule_conf and rule_conf['direction'][0].lower() == "inbound":  # case sensitivy, protocol can be *
+                    if 'protocol' in rule_conf and rule_conf['protocol'][0].lower() in ['tcp', '*']:
                         if 'destination_port_range' in rule_conf and self.is_port_in_range(rule_conf):
-                            if 'source_address_prefix' in rule_conf and rule_conf['source_address_prefix'][0] in INTERNET_ADDRESSES:
+                            if 'source_address_prefix' in rule_conf and rule_conf['source_address_prefix'][0].lower() in INTERNET_ADDRESSES:
                                 return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/tests/terraform/checks/resource/azure/test_NSGRuleRDPAccessRestricted.py
+++ b/tests/terraform/checks/resource/azure/test_NSGRuleRDPAccessRestricted.py
@@ -28,6 +28,26 @@ class TestNSGRuleRDPAccessRestricted(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_case_insensitive(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_network_security_rule" "example" {
+              name                        = "test123"
+              priority                    = 100
+              direction                   = "inbound"
+              access                      = "allow"
+              protocol                    = "Tcp"
+              source_port_range           = "*"
+              destination_port_range      = ["3380-3390", "22"]
+              source_address_prefix       = "Internet"
+              destination_address_prefix  = "*"
+              resource_group_name         = azurerm_resource_group.example.name
+              network_security_group_name = azurerm_network_security_group.example.name
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_network_security_rule']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_success(self):
         hcl_res = hcl2.loads("""
                     resource "azurerm_network_security_rule" "example" {
@@ -62,7 +82,7 @@ class TestNSGRuleRDPAccessRestricted(unittest.TestCase):
             direction                  = "Inbound"
             name                       = "RDP"
             priority                   = "300"
-            protocol                   = "TCP"
+            protocol                   = "*"
             source_address_prefix      = "*"
             source_port_range          = "*"
           }


### PR DESCRIPTION
This PR adds some flexibility in parsing components of security group rules for Azure. Values like "internet" / "Internet", "allow" / "Allow" all seem to work when creating a resource via Terraform.

Also checks for "*" in the protocol.

(Note: we may need to update a lot of checks for case insensitivity, which Azure seems to be flexible about)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
