### PR TITLE
Malformed blocks handling

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,27 +18,27 @@
     "default": {
         "bc-python-hcl2": {
             "hashes": [
-                "sha256:1b560cd4f1e9c1cd5db4c9f3ffbfcf89b6fc5eb33a390df19ebf694a6dbf66c0",
-                "sha256:e1db6fe5e13e2e3017fdb4a04202008afb8ad5ea704ab7dd12376c3192359565"
+                "sha256:ed1897a2ee1517615a5acdd8e144a31e23b7b071b45e90f486ea066fd34c881d",
+                "sha256:fc44f22ca352d5b364fdee8280b0150ca7e165706bf316ab09e71d1d2c689dfd"
             ],
             "index": "pypi",
-            "version": "==0.3.13"
+            "version": "==0.3.14"
         },
         "boto3": {
             "hashes": [
-                "sha256:3a8412020a59509e783755b5c9b910a4fc7f6b6f2b9473e7cd1e07b67672e0d1",
-                "sha256:877f204dabe1bfa21aa9cfaacc72bd4b70a897d0fdcea799afa5c4743b6fc7ac"
+                "sha256:62f06cd1e7a78d8aaa4e527c327653e9a6c1af415b59836048a90c28a27e5f09",
+                "sha256:bbc47e6f83372d9a18483895e7116ea50e8da32ffb62e8afc0a6e2323f964ed9"
             ],
             "index": "pypi",
-            "version": "==1.17.9"
+            "version": "==1.17.12"
         },
         "botocore": {
             "hashes": [
-                "sha256:c8614c230e7a8e042a8c07d47caea50ad21cb51415289bd34fa6d0382beddad7",
-                "sha256:d725840b881be62fc52e8e24a6ada651128cf7f1ed1639b87322a7a213ffdbad"
+                "sha256:39a92315a17a6f8bc1914dbb020f52e929f18e5b99a4fa1c5d8785f913427ed8",
+                "sha256:e576e1697ad9dc794961ed1ba51bdea7e0574ec27981c888482955f4be5cc4e8"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.9"
+            "version": "==1.20.12"
         },
         "certifi": {
             "hashes": [
@@ -215,11 +215,11 @@
         },
         "tabulate": {
             "hashes": [
-                "sha256:ac64cb76d53b1231d364babcd72abbb16855adac7de6665122f97b593f1eb2ba",
-                "sha256:db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007"
+                "sha256:26f2589d80d332fefd2371d396863dedeb806f51b54bdb4b264579270b621e92",
+                "sha256:d6fe298fc0a58d848d6160118d17e70905f36766552ee78f8a1f4d64e8e16916"
             ],
             "index": "pypi",
-            "version": "==0.8.7"
+            "version": "==0.8.8"
         },
         "termcolor": {
             "hashes": [
@@ -230,11 +230,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:11d544652edbdfc9cc41aa4c8a5c166513e279f3f2d9f1a9e1c89935b51de6ff",
-                "sha256:a89be573bfddb81bb0b395a416d5e55e3ecc73ce95a368a4f6360bedea33195e"
+                "sha256:65185676e9fdf20d154cffd1c5de8e39ef9696ff7e59fe0156b1b08e468736af",
+                "sha256:70657337ec104eb4f3fb229285358f23f045433f6aea26846cdd55f0fd68945c"
             ],
             "index": "pypi",
-            "version": "==4.56.2"
+            "version": "==4.57.0"
         },
         "update-checker": {
             "hashes": [

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -776,7 +776,9 @@ def _is_valid_block(block):
     if not isinstance(block, dict):
         return True
     entity_name, _ = next(iter(block.items()))
-    return entity_name.isidentifier()
+    if re.fullmatch(r'[^\W0-9][\w-]*', entity_name):
+        return True
+    return False
 
 
 def _validate_malformed_definitions(raw_data):

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -773,6 +773,8 @@ Load JSON or HCL, depending on filename.
 
 
 def _is_valid_block(block):
+    if not isinstance(block, dict):
+        return True
     entity_name, _ = next(iter(block.items()))
     return entity_name.isidentifier()
 

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -4,7 +4,7 @@ import os
 import re
 from pathlib import Path
 from typing import Mapping, Optional, Dict, Any, List, Callable, Tuple
-
+import copy
 import deep_merge
 import hcl2
 import jmespath
@@ -326,7 +326,7 @@ class Parser:
                     # the full string isn't found in the value anymore) and come back to it on another
                     # processor loop. This works... but requires another processor loop.
                     # (If you're thinking we should make a DAG and do this properly... you're probably right.)
-                    prev_matches: List[Tuple[str, str]] = []        # original value -> replaced
+                    prev_matches: List[Tuple[str, str]] = []  # original value -> replaced
                     for match in find_var_blocks(value):
                         # Update what's expected in the match, see comment above
                         for prev_match in prev_matches:
@@ -461,7 +461,8 @@ class Parser:
 
                     # Special handling for local sources to make sure we aren't double-parsing
                     if source.startswith("./") or source.startswith("../"):
-                        source = os.path.normpath(os.path.join(os.path.dirname(_remove_module_dependency_in_path(file)), source))
+                        source = os.path.normpath(
+                            os.path.join(os.path.dirname(_remove_module_dependency_in_path(file)), source))
 
                     version = module_call_data.get("version", "latest")
                     if version and isinstance(version, list):
@@ -477,10 +478,14 @@ class Parser:
 
                             if not dir_filter(os.path.abspath(content.path())):
                                 continue
-                            self._internal_dir_load(directory=content.path(), module_loader_registry=module_loader_registry,
-                                                    dir_filter=dir_filter, specified_vars=specified_vars, module_load_context=module_load_context)
+                            self._internal_dir_load(directory=content.path(),
+                                                    module_loader_registry=module_loader_registry,
+                                                    dir_filter=dir_filter, specified_vars=specified_vars,
+                                                    module_load_context=module_load_context)
 
-                            module_definitions = {path: self.out_definitions[path] for path in list(self.out_definitions.keys()) if os.path.dirname(path) == content.path()}
+                            module_definitions = {path: self.out_definitions[path] for path in
+                                                  list(self.out_definitions.keys()) if
+                                                  os.path.dirname(path) == content.path()}
 
                             if not module_definitions:
                                 continue
@@ -535,7 +540,6 @@ def _handle_single_var_pattern(orig_variable: str, var_value_and_file_map: Dict[
                                module_data_retrieval: Callable[[str], Dict[str, Any]],
                                eval_map_by_var_name: Dict[str, EvaluationContext],
                                context, orig_variable_full, root_directory: str) -> Any:
-
     ternary_info = _is_ternary(orig_variable)
     if ternary_info:
         return _process_ternary(orig_variable, ternary_info[0], ternary_info[1])
@@ -547,7 +551,7 @@ def _handle_single_var_pattern(orig_variable: str, var_value_and_file_map: Dict[
         # Reference to module outputs, example: 'module.bucket.bucket_name'
         ref_tokens = orig_variable.split(".")
         if len(ref_tokens) != 3:
-            return orig_variable        # fail safe, can the length ever be something other than 3?
+            return orig_variable  # fail safe, can the length ever be something other than 3?
 
         try:
             ref_list = jmespath.search(f"[].{ref_tokens[1]}.{RESOLVED_MODULE_ENTRY_NAME}[]", module_list)
@@ -648,7 +652,7 @@ def _handle_single_var_pattern(orig_variable: str, var_value_and_file_map: Dict[
                     else:
                         return str(int(altered_value))
                 except ValueError:
-                    return orig_variable     # no change
+                    return orig_variable  # no change
     elif orig_variable.startswith("merge(") and orig_variable.endswith(")"):
         altered_value = orig_variable[6:-1]
         args = split_merge_args(altered_value)
@@ -674,7 +678,7 @@ def _handle_single_var_pattern(orig_variable: str, var_value_and_file_map: Dict[
             if isinstance(value, dict):
                 merged_map.update(value)
             else:
-                return orig_variable            # don't know what this is, blow out
+                return orig_variable  # don't know what this is, blow out
         return merged_map
     # TODO - format() support, still in progress
     # elif orig_variable.startswith("format(") and orig_variable.endswith(")"):
@@ -692,7 +696,7 @@ def _handle_single_var_pattern(orig_variable: str, var_value_and_file_map: Dict[
             if result is not None:
                 return result
 
-    return orig_variable        # fall back to no change
+    return orig_variable  # fall back to no change
 
 
 def _handle_indexing(reference: str,
@@ -757,21 +761,36 @@ Load JSON or HCL, depending on filename.
                 return json.load(f)
             else:
                 raw_data = hcl2.load(f)
+                non_malformed_definitions = _validate_malformed_definitions(raw_data)
                 if clean_definitions:
-                    return _clean_bad_definitions(raw_data)
+                    return _clean_bad_definitions(non_malformed_definitions)
                 else:
-                    return raw_data
+                    return non_malformed_definitions
     except Exception as e:
         LOGGER.debug(f'failed while parsing file {file}', exc_info=e)
         parsing_errors[file_path] = e
         return None
 
 
+def _is_valid_block(block):
+    entity_name, _ = next(iter(block.items()))
+    return entity_name.isidentifier()
+
+
+def _validate_malformed_definitions(raw_data):
+    raw_data_cleaned = copy.deepcopy(raw_data)
+    for block_type, blocks in raw_data.items():
+        raw_data_cleaned[block_type] = [block for block in blocks if _is_valid_block(block)]
+
+    return raw_data_cleaned
+
+
 def _clean_bad_definitions(tf_definition_list):
     return {
         block_type: list(filter(lambda definition_list: block_type == 'locals' or
                                                         not isinstance(definition_list, dict)
-                                                        or len(definition_list.keys()) == 1, tf_definition_list[block_type]))
+                                                        or len(definition_list.keys()) == 1,
+                                tf_definition_list[block_type]))
         for block_type in tf_definition_list.keys()
     }
 
@@ -779,7 +798,7 @@ def _clean_bad_definitions(tf_definition_list):
 def _eval_string(value: str) -> Optional[Any]:
     try:
         value_string = value.replace("'", '"')
-        parsed = hcl2.loads(f'eval = {value_string}\n')      # NOTE: newline is needed
+        parsed = hcl2.loads(f'eval = {value_string}\n')  # NOTE: newline is needed
         return parsed["eval"][0]
     except Exception:
         return None
@@ -819,7 +838,7 @@ def _remove_module_dependency_in_path(path):
     return path
 
 
-def _is_ternary(value: str) -> Optional[Tuple[int,int]]:
+def _is_ternary(value: str) -> Optional[Tuple[int, int]]:
     """
     Determines whether or not the given string is *probably* a ternary operation
     :return:        If the expression does represent a possibly-processable ternary expression, a tuple
@@ -848,6 +867,7 @@ def _process_ternary(value: str, question_index: int, colon_index: int) -> str:
 
     # Otherwise, this isn't evaluated enough
     return value
+
 
 def _safe_index(sequence_hopefully, index) -> Optional[Any]:
     try:

--- a/tests/terraform/parser/resources/malformed_outputs/main.tf
+++ b/tests/terraform/parser/resources/malformed_outputs/main.tf
@@ -1,0 +1,17 @@
+## Outputs
+
+output "cluster_name" {
+  value = "${aws_eks_cluster.eks.name}"
+}
+
+output "kubeconfig" {
+  value = "${local.kubeconfig}"
+}
+
+output "aws-auth-cm.yaml" {
+  value = "${local.aws-auth-cm}"
+}
+
+//output "config_map_aws_auth" {
+//  value = "${local.config_map_aws_auth}"
+//}

--- a/tests/terraform/parser/resources/parser_scenarios/ternaries/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/ternaries/expected.json
@@ -5,6 +5,7 @@
         "a": ["a"],
         "b": ["b"],
         "empty": [""],
+        "local_true": [true],
         "bool_true": ["correct"],
         "bool_false": ["correct"],
         "type": ["bool"],

--- a/tests/terraform/parser/resources/parser_scenarios/ternaries/main.tf
+++ b/tests/terraform/parser/resources/parser_scenarios/ternaries/main.tf
@@ -6,10 +6,9 @@ locals {
   bool_true  = true ? "correct" : "wrong"
   bool_false = false ? "wrong" : "correct"
 
-//  local_true = true
-  // TODO: HCL2 parser doesn't like the following line
-//  multiline = (local.local_true) ?
-//    "correct" : "wrong"
+  local_true = true
+  multiline = (local.local_true) ?
+    "correct" : "wrong"
 
   // TODO: See test_hcl2_load_assumptions.py -> test_weird_ternary_string_clipping
   //       Doesn't currently pull the ternary correctly since it's evaluated inside the string.

--- a/tests/terraform/parser/test_parser_modules.py
+++ b/tests/terraform/parser/test_parser_modules.py
@@ -75,3 +75,15 @@ class TestParserInternals(unittest.TestCase):
                                external_modules_download_path=DEFAULT_EXTERNAL_MODULES_DIR)
         # check that only the original file was parsed successfully without getting bad external modules
         self.assertEqual(1, len(list(out_definitions.keys())))
+
+    def test_malformed_output_blocks(self):
+        parser = Parser()
+        directory = os.path.join(self.resources_dir, "malformed_outputs")
+        self.external_module_path = os.path.join(directory, DEFAULT_EXTERNAL_MODULES_DIR)
+        out_definitions = {}
+        parser.parse_directory(directory=directory, out_definitions=out_definitions,
+                               out_evaluations_context={},
+                               download_external_modules=True,
+                               external_modules_download_path=DEFAULT_EXTERNAL_MODULES_DIR)
+        file_path, entity_definitions = next(iter(out_definitions.items()))
+        self.assertEqual(2, len(list(out_definitions[file_path]['output'])))


### PR DESCRIPTION
Handle malformed blocks (e.g. without a valid unicode identifier) gracefully, by excluding them from the parser output