### PR TITLE
Add full param strings to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,17 @@ pip3 install -U checkov
 ### Configure an input folder or file
 
 ```sh
-checkov -d /user/path/to/iac/code
+checkov --file /user/path/to/iac/code
 ```
 
-Or a specific file
+Or a specific file or files
 
 ```sh
-checkov -f /user/tf/example.tf
+checkov --file /user/tf/example.tf
 ```
 Or
 ```sh
-checkov -f /user/cloudformation/example.yml
+checkov --file /user/cloudformation/example1.yml --file /user/cloudformation/example2.yml
 ```
 
 Or a terraform plan file in json format
@@ -115,7 +115,7 @@ Or a terraform plan file in json format
 terraform init
 terraform plan -out tf.plan
 terraform show -json tf.plan  > tf.json 
-checkov -f tf.json
+checkov --file tf.json
 ```
 Note: `terraform show` output  file `tf.json` will be single line. 
 For that reason all findings will be reported line number 0 by checkov
@@ -167,7 +167,7 @@ Start using Checkov by reading the [Getting Started](docs/1.Introduction/Getting
 
 ```sh
 docker pull bridgecrew/checkov
-docker run -t -v /user/tf:/tf bridgecrew/checkov -d /tf
+docker run --volume /user/tf:/tf bridgecrew/checkov --directory /tf
 ```
 Note: if you are using Python 3.6(Default version in Ubuntu 18.04) checkov will not work and it will fail with `ModuleNotFoundError: No module named 'dataclasses'`  error message. In this case, You can use docker version 
 
@@ -178,22 +178,22 @@ those listed (deny list).
 
 List available checks:
 ```sh
-checkov -l 
+checkov --list 
 ```
 
 Allow only 2 checks to run: 
 ```sh
-checkov -d . --check CKV_AWS_20,CKV_AWS_57
+checkov --directory . --check CKV_AWS_20,CKV_AWS_57
 ```
 
 Run all checks except 1 specified:
 ```sh
-checkov -d . --skip-check CKV_AWS_52
+checkov --directory . --skip-check CKV_AWS_52
 ```
 
 Run all checks except checks with specified patterns:
 ```sh
-checkov -d . --skip-check CKV_AWS*
+checkov --directory . --skip-check CKV_AWS*
 ```
 
 For Kubernetes workloads, you can also use allow/deny namespaces.  For example, do not report any results for the 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ pip3 install -U checkov
 ### Configure an input folder or file
 
 ```sh
-checkov --file /user/path/to/iac/code
+checkov --directory /user/path/to/iac/code
 ```
 
 Or a specific file or files
@@ -167,9 +167,11 @@ Start using Checkov by reading the [Getting Started](docs/1.Introduction/Getting
 
 ```sh
 docker pull bridgecrew/checkov
-docker run --volume /user/tf:/tf bridgecrew/checkov --directory /tf
+docker run --tty --volume /user/tf:/tf bridgecrew/checkov --directory /tf
 ```
 Note: if you are using Python 3.6(Default version in Ubuntu 18.04) checkov will not work and it will fail with `ModuleNotFoundError: No module named 'dataclasses'`  error message. In this case, you can use the docker version instead.
+
+Note that there are certain cases where redirecting `docker run --tty` output to a file - for example, if you want to save the Checkov JUnit output to a file - will cause extra control characters to be printed. This can break file parsing. If you encounter this, remove the `--tty` flag.
 
 ### Running or skipping checks 
 
@@ -199,7 +201,7 @@ checkov --directory . --skip-check CKV_AWS*
 For Kubernetes workloads, you can also use allow/deny namespaces.  For example, do not report any results for the 
 kube-system namespace:
 ```sh
-checkov -d . --skip-check kube-system
+checkov --directory . --skip-check kube-system
 ```
 
 ### Suppressing/Ignoring a check

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Start using Checkov by reading the [Getting Started](docs/1.Introduction/Getting
 docker pull bridgecrew/checkov
 docker run --volume /user/tf:/tf bridgecrew/checkov --directory /tf
 ```
-Note: if you are using Python 3.6(Default version in Ubuntu 18.04) checkov will not work and it will fail with `ModuleNotFoundError: No module named 'dataclasses'`  error message. In this case, You can use docker version 
+Note: if you are using Python 3.6(Default version in Ubuntu 18.04) checkov will not work and it will fail with `ModuleNotFoundError: No module named 'dataclasses'`  error message. In this case, you can use the docker version instead.
 
 ### Running or skipping checks 
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ checkov -d . --skip-check CKV_AWS_52
 
 Run all checks except checks with specified patterns:
 ```sh
-checkov - . --skip-check CKV_AWS*
+checkov -d . --skip-check CKV_AWS*
 ```
 
 For Kubernetes workloads, you can also use allow/deny namespaces.  For example, do not report any results for the 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ checkov --file /user/tf/example.tf
 ```
 Or
 ```sh
-checkov --file /user/cloudformation/example1.yml --file /user/cloudformation/example2.yml
+checkov -f /user/cloudformation/example1.yml -f /user/cloudformation/example2.yml
 ```
 
 Or a terraform plan file in json format
@@ -115,7 +115,7 @@ Or a terraform plan file in json format
 terraform init
 terraform plan -out tf.plan
 terraform show -json tf.plan  > tf.json 
-checkov --file tf.json
+checkov -f tf.json
 ```
 Note: `terraform show` output  file `tf.json` will be single line. 
 For that reason all findings will be reported line number 0 by checkov
@@ -190,18 +190,18 @@ checkov --directory . --check CKV_AWS_20,CKV_AWS_57
 
 Run all checks except 1 specified:
 ```sh
-checkov --directory . --skip-check CKV_AWS_52
+checkov -d . --skip-check CKV_AWS_52
 ```
 
 Run all checks except checks with specified patterns:
 ```sh
-checkov --directory . --skip-check CKV_AWS*
+checkov - . --skip-check CKV_AWS*
 ```
 
 For Kubernetes workloads, you can also use allow/deny namespaces.  For example, do not report any results for the 
 kube-system namespace:
 ```sh
-checkov --directory . --skip-check kube-system
+checkov -d . --skip-check kube-system
 ```
 
 ### Suppressing/Ignoring a check


### PR DESCRIPTION
Changes some examples to use full param strings (-d -> --directory) for clarity.

Also suggests a workaround to potential issues caused by `docker run -t`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
