### PR TITLE
Revert "update python-hcl2 to handle ternaries new line"

### DIFF
--- a/tests/terraform/parser/resources/parser_scenarios/ternaries/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/ternaries/expected.json
@@ -5,7 +5,6 @@
         "a": ["a"],
         "b": ["b"],
         "empty": [""],
-        "local_true": [true],
         "bool_true": ["correct"],
         "bool_false": ["correct"],
         "type": ["bool"],

--- a/tests/terraform/parser/resources/parser_scenarios/ternaries/main.tf
+++ b/tests/terraform/parser/resources/parser_scenarios/ternaries/main.tf
@@ -6,9 +6,10 @@ locals {
   bool_true  = true ? "correct" : "wrong"
   bool_false = false ? "wrong" : "correct"
 
-  local_true = true
-  multiline = (local.local_true) ?
-    "correct" : "wrong"
+//  local_true = true
+  // TODO: HCL2 parser doesn't like the following line
+//  multiline = (local.local_true) ?
+//    "correct" : "wrong"
 
   // TODO: See test_hcl2_load_assumptions.py -> test_weird_ternary_string_clipping
   //       Doesn't currently pull the ternary correctly since it's evaluated inside the string.


### PR DESCRIPTION
This reverts commit f18f3424

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
