### PR TITLE
TF - EKSNode Check - Attempt 2

### DIFF
--- a/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py
+++ b/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py
@@ -12,10 +12,11 @@ class EKSNodeGroupRemoteAccess(BaseResourceCheck):
 
     def scan_resource_conf(self, conf):
         if "remote_access" in conf.keys():
-            if not conf["remote_access"]:
+            try:
+                if "ec2_ssh_key" in conf["remote_access"][0].keys() and not 'source_security_group_ids' in conf["remote_access"][0].keys():
+                    return CheckResult.FAILED
+            except:
                 return CheckResult.PASSED
-            if "ec2_ssh_key" in conf["remote_access"][0].keys() and not 'source_security_group_ids' in conf["remote_access"][0].keys():
-                return CheckResult.FAILED
         return CheckResult.PASSED
 
 

--- a/tests/terraform/runner/resources/unexpected/eks_node_group_remote_access.json
+++ b/tests/terraform/runner/resources/unexpected/eks_node_group_remote_access.json
@@ -1,0 +1,138 @@
+{
+    "format_version": "0.1",
+    "terraform_version": "0.14.6",
+    "planned_values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_eks_node_group.test",
+            "mode": "managed",
+            "type": "aws_eks_node_group",
+            "name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "cluster_name": "test",
+              "force_update_version": null,
+              "labels": null,
+              "launch_template": [],
+              "node_group_name": "example",
+              "node_role_arn": "example-arn",
+              "remote_access": [],
+              "scaling_config": [
+                {
+                  "desired_size": 1,
+                  "max_size": 1,
+                  "min_size": 1
+                }
+              ],
+              "subnet_ids": [
+                "subnet-ids"
+              ],
+              "tags": null,
+              "timeouts": null
+            }
+          }
+        ]
+      }
+    },
+    "resource_changes": [
+      {
+        "address": "aws_eks_node_group.test",
+        "mode": "managed",
+        "type": "aws_eks_node_group",
+        "name": "test",
+        "provider_name": "registry.terraform.io/hashicorp/aws",
+        "change": {
+          "actions": [
+            "create"
+          ],
+          "before": null,
+          "after": {
+            "cluster_name": "test",
+            "force_update_version": null,
+            "labels": null,
+            "launch_template": [],
+            "node_group_name": "example",
+            "node_role_arn": "example-arn",
+            "remote_access": [],
+            "scaling_config": [
+              {
+                "desired_size": 1,
+                "max_size": 1,
+                "min_size": 1
+              }
+            ],
+            "subnet_ids": [
+              "subnet-ids"
+            ],
+            "tags": null,
+            "timeouts": null
+          },
+          "after_unknown": {
+            "ami_type": true,
+            "arn": true,
+            "capacity_type": true,
+            "disk_size": true,
+            "id": true,
+            "instance_types": true,
+            "launch_template": [],
+            "release_version": true,
+            "remote_access": [],
+            "resources": true,
+            "scaling_config": [
+              {}
+            ],
+            "status": true,
+            "subnet_ids": [
+              false
+            ],
+            "version": true
+          }
+        }
+      }
+    ],
+    "configuration": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_eks_node_group.test",
+            "mode": "managed",
+            "type": "aws_eks_node_group",
+            "name": "test",
+            "provider_config_key": "aws",
+            "expressions": {
+              "cluster_name": {
+                "constant_value": "test"
+              },
+              "node_group_name": {
+                "constant_value": "example"
+              },
+              "node_role_arn": {
+                "constant_value": "example-arn"
+              },
+              "scaling_config": [
+                {
+                  "desired_size": {
+                    "constant_value": 1
+                  },
+                  "max_size": {
+                    "constant_value": 1
+                  },
+                  "min_size": {
+                    "constant_value": 1
+                  }
+                }
+              ],
+              "subnet_ids": {
+                "constant_value": [
+                  "subnet-ids"
+                ]
+              }
+            },
+            "schema_version": 0
+          }
+        ]
+      }
+    }
+}

