### PR TITLE
Allow dependabot to check github actions weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This allows dependabot to check github actions weekly and submit PRs with version bumps.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
