### PR TITLE
Better handling of module data dependencies

### DIFF
--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -36,8 +36,8 @@ class Parser:
         self._parsed_directories = set()
 
         # This ensures that we don't try to double-load modules
-        # Tuple is <file>, <module_index> (see _load_modules)
-        self._loaded_modules: Set[Tuple[str, int]] = set()
+        # Tuple is <file>, <module_index>, <name> (see _load_modules)
+        self._loaded_modules: Set[Tuple[str, int, str]] = set()
 
     def _init(self, directory: str, out_definitions: Optional[Dict],
               out_evaluations_context: Dict[str, Dict[str, EvaluationContext]],
@@ -252,16 +252,39 @@ class Parser:
             self._process_vars_and_locals(directory, var_value_and_file_map, module_data_retrieval)
 
         # Stage 4: Load modules
-        self._load_modules(self.directory, module_loader_registry, dir_filter, module_load_context,
-                           keys_referenced_as_modules)
+        #          This stage needs to be done in a loop (again... alas, no DAG) because modules might not
+        #          be loadable until other modules are loaded. This happens when parameters to one module
+        #          depend on the output of another. For such cases, the base module must be loaded, then
+        #          a parameter resolution pass needs to happen, then the second module can be loaded.
+        #
+        #          One gotcha is that we need to make sure we load all modules at some point, even if their
+        #          parameters don't resolve. So, if we hit a spot where resolution doesn't change anything
+        #          and there are still modules to be loaded, they will be forced on the next pass.
+        force_final_module_load = False
+        for i in range(0, 10):      # circuit breaker - no more than 10 loops
+            logging.debug("Module load loop %d", i)
 
-        # Stage 5: Variable resolution round 2 - now with modules
-        if self.evaluate_variables:
-            self._process_vars_and_locals(directory, var_value_and_file_map, module_data_retrieval)
+            # Stage 4a: Load eligible modules
+            has_more_modules = self._load_modules(directory, module_loader_registry,
+                                                  dir_filter, module_load_context,
+                                                  keys_referenced_as_modules,
+                                                  force_final_module_load)
+
+            # Stage 4b: Variable resolution round 2 - now with (possibly more) modules
+            made_var_changes = False
+            if self.evaluate_variables:
+                made_var_changes = self._process_vars_and_locals(directory, var_value_and_file_map,
+                                                                 module_data_retrieval)
+            if not has_more_modules:
+                break       # nothing more to do
+            elif not made_var_changes:
+                # If there are more modules to load but no variables were resolved, then to a final module
+                # load, forcing things through without complete resolution.
+                force_final_module_load = True
 
     def _process_vars_and_locals(self, directory: str,
                                  var_value_and_file_map: Dict[str, Tuple[Any, str]],
-                                 module_data_retrieval: Callable[[str], Dict[str, Any]]):
+                                 module_data_retrieval: Callable[[str], Dict[str, Any]]) -> bool:
         locals_values = {}
         for file_data in self.out_definitions.values():
             file_locals = file_data.get("locals")
@@ -276,8 +299,10 @@ class Parser:
         # More than a couple loops isn't normally expected.
         # NOTE: If this approach proves to be a performance liability, a DAG will be needed.
         loop_count = 0
+        made_change_in_any_loop = False
         for i in range(0, 25):
             loop_count += 1
+            logging.debug("Parser loop %d", i)
 
             made_change = False
             # Put out file layer here so the context works inside the loop
@@ -291,21 +316,22 @@ class Parser:
                     # }
 
                 if self._process_vars_and_locals_loop(file_data,
-                                                     eval_context_dict,
-                                                     os.path.relpath(file, directory),
-                                                     var_value_and_file_map, locals_values,
-                                                     file_data.get("resource"),
-                                                     file_data.get("module"),
-                                                     module_data_retrieval,
-                                                     directory):
+                                                      eval_context_dict,
+                                                      os.path.relpath(file, directory),
+                                                      var_value_and_file_map, locals_values,
+                                                      file_data.get("resource"),
+                                                      file_data.get("module"),
+                                                      module_data_retrieval,
+                                                      directory):
                     made_change = True
 
                 if len(eval_context_dict) == 0:
                     del self.out_evaluations_context[file]
+            made_change_in_any_loop = made_change_in_any_loop or made_change
             if not made_change:
                 break
-
         LOGGER.debug("Processing variables took %d loop iterations", loop_count)
