### PR TITLE
CF - Check - ES Domain HTTPS

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ElasticsearchDomainEnforceHTTPS.py
+++ b/checkov/cloudformation/checks/resource/aws/ElasticsearchDomainEnforceHTTPS.py
@@ -1,0 +1,16 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class ElasticsearchDomainEnforceHTTPS(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Elasticsearch Domain enforces HTTPS"
+        id = "CKV_AWS_83"
+        supported_resources = ['AWS::Elasticsearch::Domain']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'Properties/DomainEndpointOptions/EnforceHTTPS'
+
+check = ElasticsearchDomainEnforceHTTPS()

--- a/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainEnforceHTTPS/ElasticsearchDomainEnforceHTTPS-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainEnforceHTTPS/ElasticsearchDomainEnforceHTTPS-FAILED.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  Resource0:
+    Type: 'AWS::Elasticsearch::Domain'
+    Properties:
+      DomainEndpointOptions:
+        EnforceHTTPS: False
+  Resource1:
+    Type: 'AWS::Elasticsearch::Domain'
+    Properties:
+      DomainEndpointOptions:
+        CustomEndpointEnabled: False
+  Resource2:
+    Type: 'AWS::Elasticsearch::Domain'
+    Properties:
+      ElasticsearchVersion: "2.3"

--- a/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainEnforceHTTPS/ElasticsearchDomainEnforceHTTPS-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainEnforceHTTPS/ElasticsearchDomainEnforceHTTPS-FAILED.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: 'AWS::Elasticsearch::Domain'
     Properties:
       DomainEndpointOptions:
-        CustomEndpointEnabled: False
+        TLSSecurityPolicy: "Policy-Min-TLS-1-2-2019-07"
   Resource2:
     Type: 'AWS::Elasticsearch::Domain'
     Properties:

--- a/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainEnforceHTTPS/ElasticsearchDomainEnforceHTTPS-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainEnforceHTTPS/ElasticsearchDomainEnforceHTTPS-PASSED.yaml
@@ -1,0 +1,7 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  Resource0:
+    Type: 'AWS::Elasticsearch::Domain'
+    Properties:
+      DomainEndpointOptions:
+        EnforceHTTPS: True

--- a/tests/cloudformation/checks/resource/aws/test_ElasticsearchDomainEnforceHTTPS.py
+++ b/tests/cloudformation/checks/resource/aws/test_ElasticsearchDomainEnforceHTTPS.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.ElasticsearchDomainEnforceHTTPS import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestElasticsearchDomainEnforceHTTPS(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ElasticsearchDomainEnforceHTTPS"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 3)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello,

Implementing this check as already done in Terraform.

Terraform check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/ElasticsearchDomainEnforceHTTPS.py
CF Doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-domainendpointoptions.html

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
