### PR TITLE
update python-hcl2 to handle ternaries new line

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,27 +18,27 @@
     "default": {
         "bc-python-hcl2": {
             "hashes": [
-                "sha256:1b560cd4f1e9c1cd5db4c9f3ffbfcf89b6fc5eb33a390df19ebf694a6dbf66c0",
-                "sha256:e1db6fe5e13e2e3017fdb4a04202008afb8ad5ea704ab7dd12376c3192359565"
+                "sha256:ed1897a2ee1517615a5acdd8e144a31e23b7b071b45e90f486ea066fd34c881d",
+                "sha256:fc44f22ca352d5b364fdee8280b0150ca7e165706bf316ab09e71d1d2c689dfd"
             ],
             "index": "pypi",
-            "version": "==0.3.13"
+            "version": "==0.3.14"
         },
         "boto3": {
             "hashes": [
-                "sha256:3a8412020a59509e783755b5c9b910a4fc7f6b6f2b9473e7cd1e07b67672e0d1",
-                "sha256:877f204dabe1bfa21aa9cfaacc72bd4b70a897d0fdcea799afa5c4743b6fc7ac"
+                "sha256:62f06cd1e7a78d8aaa4e527c327653e9a6c1af415b59836048a90c28a27e5f09",
+                "sha256:bbc47e6f83372d9a18483895e7116ea50e8da32ffb62e8afc0a6e2323f964ed9"
             ],
             "index": "pypi",
-            "version": "==1.17.9"
+            "version": "==1.17.12"
         },
         "botocore": {
             "hashes": [
-                "sha256:c8614c230e7a8e042a8c07d47caea50ad21cb51415289bd34fa6d0382beddad7",
-                "sha256:d725840b881be62fc52e8e24a6ada651128cf7f1ed1639b87322a7a213ffdbad"
+                "sha256:39a92315a17a6f8bc1914dbb020f52e929f18e5b99a4fa1c5d8785f913427ed8",
+                "sha256:e576e1697ad9dc794961ed1ba51bdea7e0574ec27981c888482955f4be5cc4e8"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.9"
+            "version": "==1.20.12"
         },
         "certifi": {
             "hashes": [
@@ -215,11 +215,11 @@
         },
         "tabulate": {
             "hashes": [
-                "sha256:ac64cb76d53b1231d364babcd72abbb16855adac7de6665122f97b593f1eb2ba",
-                "sha256:db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007"
+                "sha256:26f2589d80d332fefd2371d396863dedeb806f51b54bdb4b264579270b621e92",
+                "sha256:d6fe298fc0a58d848d6160118d17e70905f36766552ee78f8a1f4d64e8e16916"
             ],
             "index": "pypi",
-            "version": "==0.8.7"
+            "version": "==0.8.8"
         },
         "termcolor": {
             "hashes": [
@@ -230,11 +230,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:11d544652edbdfc9cc41aa4c8a5c166513e279f3f2d9f1a9e1c89935b51de6ff",
-                "sha256:a89be573bfddb81bb0b395a416d5e55e3ecc73ce95a368a4f6360bedea33195e"
+                "sha256:65185676e9fdf20d154cffd1c5de8e39ef9696ff7e59fe0156b1b08e468736af",
+                "sha256:70657337ec104eb4f3fb229285358f23f045433f6aea26846cdd55f0fd68945c"
             ],
             "index": "pypi",
-            "version": "==4.56.2"
+            "version": "==4.57.0"
         },
         "update-checker": {
             "hashes": [

--- a/tests/terraform/parser/resources/parser_scenarios/ternaries/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/ternaries/expected.json
@@ -5,6 +5,7 @@
         "a": ["a"],
         "b": ["b"],
         "empty": [""],
+        "local_true": [true],
         "bool_true": ["correct"],
         "bool_false": ["correct"],
         "type": ["bool"],

--- a/tests/terraform/parser/resources/parser_scenarios/ternaries/main.tf
+++ b/tests/terraform/parser/resources/parser_scenarios/ternaries/main.tf
@@ -6,10 +6,9 @@ locals {
   bool_true  = true ? "correct" : "wrong"
   bool_false = false ? "wrong" : "correct"
 
-//  local_true = true
-  // TODO: HCL2 parser doesn't like the following line
-//  multiline = (local.local_true) ?
-//    "correct" : "wrong"
+  local_true = true
+  multiline = (local.local_true) ?
+    "correct" : "wrong"
 
   // TODO: See test_hcl2_load_assumptions.py -> test_weird_ternary_string_clipping
   //       Doesn't currently pull the ternary correctly since it's evaluated inside the string.


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
