### PR TITLE
Provide more detail for context of resource loaded from modules

### DIFF
--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -17,13 +17,16 @@ class Record:
     code_block = ""
     file_path = ""
     file_line_range = []
+    caller_file_path = None           # When created from a module
+    caller_file_line_range = None     #
     resource = ""
     guideline = None
     fixed_definition = None
     entity_tags = None
 
     def __init__(self, check_id, check_name, check_result, code_block, file_path, file_line_range, resource,
-                 evaluations, check_class, file_abs_path, entity_tags=None):
+                 evaluations, check_class, file_abs_path, entity_tags=None,
+                 caller_file_path=None, caller_file_line_range=None):
         """
         :param evaluations: A dict with the key being the variable name, value being a dict containing:
                              - 'var_file'
@@ -42,6 +45,8 @@ class Record:
         self.check_class = check_class
         self.fixed_definition = None
         self.entity_tags = entity_tags
+        self.caller_file_path = caller_file_path
+        self.caller_file_line_range = caller_file_line_range
 
     def set_guideline(self, guideline):
         self.guideline = guideline
@@ -93,6 +98,12 @@ class Record:
         if self.code_block:
             code_lines = "\n{}\n".format("".join(
                 [self._code_line_string(self.code_block)]))
+        caller_file_details = ""
+        if self.caller_file_path:
+            caller_file_details = colored(
+                "\tCalling File: {}:{}\n".format(self.caller_file_path,
+                                                 "-".join([str(x) for x in self.caller_file_line_range])),
+                "magenta")
         if self.evaluations:
             for (var_name, var_evaluations) in self.evaluations.items():
                 var_file = var_evaluations['var_file']
@@ -106,12 +117,12 @@ class Record:
                             'white')
         status_message = colored("\t{} for resource: {}\n".format(status, self.resource), status_color)
         if self.check_result['result'] == CheckResult.FAILED and code_lines and not compact:
-            return check_message + status_message + file_details + guideline_message + code_lines + evaluation_message
+            return check_message + status_message + file_details + caller_file_details + guideline_message + code_lines + evaluation_message
 
         if self.check_result['result'] == CheckResult.SKIPPED:
-            return check_message + status_message + suppress_comment + file_details + guideline_message
+            return check_message + status_message + suppress_comment + file_details + caller_file_details + guideline_message
         else:
-            return check_message + status_message + file_details + evaluation_message + guideline_message
+            return check_message + status_message + file_details + caller_file_details + evaluation_message + guideline_message
 
     def __str__(self):
         return self.to_string()

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -142,6 +142,7 @@ class Runner(BaseRunner):
                                                    "module." + referrer_id,
                                                    separator=".")
                     except KeyError:
+                        logging.debug("Unable to find caller context for: %s", abs_caller_file)
                         caller_context = None
 
                     if caller_context:

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -134,12 +134,16 @@ class Runner(BaseRunner):
                     abs_caller_file = module_referrer[:module_referrer.rindex("#")]
                     caller_file_path = f"/{os.path.relpath(abs_caller_file, root_folder)}"
 
-                    caller_context = dpath.get(definition_context[abs_caller_file],
-                                               # HACK ALERT: module data is currently double-nested in
-                                               #             definition context. If fixed, remove the
-                                               #             addition of "module." at the beginning.
-                                               "module." + referrer_id,
-                                               separator=".")
+                    try:
+                        caller_context = dpath.get(definition_context[abs_caller_file],
+                                                   # HACK ALERT: module data is currently double-nested in
+                                                   #             definition context. If fixed, remove the
+                                                   #             addition of "module." at the beginning.
+                                                   "module." + referrer_id,
+                                                   separator=".")
+                    except KeyError:
+                        caller_context = None
+
                     if caller_context:
                         caller_file_line_range = [caller_context.get('start_line'), caller_context.get('end_line')]
                 else:

--- a/tests/terraform/runner/resources/module_failure_reporting_772/main.tf
+++ b/tests/terraform/runner/resources/module_failure_reporting_772/main.tf
@@ -1,0 +1,13 @@
+#
+# WARNING: Line numbers mater in this test!
+#          Update test_module_failure_reporting_772 if a change is made!
+#
+
+module "test_module" {
+  source = "./module"
+}
+
+# Bucket that will fail (no encryption) defined OUTSIDE a module
+resource "aws_s3_bucket" "outside" {
+  bucket = "outside-bucket"
+}

--- a/tests/terraform/runner/resources/module_failure_reporting_772/module/module.tf
+++ b/tests/terraform/runner/resources/module_failure_reporting_772/module/module.tf
@@ -1,0 +1,9 @@
+#
+# WARNING: Line numbers mater in this test!
+#          Update test_module_failure_reporting_772 if a change is made!
+#
+
+# Bucket that will fail (no encryption) defined INSIDE a module
+resource "aws_s3_bucket" "inside" {
+  bucket = "inside-bucket"
+}

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -528,12 +528,8 @@ class TestRunnerValid(unittest.TestCase):
                 self.assertEqual(record.resource, "aws_s3_bucket.outside")
                 assert record.file_path == "/main.tf"
                 self.assertEqual(record.file_line_range, [11, 13])
-                assert record.caller_file_path == ""
-                self.assertEqual(record.caller_file_path, "")
-
-                # ATTENTION!! If this breaks, see the "HACK ALERT" comment in runner.run_block.
-                #             A bug might have been fixed.
-                self.assertEqual(record.caller_file_line_range, [])
+                self.assertIsNone(record.caller_file_path)
+                self.assertIsNone(record.caller_file_line_range)
 
             if "inside" in record.resource:
                 found_inside = True
@@ -541,6 +537,8 @@ class TestRunnerValid(unittest.TestCase):
                 assert record.file_path == "/module/module.tf"
                 self.assertEqual(record.file_line_range, [7, 9])
                 assert record.caller_file_path == "/main.tf"
+                # ATTENTION!! If this breaks, see the "HACK ALERT" comment in runner.run_block.
+                #             A bug might have been fixed.
                 self.assertEqual(record.caller_file_line_range, [6, 8])
 
         self.assertTrue(found_inside)

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -508,6 +508,45 @@ class TestRunnerValid(unittest.TestCase):
         runner.run(root_folder=None, external_checks_dir=None, files=[passing_tf_file_path])
         # If we get here all is well. :-)  Failure would throw an exception.
 
+    def test_module_failure_reporting_772(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        report = Runner().run(root_folder=f"{current_dir}/resources/module_failure_reporting_772",
+                              external_checks_dir=None,
+                              runner_filter=RunnerFilter(checks="CKV_AWS_19"))       # bucket encryption
+
+        self.assertEqual(len(report.failed_checks), 2)       # 2 bucket failures
+        self.assertEqual(len(report.passed_checks), 0)
+
+        found_inside = False
+        found_outside = False
+        for record in report.failed_checks:
+            # "outside" bucket (not defined in a module) should be a direct resource path and
+            # should not have caller file info.
+            if "outside" in record.resource:
+                found_outside = True
+                self.assertEqual(record.resource, "aws_s3_bucket.outside")
+                assert record.file_path == "/main.tf"
+                self.assertEqual(record.file_line_range, [11, 13])
+                assert record.caller_file_path == ""
+                self.assertEqual(record.caller_file_path, "")
+
+                # ATTENTION!! If this breaks, see the "HACK ALERT" comment in runner.run_block.
+                #             A bug might have been fixed.
+                self.assertEqual(record.caller_file_line_range, [])
+
+            if "inside" in record.resource:
+                found_inside = True
+                self.assertEqual(record.resource, "module.test_module.aws_s3_bucket.inside")
+                assert record.file_path == "/module/module.tf"
+                self.assertEqual(record.file_line_range, [7, 9])
+                assert record.caller_file_path == "/main.tf"
+                self.assertEqual(record.caller_file_line_range, [6, 8])
+
+        self.assertTrue(found_inside)
+        self.assertTrue(found_outside)
+
+
     def tearDown(self):
         parser_registry.definitions_context = {}
 


### PR DESCRIPTION
This records the full path for resources loaded from modules. For example, `module.test_module.aws_s3_bucket.inside` rather than simply `aws_s3_bucket.inside` to indicate that the bucket (named `inside`) was loaded from the module `test_module`. In addition the "Caller File" has been added to record output for both json and textual output.

Sample output can be seen [here](https://github.com/bridgecrewio/checkov/issues/772#issuecomment-785427909)

Fixes: #772

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
