### PR TITLE
Avoid `_clean_bad_definitions` when loading json files

### DIFF
--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -701,7 +701,7 @@ Load JSON or HCL, depending on filename.
     try:
         with open(file, "r") as f:
             if file_name.endswith(".json"):
-                return _clean_bad_definitions(json.load(f))
+                return json.load(f)
             else:
                 return _clean_bad_definitions(hcl2.load(f))
     except Exception as e:
@@ -712,7 +712,8 @@ Load JSON or HCL, depending on filename.
 
 def _clean_bad_definitions(tf_definition_list):
     return {
-        block_type: list(filter(lambda definition_list: block_type == 'locals' or len(definition_list.keys()) == 1, tf_definition_list[block_type]))
+        block_type: list(filter(lambda definition_list: block_type == 'locals' or
+                                                        len(definition_list.keys()) == 1, tf_definition_list[block_type]))
         for block_type in tf_definition_list.keys()
     }
 

--- a/tests/terraform/parser/resources/parser_scenarios/json_807/cdk.tf.json
+++ b/tests/terraform/parser/resources/parser_scenarios/json_807/cdk.tf.json
@@ -1,0 +1,49 @@
+{
+  "variable": {
+    "environment": {
+      "type": "string"
+    },
+    "aws_region": {
+      "default": "us-east-1",
+      "type": "string"
+    },
+    "aws_profile": {
+      "type": "string"
+    }
+  },
+  "terraform": {
+    "required_providers": {
+      "aws": {
+        "version": "~> 2.70.0",
+        "source": "aws"
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "profile": "${var.aws_profile}",
+        "region": "${var.aws_region}",
+        "alias": "default"
+      },
+      {
+        "profile": "external",
+        "region": "us-west-1",
+        "skip_requesting_account_id": true,
+        "alias": "external"
+      }
+    ]
+  },
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "local-secret": {
+        "name": "internal-secret",
+        "provider": "aws.default"
+      },
+      "external-secret": {
+        "name": "external-secret",
+        "provider": "aws.external"
+      }
+    }
+  }
+}

--- a/tests/terraform/parser/resources/parser_scenarios/json_807/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/json_807/expected.json
@@ -1,0 +1,51 @@
+{
+  "cdk.tf.json": {
+    "variable": {
+      "environment": {
+        "type": "string"
+      },
+      "aws_region": {
+        "default": "us-east-1",
+        "type": "string"
+      },
+      "aws_profile": {
+        "type": "string"
+      }
+    },
+    "terraform": {
+      "required_providers": {
+        "aws": {
+          "version": "~> 2.70.0",
+          "source": "aws"
+        }
+      }
+    },
+    "provider": {
+      "aws": [
+        {
+          "profile": "${var.aws_profile}",
+          "region": "${var.aws_region}",
+          "alias": "default"
+        },
+        {
+          "profile": "external",
+          "region": "us-west-1",
+          "skip_requesting_account_id": true,
+          "alias": "external"
+        }
+      ]
+    },
+    "resource": {
+      "aws_secretsmanager_secret": {
+        "local-secret": {
+          "name": "internal-secret",
+          "provider": "aws.default"
+        },
+        "external-secret": {
+          "name": "external-secret",
+          "provider": "aws.external"
+        }
+      }
+    }
+  }
+}

--- a/tests/terraform/parser/test_parser_scenarios.py
+++ b/tests/terraform/parser/test_parser_scenarios.py
@@ -84,6 +84,7 @@ class TestParserScenarios(unittest.TestCase):
         self.go("doc_evaluations_verify")
 
     def test_bad_tf(self):
+        # Note: this hits the _clean_bad_definitions internal function
         self.go("bad_tf")
 
     def test_null_variables_651(self):
@@ -93,6 +94,9 @@ class TestParserScenarios(unittest.TestCase):
     def test_count_index_scenario(self):
         # Run only manually, this test currently fails on multiple issues
         self.go("count_eval")
+
+    def test_json_807(self):
+        self.go("json_807")
 
     @staticmethod
     def go(dir_name):


### PR DESCRIPTION
Fixes: #807

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
