### PR TITLE
Check for logging on google cloud storage

### DIFF
--- a/checkov/terraform/checks/resource/gcp/CloudStorageLogging.py
+++ b/checkov/terraform/checks/resource/gcp/CloudStorageLogging.py
@@ -1,0 +1,29 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class CloudStorageLogging(BaseResourceCheck):
+    def __init__(self):
+        name = "Bucket should log access"
+        id = "CKV_GCP_62"
+        supported_resources = ['google_storage_bucket']
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        #check fot logging
+        if 'logging' in conf.keys():
+            if conf['logging'][0]['log_bucket']:
+                log_bucket_name = conf['logging'][0]['log_bucket']
+                if log_bucket_name != None:
+                    return CheckResult.PASSED
+                else:
+                   return CheckResult.FAILED
+            else:
+                return CheckResult.FAILED
+            return CheckResult.FAILED
+        else:
+            return CheckResult.FAILED
+        return CheckResult.FAILED
+
+check = CloudStorageLogging()

--- a/tests/terraform/checks/resource/gcp/test_CloudStorageLogging.py
+++ b/tests/terraform/checks/resource/gcp/test_CloudStorageLogging.py
@@ -1,0 +1,39 @@
+import unittest
+
+import hcl2
+
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.gcp.CloudStorageLogging import check
+
+
+class TestCloudStorageLogging(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+        resource "google_storage_bucket" "logging" {
+                name     = "jgwloggingbucket"
+                location = var.location
+                uniform_bucket_level_access = true
+          }
+        """)
+        resource_conf = hcl_res['resource'][0]['google_storage_bucket']['logging']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+        resource "google_storage_bucket" "logging" {
+                name     = "jgwloggingbucket"
+                location = var.location
+                uniform_bucket_level_access = true
+                logging {
+                  log_bucket = "mylovelybucket"
+                }
+          }
+        """)
+        resource_conf = hcl_res['resource'][0]['google_storage_bucket']['logging']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Ensure that Accesslogging is enabled for cloud storage buckets. There are similar tests for s3, this implements same for gcp.