### PR TITLE
Feature: Skip Pattern check

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ Run all checks except 1 specified:
 checkov -d . --skip-check CKV_AWS_52
 ```
 
+Run all checks except specified patterns:
+```sh
+checkov -d . --skip-pattern CKV_AWS*
+```
+
 For Kubernetes workloads, you can also use allow/deny namespaces.  For example, do not report any results for the 
 kube-system namespace:
 ```sh

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -33,6 +33,7 @@ def run(banner=checkov_banner):
     add_parser_args(parser)
     args = parser.parse_args()
     runner_filter = RunnerFilter(framework=args.framework, checks=args.check, skip_checks=args.skip_check,
+                                 skip_pattern=args.skip_pattern,
                                  download_external_modules=convert_str_to_bool(args.download_external_modules),
                                  external_modules_download_path=args.external_modules_download_path,
                                  evaluate_variables=convert_str_to_bool(args.evaluate_variables))
@@ -59,6 +60,8 @@ def run(banner=checkov_banner):
     if args.check and args.skip_check:
         parser.error("--check and --skip-check can not be applied together. please use only one of them")
         return
+    if args.skip_check and args.skip_pattern or args.skip_pattern and args.check:
+        parser.error("--skip-check and --skip-pattern can not be applied together. please use only on of them")
     if args.list:
         print_checks(framework=args.framework)
         return
@@ -122,6 +125,9 @@ def add_parser_args(parser):
     parser.add_argument('--skip-check',
                         help='filter scan to run on all check but a specific check identifier(denylist), You can '
                              'specify multiple checks separated by comma delimiter', default=None)
+    parser.add_argument('--skip-pattern',
+                        help='filter scan to run on all check but a specific check pattern(denylist), You can '
+                             'specify multiple checks using a pattern (eg. CKV_AWS* to skeep all aws checks)', default=None)
     parser.add_argument('-s', '--soft-fail',
                         help='Runs checks but suppresses error code', action='store_true')
     parser.add_argument('--bc-api-key', help='Bridgecrew API key')

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -1,3 +1,4 @@
+import fnmatch
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 
 
@@ -7,7 +8,7 @@ class RunnerFilter(object):
     #       logically a "static" concept anyway, so this makes logical sense.
     __EXTERNAL_CHECK_IDS = set()
 
-    def __init__(self, framework='all', checks=None, skip_checks=None, download_external_modules=False, external_modules_download_path=DEFAULT_EXTERNAL_MODULES_DIR, evaluate_variables=True):
+    def __init__(self, framework='all', checks=None, skip_checks=None, skip_pattern=None, download_external_modules=False, external_modules_download_path=DEFAULT_EXTERNAL_MODULES_DIR, evaluate_variables=True):
         if checks is None:
             checks = []
         if isinstance(checks, str):
@@ -21,6 +22,11 @@ class RunnerFilter(object):
             self.skip_checks = skip_checks.split(",")
         else:
             self.skip_checks = skip_checks
+        if skip_pattern is None:
+            self.skip_pattern = []
+        else:
+            self.skip_pattern = skip_pattern
+
         self.framework = framework
         self.download_external_modules = download_external_modules
         self.external_modules_download_path = external_modules_download_path
@@ -36,6 +42,9 @@ class RunnerFilter(object):
                 return False
         if self.skip_checks and check_id in self.skip_checks:
             return False
+        elif self.skip_pattern:
+            if fnmatch.fnmatch(check_id, self.skip_pattern):
+                return False
         return True
 
     @staticmethod


### PR DESCRIPTION
Add a feature to sip checks using a pattern (eg --skip-pattern CKV_AWS* to skip all aws check). 
Useful when using custom policy to skip others checks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
