### PR TITLE
Fix - Minor - Class name for TF CodeBuildProjectEncryption check incorrect

### DIFF
--- a/checkov/terraform/checks/resource/aws/CodeBuildProjectEncryption.py
+++ b/checkov/terraform/checks/resource/aws/CodeBuildProjectEncryption.py
@@ -2,7 +2,7 @@ from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
 
-class APIGatewayAuthorization(BaseResourceCheck):
+class CodeBuildProjectEncryption(BaseResourceCheck):
 
     def __init__(self):
         name = "Ensure that CodeBuild Project encryption is not disabled"
@@ -24,4 +24,4 @@ class APIGatewayAuthorization(BaseResourceCheck):
         return CheckResult.PASSED
 
 
-check = APIGatewayAuthorization()
+check = CodeBuildProjectEncryption()


### PR DESCRIPTION
Hey,

Whilst looking at tf / cf I found that this check had the class named incorrectly.

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
