### PR TITLE
Pass image tag check if digest is present

### DIFF
--- a/checkov/kubernetes/checks/ImageTagFixed.py
+++ b/checkov/kubernetes/checks/ImageTagFixed.py
@@ -26,12 +26,13 @@ class ImageTagFixed(BaseK8Check):
     def scan_spec_conf(self, conf):
         if "image" in conf:
 
-            # Remove the digest, if present
             image_val = conf["image"]
             if not isinstance(image_val, str) or image_val.strip() == '':
                 return CheckResult.UNKNOWN
+
+            # If there's a digest, then this is even better than the tag, so the check passes
             if '@' in image_val:
-                image_val = image_val[0:image_val.index('@')]
+                return CheckResult.PASSED
 
             (image, tag) = re.findall(DOCKER_IMAGE_REGEX, image_val)[0]
             if tag == "latest" or tag == "":

--- a/tests/kubernetes/checks/example_ImageTagFixed/imageWithTagAndDigest-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ImageTagFixed/imageWithTagAndDigest-PASSED.yaml
@@ -63,7 +63,7 @@ spec:
       containers:
       - name: k8skafka
         imagePullPolicy: Always
-        image: gcr.io/google_containers/kubernetes-kafka@sha256:123456
+        image: gcr.io/google_containers/kubernetes-kafka:1.0-10.2.1@sha256:123456
         resources:
           requests:
             memory: "12Gi"

--- a/tests/kubernetes/checks/test_ImageTagFixed.py
+++ b/tests/kubernetes/checks/test_ImageTagFixed.py
@@ -16,7 +16,7 @@ class TestImageTagFixed(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 3)
+        self.assertEqual(summary['passed'], 4)
         self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
Check CKV_K8S_14 (image tag should not be latest or blank) fails when a digest is specified without a tag (which is a valid way to specify it). This PR updates the check to pass if a digest is present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
