### PR TITLE
Ensure retention is 90 days or greater

### DIFF
--- a/checkov/terraform/checks/resource/azure/SQLServerAuditPolicyRetentionPeriod.py
+++ b/checkov/terraform/checks/resource/azure/SQLServerAuditPolicyRetentionPeriod.py
@@ -14,10 +14,11 @@ class SQLServerAuditPolicyRetentionPeriod(BaseResourceCheck):
     def scan_resource_conf(self, conf):
         if 'retention_in_days' in conf: 
             retention=force_int(conf['retention_in_days'][0])
-            if retention < 90:
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+            if retention:
+                if retention < 90:
+                    return CheckResult.FAILED
+                else:
+                    return CheckResult.PASSED
         return CheckResult.FAILED
 
 

--- a/checkov/terraform/checks/resource/azure/SQLServerAuditPolicyRetentionPeriod.py
+++ b/checkov/terraform/checks/resource/azure/SQLServerAuditPolicyRetentionPeriod.py
@@ -1,0 +1,24 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.common.util.type_forcers import force_int
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+
+
+class SQLServerAuditPolicyRetentionPeriod(BaseResourceCheck):
+    def __init__(self):
+        name = "Specifies a retention period of less than 90 days."
+        id = "CKV_AZURE_46"
+        supported_resources = ['azurerm_mssql_database_extended_auditing_policy']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'retention_in_days' in conf: 
+            retention=force_int(conf['retention_in_days'][0])
+            if retention < 90:
+                return CheckResult.FAILED
+            else:
+                return CheckResult.PASSED
+        return CheckResult.FAILED
+
+
+check = SQLServerAuditPolicyRetentionPeriod()

--- a/tests/terraform/checks/resource/azure/test_SQLServerAuditPolicyRetentionPeriod.py
+++ b/tests/terraform/checks/resource/azure/test_SQLServerAuditPolicyRetentionPeriod.py
@@ -1,0 +1,53 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.azure.SQLServerAuditPolicyRetentionPeriod import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestSQLServerAuditingEnabled(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+resource "azurerm_mssql_database_extended_auditing_policy" "example" {
+  database_id                             = azurerm_mssql_database.examplea.id
+  storage_endpoint                        = azurerm_storage_account.examplea.primary_blob_endpoint
+  storage_account_access_key              = azurerm_storage_account.examplea.primary_access_key
+  storage_account_access_key_is_secondary = false
+  retention_in_days                       = 89
+}
+               """)
+        resource_conf = hcl_res['resource'][0]['azurerm_mssql_database_extended_auditing_policy']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+ 
+    def test_missingisfailure(self):
+        hcl_res = hcl2.loads("""
+resource "azurerm_mssql_database_extended_auditing_policy" "example" {
+  database_id                             = azurerm_mssql_database.examplea.id
+  storage_endpoint                        = azurerm_storage_account.examplea.primary_blob_endpoint
+  storage_account_access_key              = azurerm_storage_account.examplea.primary_access_key
+  storage_account_access_key_is_secondary = false
+}
+               """)
+        resource_conf = hcl_res['resource'][0]['azurerm_mssql_database_extended_auditing_policy']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_mssql_database_extended_auditing_policy" "example" {
+  database_id                             = azurerm_mssql_database.examplea.id
+  storage_endpoint                        = azurerm_storage_account.examplea.primary_blob_endpoint
+  storage_account_access_key              = azurerm_storage_account.examplea.primary_access_key
+  storage_account_access_key_is_secondary = false
+  retention_in_days                       = 90
+}
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_mssql_database_extended_auditing_policy']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
The location of the audit policy for sql server is now a separate resource- there's an Azure policy that checks that the retention policy is 90 days or more, this is that check for the new resource.