### PR TITLE
MSK checks not pulling in nested values correctly

### DIFF
--- a/checkov/terraform/checks/resource/aws/MSKClusterEncryption.py
+++ b/checkov/terraform/checks/resource/aws/MSKClusterEncryption.py
@@ -17,7 +17,7 @@ class MSKClusterEncryption(BaseResourceCheck):
                 if 'encryption_in_transit' in encryption:
                     transit = encryption['encryption_in_transit'][0]
                     if 'client_broker' in transit and transit['client_broker'][0] != 'TLS' or \
-                            'in_cluster' in transit and transit['in_cluster'] is False:
+                            'in_cluster' in transit and transit['in_cluster'][0] is False:
                         return CheckResult.FAILED
                     return CheckResult.PASSED
                 return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/aws/MSKClusterEncryption.py
+++ b/checkov/terraform/checks/resource/aws/MSKClusterEncryption.py
@@ -16,7 +16,7 @@ class MSKClusterEncryption(BaseResourceCheck):
             if 'encryption_at_rest_kms_key_arn' in encryption:
                 if 'encryption_in_transit' in encryption:
                     transit = encryption['encryption_in_transit'][0]
-                    if 'client_broker' in transit and transit['client_broker'] != 'TLS' or \
+                    if 'client_broker' in transit and transit['client_broker'][0] != 'TLS' or \
                             'in_cluster' in transit and transit['in_cluster'] is False:
                         return CheckResult.FAILED
                     return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/aws/MSKClusterLogging.py
+++ b/checkov/terraform/checks/resource/aws/MSKClusterLogging.py
@@ -15,7 +15,7 @@ class MSKClusterLogging(BaseResourceCheck):
             logging = conf['logging_info'][0]['broker_logs'][0]
             types = ["cloudwatch_logs", "firehose", "s3"]
             for x in types:
-                if x in logging and logging[x][0]['enabled'] is True:
+                if x in logging and logging[x][0]['enabled'][0] is True:
                     return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/tests/terraform/checks/resource/aws/test_MSKClusterEncryption.py
+++ b/tests/terraform/checks/resource/aws/test_MSKClusterEncryption.py
@@ -20,8 +20,8 @@ class TestMSKClusterEncryption(unittest.TestCase):
                 {
                     "encryption_in_transit": [
                         {
-                            "client_broker": "TLS",
-                            "in_cluster": "true",
+                            "client_broker": ["TLS"],
+                            "in_cluster": ["true"],
                         }
                     ],
                 }
@@ -38,8 +38,8 @@ class TestMSKClusterEncryption(unittest.TestCase):
                     "encryption_at_rest_kms_key_arn": "aws_kms_key.kms.arn",
                     "encryption_in_transit": [
                         {
-                            "client_broker": "PLAINTEXT",
-                            "in_cluster": "true",
+                            "client_broker": ["PLAINTEXT"],
+                            "in_cluster": ["true"],
                         }
                     ],
                 }
@@ -53,11 +53,11 @@ class TestMSKClusterEncryption(unittest.TestCase):
             "name": "test-project",
             "encryption_info": [
                 {
-                    "encryption_at_rest_kms_key_arn": "aws_kms_key.kms.arn",
+                    "encryption_at_rest_kms_key_arn": ["aws_kms_key.kms.arn"],
                     "encryption_in_transit": [
                         {
-                            "client_broker": "TLS",
-                            "in_cluster": False,
+                            "client_broker": ["TLS"],
+                            "in_cluster": [False],
                         }
                     ],
                 }
@@ -71,11 +71,11 @@ class TestMSKClusterEncryption(unittest.TestCase):
             "name": "test-project",
             "encryption_info": [
                 {
-                    "encryption_at_rest_kms_key_arn": "aws_kms_key.kms.arn",
+                    "encryption_at_rest_kms_key_arn": ["aws_kms_key.kms.arn"],
                     "encryption_in_transit": [
                         {
-                            "client_broker": "TLS",
-                            "in_cluster": "true",
+                            "client_broker": ["TLS"],
+                            "in_cluster": ["true"],
                         }
                     ],
                 }
@@ -89,7 +89,7 @@ class TestMSKClusterEncryption(unittest.TestCase):
             "name": "test-project",
             "encryption_info": [
                 {
-                    "encryption_at_rest_kms_key_arn": "aws_kms_key.kms.arn",
+                    "encryption_at_rest_kms_key_arn": ["aws_kms_key.kms.arn"],
                 }
             ],
         }

--- a/tests/terraform/checks/resource/aws/test_MSKClusterLogging.py
+++ b/tests/terraform/checks/resource/aws/test_MSKClusterLogging.py
@@ -15,7 +15,7 @@ class TestMSKClusterLogging(unittest.TestCase):
                         {
                             "cloudwatch_logs": [
                                 {
-                                    "enabled": False,
+                                    "enabled": [False],
                                 }
                             ],
                         }
@@ -42,7 +42,7 @@ class TestMSKClusterLogging(unittest.TestCase):
                         {
                             "cloudwatch_logs": [
                                 {
-                                    "enabled": True,
+                                    "enabled": [True],
                                 }
                             ],
                         }
@@ -62,21 +62,21 @@ class TestMSKClusterLogging(unittest.TestCase):
                         {
                             "cloudwatch_logs": [
                                 {
-                                    "enabled": True,
+                                    "enabled": [True],
                                 }
                             ],
                         },
                         {
                             "firehose": [
                                 {
-                                    "enabled": True,
+                                    "enabled": [True],
                                 }
                             ],
                         },
                         {
                             "s3": [
                                 {
-                                    "enabled": True,
+                                    "enabled": [True],
                                 }
                             ],
                         }
@@ -96,21 +96,21 @@ class TestMSKClusterLogging(unittest.TestCase):
                         {
                             "cloudwatch_logs": [
                                 {
-                                    "enabled": True,
+                                    "enabled": [True],
                                 }
                             ],
                         },
                         {
                             "firehose": [
                                 {
-                                    "enabled": True,
+                                    "enabled": [True],
                                 }
                             ],
                         },
                         {
                             "s3": [
                                 {
-                                    "enabled": False,
+                                    "enabled": [False],
                                 }
                             ],
                         }


### PR DESCRIPTION
We have had to customize these checks for our environment so I figured I would send them back upstream.

The objects for MSK are nested one level further than is currently being read in the checks.  Here are some examples of the objects as checkov sees them:

cloudwatch_logging: 
```
{'cloudwatch_logs': [{'enabled': [True], 'log_group': ['${aws_cloudwatch_log_group.msk[0].name}']}]}
```

encryption:
```
{'encryption_at_rest_kms_key_arn': ['${var.kms_key_id == "" ? module.kms.arn : var.kms_key_id}'], 'encryption_in_transit': [{'client_broker': ['TLS'], 'in_cluster': [True]}]}
```

As you can see from the data objects above, we need an additional `[0]` in order for the values to be compared properly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.