### PR TITLE
fix - tfplan - rare - data block with partial values scanned to cause false negatives

### DIFF
--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -49,6 +49,25 @@ def _hclify(obj):
             ret_dict[key] = [child_dict]
     return ret_dict
 
+def _prepare_resource_block(resource):
+    """
+    hclify resource if pre-conditions met.
+    :type: resource: dict: tf resource block
+    :rtype: resource_block: dict: hclifyed if conditions met
+    :rtype: prepared: boolean: whether conditions met to prepare data
+    """
+    resource_block = {}
+    resource_block[resource['type']] = {}
+    prepared = False
+    mode = ""
+    if 'mode' in resource:
+        mode = resource.get("mode")
+    # Rare cases where data block has same name as a resource block and so the scan becomes invalid
+    # and where *_module resources don't have values field
+    if mode == "managed" and 'values' in resource:
+        resource_block[resource['type']][resource.get("name", "default")] = _hclify(resource['values'])
+        prepared = True
+    return resource_block, prepared
 
 def _find_child_modules(child_modules):
     """
@@ -64,10 +83,8 @@ def _find_child_modules(child_modules):
             for resource in nested_blocks:
                 resource_blocks.append(resource)
         for resource in child_module.get("resources", []):
-            resource_block = {}
-            resource_block[resource['type']] = {}
-            if 'values' in resource: # rare cases where child_module resources don't have values field
-                resource_block[resource['type']][resource.get('name', "default")] = _hclify(resource['values'])
+            resource_block, prepared = _prepare_resource_block(resource)
+            if prepared is True:
                 resource_blocks.append(resource_block)
     return resource_blocks
 
@@ -84,10 +101,8 @@ def parse_tf_plan(tf_plan_file):
     if not template:
         return None, None
     for resource in template.get('planned_values', {}).get("root_module", {}).get("resources", []):
-        resource_block = {}
-        resource_block[resource['type']] = {}
-        if 'values' in resource: # rare cases where root_module resources don't have values field
-            resource_block[resource['type']][resource.get('name', "default")] = _hclify(resource['values'])
+        resource_block, prepared = _prepare_resource_block(resource)
+        if prepared is True:
             tf_defintions[tf_plan_file]['resource'].append(resource_block)
     child_modules = template.get('planned_values', {}).get("root_module", {}).get("child_modules",[])
     # Terraform supports modules within modules so we need to search

--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -62,7 +62,7 @@ def _prepare_resource_block(resource):
     mode = ""
     if 'mode' in resource:
         mode = resource.get("mode")
-    # Rare cases where data block has same name as a resource block and so the scan becomes invalid
+    # Rare cases where data block appears in resources with same name as resource block and only partial values
     # and where *_module resources don't have values field
     if mode == "managed" and 'values' in resource:
         resource_block[resource['type']][resource.get("name", "default")] = _hclify(resource['values'])

--- a/tests/terraform/runner/resources/plan_data_resource_partial_values/tfplan.json
+++ b/tests/terraform/runner/resources/plan_data_resource_partial_values/tfplan.json
@@ -1,0 +1,236 @@
+{
+   "format_version": "0.1",
+   "terraform_version": "0.13.5",
+   "planned_values": {
+     "root_module": {
+       "child_modules": [
+         {
+           "address": "module.child",
+           "child_modules": [
+             {
+               "resources": [
+                 {
+                   "address": "module.child.module.a.aws_eks_cluster.cluster",
+                   "mode": "managed",
+                   "type": "aws_eks_cluster",
+                   "name": "cluster",
+                   "provider_name": "registry.terraform.io/hashicorp/aws",
+                   "schema_version": 0,
+                   "values": {
+                     "enabled_cluster_log_types": [
+                       "api",
+                       "audit"
+                     ],
+                     "encryption_config": [],
+                     "name": "test",
+                     "role_arn": "arn:aws:iam::123456789012:role/test",
+                     "tags": null,
+                     "timeouts": null,
+                     "vpc_config": [
+                       {
+                         "endpoint_private_access": false,
+                         "endpoint_public_access": true,
+                         "security_group_ids": null,
+                         "subnet_ids": [
+                           "10.165.77.0/24"
+                         ]
+                       }
+                     ]
+                   }
+                 }
+               ],
+               "address": "module.child.module.a"
+             },
+             {
+               "resources": [
+                 {
+                   "address": "module.child.module.b.data.aws_eks_cluster.cluster",
+                   "mode": "data",
+                   "type": "aws_eks_cluster",
+                   "name": "cluster",
+                   "provider_name": "registry.terraform.io/hashicorp/aws",
+                   "schema_version": 0,
+                   "values": {
+                     "name": "test"
+                   }
+                 }
+               ],
+               "address": "module.child.module.b"
+             }
+           ]
+         }
+       ]
+     }
+   },
+   "resource_changes": [
+     {
+       "address": "module.child.module.a.aws_eks_cluster.cluster",
+       "module_address": "module.child.module.a",
+       "mode": "managed",
+       "type": "aws_eks_cluster",
+       "name": "cluster",
+       "provider_name": "registry.terraform.io/hashicorp/aws",
+       "change": {
+         "actions": [
+           "create"
+         ],
+         "before": null,
+         "after": {
+           "enabled_cluster_log_types": [
+             "api",
+             "audit"
+           ],
+           "encryption_config": [],
+           "name": "test",
+           "role_arn": "arn:aws:iam::123456789012:role/test",
+           "tags": null,
+           "timeouts": null,
+           "vpc_config": [
+             {
+               "endpoint_private_access": false,
+               "endpoint_public_access": true,
+               "security_group_ids": null,
+               "subnet_ids": [
+                 "10.165.77.0/24"
+               ]
+             }
+           ]
+         },
+         "after_unknown": {
+           "arn": true,
+           "certificate_authority": true,
+           "created_at": true,
+           "enabled_cluster_log_types": [
+             false,
+             false
+           ],
+           "encryption_config": [],
+           "endpoint": true,
+           "id": true,
+           "identity": true,
+           "kubernetes_network_config": true,
+           "platform_version": true,
+           "status": true,
+           "version": true,
+           "vpc_config": [
+             {
+               "cluster_security_group_id": true,
+               "public_access_cidrs": true,
+               "subnet_ids": [
+                 false
+               ],
+               "vpc_id": true
+             }
+           ]
+         }
+       }
+     },
+     {
+       "address": "module.child.module.b.data.aws_eks_cluster.cluster",
+       "module_address": "module.child.module.b",
+       "mode": "data",
+       "type": "aws_eks_cluster",
+       "name": "cluster",
+       "provider_name": "registry.terraform.io/hashicorp/aws",
+       "change": {
+         "actions": [
+           "read"
+         ],
+         "before": null,
+         "after": {
+           "name": "test"
+         },
+         "after_unknown": {
+           "arn": true,
+           "certificate_authority": true,
+           "created_at": true,
+           "enabled_cluster_log_types": true,
+           "endpoint": true,
+           "id": true,
+           "identity": true,
+           "kubernetes_network_config": true,
+           "platform_version": true,
+           "role_arn": true,
+           "status": true,
+           "tags": true,
+           "version": true,
+           "vpc_config": true
+         }
+       }
+     }
+   ],
+   "configuration": {
+     "root_module": {
+       "module_calls": {
+         "child": {
+           "source": "./module",
+           "module": {
+             "module_calls": {
+               "a": {
+                 "source": "./modules/a",
+                 "module": {
+                   "resources": [
+                     {
+                       "address": "aws_eks_cluster.cluster",
+                       "mode": "managed",
+                       "type": "aws_eks_cluster",
+                       "name": "cluster",
+                       "provider_config_key": "a:aws",
+                       "expressions": {
+                         "enabled_cluster_log_types": {
+                           "constant_value": [
+                             "audit",
+                             "api"
+                           ]
+                         },
+                         "name": {
+                           "constant_value": "test"
+                         },
+                         "role_arn": {
+                           "constant_value": "arn:aws:iam::123456789012:role/test"
+                         },
+                         "vpc_config": [
+                           {
+                             "subnet_ids": {
+                               "constant_value": [
+                                 "10.165.77.0/24"
+                               ]
+                             }
+                           }
+                         ]
+                       },
+                       "schema_version": 0
+                     }
+                   ]
+                 }
+               },
+               "b": {
+                 "source": "./modules/b",
+                 "module": {
+                   "resources": [
+                     {
+                       "address": "data.aws_eks_cluster.cluster",
+                       "mode": "data",
+                       "type": "aws_eks_cluster",
+                       "name": "cluster",
+                       "provider_config_key": "b:aws",
+                       "expressions": {
+                         "name": {
+                           "constant_value": "test"
+                         }
+                       },
+                       "schema_version": 0
+                     }
+                   ]
+                 },
+                 "depends_on": [
+                   "module.a"
+                 ]
+               }
+             }
+           }
+         }
+       }
+     }
+   }
+}

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -77,6 +77,33 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.get_summary()["failed"], 4)
         self.assertEqual(report.get_summary()["passed"], 0)
 
+    def test_runner_data_resource_partial_values(self):
+        # In rare circumstances a data resource with partial values in the plan could cause false negatives
+        # Often 'data' does not even appear in the *_modules[x].resouces field within planned_values and is not scanned as expected
+        # It can occur when tf module B depends on tf module A
+        # And tf module A creates a resource that is used in a data block in tf module B
+        # So some values can be known but other are not at plan time
+        # This can cause the data block resource to be scanned as if it were a managed resource which is not configured correctly
+        # See 'Modes': https://www.terraform.io/docs/internals/json-format.html#values-representation
+        # This test verifies that such a circumstance stops occuring.
+        # There is a EKS Managed Resource and a EKS Data Resource.
+        # The EKS Managed Resource should have 4 failures corresponding with EKS checks.
+        # The EKS Data Resource should not be scanned. Previously this would cause 8 failures. 
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_plan_path = current_dir + "/resources/plan_data_resource_partial_values/tfplan.json"
+        runner = Runner()
+        report = runner.run(root_folder=None, files=[valid_plan_path], external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework='all'))
+        report_json = report.get_json()
+        self.assertTrue(isinstance(report_json, str))
+        self.assertIsNotNone(report_json)
+        self.assertIsNotNone(report.get_test_suites())
+        self.assertEqual(report.get_exit_code(soft_fail=False), 1)
+        self.assertEqual(report.get_exit_code(soft_fail=True), 0)
+
+        self.assertEqual(report.get_summary()["failed"], 4)
+        self.assertEqual(report.get_summary()["passed"], 0)
+
     def test_runner_root_dir(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         root_dir = current_dir + "/resources"
@@ -90,11 +117,11 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
         self.assertEqual(report.get_exit_code(soft_fail=True), 0)
 
-        self.assertEqual(57, report.get_summary()["failed"])
+        self.assertEqual(61, report.get_summary()["failed"])
         self.assertEqual(60, report.get_summary()["passed"])
 
         files_scanned = list(set(map(lambda rec: rec.file_path, report.failed_checks)))
-        self.assertGreaterEqual(4, len(files_scanned))
+        self.assertGreaterEqual(5, len(files_scanned))
 
 
 if __name__ == '__main__':

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -85,8 +85,8 @@ class TestRunnerValid(unittest.TestCase):
         # So some values can be known but other are not at plan time
         # This can cause the data block resource to be scanned as if it were a managed resource which is not configured correctly
         # See 'Modes': https://www.terraform.io/docs/internals/json-format.html#values-representation
-        # This test verifies that such a circumstance stops occuring.
-        # There is a EKS Managed Resource and a EKS Data Resource.
+        # This test verifies that such a circumstance stops occurring
+        # There is a EKS Managed Resource and a EKS Data Resource
         # The EKS Managed Resource should have 4 failures corresponding with EKS checks.
         # The EKS Data Resource should not be scanned. Previously this would cause 8 failures. 
         current_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Hello again,

Hopefully this will conclude the journey I have been on this week which has raised and fixed:

https://github.com/bridgecrewio/checkov/pull/760

https://github.com/bridgecrewio/checkov/pull/768

For context I am debugging so that I can include terraform plan-time scanning into a pipeline. I am working on a _big_ complex set of terraform which includes many versioned child modules at one level and makes use of the aws, helm and kubernetes providers.

**Root Cause Description**
In rare circumstances a data resource with partial values in the plan could cause false negatives. 
Often 'data' does not even appear in the *_modules[x].resouces field within planned_values and is not scanned as expected.
It can occur when tf module B depends on tf module A.
And tf module A creates a resource that is used in a data block in tf module B.
So some values can be known but other are not at plan time.
This can cause the data block resource to be scanned as if it were a managed resource which is not configured correctly.
See 'Modes': https://www.terraform.io/docs/internals/json-format.html#values-representation.

In my implementation I have also used another helper method to reduce some duplication.

Being able to properly understand and reproduce the data for testing was the challenge here. And i'm satisfied that all regression tests are passing.

**Testing**
This test verifies that such a circumstance stops occurring.
There is a EKS Managed Resource and a EKS Data Resource.
The EKS Managed Resource should have 4 failures corresponding with EKS checks.
The EKS Data Resource should not be scanned. Previously this would cause 8 failures. 

Because the specifics of this are somewhat obscure and people will not be able to intuitively understand what is going on I have been very explicit in the 'why' in terms of comments in the unit testing added. This should make it more maintainable for the future.


**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
