### PR TITLE
Fix GCP SQL Public check

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleCloudSqlDatabasePublicallyAccessible.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudSqlDatabasePublicallyAccessible.py
@@ -15,22 +15,45 @@ class GoogleCloudSqlDatabasePublicallyAccessible(BaseResourceCheck):
         :param conf: google_sql_database_instance configuration
         :return: <CheckResult>
         """
-        authorized_networks_count = 0
-        authorized_networks_passed = 0
-        if 'settings' in conf and 'ip_configuration' in conf['settings'][0]:
-            if 'authorized_networks' in conf['settings'][0]['ip_configuration'][0].keys():
-                authorized_networks_count = len(conf['settings'][0]['ip_configuration'][0]['authorized_networks'])
-                for authorized_network in conf['settings'][0]['ip_configuration'][0]['authorized_networks']:
-                    if isinstance(authorized_network, str):
-                        return CheckResult.UNKNOWN
-                    if 'value' in authorized_network:
-                        if "/0" not in authorized_network['value'][0]:
-                            authorized_networks_passed += 1
 
-        if authorized_networks_passed == authorized_networks_count:
-            return CheckResult.PASSED
-        else: 
-            return CheckResult.FAILED
+        if 'settings' in conf and 'ip_configuration' in conf['settings'][0]:
+            ip_config = conf['settings'][0]['ip_configuration'][0]
+            if 'authorized_networks' in ip_config:
+                auth_networks = ip_config['authorized_networks'][0]
+                for network in auth_networks:
+                    if 'value' in network and str(network['value']).endswith('/0'):
+                        return CheckResult.FAILED
+            if 'dynamic' in ip_config:
+                dynamic = ip_config['dynamic']
+                for dynamic_block in dynamic:
+                    if 'authorized_networks' in dynamic_block:
+                        auth_network = dynamic_block['authorized_networks']
+                        if 'content' in auth_network:
+                            content = auth_network['content'][0]
+                            if 'value' in content and content['value'][0].endswith('/0'):
+                                return CheckResult.FAILED
+
+        return CheckResult.PASSED
+
+
+        # authorized_networks_count = 0
+        # authorized_networks_passed = 0
+        # if 'settings' in conf and 'ip_configuration' in conf['settings'][0]:
+        #     if 'authorized_networks' in conf['settings'][0]['ip_configuration'][0].keys():
+        #         authorized_networks_count = len(conf['settings'][0]['ip_configuration'][0]['authorized_networks'][0])
+        #         print(conf['settings'][0]['ip_configuration'][0]['authorized_networks'])
+        #         print(authorized_networks_count)
+        #         for authorized_network in conf['settings'][0]['ip_configuration'][0]['authorized_networks'][0]:
+        #             if isinstance(authorized_network, str):
+        #                 return CheckResult.UNKNOWN
+        #             if 'value' in authorized_network:
+        #                 if "/0" not in authorized_network['value'][0]:
+        #                     authorized_networks_passed += 1
+        #
+        # if authorized_networks_passed == authorized_networks_count:
+        #     return CheckResult.PASSED
+        # else:
+        #     return CheckResult.FAILED
 
 
 check = GoogleCloudSqlDatabasePublicallyAccessible()

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudSqlDatabasePublicallyAccessible.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudSqlDatabasePublicallyAccessible.py
@@ -20,9 +20,15 @@ class GoogleCloudSqlDatabasePublicallyAccessible(BaseResourceCheck):
             ip_config = conf['settings'][0]['ip_configuration'][0]
             if 'authorized_networks' in ip_config:
                 auth_networks = ip_config['authorized_networks'][0]
+                if type(auth_networks) != list:  # handle possible legacy case
+                    auth_networks = [auth_networks]
                 for network in auth_networks:
-                    if 'value' in network and str(network['value']).endswith('/0'):
-                        return CheckResult.FAILED
+                    if 'value' in network:
+                        val = network['value']
+                        if type(val) == list:  # handle possible parsing discrepancies
+                            val = val[0]
+                        if val.endswith('/0'):
+                            return CheckResult.FAILED
             if 'dynamic' in ip_config:
                 dynamic = ip_config['dynamic']
                 for dynamic_block in dynamic:

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudSqlDatabasePublicallyAccessible.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudSqlDatabasePublicallyAccessible.py
@@ -36,24 +36,4 @@ class GoogleCloudSqlDatabasePublicallyAccessible(BaseResourceCheck):
         return CheckResult.PASSED
 
 
-        # authorized_networks_count = 0
-        # authorized_networks_passed = 0
-        # if 'settings' in conf and 'ip_configuration' in conf['settings'][0]:
-        #     if 'authorized_networks' in conf['settings'][0]['ip_configuration'][0].keys():
-        #         authorized_networks_count = len(conf['settings'][0]['ip_configuration'][0]['authorized_networks'][0])
-        #         print(conf['settings'][0]['ip_configuration'][0]['authorized_networks'])
-        #         print(authorized_networks_count)
-        #         for authorized_network in conf['settings'][0]['ip_configuration'][0]['authorized_networks'][0]:
-        #             if isinstance(authorized_network, str):
-        #                 return CheckResult.UNKNOWN
-        #             if 'value' in authorized_network:
-        #                 if "/0" not in authorized_network['value'][0]:
-        #                     authorized_networks_passed += 1
-        #
-        # if authorized_networks_passed == authorized_networks_count:
-        #     return CheckResult.PASSED
-        # else:
-        #     return CheckResult.FAILED
-
-
 check = GoogleCloudSqlDatabasePublicallyAccessible()

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlDatabasePublicallyAccessible/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlDatabasePublicallyAccessible/main.tf
@@ -1,0 +1,131 @@
+resource "google_sql_database_instance" "instance1-fail" {
+  name   = "instance"
+  region = "us-central1"
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled    = true
+      authorized_networks = [
+        {
+          name  = "XYZ"
+          value = "1.2.3.4"
+        },
+        {
+          name  = "Public"
+          value = "0.0.0.0/0"
+        },
+        {
+          name = "ABC",
+          value = "5.5.5.0/24"
+        }
+      ]
+    }
+  }
+}
+
+resource "google_sql_database_instance" "instance2-pass" {
+  name   = "instance"
+  region = "us-central1"
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled    = true
+      authorized_networks = [
+        {
+          name  = "XYZ"
+          value = "1.2.3.4"
+        },
+        {
+          name = "ABC",
+          value = "5.5.5.0/24"
+        }
+      ]
+    }
+  }
+}
+
+# this isn't actually valid without the settings block, but testing parsing
+resource "google_sql_database_instance" "instance3-pass" {
+  name   = "instance"
+  region = "us-central1"
+}
+
+resource "google_sql_database_instance" "instance4-fail" {
+  name             = "instance"
+  database_version = "POSTGRES_11"
+
+  settings {
+    tier = "db-f1-micro"
+
+    ip_configuration {
+
+      dynamic "authorized_networks" {
+        for_each = google_compute_instance.apps
+        iterator = apps
+
+        content {
+          name  = apps.value.name
+          value = apps.value.network_interface.0.access_config.0.nat_ip
+        }
+      }
+
+      dynamic "authorized_networks" {
+        for_each = local.onprem
+        iterator = onprem
+
+        content {
+          name  = "onprem-${onprem.key}"
+          value = "0.0.0.0/0"
+        }
+      }
+    }
+  }
+}
+
+resource "google_sql_database_instance" "instance5-pass" {
+  name             = "instance"
+  database_version = "POSTGRES_11"
+  settings {
+    tier = "db-f1-micro"
+
+    ip_configuration {
+
+      dynamic "authorized_networks" {
+        for_each = google_compute_instance.apps
+        iterator = apps
+
+        content {
+          name  = apps.value.name
+          value = apps.value.network_interface.0.access_config.0.nat_ip
+        }
+      }
+
+      dynamic "authorized_networks" {
+        for_each = local.onprem
+        iterator = onprem
+
+        content {
+          name  = "onprem-${onprem.key}"
+          value = onprem.value
+        }
+      }
+    }
+  }
+}
+
+resource "google_sql_database_instance" "instance6-pass" {
+  provider = google-beta
+
+  name   = "private-instance-${random_id.db_name_suffix.hex}"
+  region = "us-central1"
+
+  depends_on = [google_service_networking_connection.private_vpc_connection]
+
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = google_compute_network.private_network.id
+    }
+  }
+}


### PR DESCRIPTION
The GCP SQL instance publicly accessible check was incorrect. It did not correctly handle the list of authorized networks. It also did not handle all possible ways in which this could be defined. The tests were not correct, so I rewrote those too.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
