### PR TITLE
CF - Check - CKV_AWS_88

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/EC2PublicIP.py
+++ b/checkov/cloudformation/checks/resource/aws/EC2PublicIP.py
@@ -1,0 +1,41 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
+
+class EC2PublicIP(BaseResourceCheck):
+    def __init__(self):
+        name = "EC2 instance should not have public IP."
+        id = "CKV_AWS_88"
+        supported_resources = ['AWS::EC2::Instance', 'AWS::EC2::LaunchTemplate']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'Properties' in conf.keys():
+            # For AWS::EC2::Instance
+            if 'NetworkInterfaces' in conf['Properties'].keys():
+                network_interfaces = conf['Properties']['NetworkInterfaces']
+                if isinstance(network_interfaces, list):
+                    for network_interface in network_interfaces:
+                        if 'AssociatePublicIpAddress' in network_interface.keys():
+                            if network_interface['AssociatePublicIpAddress'] is True:
+                                return CheckResult.FAILED
+                        else:
+                            # If not made explicit then default is true if default subnet and false otherwise.
+                            # This info can not be derived from template so result is unknown.
+                            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-iface-embedded.html#Properties%23AssociatePublicIpAddress
+                            return CheckResult.UNKNOWN    
+            # For 'AWS::EC2::LaunchTemplate'
+            if 'LaunchTemplateData' in conf['Properties'].keys():
+                if 'NetworkInterfaces' in conf['Properties']['LaunchTemplateData'].keys():
+                    network_interfaces = conf['Properties']['LaunchTemplateData']['NetworkInterfaces']
+                    if isinstance(network_interfaces, list):
+                        for network_interface in network_interfaces:
+                            if 'AssociatePublicIpAddress' in network_interface.keys():
+                                if network_interface['AssociatePublicIpAddress'] is True:
+                                    return CheckResult.FAILED
+                            else:
+                                return CheckResult.UNKNOWN
+        return CheckResult.PASSED
+
+
+check = EC2PublicIP()

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-FAILED.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Resource0:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-04169656fea786776
+      NetworkInterfaces: 
+        - AssociatePublicIpAddress: true
+          DeviceIndex: "0"
+          GroupSet: 
+            - Ref: "myVPCEC2SecurityGroup"
+          SubnetId: 
+            Ref: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-FAILED.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  Resource0:
+  EC2InstanceResource0:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: ami-04169656fea786776
@@ -11,3 +11,15 @@ Resources:
             - Ref: "myVPCEC2SecurityGroup"
           SubnetId: 
             Ref: "PublicSubnet"
+  EC2LaunchTemplateResource0:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        ImageId: ami-04169656fea786776
+        NetworkInterfaces: 
+          - AssociatePublicIpAddress: true
+            DeviceIndex: "0"
+            GroupSet: 
+              - Ref: "myVPCEC2SecurityGroup"
+            SubnetId: 
+              Ref: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-FAILED.yaml
@@ -6,7 +6,7 @@ Resources:
       ImageId: ami-04169656fea786776
       NetworkInterfaces: 
         - AssociatePublicIpAddress: true
-          DeviceIndex: 0
+          DeviceIndex: "0"
           GroupSet: 
             - "myVPCEC2SecurityGroup"
           SubnetId: "PublicSubnet"
@@ -18,6 +18,6 @@ Resources:
         NetworkInterfaces: 
           - AssociatePublicIpAddress: true
             DeviceIndex: 0
-            GroupSet: 
+            Groups: 
               - "myVPCEC2SecurityGroup"
             SubnetId: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-FAILED.yaml
@@ -6,11 +6,10 @@ Resources:
       ImageId: ami-04169656fea786776
       NetworkInterfaces: 
         - AssociatePublicIpAddress: true
-          DeviceIndex: "0"
+          DeviceIndex: 0
           GroupSet: 
-            - Ref: "myVPCEC2SecurityGroup"
-          SubnetId: 
-            Ref: "PublicSubnet"
+            - "myVPCEC2SecurityGroup"
+          SubnetId: "PublicSubnet"
   EC2LaunchTemplateResource0:
     Type: AWS::EC2::LaunchTemplate
     Properties:
@@ -18,8 +17,7 @@ Resources:
         ImageId: ami-04169656fea786776
         NetworkInterfaces: 
           - AssociatePublicIpAddress: true
-            DeviceIndex: "0"
+            DeviceIndex: 0
             GroupSet: 
-              - Ref: "myVPCEC2SecurityGroup"
-            SubnetId: 
-              Ref: "PublicSubnet"
+              - "myVPCEC2SecurityGroup"
+            SubnetId: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-PASSED.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Resource0:
+    Type: AWS::EC2::Instance
+    Properties: 
+      ImageId: ami-04169656fea786776
+  Resource1:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-04169656fea786776
+      NetworkInterfaces: 
+        - AssociatePublicIpAddress: false
+          DeviceIndex: "0"
+          GroupSet: 
+            - Ref: "myVPCEC2SecurityGroup"
+          SubnetId: 
+            Ref: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-PASSED.yaml
@@ -10,7 +10,7 @@ Resources:
       ImageId: ami-04169656fea786776
       NetworkInterfaces: 
         - AssociatePublicIpAddress: false
-          DeviceIndex: 0
+          DeviceIndex: "0"
           GroupSet: 
             - "myVPCEC2SecurityGroup"
           SubnetId: "PublicSubnet"
@@ -27,6 +27,6 @@ Resources:
         NetworkInterfaces: 
           - AssociatePublicIpAddress: false
             DeviceIndex: 0
-            GroupSet: 
+            Groups: 
               - "myVPCEC2SecurityGroup"
             SubnetId: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-PASSED.yaml
