### PR TITLE
handle off-by-one errors in CFN line range calculation

### DIFF
--- a/checkov/cloudformation/context_parser.py
+++ b/checkov/cloudformation/context_parser.py
@@ -59,11 +59,32 @@ class ContextParser(object):
             start_line = min(find_lines_result_list)
             end_line = max(list(self.find_lines(cf_resource, ENDLINE)))
 
-            entity_lines_range = [start_line, end_line - 1]
+            # start_line - 2: -1 to switch to 0-based indexing, and -1 to capture the resource name
+            entity_code_lines = self.cf_template_lines[start_line - 2: end_line - 1]
 
-            entity_code_lines = self.cf_template_lines[start_line - 1: end_line - 1]
+            # if the file did not end in a new line, and this was the last resource in the file, then we
+            # trimmed off the last line
+            if (end_line - 1) < len(self.cf_template_lines) and not self.cf_template_lines[end_line - 1][1].endswith('\n'):
+                entity_code_lines.append(self.cf_template_lines[end_line - 1])
+
+            entity_code_lines = ContextParser.trim_lines(entity_code_lines)
+            entity_lines_range = [entity_code_lines[0][0],entity_code_lines[-1][0]]
             return entity_lines_range, entity_code_lines
         return None, None
+
+    @staticmethod
+    def trim_lines(code_lines):
+        # Removes leading and trailing lines that are only whitespace, returning a new value
+        # The passed value should be a list of tuples of line numbers and line strings (entity_code_lines)
+        start = 0
+        end = len(code_lines)
+        while start < end and not code_lines[start][1].strip():
+            start += 1
+        while end > start and not code_lines[end - 1][1].strip():
+            end -= 1
+
+        # if start == end, this will just be empty
+        return code_lines[start:end]
 
     @staticmethod
     def find_lines(node, kv):

--- a/tests/cloudformation/parser/cfn_newline_at_end.yaml
+++ b/tests/cloudformation/parser/cfn_newline_at_end.yaml
@@ -1,0 +1,13 @@
+Resources:
+  MyDB:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: 'mydb'
+      DBInstanceClass: 'db.t3.micro'
+      Engine: 'mysql'
+      MasterUsername: 'master'
+      MasterUserPassword: 'password'
+  MyBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: 'hello'

--- a/tests/cloudformation/parser/cfn_nonewline_at_end.yaml
+++ b/tests/cloudformation/parser/cfn_nonewline_at_end.yaml
@@ -1,0 +1,14 @@
+Resources:
+  MyDB:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: 'mydb'
+      DBInstanceClass: 'db.t3.micro'
+      Engine: 'mysql'
+      MasterUsername: 'master'
+      MasterUserPassword: 'password'
+
+  MyBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: 'hello'

--- a/tests/cloudformation/parser/test_cfn_yaml.py
+++ b/tests/cloudformation/parser/test_cfn_yaml.py
@@ -1,8 +1,10 @@
 import os
 import unittest
 
+from checkov.cloudformation.context_parser import ContextParser
 from checkov.cloudformation.runner import Runner
 from checkov.runner_filter import RunnerFilter
+from checkov.cloudformation.parser import parse
 
 
 class TestCfnYaml(unittest.TestCase):
@@ -18,6 +20,104 @@ class TestCfnYaml(unittest.TestCase):
         self.assertEqual(summary['failed'], 0)
         self.assertEqual(summary['skipped'], 1)
         self.assertEqual(summary['parsing_errors'], 0)
+
+    def test_code_line_extraction(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        # the test data that we'll evaluate against
+        # line ranges are 1-based
+        # mapping is file name, to resource index, to resource details
+        # checking the resource index helps make sure that we are testing what we think we are testing
+        files = [f'{current_dir}/cfn_newline_at_end.yaml', f'{current_dir}/cfn_nonewline_at_end.yaml']
+        resource_properties_mapping = {
+            files[0]: {
+                0: {
+                    'name': 'MyDB',
+                    'line_range': [2, 9]
+                },
+                1: {
+                    'name': 'MyBucket',
+                    'line_range': [10, 13]
+                }
+            },
+            files[1]: {
+                0: {
+                    'name': 'MyDB',
+                    'line_range': [2, 9]
+                },
+                1: {
+                    'name': 'MyBucket',
+                    'line_range': [11, 14]
+                }
+            }
+        }
+
+        for file in files:
+            cfn_dict, cfn_str = parse(file)
+
+            cf_context_parser = ContextParser(file, cfn_dict, cfn_str)
+
+            for index, (resource_name, resource) in enumerate(cfn_dict['Resources'].items()):
+                # this filters out __startline__ and __endline__ markers
+                resource_id = cf_context_parser.extract_cf_resource_id(resource, resource_name)
+                if resource_id:
+                    # make sure we are checking the right resource
+                    self.assertEqual(resource_name, resource_properties_mapping[file][index]['name'])
+
+                    entity_lines_range, entity_code_lines = cf_context_parser.extract_cf_resource_code_lines(resource)
+                    self.assertEqual(entity_lines_range[0], entity_code_lines[0][0])
+                    self.assertEqual(entity_lines_range[1], entity_code_lines[-1][0])
+                    self.assertEqual(entity_lines_range, resource_properties_mapping[file][index]['line_range'])
+
+    def test_trim_lines(self):
+        # trim from front
+        test1 = [
+            (0, '\n'),
+            (1, ''),
+            (2, ' here is text'),
+            (3, 'more text')
+        ]
+
+        self.assertEqual(ContextParser.trim_lines(test1), test1[2:4])
+
+        # trim from back
+        test2 = [
+            (0, ' here is text'),
+            (1, 'more text'),
+            (2, '\n'),
+            (3, ''),
+        ]
+
+        self.assertEqual(ContextParser.trim_lines(test2), test2[0:2])
+
+        # trim from both
+        test3 = [
+            (0, '\n'),
+            (1, ''),
+            (2, ' here is text'),
+            (3, 'more text'),
+            (4, '\n'),
+            (5, ''),
+        ]
+
+        self.assertEqual(ContextParser.trim_lines(test3), test3[2:4])
+
+        # trim nothing
+        test4 = [
+            (2, ' here is text'),
+            (3, 'more text'),
+        ]
+
+        self.assertEqual(ContextParser.trim_lines(test4), test4)
+
+        # trim everything
+        test5 = [
+            (2, ''),
+            (3, '\n'),
+        ]
+
+        self.assertEqual(ContextParser.trim_lines(test5), [])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR changes the file line range to include the resource name in the output for CFN yaml files.

Before:
```
		11 |     Type: 'AWS::S3::Bucket'
		12 |     Properties:
		13 |       BucketName: 'hello'
```

After:
```
		10 |   MyBucket:
		11 |     Type: 'AWS::S3::Bucket'
		12 |     Properties:
		13 |       BucketName: 'hello'
```

It also handles the case when there is not a newline at the end of a file, which caused the last line of a resource to be truncated.

It *also* handles blank lines between resources.

Finally, it adds tests for these cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
