### PR TITLE
Add CKV_AWS_106 check for aws_ebs_encryption_by_default

### DIFF
--- a/checkov/terraform/checks/resource/aws/EBSDefaultEncryption.py
+++ b/checkov/terraform/checks/resource/aws/EBSDefaultEncryption.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+
+
+class EBSDefaultEncryption(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure EBS default encryption is enabled"
+        id = "CKV_AWS_106"
+        supported_resources = ["aws_ebs_encryption_by_default"]
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        enabled = conf.get("enabled")
+        if enabled and enabled == [False]:
+            return CheckResult.FAILED
+        else:
+            return CheckResult.PASSED
+
+
+check = EBSDefaultEncryption()

--- a/tests/terraform/checks/resource/aws/example_EBSDefaultEncryption/main.tf
+++ b/tests/terraform/checks/resource/aws/example_EBSDefaultEncryption/main.tf
@@ -1,0 +1,14 @@
+# pass
+
+resource "aws_ebs_encryption_by_default" "enabled" {
+  enabled = true
+}
+
+resource "aws_ebs_encryption_by_default" "default" {
+}
+
+# failure
+
+resource "aws_ebs_encryption_by_default" "disabled" {
+  enabled = false
+}

--- a/tests/terraform/checks/resource/aws/test_EBSDefaultEncryption.py
+++ b/tests/terraform/checks/resource/aws/test_EBSDefaultEncryption.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.EBSDefaultEncryption import check
+from checkov.terraform.runner import Runner
+
+
+class TestAppLoadBalancerTLS12(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_EBSDefaultEncryption"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_ebs_encryption_by_default.enabled",
+            "aws_ebs_encryption_by_default.default",
+        }
+        failing_resources = {
+            "aws_ebs_encryption_by_default.disabled",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Implements 2.2.1 of the issue #853.

Pretty easy check, it just checks, if the resource is used and not set to `false`.