### PR TITLE
Maria DB server - Make sure public access is disabled

### DIFF
--- a/checkov/terraform/checks/resource/azure/MariaDBPublicAccessDisabled.py
+++ b/checkov/terraform/checks/resource/azure/MariaDBPublicAccessDisabled.py
@@ -1,0 +1,23 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+
+
+class MariaDBPublicAccessDisabled(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure 'public network access enabled' is set to 'False' for MariaDB servers"
+        id = "CKV_AZURE_48"
+        supported_resources = ['azurerm_mariadb_server']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        #Whether or not public network access is allowed for this server. Defaults to true. Which is not optimal
+        if 'public_network_access_enabled' not in conf: 
+            return CheckResult.FAILED
+        else:
+            if  conf['public_network_access_enabled'][0]:
+                return CheckResult.FAILED
+            else:
+                return CheckResult.PASSED
+
+check = MariaDBPublicAccessDisabled()

--- a/tests/terraform/checks/resource/azure/test_MariaDBPublicAccessDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_MariaDBPublicAccessDisabled.py
@@ -1,0 +1,59 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.azure.MariaDBPublicAccessDisabled import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestMariaDBPublicAccessDisabled(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_mariadb_server" "example" {
+            name                = var.server_name
+            location            = var.resource_group.location
+            resource_group_name = var.resource_group.name
+            administrator_login          = var.admin_login
+            administrator_login_password = random_string.password.result
+            sku_name   = "B_Gen5_2"
+            storage_mb = 5120
+            version    = "10.2"
+            auto_grow_enabled             = true
+            backup_retention_days         = 7
+            geo_redundant_backup_enabled  = false
+            public_network_access_enabled = true
+            #test this i guess
+            ssl_enforcement_enabled = false
+        }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_mariadb_server']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+        resource "azurerm_mariadb_server" "example" {
+            name                = var.server_name
+            location            = var.resource_group.location
+            resource_group_name = var.resource_group.name
+            administrator_login          = var.admin_login
+            administrator_login_password = random_string.password.result
+            sku_name   = "B_Gen5_2"
+            storage_mb = 5120
+            version    = "10.2"
+            auto_grow_enabled             = true
+            backup_retention_days         = 7
+            geo_redundant_backup_enabled  = false
+            public_network_access_enabled = false
+            #test this i guess
+            ssl_enforcement_enabled = true
+        }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_mariadb_server']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Default behaviour is for mariadbs to be public. This is a rule to stop that and make it private 