### PR TITLE
Add compact CLI output option

### DIFF
--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -63,7 +63,7 @@ class Record:
                 string_block += "\t\t" + Fore.WHITE + str(line_num) + spaces + ' | ' + Fore.YELLOW + line
         return string_block
 
-    def __str__(self):
+    def to_string(self, compact=False):
         status = ''
         evaluation_message = f''
         status_color = "white"
@@ -101,10 +101,13 @@ class Record:
                             f'in expression: {colored(definition_obj["definition_name"] + " = ", "yellow")}{colored(definition_obj["definition_expression"], "yellow")}\n',
                             'white')
         status_message = colored("\t{} for resource: {}\n".format(status, self.resource), status_color)
-        if self.check_result['result'] == CheckResult.FAILED and code_lines:
+        if self.check_result['result'] == CheckResult.FAILED and code_lines and not compact:
             return check_message + status_message + file_details + guideline_message + code_lines + evaluation_message
 
         if self.check_result['result'] == CheckResult.SKIPPED:
             return check_message + status_message + suppress_comment + file_details + guideline_message
         else:
             return check_message + status_message + file_details + evaluation_message + guideline_message
+
+    def __str__(self):
+        return self.to_string()

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -71,7 +71,7 @@ class Report:
     def is_empty(self):
         return len(self.passed_checks) + len(self.failed_checks) + len(self.skipped_checks) + len(self.parsing_errors) == 0
 
-    def print_console(self, is_quiet=False):
+    def print_console(self, is_quiet=False, is_compact=False):
         summary = self.get_summary()
         print(colored(f"{self.check_type} scan results:", "blue"))
         if self.parsing_errors:
@@ -83,12 +83,12 @@ class Report:
         print(colored(message, "cyan"))
         if not is_quiet:
             for record in self.passed_checks:
-                print(record)
+                print(record.to_string(compact=is_compact))
         for record in self.failed_checks:
-            print(record)
+            print(record.to_string(compact=is_compact))
         if not is_quiet:
             for record in self.skipped_checks:
-                print(record)
+                print(record.to_string(compact=is_compact))
 
         if not is_quiet:
             for file in self.parsing_errors:

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -37,7 +37,7 @@ class RunnerRegistry(object):
         return self.scan_reports
 
     def print_reports(self, scan_reports, args):
-        if args.output == 'cli':
+        if args.output == 'cli' and not args.compact:
             print(f"{self.banner}\n")
         exit_codes = []
         report_jsons = []
@@ -52,7 +52,7 @@ class RunnerRegistry(object):
                 elif args.output == 'github_failed_only':
                     report.print_failed_github_md()
                 else:
-                    report.print_console(is_quiet=args.quiet)
+                    report.print_console(is_quiet=args.quiet, is_compact=args.compact)
             exit_codes.append(report.get_exit_code(args.soft_fail))
         if args.output == "junitxml":
             if len(junit_reports) == 1:

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -37,7 +37,7 @@ class RunnerRegistry(object):
         return self.scan_reports
 
     def print_reports(self, scan_reports, args):
-        if args.output == 'cli' and not args.compact:
+        if args.output == 'cli':
             print(f"{self.banner}\n")
         exit_codes = []
         report_jsons = []

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -113,6 +113,9 @@ def add_parser_args(parser):
     parser.add_argument('--quiet', action='store_true',
                         default=False,
                         help='in case of CLI output, display only failed checks')
+    parser.add_argument('--compact', action='store_true',
+                        default=False,
+                        help='in case of CLI output, do not display header and code blocks')
     parser.add_argument('--framework', help='filter scan to run only on a specific infrastructure code frameworks',
                         choices=['cloudformation', 'terraform', 'terraform_plan', 'kubernetes', 'serverless', 'arm',
                                  'all'],

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -115,7 +115,7 @@ def add_parser_args(parser):
                         help='in case of CLI output, display only failed checks')
     parser.add_argument('--compact', action='store_true',
                         default=False,
-                        help='in case of CLI output, do not display header and code blocks')
+                        help='in case of CLI output, do not display code blocks')
     parser.add_argument('--framework', help='filter scan to run only on a specific infrastructure code frameworks',
                         choices=['cloudformation', 'terraform', 'terraform_plan', 'kubernetes', 'serverless', 'arm',
                                  'all'],

--- a/docs/1.Introduction/Getting Started.md
+++ b/docs/1.Introduction/Getting Started.md
@@ -34,7 +34,7 @@ checkov -d /user/tf
   -o [{cli,json,junitxml,github_failed_only}], --output [{cli,json,junitxml,github_failed_only}]
                         Report output format
   --quiet               in case of CLI output, display only failed checks
-  --compact               in case of CLI output, do not display header and code blocks
+  --compact               in case of CLI output, do not display code blocks
   --framework {cloudformation,terraform,kubernetes,all}
                         filter scan to run only on a specific infrastructure
                         code frameworks

--- a/docs/1.Introduction/Getting Started.md
+++ b/docs/1.Introduction/Getting Started.md
@@ -34,6 +34,7 @@ checkov -d /user/tf
   -o [{cli,json,junitxml,github_failed_only}], --output [{cli,json,junitxml,github_failed_only}]
                         Report output format
   --quiet               in case of CLI output, display only failed checks
+  --compact               in case of CLI output, do not display header and code blocks
   --framework {cloudformation,terraform,kubernetes,all}
                         filter scan to run only on a specific infrastructure
                         code frameworks

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -58,6 +58,7 @@ class TestRunnerValid(unittest.TestCase):
         report.print_json()
         report.print_console()
         report.print_console(is_quiet=True)
+        report.print_console(is_quiet=True, is_compact=True)
         report.print_junit_xml()
         report.print_failed_github_md()
 


### PR DESCRIPTION
Otherwise, there's just too much stuff with the code blocks

Here's what it looks like:

![image (1)](https://user-images.githubusercontent.com/29210090/105405931-b9f8b280-5bf9-11eb-8c01-16b3115be0e4.png)
