### PR TITLE
update GCP DNSSEC check to skip private zones

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleCloudDNSSECEnabled.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudDNSSECEnabled.py
@@ -1,5 +1,5 @@
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class GoogleCloudDNSSECEnabled(BaseResourceValueCheck):
@@ -14,6 +14,15 @@ class GoogleCloudDNSSECEnabled(BaseResourceValueCheck):
         supported_resources = ["google_dns_managed_zone"]
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+
+        if 'visibility' in conf:
+            if conf['visibility'][0] == 'private':
+                return CheckResult.UNKNOWN  # check is irrelevant (cannot set DNSSEC to anything else)
+
+        # default visibility is public; just use base class implementation
+        return super().scan_resource_conf(conf)
 
     def get_inspected_key(self):
         return "dnssec_config/[0]/state"

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudDNSSECEnabled.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudDNSSECEnabled.py
@@ -1,7 +1,10 @@
+import os
 import unittest
 
 from checkov.terraform.checks.resource.gcp.GoogleCloudDNSSECEnabled import check
 from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
+from checkov.runner_filter import RunnerFilter
 
 
 class TestCloudDNSSECEnabled(unittest.TestCase):
@@ -31,6 +34,19 @@ class TestCloudDNSSECEnabled(unittest.TestCase):
                          }
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_visibility_check(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/test_GoogleCloudDNSSECEnabled"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 3)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
 
 
 if __name__ == '__main__':

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudDNSSECEnabled/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudDNSSECEnabled/main.tf
@@ -1,0 +1,96 @@
+resource "google_dns_managed_zone" "private1" {
+  # No result because visibility is private
+  name        = "zone"
+  dns_name    = "services.example.com."
+  description = "Example DNS Service Directory zone"
+
+  visibility = "private"
+
+}
+
+resource "google_dns_managed_zone" "private2" {
+  # No result because visibility is private
+  name        = "zone"
+  dns_name    = "services.example.com."
+  description = "Example DNS Service Directory zone"
+
+  visibility = "private"
+
+  dnssec_config {
+    state = "on"
+  }
+
+}
+
+resource "google_dns_managed_zone" "private3" {
+  # No result because visibility is private
+  name        = "zone"
+  dns_name    = "services.example.com."
+  description = "Example DNS Service Directory zone"
+
+  visibility = "private"
+
+  dnssec_config {
+    state = "off"
+  }
+
+}
+
+resource "google_dns_managed_zone" "pass1" {
+  # Pass because visibility is public and value is set
+  name        = "zone"
+  dns_name    = "services.example.com."
+  description = "Example DNS Service Directory zone"
+
+  visibility = "public"
+
+  dnssec_config {
+    state = "on"
+  }
+
+}
+
+resource "google_dns_managed_zone" "pass2" {
+  # Pass because visibility is public (by default) and value is set
+  name        = "zone"
+  dns_name    = "services.example.com."
+  description = "Example DNS Service Directory zone"
+
+  dnssec_config {
+    state = "on"
+  }
+
+}
+
+resource "google_dns_managed_zone" "fail1" {
+  # Fail because visibility is public and dnssec block is missing
+  name        = "zone"
+  dns_name    = "services.example.com."
+  description = "Example DNS Service Directory zone"
+
+  visibility = "public"
+
+}
+
+resource "google_dns_managed_zone" "fail2" {
+  # Fail because visibility is public and value is off
+  name        = "zone"
+  dns_name    = "services.example.com."
+  description = "Example DNS Service Directory zone"
+
+  visibility = "public"
+  dnssec_config {
+    state = "off"
+  }
+}
+
+resource "google_dns_managed_zone" "fail3" {
+  # Fail because visibility is public (by default) and value is off
+  name        = "zone"
+  dns_name    = "services.example.com."
+  description = "Example DNS Service Directory zone"
+
+  dnssec_config {
+    state = "off"
+  }
+}


### PR DESCRIPTION
The GCP DNS managed zone resource only allows the DNS SEC to be enabled on public zones. This PR updates the check to skip private zones.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
