### PR TITLE
Allow TF module download tests to pass locally without github creds

### DIFF
--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -20,7 +20,7 @@ class Record:
     guideline = None
 
     def __init__(self, check_id, check_name, check_result, code_block, file_path, file_line_range, resource,
-                 evaluations, check_class, helm_chart):
+                 evaluations, check_class):
         """
         :param evaluations: A dict with the key being the variable name, value being a dict containing:
                              - 'var_file'
@@ -36,7 +36,6 @@ class Record:
         self.resource = resource
         self.evaluations = evaluations
         self.check_class = check_class
-        self.helm_chart = helm_chart
 
     def set_guideline(self, guideline):
         self.guideline = guideline

--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -20,7 +20,7 @@ class Record:
     guideline = None
 
     def __init__(self, check_id, check_name, check_result, code_block, file_path, file_line_range, resource,
-                 evaluations, check_class):
+                 evaluations, check_class, helm_chart):
         """
         :param evaluations: A dict with the key being the variable name, value being a dict containing:
                              - 'var_file'
@@ -36,6 +36,7 @@ class Record:
         self.resource = resource
         self.evaluations = evaluations
         self.check_class = check_class
+        self.helm_chart = helm_chart
 
     def set_guideline(self, guideline):
         self.guideline = guideline

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -78,6 +78,8 @@ class RunnerRegistry(object):
     def filter_runner_framework(self):
         if not self.runner_filter:
             return
+        if self.runner_filter.framework is None:
+            return
         if self.runner_filter.framework == 'all':
             return
         filtered_runners = []

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -80,10 +80,12 @@ class RunnerRegistry(object):
             return
         if self.runner_filter.framework == 'all':
             return
+        filtered_runners = []
         for runner in self.runners:
-            if runner.check_type == self.runner_filter.framework:
-                self.runners = [runner]
-                return
+            if runner.check_type in self.runner_filter.framework:
+                filtered_runners.append(runner)
+        self.runners = filtered_runners
+        return
 
     @staticmethod
     def enrich_report_with_guidelines(scan_report, guidelines):

