### PR TITLE
linuxscaleset should not set passwords

### DIFF
--- a/checkov/terraform/checks/resource/azure/AzureScaleSetPassword.py
+++ b/checkov/terraform/checks/resource/azure/AzureScaleSetPassword.py
@@ -1,0 +1,27 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class AzureScaleSetPassword(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure Azure linux scale set does not use basic authentication(Use SSH Key Instead)"
+        id = "CKV_AZURE_48"
+        supported_resources = ['azurerm_linux_virtual_machine_scale_set']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        """
+            Looks for password configuration at azure_instance:
+            https://www.terraform.io/docs/providers/azurerm/r/linux_virtual_machine_scale_set.html
+        :param conf: azurerm_linux_virtual_machine_scale_set configuration
+        :return: <CheckResult>
+        """
+        if 'disable_password_authentication' in conf.keys():
+            if conf.get('disable_password_authentication', [True])[0]:
+                return CheckResult.PASSED
+
+        return CheckResult.FAILED
+
+
+check = AzureScaleSetPassword()

--- a/tests/terraform/checks/resource/azure/test_AzureScaleSetPassword.py
+++ b/tests/terraform/checks/resource/azure/test_AzureScaleSetPassword.py
@@ -1,0 +1,51 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.azure.AzureScaleSetPassword import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestAzureScaleSetPassword(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+        resource "azurerm_linux_virtual_machine_scale_set" "example" {
+            name                = var.scaleset_name
+            resource_group_name = var.resource_group.name
+            location            = var.resource_group.location
+            sku                 = var.sku
+            instances           = var.instance_count
+            admin_username      = var.admin_username
+            disable_password_authentication = false
+            tags = var.common_tags
+        }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_linux_virtual_machine_scale_set']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+        resource "azurerm_linux_virtual_machine_scale_set" "example" {
+            name                = var.scaleset_name
+            resource_group_name = var.resource_group.name
+            location            = var.resource_group.location
+            sku                 = var.sku
+            instances           = var.instance_count
+            admin_username      = var.admin_username
+            disable_password_authentication = true
+
+                admin_ssh_key {
+                    username   = var.admin_username
+                    public_key = tls_private_key.new.public_key_pem
+                }
+            tags = var.common_tags
+        }
+                        """)
+        resource_conf = hcl_res['resource'][0]['azurerm_linux_virtual_machine_scale_set']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
This test ensures that you opt for not using password auth on your scalesets. That is all.

addressed https://github.com/bridgecrewio/checkov/issues/428