### PR TITLE
Cache failed external modules

### DIFF
--- a/checkov/terraform/module_loading/content.py
+++ b/checkov/terraform/module_loading/content.py
@@ -3,9 +3,10 @@ from typing import Optional, Union
 
 
 class ModuleContent(object):
-    def __init__(self, dir: Optional[Union[tempfile.TemporaryDirectory, str]], next_url=None, exception=None) -> None:
+    def __init__(self, dir: Optional[Union[tempfile.TemporaryDirectory, str]], next_url=None, failed_url=None) -> None:
         self.dir = dir.replace('//', '/') if dir else None
         self.next_url = next_url
+        self.failed_url = failed_url
 
     def loaded(self) -> bool:
         """

--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -15,7 +15,7 @@ class GenericGitLoader(ModuleLoader):
         try:
             module_source = self.module_source.lstrip('git::')
             if module_source.startswith('ssh:'):
-                return ModuleContent(dir=None)
+                return ModuleContent(dir=None, failed_url=self.module_source)
             git_getter = GitGetter(module_source, create_clone_and_result_dirs=False)
             git_getter.temp_dir = self.dest_dir
             git_getter.do_get()
@@ -25,7 +25,7 @@ class GenericGitLoader(ModuleLoader):
             return ModuleContent(dir=return_dir)
         except Exception as e:
             self.logger.error(f'failed to get {self.module_source} because of {e}')
-            return ModuleContent(dir=None)
+            return ModuleContent(dir=None, failed_url=self.module_source)
 
 
 loader = GenericGitLoader()

--- a/checkov/terraform/module_loading/registry.py
+++ b/checkov/terraform/module_loading/registry.py
@@ -13,6 +13,7 @@ class ModuleLoaderRegistry:
         self.logger = logging.getLogger(__name__)
         self.download_external_modules = download_external_modules
         self.external_modules_folder_name = external_modules_folder_name
+        self.failed_urls_cache = set()
 
     def load(self, current_dir: str, source: str, source_version: Optional[str]) -> ModuleContent:
         """
@@ -26,6 +27,8 @@ information, see `loader.ModuleLoader.load`.
         while next_url:
             source = next_url
             next_url = ''
+            if source in self.failed_urls_cache:
+                break
             for loader in self.loaders:
                 if not self.download_external_modules and loader.is_external:
                     continue
@@ -43,6 +46,8 @@ information, see `loader.ModuleLoader.load`.
                 if content is None:
                     continue
                 elif not content.loaded():
+                    if content.failed_url:
+                        self.failed_urls_cache.add(content.failed_url)
                     content.cleanup()
                     continue
                 else:


### PR DESCRIPTION
Created a cache for failed external modules clone urls to avoid trying to clone them multiple times.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
