### PR TITLE
handle when json file is not a plan

### DIFF
--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -60,6 +60,8 @@ def parse_tf_plan(tf_plan_file):
     tf_defintions[tf_plan_file] = {}
     tf_defintions[tf_plan_file]['resource'] = []
     template, template_lines = parse(tf_plan_file)
+    if not template:
+        return None, None
     for resource in template.get('planned_values', {}).get("root_module", {}).get("resources", []):
         resource_block = {}
         resource_block[resource['type']] = {}

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -58,6 +58,8 @@ class Runner(BaseRunner):
             for file in files:
                 if file.endswith(".json"):
                     tf_definitions, template_lines = parse_tf_plan(file)
+                    if not tf_definitions:
+                        continue
                     self.tf_definitions = tf_definitions
                     self.template_lines = template_lines
                     self.check_tf_definition(report, runner_filter)


### PR DESCRIPTION
Fixes parsing json (e.g., for CFN), which crashes when it gets to the TF Plan runner.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
