### PR TITLE
Handle tf file parsing errors

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -21,13 +21,13 @@ class Report:
         self.skipped_checks = []
         self.parsing_errors = []
 
-    def add_parsing_errors(self, files):
-        for file in files:
-            self.add_parsing_error(file)
+    def add_parsing_errors(self, errors):
+        for file in errors:
+            self.add_parsing_error(file, errors[file])
 
-    def add_parsing_error(self, file):
-        if file:
-            self.parsing_errors.append(file)
+    def add_parsing_error(self, file, error):
+        if file and error:
+            self.parsing_errors.append({file: str(error)})
 
     def add_record(self, record):
         if record.check_result['result'] == CheckResult.PASSED:
@@ -69,7 +69,7 @@ class Report:
         return 0
 
     def is_empty(self):
-        return len(self.passed_checks) + len(self.failed_checks) + len(self.skipped_checks) == 0
+        return len(self.passed_checks) + len(self.failed_checks) + len(self.skipped_checks) + len(self.parsing_errors) == 0
 
     def print_console(self, is_quiet=False):
         summary = self.get_summary()

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -19,7 +19,7 @@ class Report:
         self.passed_checks = []
         self.failed_checks = []
         self.skipped_checks = []
-        self.parsing_errors = []
+        self.parsing_errors = {}
 
     def add_parsing_errors(self, errors):
         for file in errors:
@@ -27,7 +27,7 @@ class Report:
 
     def add_parsing_error(self, file, error):
         if file and error:
-            self.parsing_errors.append({file: str(error)})
+            self.parsing_errors[file] = str(error)
 
     def add_record(self, record):
         if record.check_result['result'] == CheckResult.PASSED:
@@ -89,6 +89,14 @@ class Report:
         if not is_quiet:
             for record in self.skipped_checks:
                 print(record)
+
+        if not is_quiet:
+            for file, error in self.parsing_errors.items():
+                Report._print_parsing_error_console(file, error)
+
+    @staticmethod
+    def _print_parsing_error_console(file, error):
+        print(colored(f'Error parsing file {file}: {error}', 'red'))
 
     def print_junit_xml(self):
         ts = self.get_test_suites()

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -56,7 +56,7 @@ class Report:
                 "passed_checks": [check.__dict__ for check in self.passed_checks],
                 "failed_checks": [check.__dict__ for check in self.failed_checks],
                 "skipped_checks": [check.__dict__ for check in self.skipped_checks],
-                "parsing_errors": [check for check in self.parsing_errors]
+                "parsing_errors": self.parsing_errors
             },
             "summary": self.get_summary()
         }

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -53,7 +53,7 @@ class Runner(BaseRunner):
                 resource_registry.load_external_checks(directory, runner_filter)
         if root_folder:
             root_folder = os.path.abspath(root_folder)
-
+            
             self.parser.parse_directory(directory=root_folder,
                                         out_definitions=self.tf_definitions,
                                         out_evaluations_context=self.evaluations_context,
@@ -68,10 +68,14 @@ class Runner(BaseRunner):
             root_folder = os.path.split(os.path.commonprefix(files))[0]
             for file in files:
                 if file.endswith(".tf"):
-                    self.tf_definitions[file] = self.parser.parse_file(file=file, parsing_errors=parsing_errors)
+                    file_parsing_errors = {}
+                    self.tf_definitions[file] = self.parser.parse_file(file=file, parsing_errors=file_parsing_errors)
+                    if file_parsing_errors:
+                        parsing_errors.update(file_parsing_errors)
+                        continue
                     self.check_tf_definition(report, root_folder, runner_filter, collect_skip_comments)
 
-        report.add_parsing_errors(parsing_errors.keys())
+        report.add_parsing_errors(parsing_errors)
 
         return report
 

--- a/tests/terraform/runner/resources/invalid_terraform_syntax/bad_tf_1.tf
+++ b/tests/terraform/runner/resources/invalid_terraform_syntax/bad_tf_1.tf
@@ -1,0 +1,10 @@
+variable "okay" {
+}
+
+// such bad terraform
+variable
+  name    = "test"
+  default = "test_value"
+  type    = "string"
+}
+

--- a/tests/terraform/runner/resources/invalid_terraform_syntax/bad_tf_2.tf
+++ b/tests/terraform/runner/resources/invalid_terraform_syntax/bad_tf_2.tf
@@ -1,0 +1,10 @@
+variable "okay" {
+}
+
+// such bad terraform
+variable {
+  name
+  default = "test_value"
+  type    = "string"
+}
+

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -218,6 +218,32 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(len(result.passed_checks), 1)
         self.assertIn('module.some-module', map(lambda record: record.resource, result.passed_checks))
 
+    def test_parser_error_handled_for_directory_target(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        invalid_dir_path = os.path.join(current_dir, "resources/invalid_terraform_syntax")
+        file_names = ['bad_tf_1.tf', 'bad_tf_2.tf']
+        invalid_dir_abs_path = os.path.abspath(invalid_dir_path)
+
+        runner = Runner()
+        result = runner.run(root_folder=invalid_dir_path, external_checks_dir=None)
+
+        self.assertEqual(len(result.parsing_errors), 2)
+        for file in file_names:
+            self.assertIn(os.path.join(invalid_dir_abs_path, file), result.parsing_errors)
+
+    def test_parser_error_handled_for_file_target(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        invalid_dir_path = os.path.join(current_dir, "resources/invalid_terraform_syntax")
+        file_names = ['bad_tf_1.tf', 'bad_tf_2.tf']
+        invalid_dir_abs_path = os.path.abspath(invalid_dir_path)
+
+        runner = Runner()
+        result = runner.run(files=[os.path.join(invalid_dir_path, file) for file in file_names], root_folder=None, external_checks_dir=None)
+
+        self.assertEqual(len(result.parsing_errors), 2)
+        for file in file_names:
+            self.assertIn(os.path.join(invalid_dir_abs_path, file), result.parsing_errors)
+
     def test_typed_terraform_resource_checks_are_performed(self):
         test_self = self
         check_name = "TF_M_2"


### PR DESCRIPTION
Handles Terraform parsing files when using `-f`. It already worked correctly at the directory level.

Also makes `report.parsing_errors` a map so that it stores the files and the error message.

Finally, adds them to the console output (previously only available with `-o json`). @schosterbarak maybe you intentionally left this out. I think we should show it. But another option would be to add a message like "use -o json to see the parsing errors", like this:

```
terraform scan results:

Passed checks: 0, Failed checks: 0, Skipped checks: 0, Parsing errors: 2 (use -o json to view all parsing errors)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
