### PR TITLE
Check - Bug - EKSNode - TFPlan

### DIFF
--- a/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py
+++ b/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py
@@ -12,6 +12,9 @@ class EKSNodeGroupRemoteAccess(BaseResourceCheck):
 
     def scan_resource_conf(self, conf):
         if "remote_access" in conf.keys():
+            if not conf["remote_access"]:
+                # If list is empty then x.[0].keys() will raise an error
+                return CheckResult.PASSED
             if "ec2_ssh_key" in conf["remote_access"][0].keys() and not 'source_security_group_ids' in conf["remote_access"][0].keys():
                 return CheckResult.FAILED
         return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py
+++ b/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py
@@ -13,7 +13,7 @@ class EKSNodeGroupRemoteAccess(BaseResourceCheck):
     def scan_resource_conf(self, conf):
         if "remote_access" in conf.keys():
             if not conf["remote_access"]:
-                # If list is empty then x.[0].keys() will raise an error
+                # If list is empty then x.[0].keys() would raise an error
                 return CheckResult.PASSED
             if "ec2_ssh_key" in conf["remote_access"][0].keys() and not 'source_security_group_ids' in conf["remote_access"][0].keys():
                 return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py
+++ b/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py
@@ -13,7 +13,6 @@ class EKSNodeGroupRemoteAccess(BaseResourceCheck):
     def scan_resource_conf(self, conf):
         if "remote_access" in conf.keys():
             if not conf["remote_access"]:
-                # If list is empty then x.[0].keys() would raise an error
                 return CheckResult.PASSED
             if "ec2_ssh_key" in conf["remote_access"][0].keys() and not 'source_security_group_ids' in conf["remote_access"][0].keys():
                 return CheckResult.FAILED

--- a/tests/terraform/checks/resource/aws/test_EKSNodeGroupRemoteAccess.py
+++ b/tests/terraform/checks/resource/aws/test_EKSNodeGroupRemoteAccess.py
@@ -9,22 +9,22 @@ class TestEKSNodeGroupRemoteAccess(unittest.TestCase):
 
     def test_failure(self):
         hcl_res = hcl2.loads("""
-        resource "aws_eks_node_group" "test" {
-          cluster_name    = aws_eks_cluster.example.name
-          node_group_name = "example"
-          node_role_arn   = aws_iam_role.example.arn
-          subnet_ids      = aws_subnet.example[*].id
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.example.name
+  node_group_name = "example"
+  node_role_arn   = aws_iam_role.example.arn
+  subnet_ids      = aws_subnet.example[*].id
 
-          remote_access {
-            ec2_ssh_key = "some-key"
-          }
+  remote_access {
+    ec2_ssh_key = "some-key"
+  }
 
-          scaling_config {
-            desired_size = 1
-            max_size     = 1
-            min_size     = 1
-          }
-        }
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
         """)
         resource_conf = hcl_res['resource'][0]['aws_eks_node_group']['test']
         scan_result = check.scan_resource_conf(conf=resource_conf)
@@ -32,23 +32,23 @@ class TestEKSNodeGroupRemoteAccess(unittest.TestCase):
 
     def test_success(self):
         hcl_res = hcl2.loads("""
-        resource "aws_eks_node_group" "test" {
-          cluster_name    = aws_eks_cluster.example.name
-          node_group_name = "example"
-          node_role_arn   = aws_iam_role.example.arn
-          subnet_ids      = aws_subnet.example[*].id
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.example.name
+  node_group_name = "example"
+  node_role_arn   = aws_iam_role.example.arn
+  subnet_ids      = aws_subnet.example[*].id
 
-          remote_access {
-            ec2_ssh_key = "some-key"
-            source_security_group_ids = "some-group"
-          }
+  remote_access {
+    ec2_ssh_key = "some-key"
+    source_security_group_ids = "some-group"
+  }
 
-          scaling_config {
-            desired_size = 1
-            max_size     = 1
-            min_size     = 1
-          }
-        }
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
         """)
         resource_conf = hcl_res['resource'][0]['aws_eks_node_group']['test']
         scan_result = check.scan_resource_conf(conf=resource_conf)
@@ -56,22 +56,25 @@ class TestEKSNodeGroupRemoteAccess(unittest.TestCase):
 
     def test_success_implicit(self):
         hcl_res = hcl2.loads("""
-        resource "aws_eks_node_group" "test" {
-          cluster_name    = aws_eks_cluster.example.name
-          node_group_name = "example"
-          node_role_arn   = aws_iam_role.example.arn
-          subnet_ids      = aws_subnet.example[*].id
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.example.name
+  node_group_name = "example"
+  node_role_arn   = aws_iam_role.example.arn
+  subnet_ids      = aws_subnet.example[*].id
 
-          scaling_config {
-            desired_size = 1
-            max_size     = 1
-            min_size     = 1
-          }
-        }
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
         """)
         resource_conf = hcl_res['resource'][0]['aws_eks_node_group']['test']
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+
 if __name__ == '__main__':
     unittest.main()
+
+