--- a/tests/terraform/runner/resources/unexpected/unexpected.md
+++ b/tests/terraform/runner/resources/unexpected/unexpected.md
@@ -1,0 +1,26 @@
+# Unexpected
+This folder is for different cases of test runner test data where the input HCL is maybe unexpectedly transformed when you see the json representation.
+
+This area can be used to verify that certain checks are robust in catching issues which can't be caught by unit testing the HCL input level alone.
+
+## eks_node_group_remote_access
+### Description
+`remote_access` is ommitted in HCL. But is represented as `remote_access: [ ]` in the Plan.
+
+This needs to be taken in to account when writing the check.
+### HCL Input**
+```
+resource "aws_eks_node_group" "test" {
+  cluster_name    = "test"
+  node_group_name = "example"
+  node_role_arn   = "example-arn"
+  subnet_ids      = ["subnet-ids"]
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+```
+### JSON Output**
+[eks_node_group_remote_access.json](eks_node_group_remote_access.json)

--- a/tests/terraform/runner/resources/unexpected/unexpected.md
+++ b/tests/terraform/runner/resources/unexpected/unexpected.md
@@ -8,7 +8,7 @@ This area can be used to verify that certain checks are robust in catching issue
 `remote_access` is ommitted in HCL. But is represented as `remote_access: [ ]` in the Plan.
 
 This needs to be taken in to account when writing the check.
-### HCL Input**
+### HCL Input
 ```
 resource "aws_eks_node_group" "test" {
   cluster_name    = "test"
@@ -22,5 +22,5 @@ resource "aws_eks_node_group" "test" {
   }
 }
 ```
-### JSON Output**
+### JSON Output
 [eks_node_group_remote_access.json](eks_node_group_remote_access.json)

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -118,7 +118,7 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.get_exit_code(soft_fail=True), 0)
 
         self.assertEqual(61, report.get_summary()["failed"])
-        self.assertEqual(62, report.get_summary()["passed"])
+        self.assertEqual(63, report.get_summary()["passed"])
 
         files_scanned = list(set(map(lambda rec: rec.file_path, report.failed_checks)))
         self.assertGreaterEqual(5, len(files_scanned))
@@ -205,6 +205,22 @@ class TestRunnerValid(unittest.TestCase):
             # The plan runner sets file_path to be relative from the CWD already, so this is easy
             self.assertEqual(record.repo_file_path, record.file_path)
 
+
+    def test_runner_unexpected_eks_node_group_remote_access(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_plan_path = current_dir + "/resources/unexpected/eks_node_group_remote_access.json"
+        runner = Runner()
+        report = runner.run(root_folder=None, files=[valid_plan_path], external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework='all'))
+        report_json = report.get_json()
+        self.assertTrue(isinstance(report_json, str))
+        self.assertIsNotNone(report_json)
+        self.assertIsNotNone(report.get_test_suites())
+        self.assertEqual(report.get_exit_code(soft_fail=False), 0)
+        self.assertEqual(report.get_exit_code(soft_fail=True), 0)
+
+        self.assertEqual(report.get_summary()["failed"], 0)
+        self.assertEqual(report.get_summary()["passed"], 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hello,

I've explained the issue I was facing yesterday with https://github.com/bridgecrewio/checkov/pull/910

Checking that the (assumed) list had no items for some reason did not fix the problem.

This is the same issue as https://github.com/bridgecrewio/checkov/issues/876

This method does fix the issue (tested with local build):

**Before**
```
    File "/usr/local/lib/python3.8/site-packages/checkov/terraform/checks/resource/aws/EKSNodeGroupRemoteAccess.py", line 17, in scan_resource_conf
    if "ec2_ssh_key" in conf["remote_access"][0].keys() and not 'source_security_group_ids' in conf["remote_access"][0].keys():
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/context_parsers/tf_plan/node.py", line 202, in __getattr__
    raise TemplateAttributeError('%s.%s is invalid' % (self.__class__.__name__, name))
checkov.terraform.context_parsers.tf_plan.node.TemplateAttributeError: list_node.keys is invalid
```

**After**
```
terraform_plan scan results:

Passed checks: 1, Failed checks: 0, Skipped checks: 0

Check: CKV_AWS_100: "Ensure Amazon EKS Node group has implict SSH access from 0.0.0.0/0"
	PASSED for resource: aws_eks_node_group.test
	File: /tf.json:0-0
```

**Test Data**
This must be converted to tfplan.json via the checkov helper docs and tested on the plan to show the issue.
```
resource "aws_eks_node_group" "test" {
  cluster_name    = "test"
  node_group_name = "example"
  node_role_arn   = "example-arn"
  subnet_ids      = ["subnet-ids"]
  scaling_config {
    desired_size = 1
    max_size     = 1
    min_size     = 1
  }
}
```

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
