### PR TITLE
Handle empty azure storage configuration

### DIFF
--- a/checkov/terraform/checks/resource/azure/StorageAccountName.py
+++ b/checkov/terraform/checks/resource/azure/StorageAccountName.py
@@ -21,7 +21,7 @@ class StorageAccountName(BaseResourceCheck):
         :param conf: azurerm_storage_account configuration
         :return: <CheckResult>
         """
-        return CheckResult.PASSED if re.match(STO_NAME_REGEX, conf['name'][0]) else CheckResult.FAILED
+        return CheckResult.PASSED if conf.get('name') and re.match(STO_NAME_REGEX, conf['name'][0]) else CheckResult.FAILED
 
 
 check = StorageAccountName()

--- a/tests/terraform/checks/resource/azure/test_StorageAccountName.py
+++ b/tests/terraform/checks/resource/azure/test_StorageAccountName.py
@@ -64,6 +64,15 @@ class TestAzureStorageAccountNamingRule(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_failure_empty_configuration(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_storage_account" "example" {
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
check for the name field to exist, in case an empty configuration is scanned

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
