### PR TITLE
CF - Check - ES Logging

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ElasticsearchDomainLogging.py
+++ b/checkov/cloudformation/checks/resource/aws/ElasticsearchDomainLogging.py
@@ -11,6 +11,6 @@ class ElasticsearchDomainLogging(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):
-        return 'Properties/LogPublishingOption/Enabled'
+        return 'Properties/LogPublishingOptions/Enabled'
 
 check = ElasticsearchDomainLogging()

--- a/checkov/cloudformation/checks/resource/aws/ElasticsearchDomainLogging.py
+++ b/checkov/cloudformation/checks/resource/aws/ElasticsearchDomainLogging.py
@@ -1,0 +1,16 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class ElasticsearchDomainLogging(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Elasticsearch Domain Logging is enabled"
+        id = "CKV_AWS_84"
+        supported_resources = ['AWS::Elasticsearch::Domain']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'Properties/LogPublishingOption/Enabled'
+
+check = ElasticsearchDomainLogging()

--- a/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainLogging/ElasticsearchDomainLogging-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainLogging/ElasticsearchDomainLogging-FAILED.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  Resource0:
+    Type: 'AWS::Elasticsearch::Domain'
+    Properties:
+      DomainEndpointOptions:
+        EnforceHTTPS: True
+      LogPublishingOptions:
+        Enabled: False
+  Resource0:
+    Type: 'AWS::Elasticsearch::Domain'
+    Properties:
+      DomainEndpointOptions:
+        EnforceHTTPS: True

--- a/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainLogging/ElasticsearchDomainLogging-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainLogging/ElasticsearchDomainLogging-FAILED.yaml
@@ -7,7 +7,7 @@ Resources:
         EnforceHTTPS: True
       LogPublishingOptions:
         Enabled: False
-  Resource0:
+  Resource1:
     Type: 'AWS::Elasticsearch::Domain'
     Properties:
       DomainEndpointOptions:

--- a/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainLogging/ElasticsearchDomainLogging-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ElasticsearchDomainLogging/ElasticsearchDomainLogging-PASSED.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  Resource0:
+    Type: 'AWS::Elasticsearch::Domain'
+    Properties:
+      DomainEndpointOptions:
+        EnforceHTTPS: True
+      LogPublishingOptions:
+        Enabled: True
+        CloudWatchLogsLogGroupArn: CloudWatchLogsLogGroupArn

--- a/tests/cloudformation/checks/resource/aws/test_ElasticsearchDomainLogging.py
+++ b/tests/cloudformation/checks/resource/aws/test_ElasticsearchDomainLogging.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.ElasticsearchDomainLogging import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestElasticsearchDomainLogging(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ElasticsearchDomainLogging"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello,

Implementing this check as already done for tf.

TF Check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/ElasticsearchDomainLogging.py
CF Doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-logpublishingoption.html

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
