### PR TITLE
remove funky char in update string causing crashes in windows installs.

### DIFF
--- a/checkov/common/util/banner.py
+++ b/checkov/common/util/banner.py
@@ -14,5 +14,5 @@ By bridgecrew.io | version: {} """.format(version)
 
 new_version = check_for_update("checkov", version)
 if new_version:
-    banner = "\n" + banner + "\nUpdate available " + colored(version,"grey") + " > " + colored(new_version, "green") + "\nRun " + colored(
+    banner = "\n" + banner + "\nUpdate available " + colored(version,"grey") + " -> " + colored(new_version, "green") + "\nRun " + colored(
         "pip3 install -U checkov", "magenta") + " to update \n"

--- a/checkov/common/util/banner.py
+++ b/checkov/common/util/banner.py
@@ -14,5 +14,5 @@ By bridgecrew.io | version: {} """.format(version)
 
 new_version = check_for_update("checkov", version)
 if new_version:
-    banner = "\n" + banner + "\nUpdate available " + colored(version,"grey",attrs=["blink"]) + " → " + colored(new_version, "green") + "\nRun " + colored(
+    banner = "\n" + banner + "\nUpdate available " + colored(version,"grey") + " > " + colored(new_version, "green") + "\nRun " + colored(
         "pip3 install -U checkov", "magenta") + " to update \n"


### PR DESCRIPTION
Some windows users report repeatable crashes due to an unknown char for the arrow we were using in the "update available" output, debugging was done to work out if this was a version specific or colorama specific thing, however no specific commit/history item was found. 

Best thing for stability for these users is to remove the offending char.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
