### PR TITLE
CF - Check -  ckv_aws_100 as done in TF

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/EKSNodeGroupRemoteAccess.py
+++ b/checkov/cloudformation/checks/resource/aws/EKSNodeGroupRemoteAccess.py
@@ -1,0 +1,23 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
+
+class EKSNodeGroupRemoteAccess(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure Amazon EKS Node group has implict SSH access from 0.0.0.0/0"
+        id = "CKV_AWS_100"
+        supported_resources = ['AWS::EKS::Nodegroup']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'Properties' in conf.keys():
+            if 'RemoteAccess' in conf['Properties'].keys():
+                if 'Ec2SshKey' in conf['Properties']['RemoteAccess'].keys():
+                    if 'SourceSecurityGroups' in conf['Properties']['RemoteAccess'].keys():
+                        return CheckResult.PASSED
+                    else:
+                        return CheckResult.FAILED
+        return CheckResult.PASSED
+
+
+check = EKSNodeGroupRemoteAccess()

--- a/tests/cloudformation/checks/resource/aws/example_EKSNodeGroupRemoteAccess/EKSNodeGroupRemoteAccess-FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_EKSNodeGroupRemoteAccess/EKSNodeGroupRemoteAccess-FAILED.yml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  Resource0:
+    Type: 'AWS::EKS::Nodegroup'
+    Properties:
+      ClusterName: test
+      NodeRole: 'arn:aws:iam::012345678910:role/eksInstanceRole'
+      ScalingConfig:
+        MinSize: 3
+        DesiredSize: 5
+        MaxSize: 7
+      Labels:
+        Key1: Value1
+        Key2: Value2
+      Subnets:
+        - subnet-6782e71e
+        - subnet-e7e761ac
+      RemoteAccess: 
+        Ec2SshKey: SshKeyString

--- a/tests/cloudformation/checks/resource/aws/example_EKSNodeGroupRemoteAccess/EKSNodeGroupRemoteAccess-PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_EKSNodeGroupRemoteAccess/EKSNodeGroupRemoteAccess-PASSED.yml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  Resource0:
+    Type: 'AWS::EKS::Nodegroup'
+    Properties:
+      ClusterName: test
+      NodeRole: 'arn:aws:iam::012345678910:role/eksInstanceRole'
+      ScalingConfig:
+        MinSize: 3
+        DesiredSize: 5
+        MaxSize: 7
+      Labels:
+        Key1: Value1
+        Key2: Value2
+      Subnets:
+        - subnet-6782e71e
+        - subnet-e7e761ac
+      RemoteAccess: 
+        Ec2SshKey: SshKeyString
+        SourceSecurityGroups: 
+          - sg-0
+  Resource1:
+    Type: 'AWS::EKS::Nodegroup'
+    Properties:
+      ClusterName: test
+      NodeRole: 'arn:aws:iam::012345678910:role/eksInstanceRole'
+      ScalingConfig:
+        MinSize: 3
+        DesiredSize: 5
+        MaxSize: 7
+      Labels:
+        Key1: Value1
+        Key2: Value2
+      Subnets:
+        - subnet-6782e71e
+        - subnet-e7e761ac

--- a/tests/cloudformation/checks/resource/aws/test_EKSNodeGroupRemoteAccess.py
+++ b/tests/cloudformation/checks/resource/aws/test_EKSNodeGroupRemoteAccess.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.EKSNodeGroupRemoteAccess import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestEKSNodeGroupRemoteAccess(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_EKSNodeGroupRemoteAccess"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello 🙂 

Check for CF as already done for Terraform.

TF Check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py

CF Docs:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
