### PR TITLE
Adding additional debug logging to TF Plan Runner

### DIFF
--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -63,7 +63,7 @@ class Runner(BaseRunner):
                     self.tf_definitions = tf_definitions
                     self.template_lines = template_lines
                     self.check_tf_definition(report, runner_filter)
-                else
+                else:
                     logging.debug(f'Failed to load {root}/{file} as is not a .json file, skipping')
 
         report.add_parsing_errors(parsing_errors.keys())

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -63,6 +63,8 @@ class Runner(BaseRunner):
                     self.tf_definitions = tf_definitions
                     self.template_lines = template_lines
                     self.check_tf_definition(report, runner_filter)
+                else
+                    logging.debug(f'Failed to load {root}/{file} as is not a .json file, skipping')
 
         report.add_parsing_errors(parsing_errors.keys())
 


### PR DESCRIPTION
Hello,

We had some issues running Checkov on a Terraform plan which did not have a `.json` file extension, the additional debug logging would have helped us diagnose the issue. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Many Thanks,
Tyler Allen.
