### PR TITLE
GCP Cloud Storage: A bucket shouldn't log to itself

### DIFF
--- a/checkov/terraform/checks/resource/gcp/CloudStorageSelfLogging.py
+++ b/checkov/terraform/checks/resource/gcp/CloudStorageSelfLogging.py
@@ -1,0 +1,28 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class CloudStorageSelfLogging(BaseResourceCheck):
+    def __init__(self):
+        name = "Bucket should not log to itself"
+        id = "CKV_GCP_62"
+        supported_resources = ['google_storage_bucket']
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        bucket_name = conf['name']
+        #check fot logging
+        if 'logging' in conf.keys():
+            if conf['logging'][0]['log_bucket']:
+                log_bucket_name = conf['logging'][0]['log_bucket']
+                if log_bucket_name != bucket_name:
+                    return CheckResult.PASSED
+                else:
+                   return CheckResult.FAILED
+            else:
+                return CheckResult.FAILED
+            return CheckResult.FAILED
+        return CheckResult.UNKNOWN
+
+check = CloudStorageSelfLogging()

--- a/tests/terraform/checks/resource/gcp/test_CloudStorageSelfLogging.py
+++ b/tests/terraform/checks/resource/gcp/test_CloudStorageSelfLogging.py
@@ -1,0 +1,45 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.gcp.CloudStorageSelfLogging import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestCloudStorageSelfLogging(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+                resource "google_storage_bucket" "static-site" {
+                  name          = "image-store.com"
+                  location      = "EU"
+                  force_destroy = true
+                  logging {
+                    log_bucket="image-store.com"
+                  }
+                }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_storage_bucket']['static-site']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+
+    def test_success(self):
+         hcl_res = hcl2.loads("""
+                         resource "google_storage_bucket" "static-site" {
+                           name          = "image-store.com"
+                           location      = "EU"
+                           force_destroy = true
+                           uniform_bucket_level_access = true
+                           logging {
+                             log_bucket="mybestbucket"
+                             }
+                         }
+                         """)
+         resource_conf = hcl_res['resource'][0]['google_storage_bucket']['static-site']
+         scan_result = check.scan_resource_conf(conf=resource_conf)
+         self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
If you set up logging for your bucket GREAT! But set up logging and then set it itself, FAIL.
Thats what this check does is make sure you dont fudge a logging requirement by logging to self.