### PR TITLE
null check for IAM users in policy attach

### DIFF
--- a/checkov/terraform/checks/resource/aws/IAMPolicyAttachedToGroupOrRoles.py
+++ b/checkov/terraform/checks/resource/aws/IAMPolicyAttachedToGroupOrRoles.py
@@ -15,6 +15,8 @@ class IAMPolicyAttachedToGroupOrRoles(BaseResourceCheck):
         self.evaluated_keys = ['user', 'users']
         if 'user' in conf.keys():
             return CheckResult.FAILED
+        if 'users' in conf.keys() and conf['users'][0] is None: #"users": null case 
+            return CheckResult.PASSED
         if 'users' in conf.keys() and len(conf['users'][0]) > 0:
             return CheckResult.FAILED
         return CheckResult.PASSED


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Fix for #802 

`users` is null if there is no user in aws_iam_policy_attachment
```
sample output from terraform json
{
  86               "address": "module.aws_cloudtrail.aws_iam_policy_attachment.main",
  87               "mode": "managed",
  88               "type": "aws_iam_policy_attachment",
  89               "name": "main",
  90               "provider_name": "registry.terraform.io/hashicorp/aws",
  91               "schema_version": 0,
  92               "values": {
  93                 "groups": null,
  94                 "name": "cloudtrail-cloudwatch-logs-policy-attachment",
  95                 "roles": [
  96                   "cloudtrail-cloudwatch-logs-role"
  97                 ],
  98                 "users": null
  99               }

```