+        return made_change_in_any_loop
 
     def _process_vars_and_locals_loop(self, out_definitions: Dict,
                                       eval_map_by_var_name: Dict[str, EvaluationContext], relative_file_path: str,
@@ -387,10 +413,10 @@ class Parser:
                         made_change = True
                 elif isinstance(value, dict):
                     if self._process_vars_and_locals_loop(value, eval_map_by_var_name, relative_file_path,
-                                                     var_value_and_file_map,
-                                                     locals_values, resource_list,
-                                                     module_list, module_data_retrieval, root_directory,
-                                                     new_context):
+                                                          var_value_and_file_map,
+                                                          locals_values, resource_list,
+                                                          module_list, module_data_retrieval, root_directory,
+                                                          new_context):
                         made_change = True
 
                 elif isinstance(value, list):
@@ -406,10 +432,24 @@ class Parser:
 
     def _load_modules(self, root_dir: str, module_loader_registry: ModuleLoaderRegistry,
                       dir_filter: Callable[[str], bool], module_load_context: Optional[str],
-                      keys_referenced_as_modules: Set[str]):
+                      keys_referenced_as_modules: Set[str], ignore_unresolved_params: bool = False) -> bool:
+        """
+        Load modules which have not already been loaded and can be loaded (don't have unresolved parameters).
+
+        :param ignore_unresolved_params:    If true, not-yet-loaded modules will be loaded even if they are
+                                            passed parameters that are not fully resolved.
+        :return:                            True if there were modules that were not loaded due to unresolved
+                                            parameters.
+        """
         all_module_definitions = {}
         all_module_evaluations_context = {}
+        skipped_a_module = False
         for file in list(self.out_definitions.keys()):
+            # Don't process a file in a directory other than the directory we're processing. For example,
+            # if we're down dealing with <top_dir>/<module>/something.tf, we don't want to rescan files
+            # up in <top_dir>.
+            if os.path.dirname(file) != root_dir:
+                continue
             # Don't process a file reference which has already been processed
             if file.endswith("]"):
                 continue
@@ -422,10 +462,6 @@ class Parser:
                 continue
 
             for module_index, module_call in enumerate(module_calls):
-                module_address = (file, module_index)
-                if module_address in self._loaded_modules:
-                    continue
-                self._loaded_modules.add(module_address)
 
                 if not isinstance(module_call, dict):
                     continue
@@ -434,6 +470,25 @@ class Parser:
                 for module_call_name, module_call_data in module_call.items():
                     if not isinstance(module_call_data, dict):
                         continue
+
+                    module_address = (file, module_index, module_call_name)
+                    if module_address in self._loaded_modules:
+                        continue
+
+                    # Variables being passed to module, "source" and "version" are reserved
+                    specified_vars = {k: v[0] for k, v in module_call_data.items()
+                                      if k != "source" and k != "version"}
+
+                    if not ignore_unresolved_params:
+                        has_unresolved_params = False
+                        for k, v in specified_vars.items():
+                            if not is_acceptable_module_param(v) or not is_acceptable_module_param(k):
+                                has_unresolved_params = True
+                                break
+                        if has_unresolved_params:
+                            skipped_a_module = True
+                            continue
+                    self._loaded_modules.add(module_address)
 
                     source = module_call_data.get("source")
                     if not source or not isinstance(source, list):
@@ -452,10 +507,6 @@ class Parser:
                         with module_loader_registry.load(root_dir, source, version) as content:
                             if not content.loaded():
                                 continue
