### PR TITLE
Only check cluster for DocDB encryption on Terraform

### DIFF
--- a/checkov/terraform/checks/resource/aws/DocDBEncryption.py
+++ b/checkov/terraform/checks/resource/aws/DocDBEncryption.py
@@ -6,7 +6,7 @@ class DocDBEncryption(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure DocDB is encrypted at rest (default is unencrypted)"
         id = "CKV_AWS_74"
-        supported_resources = ['aws_docdb_cluster', 'aws_docdb_cluster_instance']
+        supported_resources = ['aws_docdb_cluster']
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Currently, checkov checks both the DocDB cluster and its instances for `storage_encrypted = true`. However, `storage_encrypted` is only an attribute of `aws_docdb_cluster`, not `aws_docdb_cluster_instance`.


