### PR TITLE
fix CKV_GCP_33 reports a false positive `true` vs `"TRUE"` #790

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleComputeProjectOSLogin.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeProjectOSLogin.py
@@ -13,5 +13,8 @@ class GoogleComputeProjectOSLogin(BaseResourceValueCheck):
     def get_inspected_key(self):
         return 'metadata/[0]/enable-oslogin'
 
+    def get_expected_value(self):
+        return "TRUE"
+
 
 check = GoogleComputeProjectOSLogin()

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeProjectOSLogin.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeProjectOSLogin.py
@@ -25,7 +25,7 @@ class TestGoogleComputeProjectOSLogin(unittest.TestCase):
                     resource "google_compute_project_metadata" "default" {
                       metadata = {
                         foo  = "bar"
-                        enable-oslogin = true
+                        enable-oslogin = "TRUE"
                       }
                     }
                         """)


### PR DESCRIPTION
fix CKV_GCP_33 reports a false positive `true` vs `"TRUE"` #790