### PR TITLE
Functioning --quiet for -o json.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
           pipenv run checkov -s -d cfngoat/ -o json > checkov_report_cfngoat.json
           pipenv run checkov -s -d kubernetes-goat/ -o json > checkov_report_kubernetes-goat.json
           pipenv run checkov -s  --skip-check CKV_AWS_33,CKV_AWS_41 -d terragoat/terraform/ -o json > checkov_report_terragoat_with_skip.json
+          pipenv run checkov -s -d cfngoat/ -o json --quiet > checkov_report_cfngoat_quiet.json
 
       - name: Run integration tests
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -78,6 +78,7 @@ jobs:
           pipenv run checkov -s -d cfngoat/ -o json > checkov_report_cfngoat.json
           pipenv run checkov -s -d kubernetes-goat/ -o json > checkov_report_kubernetes-goat.json
           pipenv run checkov -s  --skip-check CKV_AWS_33,CKV_AWS_41 -d terragoat/terraform/ -o json > checkov_report_terragoat_with_skip.json
+          pipenv run checkov -s -d cfngoat/ -o json --quiet > checkov_report_cfngoat_quiet.json
 
       - name: Run integration tests
         run: |

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -49,17 +49,26 @@ class Report:
     def get_json(self):
         return json.dumps(self.get_dict(), indent=4)
 
-    def get_dict(self):
-        return {
-            "check_type": self.check_type,
-            "results": {
-                "passed_checks": [check.__dict__ for check in self.passed_checks],
-                "failed_checks": [check.__dict__ for check in self.failed_checks],
-                "skipped_checks": [check.__dict__ for check in self.skipped_checks],
-                "parsing_errors": list(self.parsing_errors)
-            },
-            "summary": self.get_summary()
+    def get_dict(self, is_quiet=False):
+        if is_quiet:
+            return {
+                "check_type": self.check_type,
+                "results": {
+                    "failed_checks": [check.__dict__ for check in self.failed_checks]
+                },
+                "summary": self.get_summary()
         }
+        else: 
+            return {
+                "check_type": self.check_type,
+                "results": {
+                    "passed_checks": [check.__dict__ for check in self.passed_checks],
+                    "failed_checks": [check.__dict__ for check in self.failed_checks],
+                    "skipped_checks": [check.__dict__ for check in self.skipped_checks],
+                    "parsing_errors": list(self.parsing_errors)
+                },
+                "summary": self.get_summary()
+            }
 
     def get_exit_code(self, soft_fail):
         if soft_fail:

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -48,7 +48,7 @@ class RunnerRegistry(object):
         for report in scan_reports:
             if not report.is_empty():
                 if args.output == "json":
-                    report_jsons.append(report.get_dict())
+                    report_jsons.append(report.get_dict(is_quiet=args.quiet))
                 elif args.output == "junitxml":
                     junit_reports.append(report)
                     # report.print_junit_xml()

--- a/integration_tests/test_checkov_json_report.py
+++ b/integration_tests/test_checkov_json_report.py
@@ -33,6 +33,13 @@ class TestCheckovJsonReport(unittest.TestCase):
             self.assertEqual(data["summary"]["parsing_errors"], 0, "expecting 0 parsing errors")
             self.assertGreater(data["summary"]["failed"], 1, "expecting more then 1 failed checks")
 
+    def validate_json_quiet(self):
+        report_path = current_dir + "/../checkov_report_cfngoat_quiet.json"
+        with open(report_path) as json_file:
+            data = json.load(json_file)
+            self.assertTrue(data["results"]["failed_checks"])
+            self.assertFalse(data["results"]["passed_checks"])
+            self.assertTrue(data["summary"])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Functioning `--quiet` option for `-o json`requested in #704. Fixes #704 
Looking at #774 for callable unit test and passing in cli params for tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
