### PR TITLE
CF - Check - CKV_AWS_46 - EC2Credentials

### DIFF
--- a/.github/exclude-patterns.txt
+++ b/.github/exclude-patterns.txt
@@ -13,3 +13,4 @@ tests/terraform/runner/resources/plan/tfplan.json
 tests/terraform/parser/resources/plan_tags/tfplan.json
 .*Scans.md
 docs/5.Contribution/New-Provider.md
+tests/cloudformation/checks/resource/aws/example_AWSCredentials/EC2Credentials-FAILED.yaml

--- a/checkov/cloudformation/checks/resource/aws/EC2Credentials.py
+++ b/checkov/cloudformation/checks/resource/aws/EC2Credentials.py
@@ -1,0 +1,26 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.util.secrets import string_has_secrets, AWS
+
+class EC2Credentials(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure no hard-coded secrets exist in EC2 user data"
+        id = "CKV_AWS_46"
+        supported_resources = ['AWS::EC2::Instance']
+        categories = [CheckCategories.SECRETS]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'Properties' in conf.keys():
+            if 'UserData' in conf['Properties'].keys():
+                user_data = conf['Properties']['UserData']
+                # Cast to string as user data object can look slightly different depending
+                # on Yaml or JSON CF Templates and how the B64 conversion is done.
+                user_data_str = str(user_data)
+                if isinstance(user_data_str, str):
+                    if string_has_secrets(user_data_str, AWS):
+                        return CheckResult.FAILED
+        return CheckResult.PASSED
+
+
+check = EC2Credentials()

--- a/checkov/terraform/checks/resource/aws/EC2Credentials.py
+++ b/checkov/terraform/checks/resource/aws/EC2Credentials.py
@@ -6,7 +6,7 @@ from checkov.common.util.secrets import string_has_secrets, AWS
 class EC2Credentials(BaseResourceCheck):
 
     def __init__(self):
-        name = "Ensure no hard-coded secrets exist in exists in EC2 user data"
+        name = "Ensure no hard-coded secrets exist in EC2 user data"
         id = "CKV_AWS_46"
         supported_resources = ['aws_instance']
         categories = [CheckCategories.SECRETS]

--- a/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-FAILED.yaml
@@ -3,7 +3,7 @@ Resources:
   Resource0:
     Type: AWS::EC2::Instance
     Properties: 
-      ImageID: ami-04169656fea786776
+      ImageId: ami-04169656fea786776
       UserData:
         Fn::Base64:
           !Sub |

--- a/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-FAILED.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Resource0:
+    Type: AWS::EC2::Instance
+    Properties: 
+      UserData:
+        Fn::Base64:
+          !Sub |
+            #! /bin/bash
+            sudo apt-get update
+            sudo apt-get install -y apache2
+            sudo systemctl start apache2
+            sudo systemctl enable apache2
+            export AWS_ACCESS_KEY_ID
+            export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+            export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+            export AWS_DEFAULT_REGION=us-west-2
+            echo "<h1>Deployed via Terraform</h1>" | sudo tee /var/www/html/index.html

--- a/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-FAILED.yaml
@@ -3,6 +3,7 @@ Resources:
   Resource0:
     Type: AWS::EC2::Instance
     Properties: 
+      ImageID: ami-04169656fea786776
       UserData:
         Fn::Base64:
           !Sub |

--- a/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-PASSED.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Resource0:
+    Type: AWS::EC2::Instance
+  Resource1:
+    Type: AWS::EC2::Instance
+    Properties: 
+      UserData:
+        Fn::Base64:
+          !Sub |
+            #! /bin/bash
+            sudo apt-get update
+            sudo apt-get install -y apache2
+            sudo systemctl start apache2
+            sudo systemctl enable apache2
+            export AWS_ACCESS_KEY_ID
+            export AWS_ACCESS_KEY_ID=FOO
+            export AWS_SECRET_ACCESS_KEY=bar
+            export AWS_DEFAULT_REGION=us-west-2
+            echo "<h1>Deployed via Terraform</h1>" | sudo tee /var/www/html/index.html

--- a/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-PASSED.yaml
@@ -2,9 +2,12 @@ AWSTemplateFormatVersion: "2010-09-09"
 Resources:
   Resource0:
     Type: AWS::EC2::Instance
+    Properties: 
+      ImageID: ami-04169656fea786776
   Resource1:
     Type: AWS::EC2::Instance
-    Properties: 
+    Properties:
+      ImageID: ami-04169656fea786776
       UserData:
         Fn::Base64:
           !Sub |

--- a/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-PASSED.yaml
@@ -3,11 +3,11 @@ Resources:
   Resource0:
     Type: AWS::EC2::Instance
     Properties: 
-      ImageID: ami-04169656fea786776
+      ImageId: ami-04169656fea786776
   Resource1:
     Type: AWS::EC2::Instance
     Properties:
-      ImageID: ami-04169656fea786776
+      ImageId: ami-04169656fea786776
       UserData:
         Fn::Base64:
           !Sub |

--- a/tests/cloudformation/checks/resource/aws/test_EC2Credentials.py
+++ b/tests/cloudformation/checks/resource/aws/test_EC2Credentials.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.EC2Credentials import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestEC2Credentials(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_EC2Credentials"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello 🙂 

Implementing this check as already done for terraform.

I have used the same key test data as is already in-use in the terraform check to verify the same outcome.

Also changed minor typo so that text is the same for both terraform and clloudformation checks.

Terraform Check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/EC2Credentials.py

CloudFormation Doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html

Examples of CF UserData (to verify formatting): https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-ec2.html
https://gist.github.com/jeffbrl/abfd84d8d8586495632ba9b8489322e2
https://stackoverflow.com/questions/48197526/using-userdata-in-cloudformation

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
