### PR TITLE
Fix parser error when TF locals are ints and floats

### DIFF
--- a/checkov/terraform/context_parsers/parsers/locals_context_parser.py
+++ b/checkov/terraform/context_parsers/parsers/locals_context_parser.py
@@ -10,7 +10,8 @@ class LocalsContextParser(BaseContextParser):
     def _collect_local_values(self, local_block):
         if isinstance(local_block,dict):
             for local_name, local_value in local_block.items():
-                local_value = local_value[0]
+                if type(local_value) not in (int, float):
+                    local_value = local_value[0]
                 if type(local_value) in (int, float, bool, str):
                     dpath.new(self.context, ['assignments', local_name], local_value)
 

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -252,7 +252,10 @@ class Parser:
             if not file_locals:
                 continue
             for k, v in file_locals[0].items():
-                locals_values[k] = v[0]
+                if type(v) in (float, int):
+                    locals_values[k] = v
+                else:
+                    locals_values[k] = v[0]
 
         # Processing is done in a loop to deal with chained references and the like.
         # Loop while the data is being changed, stop when no more changes are happening.


### PR DESCRIPTION
ints and floats are [valid Terraform expressions](https://www.terraform.io/docs/configuration/expressions/index.html) and can be assigned to locals. However, they are returned by the parser as single variables instead of as arrays. This commit treats them as individual objects. 

For example, running `checkov -f test.tf` on the following file crashes:
```
data "aws_region" "current" {}
data "aws_caller_identity" "current" {}

locals = {
  env                 = "prod"
  kube2iam_user_arn   = "arn:aws:iam::000000000000:user/sample"
  database_identifier = "my-pgsql-db"
  database_storage    = 100
}
````

-- with the following stack trace:
```
Traceback (most recent call last):
  File "/usr/local/bin/checkov", line 5, in <module>
    run()
  File "/usr/local/lib/python3.9/site-packages/checkov/main.py", line 79, in run
    scan_reports = runner_registry.run(external_checks_dir=external_checks_dir, files=args.file,
  File "/usr/local/lib/python3.9/site-packages/checkov/common/runners/runner_registry.py", line 32, in run
    scan_report = runner.run(root_folder, external_checks_dir=external_checks_dir, files=files,
  File "/usr/local/lib/python3.9/site-packages/checkov/terraform/runner.py", line 76, in run
    self.check_tf_definition(report, root_folder, runner_filter, collect_skip_comments)
  File "/usr/local/lib/python3.9/site-packages/checkov/terraform/runner.py", line 89, in check_tf_definition
    definitions_context = parser_registry.enrich_definitions_context(definition, collect_skip_comments)
  File "/usr/local/lib/python3.9/site-packages/checkov/terraform/context_parsers/registry.py", line 28, in enrich_definitions_context
    self.definitions_context[tf_file][definition_type] = context_parser.run(tf_file, definition_blocks, collect_skip_comments)
  File "/usr/local/lib/python3.9/site-packages/checkov/terraform/context_parsers/base_parser.py", line 121, in run
    self.context = self.enrich_definition_block(definition_blocks)
  File "/usr/local/lib/python3.9/site-packages/checkov/terraform/context_parsers/parsers/locals_context_parser.py", line 26, in enrich_definition_block
    self._collect_local_values(locals_block)
  File "/usr/local/lib/python3.9/site-packages/checkov/terraform/context_parsers/parsers/locals_context_parser.py", line 13, in _collect_local_values
    local_value = local_value[0]
TypeError: 'int' object is not subscriptable
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
