### PR TITLE
Revert "docs: update brew install/upgrade instruction"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,9 @@ pip3 install checkov
 or using homebrew (MacOS only)
 
 ```sh
+brew tap bridgecrewio/checkov https://github.com/bridgecrewio/checkov
+brew update
 brew install checkov
-```
-
-or
-
-```sh
-brew upgrade checkov
 ```
 
 ### Configure an input folder


### PR DESCRIPTION
Main formula doesn't get updated, so reverting to managing our own formula

Reverts bridgecrewio/checkov#659