### PR TITLE
CF - Check - ELBAccessLogs

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ELBAccessLogs.py
+++ b/checkov/cloudformation/checks/resource/aws/ELBAccessLogs.py
@@ -1,0 +1,17 @@
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class ELBAccessLogs(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure the ELB has access logging enabled"
+        id = "CKV_AWS_92"
+        supported_resources = ['AWS::ElasticLoadBalancing::LoadBalancer']
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'Properties/AccessLoggingPolicy/Enabled'
+
+
+check = ELBAccessLogs()

--- a/tests/cloudformation/checks/resource/aws/example_ELBAccessLogs/ELBAccessLogs-FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ELBAccessLogs/ELBAccessLogs-FAILED.yml
@@ -4,10 +4,10 @@ Resources:
     Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
     Properties:
       Listeners:
-      - InstancePort: '443'
-        InstanceProtocol: HTTPS
-        LoadBalancerPort: '443'
-        Protocol: HTTPS
+      - InstancePort: '80'
+        InstanceProtocol: HTTP
+        LoadBalancerPort: '80'
+        Protocol: HTTP
       AccessLoggingPolicy:
         Enabled: false
         S3BucketName: MyBucket
@@ -15,8 +15,7 @@ Resources:
     Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
     Properties:
       Listeners:
-      - InstancePort: '443'
-        InstanceProtocol: HTTPS
-        LoadBalancerPort: '443'
-        Protocol: HTTPS
-
+      - InstancePort: '80'
+        InstanceProtocol: HTTP
+        LoadBalancerPort: '80'
+        Protocol: HTTP

--- a/tests/cloudformation/checks/resource/aws/example_ELBAccessLogs/ELBAccessLogs-FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ELBAccessLogs/ELBAccessLogs-FAILED.yml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  Resource0:
+    Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
+    Properties:
+      Listeners:
+      - InstancePort: '443'
+        InstanceProtocol: HTTPS
+        LoadBalancerPort: '443'
+        Protocol: HTTPS
+      AccessLoggingPolicy:
+        Enabled: false
+        S3BucketName: MyBucket
+  Resource1:
+    Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
+    Properties:
+      Listeners:
+      - InstancePort: '443'
+        InstanceProtocol: HTTPS
+        LoadBalancerPort: '443'
+        Protocol: HTTPS
+

--- a/tests/cloudformation/checks/resource/aws/example_ELBAccessLogs/ELBAccessLogs-PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ELBAccessLogs/ELBAccessLogs-PASSED.yml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  Resource0:
+    Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
+    Properties:
+      Listeners:
+      - InstancePort: '443'
+        InstanceProtocol: HTTPS
+        LoadBalancerPort: '443'
+        Protocol: HTTPS
+      AccessLoggingPolicy:
+        Enabled: true
+        S3BucketName: MyBucket

--- a/tests/cloudformation/checks/resource/aws/example_ELBAccessLogs/ELBAccessLogs-PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ELBAccessLogs/ELBAccessLogs-PASSED.yml
@@ -4,10 +4,10 @@ Resources:
     Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
     Properties:
       Listeners:
-      - InstancePort: '443'
-        InstanceProtocol: HTTPS
-        LoadBalancerPort: '443'
-        Protocol: HTTPS
+      - InstancePort: '80'
+        InstanceProtocol: HTTP
+        LoadBalancerPort: '80'
+        Protocol: HTTP
       AccessLoggingPolicy:
         Enabled: true
         S3BucketName: MyBucket

--- a/tests/cloudformation/checks/resource/aws/test_ELBAccessLogs.py
+++ b/tests/cloudformation/checks/resource/aws/test_ELBAccessLogs.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.ELBAccessLogs import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestELBAccessLogs(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ELBAccessLogs"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello,

Congrats all on the recent news! :)

Implementing this check as already done in TF. Able to use ValueCheck in this case because in CF world when AccessLoggingPolicy exists then Enabled is a required field and does not have a default value. So it must always be true or false.


TF Check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/ELBAccessLogs.py
CF Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-accessloggingpolicy.html

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
