### PR TITLE
Report results, Align with AutoDevOps

### DIFF
--- a/docs/4.Integrations/gitlab.md
+++ b/docs/4.Integrations/gitlab.md
@@ -9,17 +9,37 @@ Add a new job in the `.gitlab-ci.yml` file in your repository as part of whichev
 Here is a minimalistic example:
 ```yaml
 stages:
-    - validate
+    - test
+variables: 
+  ALLOWFAILURE: true #True for AutoDevOps compatibility
 
 checkov:
+  stage: test
+  allow_failure: $ALLOWFAILURE
   image:
     name: bridgecrew/checkov:latest
     entrypoint:
       - '/usr/bin/env'
       - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-  stage: validate
+  rules:
+    - if: $SAST_DISABLED
+      when: never
+    - if: $CI_COMMIT_BRANCH
+      exists:
+      - '**/*.yml'
+      - '**/*.yaml'
+      - '**/*.json'
+      - '**/*.template'
+      - '**/*.tf'      
+      - '**/serverless.yml'
+      - '**/serverless.yaml'
   script:
-    - checkov -d .
+    - checkov -d . -o junitxml | tee checkov.test.xml
+  artifacts:
+    reports:
+      junit: "checkov.test.xml"
+    paths:
+      - "checkov.test.xml"
 ```
 
 ## Example Results
@@ -34,6 +54,8 @@ For example, I have an S3 bucket that does not have versioning enabled. Checkov 
 
 This will comment on an associated merge request or fail the build depending on the context.
 
+GitLab will collect the results into the normal unit testing area of the pipeline and/or the merge request.
+
 ### Pipeline Success
 
 Once I have corrected the configuration, checkov verifies that all is well.
@@ -45,21 +67,42 @@ Once I have corrected the configuration, checkov verifies that all is well.
 Note that in the above examples the output of the test results does not display colors. This is because GitLab Runner runs without an interactive TTY. Although checkov does not currently support an environment variable to force colored output, the `script` command can be used to emulate `tty` so colors are displayed:
 ```yaml
 stages:
-    - validate
+    - test
+variables: 
+  ALLOWFAILURE: true #True for AutoDevOps compatibility
 
 checkov:
+  stage: test
+  allow_failure: $ALLOWFAILURE
   image:
     name: bridgecrew/checkov:latest
     entrypoint:
       - '/usr/bin/env'
       - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-  stage: validate
+  rules:
+    - if: $SAST_DISABLED
+      when: never
+    - if: $CI_COMMIT_BRANCH
+      exists:
+      - '**/*.yml'
+      - '**/*.yaml'
+      - '**/*.json'
+      - '**/*.template'
+      - '**/*.tf'      
+      - '**/serverless.yml'
+      - '**/serverless.yaml'
   script:
     # Use `script` to emulate `tty` for colored output.
     - script -q -c 'checkov -d . ; echo $? > CKVEXIT'
     - exit $(cat CKVEXIT)
+  artifacts:
+    reports:
+      junit: "checkov.test.xml"
+    paths:
+      - "checkov.test.xml"
 ```
 
 ## Further Reading
 
 See the [GitLab CI documentation](https://docs.gitlab.com/ee/ci/) for additional information.
+The there is also a working example of using GitLab CI with Checkov here: https://gitlab.com/guided-explorations/ci-cd-plugin-extensions/checkov-iac-sast - this example also shows how to use the same checkov yaml as an includable extension so that all your jobs reuse the same job definition.


### PR DESCRIPTION
I have prepared a GitLab CI file that aligns with GitLab AutoDevOps a bit better as well as collects the junit output into the built-in Junit results display.

You could have your results placed in the GitLab Security Findings Consoles and Merge Requests, if you were able to provide an additional JSON output in the following documented format for security specific integrations: https://docs.gitlab.com/ee/user/application_security/sast/#reports-json-format

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

FYI I am a GitLab Solutions Architect and enjoy making CI CD extensions for it - let me know if there are any other ways I can help.