### PR TITLE
Check Listener is using TLS 1.2

### DIFF
--- a/checkov/terraform/checks/resource/aws/AppLoadBalancerTLS12.py
+++ b/checkov/terraform/checks/resource/aws/AppLoadBalancerTLS12.py
@@ -1,0 +1,33 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class AppLoadBalancerTLS12(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure that load balancer is using TLS 1.2"
+        id = "CKV_AWS_103"
+        supported_resources = ['aws_lb_listener']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        key="protocol"
+        if key in conf.keys():
+            if conf[key] == ["HTTPS"]:
+              # Only interested in HTTPS listeners
+                policy="ssl_policy"
+                if policy in conf.keys():
+                  name=str(conf[policy]).strip("['']") 
+                  if name.startswith("ELBSecurityPolicy-FS-1-2") or name.startswith("ELBSecurityPolicy-TLS-1-2"):
+                    return CheckResult.PASSED
+                  else:
+                    return CheckResult.FAILED
+                else:
+                  return CheckResult.FAILED
+            else:
+                return CheckResult.FAILED
+        else:
+            return CheckResult.FAILED
+
+
+check = AppLoadBalancerTLS12()

--- a/tests/terraform/checks/resource/aws/test_AppLoadBalancerTLS12.py
+++ b/tests/terraform/checks/resource/aws/test_AppLoadBalancerTLS12.py
@@ -1,0 +1,37 @@
+import unittest
+
+
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.aws.AppLoadBalancerTLS12 import check
+
+class TestAppLoadBalancerTLS12(unittest.TestCase):
+
+    def test_failure(self):
+        resource_conf =  {'load_balancer_arn': ['${aws_lb.examplea.arn}'], 'port': ['443'], 'protocol': ['HTTPS'], 'ssl_policy': ["ELBSecurityPolicy-2016-08"],
+                         'default_action': [{'type': ['forward'], 'target_group_arn': ['${aws_lb_target_group.examplea.arn}'] }]}
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+ 
+    def test_success(self):
+        resource_conf =  {
+            'load_balancer_arn': [
+                '${aws_lb.examplea.arn}'
+                ], 
+            'port': ['443'], 
+            'protocol': ['HTTPS'], 
+            'ssl_policy': ["ELBSecurityPolicy-TLS-1-2-2017-01"],
+            'default_action': [
+                {
+                    'type': ['forward'], 
+                    'target_group_arn': [
+                        '${aws_lb_target_group.examplea.arn}'
+                ]
+            }
+        ]
+        }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This check examines an ALB listener, if it's using HTTPS it checks that it is using a policy that mandates the use of TLS 1.2.
Thats means policies starting:
ELBSecurityPolicy-FS-1-2 or ELBSecurityPolicy-TLS-1-2
See the policies here: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html