### PR TITLE
Fix NLB TLS 1.2 issue

### DIFF
--- a/checkov/terraform/checks/resource/aws/AppLoadBalancerTLS12.py
+++ b/checkov/terraform/checks/resource/aws/AppLoadBalancerTLS12.py
@@ -13,8 +13,8 @@ class AppLoadBalancerTLS12(BaseResourceCheck):
     def scan_resource_conf(self, conf):
         key="protocol"
         if key in conf.keys():
-            if conf[key] == ["HTTPS"]:
-              # Only interested in HTTPS listeners
+            if conf[key] in (["HTTPS"], ["TLS"]):
+              # Only interested in HTTPS & TLS listeners
                 policy="ssl_policy"
                 if policy in conf.keys():
                   name=str(conf[policy]).strip("['']") 

--- a/tests/terraform/checks/resource/aws/test_AppLoadBalancerTLS12.py
+++ b/tests/terraform/checks/resource/aws/test_AppLoadBalancerTLS12.py
@@ -33,6 +33,26 @@ class TestAppLoadBalancerTLS12(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_nlb_tls_success(self):
+        resource_conf = {
+            'load_balancer_arn': [
+                '${aws_lb.example.arn}'
+            ],
+            'port': ['443'],
+            'protocol': ['TLS'],
+            'ssl_policy': ["ELBSecurityPolicy-FS-1-2-Res-2019-08"],
+            'default_action': [
+                {
+                    'type': ['forward'],
+                    'target_group_arn': [
+                        '${aws_lb_target_group.example.arn}'
+                    ]
+                }
+            ]
+        }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
     def test_redirect(self):
         hcl_res = hcl2.loads("""
             resource "aws_lb_listener" "http" {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

With PR #838 `checkov` is now raising a false positive for the `CKV_AWS_103` check, because also NLBs can have a TLS certificate and apply a security policy.

```
Check: CKV_AWS_103: "Ensure that load balancer is using TLS 1.2"
        FAILED for resource: aws_lb_listener.https
        File: /../../modules/example/network.tf:54-65

                54 | resource "aws_lb_listener" "https" {
                55 |   load_balancer_arn = aws_lb.this.arn
                56 |   protocol          = "TLS"
                57 |   port              = "443"
                58 |   ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
                59 |   certificate_arn   = module.certificate.arn
                60 | 
                61 |   default_action {
                62 |     type             = "forward"
                63 |     target_group_arn = aws_lb_target_group.web.arn
                64 |   }
                65 | }
```