### PR TITLE
Draft: Test case for infinite loop in parsing of unbalanced TF eval

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -19,6 +19,7 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python 3.7

--- a/tests/terraform/parser/resources/parser_scenarios/unbalanced_eval_brackets/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/unbalanced_eval_brackets/expected.json
@@ -1,0 +1,9 @@
+{
+  "main.tf": {
+    "locals": [
+      {
+        "s3_access_logs_prefix": ["${replace(var.cdn_logging_prefix, 'cdn', 's3')/${var.bucket_name}"]
+      }
+    ]
+  }
+}

--- a/tests/terraform/parser/resources/parser_scenarios/unbalanced_eval_brackets/main.tf
+++ b/tests/terraform/parser/resources/parser_scenarios/unbalanced_eval_brackets/main.tf
@@ -1,0 +1,4 @@
+locals {
+  # This is intentionally missing the closing bracket
+  s3_access_logs_prefix = "${replace(var.cdn_logging_prefix, "cdn", "s3")/${var.bucket_name}"
+}

--- a/tests/terraform/parser/test_parser_scenarios.py
+++ b/tests/terraform/parser/test_parser_scenarios.py
@@ -98,6 +98,9 @@ class TestParserScenarios(unittest.TestCase):
     def test_json_807(self):
         self.go("json_807")
 
+    def test_unbalanced_eval_brackets(self):
+        self.go("unbalanced_eval_brackets")
+
     @staticmethod
     def go(dir_name):
         dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),


### PR DESCRIPTION
DO NOT MERGE YET!

This is a test case which exposes an infinite loop parsing unbalanced TF eval statements. The hang happens in the python-hcl2 parser (in `_load_or_die_quietly` on the `hcl2.load(f)` call).

This should be merged once we have a fix for that library.

Relates to: #822

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
