### PR TITLE
MySQLPublicAccessDisabled - dont default to public

### DIFF
--- a/checkov/terraform/checks/resource/azure/MySQLPublicAccessDisabled.py
+++ b/checkov/terraform/checks/resource/azure/MySQLPublicAccessDisabled.py
@@ -1,0 +1,24 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+
+
+class MySQLPublicAccessDisabled(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure 'public network access enabled' is set to 'False' for mySQL servers"
+        id = "CKV_AZURE_53"
+        supported_resources = ['azurerm_mysql_server']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        #Whether or not public network access is allowed for this server. Defaults to true. Which is not optimal
+        if 'public_network_access_enabled' not in conf: 
+            return CheckResult.FAILED
+        else:
+            if  conf['public_network_access_enabled'][0]:
+                return CheckResult.FAILED
+            else:
+                return CheckResult.PASSED
+
+check = MySQLPublicAccessDisabled()
+

--- a/checkov/terraform/checks/resource/azure/MySQLPublicAccessDisabled.py
+++ b/checkov/terraform/checks/resource/azure/MySQLPublicAccessDisabled.py
@@ -1,8 +1,8 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class MySQLPublicAccessDisabled(BaseResourceCheck):
+class MySQLPublicAccessDisabled(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure 'public network access enabled' is set to 'False' for mySQL servers"
         id = "CKV_AZURE_53"
@@ -10,15 +10,15 @@ class MySQLPublicAccessDisabled(BaseResourceCheck):
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        #Whether or not public network access is allowed for this server. Defaults to true. Which is not optimal
-        if 'public_network_access_enabled' not in conf: 
-            return CheckResult.FAILED
-        else:
-            if  conf['public_network_access_enabled'][0]:
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+    def get_inspected_key(self):
+        return 'public_network_access_enabled'
+
+    def get_expected_value(self):
+        """
+        Returns the default expected value, governed by provider best practices
+        """
+        return False
+
 
 check = MySQLPublicAccessDisabled()
 

--- a/tests/terraform/checks/resource/azure/test_MySQLPublicAccessDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_MySQLPublicAccessDisabled.py
@@ -1,0 +1,84 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.azure.MySQLPublicAccessDisabled import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestMySQLPublicAccessDisabled(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_mysql_server" "examplea" {
+  name                = var.mysqlserver_name
+  location            = var.resource_group.location
+  resource_group_name = var.resource_group.name
+
+  administrator_login          = var.admin_name
+  administrator_login_password = var.password
+  sku_name = var.sku_name
+  storage_mb = var.storage_mb
+  version    = var.server_version
+
+  auto_grow_enabled            = true
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+  infrastructure_encryption_enabled = false
+    public_network_access_enabled = true
+}
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_mysql_server']['examplea']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_missing_failure(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_mysql_server" "examplea" {
+  name                = var.mysqlserver_name
+  location            = var.resource_group.location
+  resource_group_name = var.resource_group.name
+
+  administrator_login          = var.admin_name
+  administrator_login_password = var.password
+  sku_name = var.sku_name
+  storage_mb = var.storage_mb
+  version    = var.server_version
+
+  auto_grow_enabled            = true
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+  infrastructure_encryption_enabled = false
+}
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_mysql_server']['examplea']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+        
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+resource "azurerm_mysql_server" "examplea" {
+  name                = var.mysqlserver_name
+  location            = var.resource_group.location
+  resource_group_name = var.resource_group.name
+
+  administrator_login          = var.admin_name
+  administrator_login_password = var.password
+  sku_name = var.sku_name
+  storage_mb = var.storage_mb
+  version    = var.server_version
+
+  auto_grow_enabled            = true
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+  infrastructure_encryption_enabled = false
+  public_network_access_enabled = false
+}
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_mysql_server']['examplea']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
By default the dbs are created public. Not a great option. This checks and errors if its is.