### PR TITLE
A check for auditlogs being enabled on docdb via parameter groups

### DIFF
--- a/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
+++ b/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
@@ -1,0 +1,28 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class DocDBAuditLogs(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure DocDB has audit logs enabled"
+        id = "CKV_AWS_104"
+        supported_resources = ['aws_docdb_cluster_parameter_group']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'parameter' in conf:
+            for elem in conf["parameter"]:
+                if isinstance(elem, dict) and elem["name"][0] == "audit_logs" and elem["value"][0] == "enabled":
+                    self.evaluated_keys = [f'parameter/[{conf["parameter"].index(elem)}]/name', f'parameter/[{conf["parameter"].index(elem)}]/value']
+                    return CheckResult.PASSED
+
+            #no matching params
+            return CheckResult.FAILED
+
+        else:
+          # no params at all
+          return CheckResult.FAILED
+
+
+check = DocDBAuditLogs()

--- a/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
+++ b/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
@@ -1,8 +1,8 @@
 from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
 
 
-class DocDBAuditLogs(BaseResourceValueCheck):
+class DocDBAuditLogs(BaseResourceCheck):
     def __init__(self):
         name = "Ensure DocDB has audit logs enabled"
         id = "CKV_AWS_104"

--- a/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
+++ b/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
@@ -7,7 +7,7 @@ class DocDBAuditLogs(BaseResourceCheck):
         name = "Ensure DocDB has audit logs enabled"
         id = "CKV_AWS_104"
         supported_resources = ['aws_docdb_cluster_parameter_group']
-        categories = [CheckCategories.ENCRYPTION]
+        categories = [CheckCategories.LOGGING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):

--- a/tests/terraform/checks/resource/aws/test_DocDBAuditLogs.py
+++ b/tests/terraform/checks/resource/aws/test_DocDBAuditLogs.py
@@ -1,0 +1,62 @@
+import unittest
+import hcl2
+
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.aws.DocDBAuditLogs import check
+
+
+class TestDocDBAuditLogs(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+                resource "aws_docdb_cluster_parameter_group" "test" {
+                  family      = "docdb3.6"
+                  name        = "test"
+                  description = "docdb cluster parameter group"
+
+                  parameter {
+                    name  = "tls"
+                    value = "disabled"
+                  }
+
+                  parameter {
+                    name  = "audit_logs"
+                    value = "disabled"
+                  }
+                }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_docdb_cluster_parameter_group']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_no_parameters(self):
+        hcl_res = hcl2.loads("""
+                resource "aws_docdb_cluster_parameter_group" "test" {
+                  family      = "docdb3.6"
+                  name        = "test"
+                  description = "docdb cluster parameter group"
+                }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_docdb_cluster_parameter_group']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_with_parameters(self):
+        hcl_res = hcl2.loads("""
+                resource "aws_docdb_cluster_parameter_group" "test" {
+                  family      = "docdb3.6"
+                  name        = "test"
+                  description = "docdb cluster parameter group"
+
+                  parameter {
+                    name  = "audit_logs"
+                    value = "enabled"
+                  }
+                }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_docdb_cluster_parameter_group']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