--- a/checkov/helm/base_registry.py
+++ b/checkov/helm/base_registry.py
@@ -1,0 +1,86 @@
+from checkov.common.checks.base_check_registry import BaseCheckRegistry
+from checkov.runner_filter import RunnerFilter
+
+
+class Registry(BaseCheckRegistry):
+
+    def __init__(self):
+        super().__init__()
+
+    def extract_entity_details(self, entity):
+        kind = entity["kind"]
+        conf = entity
+        return kind, conf
+
+    def scan(self, scanned_file, entity, skipped_checks, runner_filter):
+        (entity_type, entity_configuration) = self.extract_entity_details(entity)
+        results = {}
+        checks = self.get_checks(entity_type)
+        for check in checks:
+            skip_info = {}
+            if skipped_checks:
+                if check.id in [x['id'] for x in skipped_checks]:
+                    skip_info = [x for x in skipped_checks if x['id'] == check.id][0]
+
+            if self._should_run_scan(check.id, entity_configuration, runner_filter):
+                self.logger.debug("Running check: {} on file {}".format(check.name, scanned_file))
+
+                result = check.run(scanned_file=scanned_file, entity_configuration=entity_configuration,
+                                   entity_name=entity_type, entity_type=entity_type, skip_info=skip_info)
+                results[check] = result
+        return results
+
+    @staticmethod
+    def _should_run_scan(check_id, entity_configuration, runner_filter):
+        check_id_allowlist = runner_filter.checks
+        check_id_denylist = runner_filter.skip_checks
+        if check_id_allowlist:
+            # Allow list provides namespace-only allows, check-only allows, or both
+            # If namespaces not specified, all namespaces are scanned
+            # If checks not specified, all checks are scanned
+            run_check = False
+            allowed_namespaces = [string for string in check_id_allowlist if "CKV_" not in string]
+            if not any("CKV_" in check for check in check_id_allowlist):
+                if "metadata" in entity_configuration and "namespace" in entity_configuration["metadata"]:
+                    if entity_configuration["metadata"]["namespace"] in allowed_namespaces:
+                        run_check = True
+                elif "parent_metadata" in entity_configuration and "namespace" in entity_configuration["parent_metadata"]:
+                    if entity_configuration["parent_metadata"]["namespace"] in allowed_namespaces:
+                        run_check = True
+                else:
+                    if "default" in allowed_namespaces:
+                        run_check = True
+            else:
+                if check_id in check_id_allowlist or RunnerFilter.is_external_check(check_id):
+                    if allowed_namespaces:
+                        # Check if namespace in allowed namespaces
+                        if "metadata" in entity_configuration and "namespace" in entity_configuration["metadata"]:
+                            if entity_configuration["metadata"]["namespace"] in allowed_namespaces:
+                                run_check = True
+                        elif "parent_metadata" in entity_configuration and "namespace" in entity_configuration["parent_metadata"]:
+                            if entity_configuration["parent_metadata"]["namespace"] in allowed_namespaces:
+                                run_check = True
+                        else:
+                            if "default" in allowed_namespaces:
+                                run_check = True
+                    else:
+                        # No namespaces to filter
+                        run_check = True
+            if run_check:
+                return True
+        elif check_id_denylist:
+            namespace_skip = False
+            if "metadata" in entity_configuration and "namespace" in entity_configuration["metadata"]:
+                if entity_configuration["metadata"]["namespace"] in check_id_denylist:
+                    namespace_skip = True
+            elif "parent_metadata" in entity_configuration and "namespace" in entity_configuration["parent_metadata"]:
+                if entity_configuration["parent_metadata"]["namespace"] in check_id_denylist:
+                    namespace_skip = True
+            else:
+                if "default" in check_id_denylist:
+                    namespace_skip = True
+            if check_id not in check_id_denylist and namespace_skip == False:
+                return True
+        else:
+            return True
+        return False

--- a/checkov/helm/registry.py
+++ b/checkov/helm/registry.py
@@ -1,0 +1,3 @@
+from checkov.helm.base_registry import Registry
+
+registry = Registry()

--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -2,7 +2,7 @@ import io
 import logging
 import operator
 import os
-import subprocess
+import subprocess #nosec
 import tempfile
 from functools import reduce
 import shutil
@@ -73,7 +73,7 @@ class Runner(BaseRunner):
         # Returns framework names to skip if deps fail.
         logging.info(f"Checking necessary system dependancies for {self.check_type} checks.")
         try:
