### PR TITLE
CloudFormation Check - KMS key policy wildcard principal

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
+++ b/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
@@ -4,7 +4,7 @@ from checkov.cloudformation.checks.resource.base_resource_value_check import Bas
 
 class KMSKeyWildCardPrincipal(BaseResourceValueCheck):
     def __init__(self):
-        name = "Ensure rotation for customer created CMKs is enabled"
+        name = "Ensure KMS key policy does not contain wildcard (*) principal"
         id = "CKV_AWS_28"
         supported_resources = ['AWS::KMS::Key']
         categories = [CheckCategories.ENCRYPTION]

--- a/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
+++ b/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
@@ -1,0 +1,32 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class KMSKeyWildCardPrincipal(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure rotation for customer created CMKs is enabled"
+        id = "CKV_AWS_28"
+        supported_resources = ['AWS::KMS::Key']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'Properties/KeyPolicy/Statement/Principal'
+
+    def scan_resource_conf(self, conf):
+        if conf.get('Properties'):
+            if conf['Properties'].get('KeyPolicy'):
+                policy_block = conf['Properties']['KeyPolicy']
+                if 'Statement' in policy_block.keys():
+                    for policy_property in policy_block:
+                        if policy_property == 'Statement':
+                            for policy_statement in policy_block['Statement']:
+                                if 'Principal' in policy_statement.keys():
+                                    for policy_principal_property in policy_statement['Principal']:
+                                        policy_principal_value = policy_statement['Principal'][policy_principal_property]
+                                        if str(policy_principal_value) == '*':
+                                            return CheckResult.FAILED
+        return CheckResult.PASSED
+
+
+check = KMSKeyWildCardPrincipal()

--- a/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
+++ b/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
@@ -33,7 +33,7 @@ def get_recursively(search_dict, field):
 class KMSKeyWildCardPrincipal(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure KMS key policy does not contain wildcard (*) principal"
-        id = "CKV_AWS_28"
+        id = "CKV_AWS_33"
         supported_resources = ['AWS::KMS::Key']
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
+++ b/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
@@ -2,6 +2,34 @@ from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
+def get_recursively(search_dict, field):
+    """
+    Takes a dict with nested lists and dicts,
+    and searches all dicts for a key of the field
+    provided.
+    """
+    fields_found = []
+
+    for key, value in search_dict.items():
+
+        if key == field:
+            fields_found.append(value)
+
+        elif isinstance(value, dict):
+            results = get_recursively(value, field)
+            for result in results:
+                fields_found.append(result)
+
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    more_results = get_recursively(item, field)
+                    for another_result in more_results:
+                        fields_found.append(another_result)
+
+    return fields_found
+
+
 class KMSKeyWildCardPrincipal(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure KMS key policy does not contain wildcard (*) principal"
@@ -17,15 +45,16 @@ class KMSKeyWildCardPrincipal(BaseResourceValueCheck):
         if conf.get('Properties'):
             if conf['Properties'].get('KeyPolicy'):
                 policy_block = conf['Properties']['KeyPolicy']
-                if 'Statement' in policy_block.keys():
-                    for policy_property in policy_block:
-                        if policy_property == 'Statement':
-                            for policy_statement in policy_block['Statement']:
-                                if 'Principal' in policy_statement.keys():
-                                    for policy_principal_property in policy_statement['Principal']:
-                                        policy_principal_value = policy_statement['Principal'][policy_principal_property]
-                                        if str(policy_principal_value) == '*':
-                                            return CheckResult.FAILED
+                principals_list = get_recursively(policy_block, 'Principal')
+                for principal in principals_list:
+                    if isinstance(principal, dict):
+                        for principal_key, principal_value in principal.items():
+                            if principal_value == '*':
+                                return CheckResult.FAILED
+                    else:
+                        if principal == '*':
+                            return CheckResult.FAILED
+
         return CheckResult.PASSED
 
 

--- a/tests/cloudformation/checks/resource/aws/example_KMSKeyWildCardPrincipal/KMSKeyWildCardPrincipal-FAILED-AWS-Wildcard.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_KMSKeyWildCardPrincipal/KMSKeyWildCardPrincipal-FAILED-AWS-Wildcard.yaml
@@ -8,10 +8,10 @@ Resources:
         Version: '2012-10-17'
         Id: key-default-1
         Statement:
-        - Sid: Enable IAM User Permissions
+        - Sid: Enable Permissions for All AWS Principals
           Effect: Allow
           Principal:
-            AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-          Action: 'kms:*'
+            AWS: '*'
+          Action: kms:*
           Resource: '*'
       EnableKeyRotation: true

--- a/tests/cloudformation/checks/resource/aws/example_KMSKeyWildCardPrincipal/KMSKeyWildCardPrincipal-FAILED-Wildcard.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_KMSKeyWildCardPrincipal/KMSKeyWildCardPrincipal-FAILED-Wildcard.yaml
@@ -8,10 +8,9 @@ Resources:
         Version: '2012-10-17'
         Id: key-default-1
         Statement:
-        - Sid: Enable IAM User Permissions
+        - Sid: Enable Permissions for Everyone
           Effect: Allow
-          Principal:
-            AWS: '*'
-          Action: kms:*
+          Principal: '*'
+          Action: 'kms:*'
           Resource: '*'
       EnableKeyRotation: true

--- a/tests/cloudformation/checks/resource/aws/example_KMSKeyWildCardPrincipal/KMSKeyWildCardPrincipal-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_KMSKeyWildCardPrincipal/KMSKeyWildCardPrincipal-FAILED.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: KMS key example template
+Resources:
+  myKey:
+    Type: AWS::KMS::Key
+    Properties:
+      KeyPolicy:
+        Version: '2012-10-17'
+        Id: key-default-1
+        Statement:
+        - Sid: Enable IAM User Permissions
+          Effect: Allow
+          Principal:
+            AWS: '*'
+          Action: kms:*
+          Resource: '*'
+      EnableKeyRotation: true

--- a/tests/cloudformation/checks/resource/aws/example_KMSKeyWildCardPrincipal/KMSKeyWildCardPrincipal-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_KMSKeyWildCardPrincipal/KMSKeyWildCardPrincipal-PASSED.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: KMS key example template
+Resources:
+  myKey:
+    Type: AWS::KMS::Key
+    Properties:
+      KeyPolicy:
+        Version: '2012-10-17'
+        Id: key-default-1
+        Statement:
+        - Sid: Enable IAM User Permissions
+          Effect: Allow
+          Principal:
+            AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+          Action: kms:*
+          Resource: '*'
+      EnableKeyRotation: true

--- a/tests/cloudformation/checks/resource/aws/test_KMSKeyWildCardPrincipal.py
+++ b/tests/cloudformation/checks/resource/aws/test_KMSKeyWildCardPrincipal.py
@@ -17,7 +17,7 @@ class TestKMSKeyWildCardPrincipal(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/cloudformation/checks/resource/aws/test_KMSKeyWildCardPrincipal.py
+++ b/tests/cloudformation/checks/resource/aws/test_KMSKeyWildCardPrincipal.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.KMSKeyWildCardPrincipal import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestKMSKeyWildCardPrincipal(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_KMSKeyWildCardPrincipal"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi everyone,
I implemented this check as I believe this should be a security best practice - not to allow wildcard principal on KMS Key policies.

This check tackles both cases with `"Principal": "*"` and `"Principal": {"AWS": "*"}` which should be considered dangerous, and tests are handling both implementations.

More information can be found on the AWS documentation here:
https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
