### PR TITLE
Add v to version tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           git fetch --tags
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
           echo "latest tag: $latest_tag"
-          new_tag=$(echo $latest_tag | awk -F. -v a="$1" -v b="$2" -v c="$3" '{printf("%d.%d.%d", $1+a, $2+b , $3+1)}')
+          new_tag=$(echo $latest_tag | sed s/v//g | awk -F. -v a="$1" -v b="$2" -v c="$3" '{printf("v%d.%d.%d", $1+a, $2+b , $3+1)}')
           echo "new tag: $new_tag"
 
           ## update docs


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This will cause the workflow from #663 to run - the tag should be `v<VERSION>`

cc @chenrui333 