### PR TITLE
Update LambdaEnvironmentCredentials.py

### DIFF
--- a/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -15,7 +15,7 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
 
     def scan_resource_conf(self, conf):
         self.evaluated_keys = 'environment/[0]/variables'
-        if 'environment' in conf.keys():
+        if len(conf.get('environment', [])) > 0:
             if isinstance(conf['environment'][0], dict):
                 if 'variables' in conf['environment'][0]:
                     if isinstance(force_list(conf['environment'][0]['variables'])[0], dict):


### PR DESCRIPTION
Ensure that the environment check is only applied when an environment is defined, solving a crash that happens when a lambda function does not define static environment variables, in which case the configuration looks like {..., 'environment': []}

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
