### PR TITLE
Fix IAM star action check - handle strings

### DIFF
--- a/checkov/terraform/checks/data/aws/StarActionPolicyDocument.py
+++ b/checkov/terraform/checks/data/aws/StarActionPolicyDocument.py
@@ -1,3 +1,4 @@
+from checkov.common.util.type_forcers import force_list
 from checkov.terraform.checks.data.base_check import BaseDataCheck
 from checkov.common.models.enums import CheckResult, CheckCategories
 
@@ -20,7 +21,7 @@ class StarActionPolicyDocument(BaseDataCheck):
         key = 'statement'
         if key in conf.keys():
             for statement in conf[key]:
-                if 'actions' in statement and '*' in statement['actions'][0] and statement.get('effect', ['Allow'])[0] == 'Allow':
+                if 'actions' in statement and '*' in force_list(statement['actions'][0]) and statement.get('effect', ['Allow'])[0] == 'Allow':
                     return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/aws/IAMStarActionPolicyDocument.py
+++ b/checkov/terraform/checks/resource/aws/IAMStarActionPolicyDocument.py
@@ -21,7 +21,7 @@ class IAMStarActionPolicyDocument(BaseResourceCheck):
                     for statement in force_list(policy_block['Statement']):
                         if 'Action' in statement and \
                                 statement.get('Effect', ['Allow']) == 'Allow' and \
-                                '*' in statement.get('Action', ['']):
+                                '*' in force_list(statement['Action']):
                             return CheckResult.FAILED
             except: # nosec
                 pass

--- a/tests/terraform/checks/resource/aws/test_IAMStarActionPolicyDocument.py
+++ b/tests/terraform/checks/resource/aws/test_IAMStarActionPolicyDocument.py
@@ -16,6 +16,16 @@ class TestAdminPolicyDocument(unittest.TestCase):
         scan_result = check.scan_entity_conf(conf=resource_conf, entity_type='aws_iam_policy')
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_success_service_star(self):
+        resource_conf = {'name': ['test'], 'user': ['${aws_iam_user.lb.name}'],
+                         'policy': ['{\n  "Version": "2012-10-17", \n  \
+                         "Statement": [\n    {\n      \
+                         "Action": "ec2:*",\n      \
+                         "Effect": "Allow",\n     \
+                          "Resource": "abc*"\n    }\n  ]\n}']}
+        scan_result = check.scan_entity_conf(conf=resource_conf, entity_type='aws_iam_policy')
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
     def test_failure(self):
         resource_conf = {'name': ['test'], 'user': ['${aws_iam_user.lb.name}'],
                          'policy': ['{\n  "Version": "2012-10-17", \n  \


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


IAM Action can be specified as a string and not a list - which means the `in` operator would search for * in a string instead of a list, missing the entire point of the check. Using force_list fixes this