--- a/tests/terraform/checks/resource/aws/test_EKSNodeGroupRemoteAccess.py
+++ b/tests/terraform/checks/resource/aws/test_EKSNodeGroupRemoteAccess.py
@@ -9,22 +9,22 @@ class TestEKSNodeGroupRemoteAccess(unittest.TestCase):
 
     def test_failure(self):
         hcl_res = hcl2.loads("""
-resource "aws_eks_node_group" "test" {
-  cluster_name    = aws_eks_cluster.example.name
-  node_group_name = "example"
-  node_role_arn   = aws_iam_role.example.arn
-  subnet_ids      = aws_subnet.example[*].id
+        resource "aws_eks_node_group" "test" {
+          cluster_name    = aws_eks_cluster.example.name
+          node_group_name = "example"
+          node_role_arn   = aws_iam_role.example.arn
+          subnet_ids      = aws_subnet.example[*].id
 
-  remote_access {
-    ec2_ssh_key = "some-key"
-  }
+          remote_access {
+            ec2_ssh_key = "some-key"
+          }
 
-  scaling_config {
-    desired_size = 1
-    max_size     = 1
-    min_size     = 1
-  }
-}
+          scaling_config {
+            desired_size = 1
+            max_size     = 1
+            min_size     = 1
+          }
+        }
         """)
         resource_conf = hcl_res['resource'][0]['aws_eks_node_group']['test']
         scan_result = check.scan_resource_conf(conf=resource_conf)
@@ -32,23 +32,23 @@ resource "aws_eks_node_group" "test" {
 
     def test_success(self):
         hcl_res = hcl2.loads("""
-resource "aws_eks_node_group" "test" {
-  cluster_name    = aws_eks_cluster.example.name
-  node_group_name = "example"
-  node_role_arn   = aws_iam_role.example.arn
-  subnet_ids      = aws_subnet.example[*].id
+        resource "aws_eks_node_group" "test" {
+          cluster_name    = aws_eks_cluster.example.name
+          node_group_name = "example"
+          node_role_arn   = aws_iam_role.example.arn
+          subnet_ids      = aws_subnet.example[*].id
 
-  remote_access {
-    ec2_ssh_key = "some-key"
-    source_security_group_ids = "some-group"
-  }
+          remote_access {
+            ec2_ssh_key = "some-key"
+            source_security_group_ids = "some-group"
+          }
 
-  scaling_config {
-    desired_size = 1
-    max_size     = 1
-    min_size     = 1
-  }
-}
+          scaling_config {
+            desired_size = 1
+            max_size     = 1
+            min_size     = 1
+          }
+        }
         """)
         resource_conf = hcl_res['resource'][0]['aws_eks_node_group']['test']
         scan_result = check.scan_resource_conf(conf=resource_conf)
@@ -56,25 +56,22 @@ resource "aws_eks_node_group" "test" {
 
     def test_success_implicit(self):
         hcl_res = hcl2.loads("""
-resource "aws_eks_node_group" "test" {
-  cluster_name    = aws_eks_cluster.example.name
-  node_group_name = "example"
-  node_role_arn   = aws_iam_role.example.arn
-  subnet_ids      = aws_subnet.example[*].id
+        resource "aws_eks_node_group" "test" {
+          cluster_name    = aws_eks_cluster.example.name
+          node_group_name = "example"
+          node_role_arn   = aws_iam_role.example.arn
+          subnet_ids      = aws_subnet.example[*].id
 
-  scaling_config {
-    desired_size = 1
-    max_size     = 1
-    min_size     = 1
-  }
-}
+          scaling_config {
+            desired_size = 1
+            max_size     = 1
+            min_size     = 1
+          }
+        }
         """)
         resource_conf = hcl_res['resource'][0]['aws_eks_node_group']['test']
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-
 if __name__ == '__main__':
     unittest.main()
-
-


### PR DESCRIPTION
Hello,

Raising this to fix an edge case issue that I am seeing.

When the `aws_eks_node_group`  `remote_access` block is omitted then the check should pass.

All of the tests check the cases you would expect and it is all fine. However, when you omit this and run a terraform plan then the json ends up outputting the resource as `"remote_access": []". This ultimately causes the check to error out and crash.

Because it is an empty list, the `conf["remote_access"][0].keys()` throws an error because there is no list item which is a dict and so there you can not call `.keys()`.

It is not caught in tests because it is an issue in how terraform is setting an odd (and not possible to predict?) default when it goes from HCL to the json representation. It should be not there or even perhaps [{ }] would be better. Either way I can't replicate the issue by passing data in because at the HCL level all makes sense.

Checking that the list has items if it exists (even though it probably always does) is probably just a good defensive strategy anyways.

**Error log excerpt**
```
File "/usr/local/lib/python3.8/site-packages/checkov/terraform/checks/resource/base_resource_check.py", line 33, in wrapper
return wrapped(self, conf)
File "/usr/local/lib/python3.8/site-packages/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py", line 15, in scan_resource_conf
if "ec2_ssh_key" in conf["remote_access"][0].keys() and not 'source_security_group_ids' in conf["remote_access"][0].keys():
File "/usr/local/lib/python3.8/site-packages/checkov/terraform/context_parsers/tf_plan/node.py", line 202, in __getattr__
raise TemplateAttributeError('%s.%s is invalid' % (self.__class__.__name__, name))
checkov.terraform.context_parsers.tf_plan.node.TemplateAttributeError: list_node.keys is invalid
```


**Code refs for ease of clicking**

Check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py

Tests: https://github.com/bridgecrewio/checkov/blob/master/tests/terraform/checks/resource/aws/test_EKSNodeGroupRemoteAccess.py

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