-
-                            # Variables being passed to module, "source" and "version" are reserved
-                            specified_vars = {k: v[0] for k, v in module_call_data.items()
-                                              if k != "source" and k != "version"}
 
                             self._internal_dir_load(directory=content.path(),
                                                     module_loader_registry=module_loader_registry,
@@ -512,6 +563,7 @@ class Parser:
         if all_module_definitions:
             deep_merge.merge(self.out_definitions, all_module_definitions)
             deep_merge.merge(self.out_evaluations_context, all_module_evaluations_context)
+        return skipped_a_module
 
 
 def _handle_single_var_pattern(orig_variable: str, var_value_and_file_map: Dict[str, Tuple[Any, str]],
@@ -781,3 +833,29 @@ def function_nyi_handler(original, function_name, **_):
                   "feature request if it is important to your evaluation (value: '%s')",
                   function_name, original)
     return FUNCTION_FAILED
+
+
+def is_acceptable_module_param(value: Any) -> bool:
+    """
+    This function determines if a value should be passed to a module as a parameter. We don't want to pass
+    unresolved var, local or module references because they can't be resolved from the module, so they need
+    to be resolved prior to being passed down.
+    """
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if not is_acceptable_module_param(v) or not is_acceptable_module_param(k):
+                return False
+        return True
+    if isinstance(value, set) or isinstance(value, list):
+        for v in value:
+            if not is_acceptable_module_param(v):
+                return False
+        return True
+
+    if not isinstance(value, str):
+        return True
+
+    for vbm in find_var_blocks(value):
+        if vbm.is_simple_var():
+            return False
+    return True

--- a/checkov/terraform/parser_utils.py
+++ b/checkov/terraform/parser_utils.py
@@ -1,10 +1,15 @@
 import json
+import re
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from typing import Any, Dict, List, Optional
 
 import hcl2
 
+
+_FUNCTION_NAME_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+_ARG_VAR_PATTERN = re.compile(r"[a-zA-Z_]+(\.[a-zA-Z_]+)+")
 
 @dataclass
 class VarBlockMatch:
@@ -46,8 +51,12 @@ def find_var_blocks(value: str) -> List[VarBlockMatch]:
 
     mode_stack: List[ParserMode] = []
     eval_start_pos_stack: List[int] = []            # location of first char inside brackets
+    param_start_pos_stack: List[int] = []           # location of open parens
     preceding_dollar = False
     preceding_string_escape = False
+    # NOTE: function calls can be nested, but since param args are only being inspected for variables,
+    #       it's alright to ignore outer calls.
+    param_arg_start = -1
     for index, c in enumerate(value):
         current_mode = "  " if not mode_stack else mode_stack[-1]
 
@@ -86,7 +95,31 @@ def find_var_blocks(value: str) -> List[VarBlockMatch]:
         elif c == "]" and current_mode == ParserMode.ARRAY:
             mode_stack.pop()
         elif c == ")" and current_mode == ParserMode.PARAMS:
+            if param_arg_start > 0:
+                param_arg = value[param_arg_start: index].strip()
+                if _ARG_VAR_PATTERN.match(param_arg):
+                    to_return.append(VarBlockMatch(param_arg, param_arg))
+                param_arg_start = -1
+
             mode_stack.pop()
+            start_pos = param_start_pos_stack.pop()
+            # See if these params are for a function call. Back up from the index to determine if there's
+            # a function preceding.
+            function_name_start_index = start_pos
+            for function_index in range(start_pos - 1, 0, -1):
+                if value[function_index] in _FUNCTION_NAME_CHARS:
+                    function_name_start_index = function_index
+                else:
+                    break
+            # We know now there's a function call here. But, don't call it out if it's directly wrapped
+            # in eval markers.
+            in_eval_markers = False
+            if function_name_start_index >= 2:
+                in_eval_markers = value[function_name_start_index - 2] == "$" and \
+                                  value[function_name_start_index - 1] == "{"
+            if function_name_start_index < start_pos and not in_eval_markers:
+                to_return.append(VarBlockMatch(value[function_name_start_index: index + 1],
+                                               value[function_name_start_index: index + 1]))
         elif c == '"':
             if preceding_string_escape:
                 preceding_string_escape = False
@@ -113,6 +146,14 @@ def find_var_blocks(value: str) -> List[VarBlockMatch]:
         elif c == "(":                                      # do we care?
             if not ParserMode.is_string(current_mode):
                 mode_stack.append(ParserMode.PARAMS)
+                param_start_pos_stack.append(index)
+                param_arg_start = index + 1
+        elif c == ",":
+            if current_mode == ParserMode.PARAMS and param_arg_start > 0:
+                param_arg = value[param_arg_start: index].strip()
+                if _ARG_VAR_PATTERN.match(param_arg):
+                    to_return.append(VarBlockMatch(param_arg, param_arg))
+                param_arg_start = index + 1
         elif c == "?" and current_mode == ParserMode.EVAL:  # ternary
             # If what's been processed in the ternary so far is "true" or "false" (boolean or string type)
             # then nothing special will happen here and only the full expression will be returned.

--- a/checkov/terraform/parser_utils.py
+++ b/checkov/terraform/parser_utils.py
@@ -20,6 +20,13 @@ class VarBlockMatch:
         self.full_str = self.full_str.replace(original, replaced)
         self.var_only = self.var_only.replace(original, replaced)
 
+    def is_simple_var(self):
+        """
+        Indicates whether or not the value of the var block matches a "simple" var pattern. For example:
+        local.blah, var.foo, module.one.a_resource.
+        """
+        return _ARG_VAR_PATTERN.match(self.var_only) is not None
+
 
 class ParserMode(Enum):
     # Note: values are just for debugging.

--- a/integration_tests/test_checkov_json_report.py
+++ b/integration_tests/test_checkov_json_report.py
@@ -35,7 +35,7 @@ class TestCheckovJsonReport(unittest.TestCase):
         with open(report_path) as json_file:
             data = json.load(json_file)
             self.assertEqual(data["summary"]["parsing_errors"], 0,
-                             f"expecting 0 parsing errors but got: {data}")
+                             f"expecting 0 parsing errors but got: {data['results']['parsing_errors']}")
             self.assertGreater(data["summary"]["failed"], 1,
                                f"expecting more than 1 failed checks, got: {data['summary']['failed']}")
 

