### PR TITLE
chore(ci): use python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: 
+on:
   push:
     branches:
     - master
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - uses: dschep/install-pipenv-action@v1
       - name: Build & install checkov package
         run: |
@@ -56,10 +56,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.9
       - uses: dschep/install-pipenv-action@v1
       - name: Install dependencies
         run: |
@@ -114,10 +114,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.9
       - uses: dschep/install-pipenv-action@v1
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+      - name: setup pyenv
+        uses: gabrielfalcao/pyenv-action@v5
         with:
-          python-version: 3.9
+            default: 3.9.1
       - uses: dschep/install-pipenv-action@v1
       - name: Install dependencies
         run: |
@@ -114,10 +114,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+      - name: setup pyenv
+        uses: gabrielfalcao/pyenv-action@v5
         with:
-          python-version: 3.9
+            default: 3.9.1
       - uses: dschep/install-pipenv-action@v1
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: setup pyenv
-        uses: gabrielfalcao/pyenv-action@v5
+        uses: gabrielfalcao/pyenv-action@v7
         with:
             default: 3.9.1
       - uses: dschep/install-pipenv-action@v1
@@ -115,7 +115,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: setup pyenv
-        uses: gabrielfalcao/pyenv-action@v5
+        uses: gabrielfalcao/pyenv-action@v7
         with:
             default: 3.9.1
       - uses: dschep/install-pipenv-action@v1

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,9 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: setup pyenv
+        uses: gabrielfalcao/pyenv-action@v5
         with:
-          python-version: 3.9
+            default: 3.9.1
       - name: Install cfn-lint
         run: |
           pip install cfn-lint==0.41.0
@@ -21,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+      - name: setup pyenv
+        uses: gabrielfalcao/pyenv-action@v5
         with:
-          python-version: 3.9
+            default: 3.9.1
       - uses: dschep/install-pipenv-action@v1
       - name: Install dependencies
         run: |
@@ -41,9 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: setup pyenv
+        uses: gabrielfalcao/pyenv-action@v5
         with:
-          python-version: 3.9
+            default: 3.9.1
       - uses: dschep/install-pipenv-action@v1
       - name: Build & install checkov package
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: setup pyenv
-        uses: gabrielfalcao/pyenv-action@v5
+        uses: gabrielfalcao/pyenv-action@v7
         with:
             default: 3.9.1
       - name: Install cfn-lint
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: setup pyenv
-        uses: gabrielfalcao/pyenv-action@v5
+        uses: gabrielfalcao/pyenv-action@v7
         with:
             default: 3.9.1
       - uses: dschep/install-pipenv-action@v1
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: setup pyenv
-        uses: gabrielfalcao/pyenv-action@v5
+        uses: gabrielfalcao/pyenv-action@v7
         with:
             default: 3.9.1
       - uses: dschep/install-pipenv-action@v1

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install cfn-lint
         run: |
           pip install cfn-lint==0.41.0
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - uses: dschep/install-pipenv-action@v1
       - name: Install dependencies
         run: |
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - uses: dschep/install-pipenv-action@v1
       - name: Build & install checkov package
         run: |
@@ -83,6 +83,3 @@ jobs:
       - name: Run integration tests
         run: |
           pipenv run pytest integration_tests
-
-
-

--- a/Pipfile
+++ b/Pipfile
@@ -37,4 +37,4 @@ semantic_version = "*"
 packaging = "*"
 
 [requires]
-python_version = "3.7"
+python_version = ">=3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d48bdf7be0ef344ff37e353cabbe325ea4f276dbdb48bf53dcc981bebae5ae5b"
+            "sha256": "e644a16aa1b8b9f343ae82e30ebde4c6e39e9623aad598b4b4c1a2f5f53bd941"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": ">=3.7"
         },
         "sources": [
             {
@@ -26,19 +26,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:3a8412020a59509e783755b5c9b910a4fc7f6b6f2b9473e7cd1e07b67672e0d1",
-                "sha256:877f204dabe1bfa21aa9cfaacc72bd4b70a897d0fdcea799afa5c4743b6fc7ac"
+                "sha256:1709ff5feb363fee7fcaa2330e659fcbc2b4c03a14f75a884ed682ee66011fc4",
+                "sha256:80a761eff3b1cb0798d7e1a41b7c8e6d85c9647a8f7b6105335201a69404caa2"
             ],
             "index": "pypi",
-            "version": "==1.17.9"
+            "version": "==1.17.10"
         },
         "botocore": {
             "hashes": [
-                "sha256:c8614c230e7a8e042a8c07d47caea50ad21cb51415289bd34fa6d0382beddad7",
-                "sha256:d725840b881be62fc52e8e24a6ada651128cf7f1ed1639b87322a7a213ffdbad"
+                "sha256:8c84eac6daf38890714e005623083106d68e9b2088e62132fdbf7d2b1228ecbd",
+                "sha256:a601ee5a4ae66832f328ca362b5404d22b75f1c181f6cc0934f3cfca749eb27d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.9"
+            "version": "==1.20.10"
         },
         "certifi": {
             "hashes": [
@@ -423,14 +423,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771",
-                "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==3.4.0"
-        },
         "iniconfig": {
             "hashes": [
                 "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
@@ -712,15 +704,6 @@
             ],
             "version": "==1.4.2"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
-                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
-                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==3.7.4.3"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80",
@@ -752,14 +735,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.36.2"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
-                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==3.4.0"
         }
     }
 }

--- a/docs/4.Integrations/github-actions.md
+++ b/docs/4.Integrations/github-actions.md
@@ -30,16 +30,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Test with Checkov
         id: checkov
         uses: bridgecrewio/checkov-action@master
         with:
           directory: example/examplea
-          framework: terraform 
+          framework: terraform
 ```
 
 ## Example Results


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

The formulae is buildable with [python 3.9](https://github.com/Homebrew/homebrew-core/pull/67440), hence update the CI to pointing to the latest version.
