### PR TITLE
Skip .tf.json files until they are truly supported

### DIFF
--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -168,7 +168,7 @@ class Parser:
                 continue
 
             # Resource files
-            if file.name.endswith(".tf.json") or file.name.endswith(".tf"):
+            if file.name.endswith(".tf"):  # TODO: add support for .tf.json
                 data = _load_or_die_quietly(file, self.out_parsing_errors)
             else:
                 continue

--- a/tests/terraform/parser/test_parser_scenarios.py
+++ b/tests/terraform/parser/test_parser_scenarios.py
@@ -101,6 +101,7 @@ class TestParserScenarios(unittest.TestCase):
         # Run only manually, this test currently fails on multiple issues
         self.go("count_eval")
 
+    @unittest.skip
     def test_json_807(self):
         self.go("json_807")
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

We don't support .tf.json yet, as it has a different structure than the output of hcl2 lib. Removing it from scanned file extensions until we add support for it