-            proc = subprocess.Popen([self.helm_command, 'version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            proc = subprocess.Popen([self.helm_command, 'version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE) #nosec
             o, e = proc.communicate()
             oString = str(o, 'utf-8')
             if "Version:" in oString:
@@ -107,7 +107,7 @@ class Runner(BaseRunner):
             logging.info(f"Processing chart found at: {chart_dir}, name: {chart_meta['name']}, version: {chart_meta['version']}")
             with tempfile.TemporaryDirectory() as target_dir:
                 #dependency list is nicer to parse than dependency update.
-                proc = subprocess.Popen([self.helm_command, 'dependency', 'list' , chart_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                proc = subprocess.Popen([self.helm_command, 'dependency', 'list' , chart_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE) #nosec
                 o, e = proc.communicate()
                 if e:
                     if "Warning: Dependencies" in str(e, 'utf-8'):
@@ -119,7 +119,7 @@ class Runner(BaseRunner):
 
                 try:
                     #--dependency-update needed to pull in deps before templating.
-                    proc = subprocess.Popen([self.helm_command, 'template', '--dependency-update', chart_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    proc = subprocess.Popen([self.helm_command, 'template', '--dependency-update', chart_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE) #nosec
                     o, e = proc.communicate()
                     logging.debug(f"Ran helm command to template chart output. Chart: {chart_meta['name']}. dir: {target_dir}. Output: {str(o, 'utf-8')}")
 

--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -1,0 +1,269 @@
+import io
+import logging
+import operator
+import os
+import subprocess
+import tempfile
+from functools import reduce
+import shutil
+import json
+
+from checkov.common.output.record import Record
+from checkov.common.output.report import Report
+from checkov.common.runners.base_runner import BaseRunner, filter_ignored_directories
+from checkov.kubernetes.runner import Runner as k8_runner
+from checkov.helm.registry import registry
+from checkov.runner_filter import RunnerFilter
+
+import yaml
+import asyncio
+
+K8_POSSIBLE_ENDINGS = [".yaml", ".yml", ".json"]
+
+
+class Runner(BaseRunner):
+    check_type = "helm"
+    helm_command = 'helm'
+    system_deps = True
+
+    @staticmethod
+    def find_chart_directories(root_folder, files):
+        chart_directories = []
+        if files:
+            logging.info('Running with --file argument; checking for Helm Chart.yaml files')
+            for file in files:
+                if os.path.basename(file) == 'Chart.yaml':
+                    chart_directories.append(os.path.dirname(file))
+
+        if root_folder:
+            for root, d_names, f_names in os.walk(root_folder):
+                filter_ignored_directories(d_names)
+                if 'Chart.yaml' in f_names:
+                    chart_directories.append(root)
+
+        return chart_directories
+
+    @staticmethod
+    def parse_helm_dependency_output(o):
+        output = o.decode('utf-8')
+        chart_dependencies={}
+        if "WARNING" in output:
+            #Helm  output showing no deps, example: 'WARNING: no dependencies at helm-charts/charts/prometheus-kafka-exporter/charts\n'
+            pass
+        else: 
+            lines = output.split('\n')
+            for line in lines:
+                if line is not "":
+                    if not "NAME" in line:
+                        chart_name, chart_version, chart_repo, chart_status = line.split("\t")
+                        chart_dependencies.update({chart_name.rstrip():{'chart_name': chart_name.rstrip(), 'chart_version': chart_version.rstrip(), 'chart_repo': chart_repo.rstrip(), 'chart_status': chart_status.rstrip()}})
+        return chart_dependencies
+
+    @staticmethod
+    def parse_helm_chart_details(chart_path):
+        with open(f"{chart_path}/Chart.yaml", 'r') as chartyaml:
+            try:
+                chart_meta = yaml.safe_load(chartyaml)
+            except yaml.YAMLError as exc:
+                logging.info(f"Failed to load chart metadata from {chart_path}/Chart.yaml. details: {exc}")
+        return chart_meta
+
+    def check_system_deps(self):
+        # Ensure local system dependancies are available and of the correct version.
+        # Returns framework names to skip if deps fail.
+        logging.info(f"Checking necessary system dependancies for {self.check_type} checks.")
+        try:
+            proc = subprocess.Popen([self.helm_command, 'version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            o, e = proc.communicate()
+            oString = str(o, 'utf-8')
+            if "Version:" in oString:
+                helmVersionOutput = oString[oString.find(':')+2 : oString.find(',')-1]
+                if "v3" in helmVersionOutput:
+                    logging.info(f"Found working version of {self.check_type} dependancies: {helmVersionOutput}")
+                    return None
+            else:
+                return self.check_type
+        except Exception:
+            logging.info(f"Error running necessary tools to process {self.check_type} checks.")
+            return self.check_type
+
+    def run(self, root_folder, external_checks_dir=None, files=None, runner_filter=RunnerFilter(), collect_skip_comments=True):
+
+        definitions = {}
+        definitions_raw = {}
+        parsing_errors = {}
+        files_list = []
+        if external_checks_dir:
+            for directory in external_checks_dir:
+                registry.load_external_checks(directory, runner_filter)
+
+        chart_directories = self.find_chart_directories(root_folder, files)
+
+        report = Report(self.check_type)
+    
+        for chart_dir in chart_directories:
+            #chart_name = os.path.basename(chart_dir)
+            chart_meta = self.parse_helm_chart_details(chart_dir)
+            logging.info(f"Processing chart found at: {chart_dir}, name: {chart_meta['name']}, version: {chart_meta['version']}")
+            with tempfile.TemporaryDirectory() as target_dir:
+                #dependency list is nicer to parse than dependency update.
+                proc = subprocess.Popen([self.helm_command, 'dependency', 'list' , chart_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                o, e = proc.communicate()
+                if e:
+                    if "Warning: Dependencies" in str(e, 'utf-8'):
+                        logging.info(f"V1 API chart without Chart.yaml dependancies. Skipping chart dependancy list for {chart_meta['name']} at dir: {chart_dir}. Working dir: {target_dir}. Error details: {str(e, 'utf-8')}")       
+                    else: 
+                        logging.info(f"Error processing helm dependancies for {chart_meta['name']} at source dir: {chart_dir}. Working dir: {target_dir}. Error details: {str(e, 'utf-8')}")
+                        
+                self.parse_helm_dependency_output(o)
+
+                try:
+                    #--dependency-update needed to pull in deps before templating.
+                    proc = subprocess.Popen([self.helm_command, 'template', '--dependency-update', chart_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    o, e = proc.communicate()
+                    logging.debug(f"Ran helm command to template chart output. Chart: {chart_meta['name']}. dir: {target_dir}. Output: {str(o, 'utf-8')}")
+
+                except Exception:
+                    logging.info(f"Error processing helm chart {chart_meta['name']} at dir: {chart_dir}. Working dir: {target_dir}. Error details: {str(e, 'utf-8')}")
+            
+                output = str(o, 'utf-8')
+                reader = io.StringIO(output)
+                cur_source_file = None
+                cur_writer = None
+                last_line_dashes = False
+                line_num = 1
+                for s in reader:
+                    s = s.rstrip()
+                    if s == '---':
+                        last_line_dashes = True
+                        continue
+
+                    if last_line_dashes:
+                        # The next line should contain a "Source" comment saying the name of the file it came from
+                        # So we will close the old file, open a new file, and write the dashes from last iteration plus this line
+
+                        if not s.startswith('# Source: '):
+                            raise Exception(f'Line {line_num}: Expected line to start with # Source: {s}')
+                        source = s[10:]
+                        if source != cur_source_file:
+                            if cur_writer:
+                                cur_writer.close()
+                            file_path = os.path.join(target_dir, source)
+                            parent = os.path.dirname(file_path)
+                            os.makedirs(parent, exist_ok=True)
+                            cur_source_file = source
+                            cur_writer = open(os.path.join(target_dir, source), 'a')
+                        cur_writer.write('---' + os.linesep)
+                        cur_writer.write(s + os.linesep)
+
+                        last_line_dashes = False
+                    else:
+                        if s.startswith('# Source: '):
+                            raise Exception(f'Line {line_num}: Unexpected line starting with # Source: {s}')
+
+                        if not cur_writer:
+                            continue
+                        else:
+                            cur_writer.write(s + os.linesep)
+
+                    line_num += 1
+
+                if cur_writer:
+                    cur_writer.close()
+
+                try:
+                    k8s_runner = k8_runner()
+                    chart_results = k8s_runner.run(target_dir, external_checks_dir=external_checks_dir, runner_filter=runner_filter, helmChart=chart_meta['name'])
+                    logging.debug(f"Sucessfully ran k8s scan on {chart_meta['name']}. Scan dir : {target_dir}")
+                    report.failed_checks += chart_results.failed_checks
+                    report.passed_checks += chart_results.passed_checks
+                    report.parsing_errors += chart_results.parsing_errors
+                    report.skipped_checks += chart_results.skipped_checks
+
+                except:
+                    with tempfile.TemporaryDirectory() as save_error_dir:
+                        logging.debug(f"Error running k8s scan on {chart_meta['name']}. Scan dir: {target_dir}. Saved context dir: {save_error_dir}")
+                        shutil.move(target_dir, save_error_dir) 
+                    
+        
+        ## TODO: Export helm dependancies for the chart we've extracted in chart_dependencies
+        return report
+
+
+    def _search_deep_keys(self, search_text, k8n_dict, path):
+        """Search deep for keys and get their values"""
+        keys = []
+        if isinstance(k8n_dict, dict):
+            for key in k8n_dict:
+                pathprop = path[:]
+                pathprop.append(key)
+                if key == search_text:
+                    pathprop.append(k8n_dict[key])
+                    keys.append(pathprop)
+                    # pop the last element off for nesting of found elements for
+                    # dict and list checks
+                    pathprop = pathprop[:-1]
+                if isinstance(k8n_dict[key], dict):
+                    keys.extend(self._search_deep_keys(search_text, k8n_dict[key], pathprop))
+                elif isinstance(k8n_dict[key], list):
+                    for index, item in enumerate(k8n_dict[key]):
+                        pathproparr = pathprop[:]
+                        pathproparr.append(index)
+                        keys.extend(self._search_deep_keys(search_text, item, pathproparr))
+        elif isinstance(k8n_dict, list):
+            for index, item in enumerate(k8n_dict):
+                pathprop = path[:]
+                pathprop.append(index)
+                keys.extend(self._search_deep_keys(search_text, item, pathprop))
+
+        return keys
+
+def get_skipped_checks(entity_conf):
+    skipped = []
+    metadata = {}
+    if not isinstance(entity_conf,dict):
+        return skipped
+    if entity_conf["kind"] == "containers" or entity_conf["kind"] == "initContainers":
+        metadata = entity_conf["parent_metadata"]
+    else:
+        if "metadata" in entity_conf.keys():
+            metadata = entity_conf["metadata"]
+    if "annotations" in metadata.keys() and metadata["annotations"] is not None:
+        for key in metadata["annotations"].keys():
+            skipped_item = {}
+            if "checkov.io/skip" in key or "bridgecrew.io/skip" in key:
+                if "CKV_K8S" in metadata["annotations"][key]:
+                    if "=" in metadata["annotations"][key]:
+                        (skipped_item["id"], skipped_item["suppress_comment"]) = metadata["annotations"][key].split("=")
+                    else:
+                        skipped_item["id"] = metadata["annotations"][key]
+                        skipped_item["suppress_comment"] = "No comment provided"
+                    skipped.append(skipped_item)
+                else:
+                    logging.info("Parse of Annotation Failed for {}: {}".format(metadata["annotations"][key], entity_conf, indent=2))
+                    continue
+    return skipped
+
+def _get_from_dict(data_dict, map_list):
+    return reduce(operator.getitem, map_list, data_dict)
+
+
+def _set_in_dict(data_dict, map_list, value):
+    _get_from_dict(data_dict, map_list[:-1])[map_list[-1]] = value
+
+
+def find_lines(node, kv):
+    if isinstance(node, str):
+        return node
+    if isinstance(node, list):
+        for i in node:
+            for x in find_lines(i, kv):
+                yield x
+    elif isinstance(node, dict):
+        if kv in node:
+            yield node[kv]
+        for j in node.values():
+            for x in find_lines(j, kv):
+                yield x
+
+

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -170,9 +170,7 @@ class Runner(BaseRunner):
                                         code_block=entity_code_lines, file_path=k8_file,
                                         file_line_range=entity_lines_range,
                                         resource=check.get_resource_id(entity_conf), evaluations=variable_evaluations,
-                                        check_class=check.__class__.__module__, helm_chart=None)
-                        if helmChart is not None:
-                            record.helm_chart = helmChart
+                                        check_class=check.__class__.__module__)
                         report.add_record(record=record)
 
         return report

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -16,7 +16,7 @@ K8_POSSIBLE_ENDINGS = [".yaml", ".yml", ".json"]
 class Runner(BaseRunner):
     check_type = "kubernetes"
 
-    def run(self, root_folder, external_checks_dir=None, files=None, runner_filter=RunnerFilter(), collect_skip_comments=True):
+    def run(self, root_folder, external_checks_dir=None, files=None, runner_filter=RunnerFilter(), collect_skip_comments=True, helmChart=None):
         report = Report(self.check_type)
         definitions = {}
         definitions_raw = {}
@@ -170,7 +170,9 @@ class Runner(BaseRunner):
                                         code_block=entity_code_lines, file_path=k8_file,
                                         file_line_range=entity_lines_range,
                                         resource=check.get_resource_id(entity_conf), evaluations=variable_evaluations,
-                                        check_class=check.__class__.__module__)
+                                        check_class=check.__class__.__module__, helm_chart=None)
+                        if helmChart is not None:
+                            record.helm_chart = helmChart
                         report.add_record(record=record)
 
         return report

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -38,8 +38,9 @@ for runner in checkov_runner_module_names:
     try:
         globals()[f"{runner}_runner"]().system_deps
     except:
-        logging.info(f"{runner}_runner declares no system dependency checks required.")
-    
+        logging.debug(f"{runner}_runner declares no system dependency checks required.")
+        continue
+
     if globals()[f"{runner}_runner"]().system_deps:
             result = globals()[f"{runner}_runner"]().check_system_deps()
             if result is not None:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
+import logging
 
 from checkov.arm.runner import Runner as arm_runner
 from checkov.cloudformation.runner import Runner as cfn_runner
@@ -37,7 +38,7 @@ for runner in checkov_runner_module_names:
     try:
         globals()[f"{runner}_runner"]().system_deps
     except:
-        continue
+        logging.info(f"{runner}_runner declares no system dependency checks required.")
     
     if globals()[f"{runner}_runner"]().system_deps:
             result = globals()[f"{runner}_runner"]().check_system_deps()
@@ -49,7 +50,7 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
     add_parser_args(parser)
     args = parser.parse_args(argv)
     if checkov_frameworks_unmatched_deps:
-        print(f"The following frameworks have been automatically disabled due to missing system dependancies: {','.join(checkov_frameworks_unmatched_deps)}")
+        print(f"The following frameworks have been automatically disabled due to missing system dependency: {','.join(checkov_frameworks_unmatched_deps)}")
         if args.skip_framework is None:
             args.skip_framework = ",".join(checkov_frameworks_unmatched_deps)
         else:
@@ -139,7 +140,7 @@ def add_parser_args(parser):
                         choices=checkov_runners + ["all"],
                         default='all')
     parser.add_argument('--skip-framework', help='filter scan to skip specific infrastructure code frameworks. \n'
-                                                 'will be included automatically for some frameworks if system dependancies are missing.',
+                                                 'will be included automatically for some frameworks if system dependencies are missing.',
                         choices=checkov_runners,
                         default=None)
     parser.add_argument('-c', '--check',

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -44,7 +44,7 @@ for runner in checkov_runner_module_names:
             if result is not None:
                 checkov_frameworks_unmatched_deps.append(result)
 
-def run(banner=checkov_banner, runners=checkov_runners, argv=sys.argv[1:]):
+def run(banner=checkov_banner, argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(description='Infrastructure as code static analysis')
     add_parser_args(parser)
     args = parser.parse_args(argv)

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -1,3 +1,4 @@
+import logging
 import fnmatch
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 
@@ -8,7 +9,7 @@ class RunnerFilter(object):
     #       logically a "static" concept anyway, so this makes logical sense.
     __EXTERNAL_CHECK_IDS = set()
 
-    def __init__(self, framework='all', checks=None, skip_checks=None, download_external_modules=False, external_modules_download_path=DEFAULT_EXTERNAL_MODULES_DIR, evaluate_variables=True):
+    def __init__(self, framework='all', skip_framework=None, checks=None, skip_checks=None, download_external_modules=False, external_modules_download_path=DEFAULT_EXTERNAL_MODULES_DIR, evaluate_variables=True, runners=None):
         if checks is None:
             checks = []
         if isinstance(checks, str):
@@ -22,7 +23,19 @@ class RunnerFilter(object):
             self.skip_checks = skip_checks.split(",")
         else:
             self.skip_checks = skip_checks
-        self.framework = framework
+
+        if skip_framework is None:
+            self.framework = framework
+        else:
+            if isinstance(skip_framework, str):
+                if framework == "all":
+                    selected_frameworks = list(set(runners) - set(skip_framework.split(",")))
+                    self.framework = ','.join(selected_frameworks)
+                else:
+                    selected_frameworks = list(set(framework.split(",")) - set(skip_framework.split(",")))
+                    self.framework = ','.join(selected_frameworks)
+        logging.info(f'Resultant set of frameworks (removing skipped frameworks): {self.framework}')
+
         self.download_external_modules = download_external_modules
         self.external_modules_download_path = external_modules_download_path
         self.evaluate_variables = evaluate_variables

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -9,7 +9,7 @@ class RunnerFilter(object):
     #       logically a "static" concept anyway, so this makes logical sense.
     __EXTERNAL_CHECK_IDS = set()
 
-    def __init__(self, framework='all', skip_framework=None, checks=None, skip_checks=None, download_external_modules=False, external_modules_download_path=DEFAULT_EXTERNAL_MODULES_DIR, evaluate_variables=True, runners=None):
+    def __init__(self, framework='all', checks=None, skip_checks=None, download_external_modules=False, external_modules_download_path=DEFAULT_EXTERNAL_MODULES_DIR, evaluate_variables=True, runners=None, skip_framework=None):
         if checks is None:
             checks = []
         if isinstance(checks, str):

--- a/tests/terraform/module_loading/test_registry.py
+++ b/tests/terraform/module_loading/test_registry.py
@@ -24,10 +24,10 @@ class TestModuleLoaderRegistry(unittest.TestCase):
 
     def test_load_terraform_registry_check_cache(self):
         registry = ModuleLoaderRegistry(download_external_modules=True)
-        source1 = "https://github.com/bridgecrewio/checkov_not_working1.git"
+        source1 = "https://fakecreds:fakecreds@github.com/bridgecrewio/example_nonexistant_repo.git"
         registry.load(current_dir=self.current_dir, source=source1, source_version="latest")
         self.assertTrue(source1 in registry.failed_urls_cache)
-        source2 = "https://github.com/bridgecrewio/checkov_not_working2.git"
+        source2 = "https://ifakecreds:fakecreds@github.com/bridgecrewio/example_nonexistant_repo2.git"
         registry.load(current_dir=self.current_dir, source=source2, source_version="latest")
         self.assertTrue(source1 in registry.failed_urls_cache and source2 in registry.failed_urls_cache)
 

--- a/tests/terraform/parser/resources/failing_module_address/registry_security_group.tf
+++ b/tests/terraform/parser/resources/failing_module_address/registry_security_group.tf
@@ -1,5 +1,5 @@
 module "security_group1" {
-  source  = "https://github.com/bridgecrewio/checkov_not_working.git"
+  source  = "https://fakecreds:fakecreds@github.com/bridgecrewio/nonexistant_sample_repo.git"
   version = "latest"
 
   name        = "example"
@@ -13,7 +13,7 @@ module "security_group1" {
 
 
 module "security_group2" {
-  source  = "https://github.com/bridgecrewio/checkov_not_working.git"
+  source  = "https://fakecreds:fakecreds@github.com/bridgecrewio/nonexistantsamplerepo2.git"
   version = "latest"
 
   name        = "example"


### PR DESCRIPTION
Two tests check that a nonexistant github repo as a module resource doesn't interfere with the correct rendering of the output and correctly caches the non working url.

These tests when run by a developer locally ie `pipenv run pytest` prompt on the CLI for local creds.
As the repo is going to error anyway (it doesnt exist), i've embedded fake creds to allow the run to proceed automatically, internally the git client will be handling an auth error vs repo not existing, but I dont think that matters and gives a better testing experience for checkov contributors.

Also updated the names of the nonexistant repo's for readability.

cc/ @JamesWoolfenden 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