--- a/integration_tests/test_checkov_json_report.py
+++ b/integration_tests/test_checkov_json_report.py
@@ -34,8 +34,10 @@ class TestCheckovJsonReport(unittest.TestCase):
     def validate_report(self, report_path):
         with open(report_path) as json_file:
             data = json.load(json_file)
-            self.assertEqual(data["summary"]["parsing_errors"], 0, "expecting 0 parsing errors")
-            self.assertGreater(data["summary"]["failed"], 1, "expecting more then 1 failed checks")
+            self.assertEqual(data["summary"]["parsing_errors"], 0,
+                             f"expecting 0 parsing errors but got: {data}")
+            self.assertGreater(data["summary"]["failed"], 1,
+                               f"expecting more than 1 failed checks, got: {data['summary']['failed']}")
 
     def validate_json_quiet(self):
         report_path = current_dir + "/../checkov_report_cfngoat_quiet.json"

--- a/tests/terraform/parser/resources/parser_scenarios/module_output_reference/bucket/bucket.tf
+++ b/tests/terraform/parser/resources/parser_scenarios/module_output_reference/bucket/bucket.tf
@@ -1,0 +1,8 @@
+variable "tags" {}
+
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "its.a.bucket"
+  # NOTE: Prior to find_var_blocks handling vars in parameters, this didn't work
+  tags = merge(var.tags, {"more_tags" = "yes"})
+}

--- a/tests/terraform/parser/resources/parser_scenarios/module_output_reference/common/common.tf
+++ b/tests/terraform/parser/resources/parser_scenarios/module_output_reference/common/common.tf
@@ -1,0 +1,6 @@
+output "tags" {
+  value = {
+    Team  = "my_team"
+    Color = "red"
+  }
+}

