### PR TITLE
skip check using pattern (wildcards)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ Run all checks except 1 specified:
 checkov -d . --skip-check CKV_AWS_52
 ```
 
+Run all checks except checks with specified patterns:
+```sh
+checkov -d . --skip-check CKV_AWS*
+```
+
 For Kubernetes workloads, you can also use allow/deny namespaces.  For example, do not report any results for the 
 kube-system namespace:
 ```sh

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -1,3 +1,4 @@
+import fnmatch
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 
 
@@ -34,7 +35,7 @@ class RunnerFilter(object):
                 return True
             else:
                 return False
-        if self.skip_checks and check_id in self.skip_checks:
+        if self.skip_checks and any(fnmatch.fnmatch(check_id, pattern) for pattern in self.skip_checks):
             return False
         return True
 

--- a/tests/common/test_runner_filter.py
+++ b/tests/common/test_runner_filter.py
@@ -60,6 +60,23 @@ class TestRunnerFilter(unittest.TestCase):
     def test_should_run_specific_disable_AND_enable(self):
         instance = RunnerFilter(checks=["CHECK_1"], skip_checks=["CHECK_1"])
         self.assertTrue(instance.should_run_check("CHECK_1"))
+    
+    def test_should_run_omitted_wildcard(self):
+        instance = RunnerFilter(skip_checks=["CHECK_AWS*"])
+        self.assertTrue(instance.should_run_check("CHECK_999"))
+    
+    def test_should_run_omitted_wildcard2(self):
+        instance = RunnerFilter(skip_checks=["CHECK_AWS*"])
+        self.assertFalse(instance.should_run_check("CHECK_AWS_909"))    
+    
+    def test_should_run_omitted_wildcard3(self):
+        instance = RunnerFilter(skip_checks=["CHECK_AWS*","CHECK_AZURE*"])
+        self.assertTrue(instance.should_run_check("EXT_CHECK_909")) 
+
+    def test_should_run_omitted_wildcard4(self):
+        instance = RunnerFilter(skip_checks=["CHECK_AWS*","CHECK_AZURE_01"])
+        self.assertFalse(instance.should_run_check("CHECK_AZURE_01"))        
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add the ability to skip check using a pattern. (eg --skip-check CKV_AWS* to skip all aws check).
You can also use a deny list (--skip-check ) like before but with wildcards now like this --skip-check CKV_AWS*,CKV_AZURE*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
