### PR TITLE
Explicitly scan only k8s when running with k8s docker

### DIFF
--- a/kubernetes/run_checkov.sh
+++ b/kubernetes/run_checkov.sh
@@ -41,8 +41,8 @@ if [ -f /etc/checkov/apikey ]; then
     repoid="runtime/unknown"
   fi
 
-  checkov -s -d /data --bc-api-key "$apikey" --repo-id "$repoid" --branch runtime
+  checkov -s -d /data --bc-api-key "$apikey" --repo-id "$repoid" --branch runtime --framework kubernetes
 else
-  checkov -s -d /data
+  checkov -s -d /data --framework kubernetes
 fi
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
