### PR TITLE
check - cf - cloudtrail multi region to correspond with tf

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/CloudtrailMultiRegion.py
+++ b/checkov/cloudformation/checks/resource/aws/CloudtrailMultiRegion.py
@@ -1,0 +1,16 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class CloudtrailMultiRegion(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure CloudTrail is enabled in all Regions"
+        id = "CKV_AWS_67"
+        supported_resources = ['AWS::CloudTrail::Trail']
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'Properties/IsMultiRegionTrail'
+
+check = CloudtrailMultiRegion()

--- a/tests/cloudformation/checks/resource/aws/example_CloudtrailMultiRegion/CloudtrailMultiRegion-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_CloudtrailMultiRegion/CloudtrailMultiRegion-FAILED.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources: 
+  MyTrail0:
+    Type: AWS::CloudTrail::Trail
+    Properties: 
+      IsLogging: True
+      IsMultiRegionTrail: False
+      S3BucketName: String
+  MyTrail1:
+    Type: AWS::CloudTrail::Trail
+    Properties: 
+      IsLogging: True
+      IsMultiRegionTrail: False
+      S3BucketName: String

--- a/tests/cloudformation/checks/resource/aws/example_CloudtrailMultiRegion/CloudtrailMultiRegion-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_CloudtrailMultiRegion/CloudtrailMultiRegion-PASSED.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources: 
+  MyTrail0:
+    Type: AWS::CloudTrail::Trail
+    Properties: 
+      IsLogging: True
+      IsMultiRegionTrail: True
+      S3BucketName: String

--- a/tests/cloudformation/checks/resource/aws/test_CloudtrailMultiRegion.py
+++ b/tests/cloudformation/checks/resource/aws/test_CloudtrailMultiRegion.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.CloudtrailMultiRegion import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestCloudtrailMultiRegion(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_CloudtrailMultiRegion"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello,

After some terraform plan related stuff last week I am back  to my quest of slowly aligning Cloudformation with Terraform checks 🙂.

This change adds in the cloudtrail multi region check.

Cloudformation Cloudtrail doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudtrail-trail.html

Terraform Check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/CloudtrailMultiRegion.py

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
