### PR TITLE
Fixing debug logging to TF Plan Runner

### DIFF
--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -64,7 +64,7 @@ class Runner(BaseRunner):
                     self.template_lines = template_lines
                     self.check_tf_definition(report, runner_filter)
                 else:
-                    logging.debug(f'Failed to load {root}/{file} as is not a .json file, skipping')
+                    logging.debug(f'Failed to load {file} as is not a .json file, skipping')
 
         report.add_parsing_errors(parsing_errors.keys())
 


### PR DESCRIPTION
Hello,

I noticed today during some testing that the previous PR throws an error as {root} does not exist on file runners, sorry about that. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Many Thanks,
Tyler Allen. 