@@ -10,25 +10,23 @@ Resources:
       ImageId: ami-04169656fea786776
       NetworkInterfaces: 
         - AssociatePublicIpAddress: false
-          DeviceIndex: "0"
+          DeviceIndex: 0
           GroupSet: 
-            - Ref: "myVPCEC2SecurityGroup"
-          SubnetId: 
-            Ref: "PublicSubnet"
-  Ec2LaunchTemplateResource0:
+            - "myVPCEC2SecurityGroup"
+          SubnetId: "PublicSubnet"
+  EC2LaunchTemplateResource0:
     Type: AWS::EC2::LaunchTemplate
     Properties:
       LaunchTemplateData:
         ImageId: ami-04169656fea786776
-  Ec2LaunchTemplateResource1:
+  EC2LaunchTemplateResource1:
     Type: AWS::EC2::LaunchTemplate
     Properties:
       LaunchTemplateData:
         ImageId: ami-04169656fea786776
         NetworkInterfaces: 
           - AssociatePublicIpAddress: false
-            DeviceIndex: "0"
+            DeviceIndex: 0
             GroupSet: 
-              - Ref: "myVPCEC2SecurityGroup"
-            SubnetId: 
-              Ref: "PublicSubnet"
+              - "myVPCEC2SecurityGroup"
+            SubnetId: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-PASSED.yaml
@@ -1,10 +1,10 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  Resource0:
+  EC2InstanceResource0:
     Type: AWS::EC2::Instance
     Properties: 
       ImageId: ami-04169656fea786776
-  Resource1:
+  EC2InstanceResource1:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: ami-04169656fea786776
@@ -15,3 +15,20 @@ Resources:
             - Ref: "myVPCEC2SecurityGroup"
           SubnetId: 
             Ref: "PublicSubnet"
+  Ec2LaunchTemplateResource0:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        ImageId: ami-04169656fea786776
+  Ec2LaunchTemplateResource1:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        ImageId: ami-04169656fea786776
+        NetworkInterfaces: 
+          - AssociatePublicIpAddress: false
+            DeviceIndex: "0"
+            GroupSet: 
+              - Ref: "myVPCEC2SecurityGroup"
+            SubnetId: 
+              Ref: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-UNKNOWN.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-UNKNOWN.yaml
@@ -5,7 +5,7 @@ Resources:
     Properties:
       ImageId: ami-04169656fea786776
       NetworkInterfaces: 
-        - DeviceIndex: 0
+        - DeviceIndex: "0"
           GroupSet: 
             - "myVPCEC2SecurityGroup"
           SubnetId: "PublicSubnet"
@@ -16,6 +16,6 @@ Resources:
         ImageId: ami-04169656fea786776
         NetworkInterfaces: 
           - DeviceIndex: 0
-            GroupSet: 
+            Groups: 
               - "myVPCEC2SecurityGroup"
             SubnetId: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-UNKNOWN.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-UNKNOWN.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  Resource0:
+  EC2InstanceResource0:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: ami-04169656fea786776
@@ -10,3 +10,14 @@ Resources:
             - Ref: "myVPCEC2SecurityGroup"
           SubnetId: 
             Ref: "PublicSubnet"
+  EC2LaunchTemplateResource0:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        ImageId: ami-04169656fea786776
+        NetworkInterfaces: 
+          - DeviceIndex: "0"
+            GroupSet: 
+              - Ref: "myVPCEC2SecurityGroup"
+            SubnetId: 
+              Ref: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-UNKNOWN.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-UNKNOWN.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Resource0:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-04169656fea786776
+      NetworkInterfaces: 
+        - DeviceIndex: "0"
+          GroupSet: 
+            - Ref: "myVPCEC2SecurityGroup"
+          SubnetId: 
+            Ref: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-UNKNOWN.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_EC2PublicIP/EC2PublicIP-UNKNOWN.yaml
@@ -5,19 +5,17 @@ Resources:
     Properties:
       ImageId: ami-04169656fea786776
       NetworkInterfaces: 
-        - DeviceIndex: "0"
+        - DeviceIndex: 0
           GroupSet: 
-            - Ref: "myVPCEC2SecurityGroup"
-          SubnetId: 
-            Ref: "PublicSubnet"
+            - "myVPCEC2SecurityGroup"
+          SubnetId: "PublicSubnet"
   EC2LaunchTemplateResource0:
     Type: AWS::EC2::LaunchTemplate
     Properties:
       LaunchTemplateData:
         ImageId: ami-04169656fea786776
         NetworkInterfaces: 
-          - DeviceIndex: "0"
+          - DeviceIndex: 0
             GroupSet: 
-              - Ref: "myVPCEC2SecurityGroup"
-            SubnetId: 
-              Ref: "PublicSubnet"
+              - "myVPCEC2SecurityGroup"
+            SubnetId: "PublicSubnet"

--- a/tests/cloudformation/checks/resource/aws/test_EC2PublicIP.py
+++ b/tests/cloudformation/checks/resource/aws/test_EC2PublicIP.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.EC2PublicIP import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestEC2PublicIP(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_EC2PublicIP"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_EC2PublicIP.py
+++ b/tests/cloudformation/checks/resource/aws/test_EC2PublicIP.py
@@ -16,8 +16,8 @@ class TestEC2PublicIP(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 2)
-        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['passed'], 4)
+        self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
Hello,

Implementing check for EC2 Public IP in CloudFormation as done in Terraform.

Terraform Check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/EC2PublicIP.py

CloudFormation Docs: 
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-iface-embedded.html#aws-properties-ec2-network-iface-embedded-associatepubip
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-networkinterface.html

Note (for if you take a closer look at the test data):
It is odd how they have chose to have 'NetworkInterfaces' as a slightly different type in instances and launch templates and how they have some of the same field names with different types and such. But that is the way it is.

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
