### PR TITLE
Handle cases when soft_delete_enabled is not set or is false

### DIFF
--- a/checkov/terraform/checks/resource/azure/KeyvaultRecoveryEnabled.py
+++ b/checkov/terraform/checks/resource/azure/KeyvaultRecoveryEnabled.py
@@ -12,7 +12,7 @@ class KeyVaultRecoveryEnabled(BaseResourceCheck):
 
     def scan_resource_conf(self, conf):
         if 'purge_protection_enabled' in conf and conf['purge_protection_enabled'][0] and \
-                'soft_delete_enabled' in conf and conf['soft_delete_enabled'][0]:
+                ('soft_delete_enabled' not in conf or conf['soft_delete_enabled'][0]):
             return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/tests/terraform/checks/resource/azure/test_KeyVaultRecoveryEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_KeyVaultRecoveryEnabled.py
@@ -23,6 +23,22 @@ class TestKeyVaultRecoveryEnabled(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure2(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_key_vault" "example" {
+              name                        = "testvault"
+              location                    = azurerm_resource_group.example.location
+              resource_group_name         = azurerm_resource_group.example.name
+              enabled_for_disk_encryption = true
+              tenant_id                   = data.azurerm_client_config.current.tenant_id
+              soft_delete_enabled         = false
+              sku_name = "standard"
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_key_vault']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_success(self):
         hcl_res = hcl2.loads("""
             resource "azurerm_key_vault" "example" {
@@ -32,6 +48,22 @@ class TestKeyVaultRecoveryEnabled(unittest.TestCase):
               enabled_for_disk_encryption = true
               tenant_id                   = data.azurerm_client_config.current.tenant_id
               soft_delete_enabled         = true
+              purge_protection_enabled    = true
+              sku_name = "standard"
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_key_vault']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success2(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_key_vault" "example" {
+              name                        = "testvault"
+              location                    = azurerm_resource_group.example.location
+              resource_group_name         = azurerm_resource_group.example.name
+              enabled_for_disk_encryption = true
+              tenant_id                   = data.azurerm_client_config.current.tenant_id
               purge_protection_enabled    = true
               sku_name = "standard"
             }


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/azure/key-vault/general/soft-delete-change, the attribute will no longer have any effect on new Key Vaults.
Furthermore, soft_delete_enabled now defaults to true as per the provider breaking changes: https://github.com/terraform-providers/terraform-provider-azurerm/releases/tag/v2.42.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
