### PR TITLE
Avoid attempting to clean data from tfvars

### DIFF
--- a/tests/terraform/parser/resources/parser_scenarios/tfvars/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/tfvars/expected.json
@@ -3,6 +3,12 @@
     "variable": [
       {
         "foo": {}
+      },
+      {
+        "list_data": {}
+      },
+      {
+        "map_data": {}
       }
     ],
     "resource": [

--- a/tests/terraform/parser/resources/parser_scenarios/tfvars/main.tf
+++ b/tests/terraform/parser/resources/parser_scenarios/tfvars/main.tf
@@ -1,5 +1,9 @@
 variable "foo" {}
+variable "list_data" {}
+variable "map_data" {}
 
 resource "aws_s3_bucket" "my_bucket" {
+  // TODO: List/map isn't resolving correctly
+//  bucket = "${var.foo}-${var.list_data[0]}-${var.map_data[stage]}"
   bucket = var.foo
 }

--- a/tests/terraform/parser/resources/parser_scenarios/tfvars/terraform.tfvars
+++ b/tests/terraform/parser/resources/parser_scenarios/tfvars/terraform.tfvars
@@ -1,1 +1,12 @@
 foo = "fü"
+
+list_data = [
+  "one",
+  "two"
+]
+
+map_data = {
+  namespace = "customer"
+  stage     = "dev"
+  name      = "app"
+}


### PR DESCRIPTION
This avoids a problem where map data in `.tfvars` files is improperly removed. Note, there are still some resolution issues with tfvars files which will be addressed in subsequent work... but this avoids explosions.

Fixes: #868

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
