### PR TITLE
fix AWS_62 to check only for actual action/resource=*

### DIFF
--- a/checkov/terraform/checks/resource/aws/IAMAdminPolicyDocument.py
+++ b/checkov/terraform/checks/resource/aws/IAMAdminPolicyDocument.py
@@ -19,11 +19,12 @@ class IAMAdminPolicyDocument(BaseResourceCheck):
                 policy_block = json.loads(conf['policy'][0])
                 if 'Statement' in policy_block.keys():
                     for statement in force_list(policy_block['Statement']):
-                        if 'Action' in statement and \
-                                statement.get('Effect', ['Allow']) == 'Allow' and \
-                                '*' in statement.get('Action', ['']) and \
-                                '*' in statement.get('Resource', ['']):
-                            return CheckResult.FAILED
+                        if 'Action' in statement:
+                            effect = statement.get('Effect', 'Allow')
+                            action = force_list(statement.get('Action', ['']))
+                            resource = force_list(statement.get('Resource', ['']))
+                            if effect == 'Allow' and '*' in action and '*' in resource:
+                                return CheckResult.FAILED
             except:  # nosec
                 pass
         return CheckResult.PASSED

--- a/tests/terraform/checks/resource/aws/example_IAMAdminPolicyDocument/iam.tf
+++ b/tests/terraform/checks/resource/aws/example_IAMAdminPolicyDocument/iam.tf
@@ -1,0 +1,135 @@
+resource "aws_iam_policy" "pass1" {
+  name = "pass1"
+  path = "/"
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Action": [
+        "s3:ListBucket*",
+        "s3:HeadBucket",
+        "s3:Get*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::b1",
+        "arn:aws:s3:::b1/*",
+        "arn:aws:s3:::b2",
+        "arn:aws:s3:::b2/*"
+      ],
+      "Sid": ""
+    },
+    {
+      "Action": "s3:PutObject*",
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::b1/*",
+      "Sid": ""
+    }
+  ],
+  "Version": "2012-10-17"
+}
+POLICY
+}
+
+resource "aws_iam_policy" "fail1" {
+  name = "fail1"
+  path = "/"
+  # the policy doesn't actually make sense, but it tests checking arrays for *
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Action": [
+        "s3:HeadBucket",
+        "*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::b1",
+        "arn:aws:s3:::b1/*",
+        "*"
+      ],
+      "Sid": ""
+    }
+  ],
+  "Version": "2012-10-17"
+}
+POLICY
+}
+
+resource "aws_iam_policy" "fail2" {
+  name = "fail2"
+  path = "/"
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Action": [
+        "*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Sid": ""
+    }
+  ],
+  "Version": "2012-10-17"
+}
+POLICY
+}
+
+resource "aws_iam_policy" "fail3" {
+  name = "fail3"
+  path = "/"
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Action": "*",
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": ""
+    }
+  ],
+  "Version": "2012-10-17"
+}
+POLICY
+}
+
+resource "aws_iam_policy" "fail4" {
+  name = "fail4"
+  path = "/"
+  # implicit allow, not actually valid, but it's a default that we check
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Action": "*",
+      "Resource": "*",
+      "Sid": ""
+    }
+  ],
+  "Version": "2012-10-17"
+}
+POLICY
+}
+
+resource "aws_iam_policy" "pass2" {
+  name = "pass2"
+  path = "/"
+  # deny
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Action": "*",
+      "Effect": "Deny",
+      "Resource": "*",
+      "Sid": ""
+    }
+  ],
+  "Version": "2012-10-17"
+}
+POLICY
+}


### PR DESCRIPTION
Previously, this check failed when action and resource were a string containing *. For example, the following statement failed:

```
{
      "Action": "s3:PutObject*",
      "Effect": "Allow",
      "Resource": "arn:aws:s3:::b1/*",
      "Sid": ""
    }
```

This PR updates the logic to only fail when a statement contains both an action and a resource that equal `*`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