--- a/tests/terraform/parser/resources/parser_scenarios/module_output_reference/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/module_output_reference/expected.json
@@ -1,0 +1,59 @@
+{
+  "main.tf": {
+    "module": [
+      {
+        "common": {
+          "source": ["./common"],
+          "__resolved__": ["common/common.tf[main.tf#0]"]
+        }
+      },
+      {
+        "bucket": {
+          "source": ["./bucket"],
+          "tags": [
+            {
+              "Team": "my_team",
+              "Color": "red"
+            }
+          ],
+          "__resolved__": ["bucket/bucket.tf[main.tf#1]"]
+        }
+      }
+    ]
+  },
+  "bucket/bucket.tf[main.tf#1]": {
+    "variable": [
+      {
+        "tags": {}
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket": {
+          "bucket": {
+            "bucket": ["its.a.bucket"],
+            "tags": [
+              {
+                "Team": "my_team",
+                "Color": "red",
+                "more_tags": "yes"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "common/common.tf[main.tf#0]": {
+    "output": [
+      {
+        "tags": {
+          "value": [{
+            "Team": "my_team",
+            "Color": "red"
+          }]
+        }
+      }
+    ]
+  }
+}

--- a/tests/terraform/parser/resources/parser_scenarios/module_output_reference/main.tf
+++ b/tests/terraform/parser/resources/parser_scenarios/module_output_reference/main.tf
@@ -3,5 +3,5 @@ module "common" {
 }
 module "bucket" {
   source = "./bucket"
-  tags = module.common.tags
+  tags = module.common.tags   # <-- reference to other module, must be resolved in second pass
 }

--- a/tests/terraform/parser/resources/parser_scenarios/module_output_reference/main.tf
+++ b/tests/terraform/parser/resources/parser_scenarios/module_output_reference/main.tf
@@ -1,0 +1,7 @@
+module "common" {
+  source = "./common"
+}
+module "bucket" {
+  source = "./bucket"
+  tags = module.common.tags
+}

--- a/tests/terraform/parser/test_parser_scenarios.py
+++ b/tests/terraform/parser/test_parser_scenarios.py
@@ -92,6 +92,9 @@ class TestParserScenarios(unittest.TestCase):
     def test_module_reference(self):
         self.go("module_reference")
 
+    def test_module_output_reference(self):
+        self.go("module_output_reference")
+
     def test_bad_ref_fallbacks(self):
         self.go("bad_ref_fallbacks")
 

--- a/tests/terraform/parser/test_parser_var_blocks.py
+++ b/tests/terraform/parser/test_parser_var_blocks.py
@@ -125,6 +125,17 @@ class TestParserInternals(unittest.TestCase):
                 ]
             ),
             (
+                "${merge(${local.common_tags},${local.common_data_tags},{'Name': 'my-thing-${var.ENVIRONMENT}-${var.REGION}'})}",
+                [
+                    VBM("${local.common_tags}", "local.common_tags"),
+                    VBM("${local.common_data_tags}", "local.common_data_tags"),
+                    VBM("${var.ENVIRONMENT}", "var.ENVIRONMENT"),
+                    VBM("${var.REGION}", "var.REGION"),
+                    VBM("${merge(${local.common_tags},${local.common_data_tags},{'Name': 'my-thing-${var.ENVIRONMENT}-${var.REGION}'})}",
+                        "merge(${local.common_tags},${local.common_data_tags},{'Name': 'my-thing-${var.ENVIRONMENT}-${var.REGION}'})")
+                ]
+            ),
+            (
                 '${merge(var.tags, map("Name", "${var.name}", "data_classification", "none"))}',
                 [
                     VBM("var.tags", "var.tags"),

--- a/tests/terraform/parser/test_parser_var_blocks.py
+++ b/tests/terraform/parser/test_parser_var_blocks.py
@@ -116,10 +116,23 @@ class TestParserInternals(unittest.TestCase):
             (
                 "${merge(local.common_tags,local.common_data_tags,{'Name': 'my-thing-${var.ENVIRONMENT}-${var.REGION}'})}",
                 [
+                    VBM("local.common_tags", "local.common_tags"),
+                    VBM("local.common_data_tags", "local.common_data_tags"),
                     VBM("${var.ENVIRONMENT}", "var.ENVIRONMENT"),
                     VBM("${var.REGION}", "var.REGION"),
                     VBM("${merge(local.common_tags,local.common_data_tags,{'Name': 'my-thing-${var.ENVIRONMENT}-${var.REGION}'})}",
                         "merge(local.common_tags,local.common_data_tags,{'Name': 'my-thing-${var.ENVIRONMENT}-${var.REGION}'})")
+                ]
+            ),
+            (
+                '${merge(var.tags, map("Name", "${var.name}", "data_classification", "none"))}',
+                [
+                    VBM("var.tags", "var.tags"),
+                    VBM("${var.name}", "var.name"),
+                    VBM('map("Name", "${var.name}", "data_classification", "none")',
+                        'map("Name", "${var.name}", "data_classification", "none")'),
+                    VBM('${merge(var.tags, map("Name", "${var.name}", "data_classification", "none"))}',
+                        'merge(var.tags, map("Name", "${var.name}", "data_classification", "none"))')
                 ]
             ),
 


### PR DESCRIPTION
This fixes a resolution problem where module data dependencies didn't previously work. For example (from the new `module_output_reference` parser scenario):
```
module "common" {
  source = "./common"
}
module "bucket" {
  source = "./bucket"
  tags = module.common.tags
}
```
Previously, both modules would attempt to load in the same pass, before variable resolution, which means that the reference to "module.common.tags" would slip into the data for the "bucket" module. This would not be resolvable, so the broken reference would be all it would ever see.

This change recognizes that the data is unresolved and so delays loading of the "bucket" module. So now, "common" is loaded, then variables are resolved, then in the next pass "bucket" is loaded... this time with resolved tag data.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
