### PR TITLE
Avoid parsing serverless resources that don't have 'Type'

### DIFF
--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -107,6 +107,9 @@ class Runner(BaseRunner):
                     if not isinstance(resource, dict_node):
                         continue
                     cf_resource_id = cf_context_parser.extract_cf_resource_id(resource, resource_name)
+                    if not cf_resource_id:
+                        # Not Type attribute for resource
+                        continue
                     entity_lines_range, entity_code_lines = cf_context_parser.extract_cf_resource_code_lines(
                         resource)
                     if entity_lines_range and entity_code_lines:

--- a/tests/serverless/runner/resources/serverless.yml
+++ b/tests/serverless/runner/resources/serverless.yml
@@ -29,3 +29,10 @@ layers:
 functions:
   myFunction:
     handler: myfunction.invoke
+
+resources:
+  Resources:
+    ApiGatewayRestApi:
+      Properties:
+        BinaryMediaTypes:
+          - "*/*"


### PR DESCRIPTION
* Added to the serverless runner a check to validate that the resource_id is not None. 
If it is None there is no need to scan it.

* Added a malformed resource to the `serverless.yml` in the tests resources to make sure there is no exception thrown when it exists in the file and the tests still pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
