### PR TITLE
Add CKV_AWS_112 check for aws_ssm_document session type

### DIFF
--- a/checkov/terraform/checks/resource/aws/SSMSessionManagerDocumentEncryption.py
+++ b/checkov/terraform/checks/resource/aws/SSMSessionManagerDocumentEncryption.py
@@ -8,7 +8,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 class SSMSessionManagerDocumentEncryption(BaseResourceCheck):
     def __init__(self):
         name = "Ensure Session Manager data is encrypted in transit"
-        id = "CKV_AWS_107"
+        id = "CKV_AWS_112"
         supported_resources = ["aws_ssm_document"]
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
@@ -29,7 +29,9 @@ class SSMSessionManagerDocumentEncryption(BaseResourceCheck):
                 if inputs and not inputs.get("kmsKeyId"):
                     return CheckResult.FAILED
 
-        return CheckResult.PASSED
+                return CheckResult.PASSED
+
+        return CheckResult.UNKNOWN
 
 
 def is_json(data):

--- a/checkov/terraform/checks/resource/aws/SSMSessionManagerDocumentEncryption.py
+++ b/checkov/terraform/checks/resource/aws/SSMSessionManagerDocumentEncryption.py
@@ -1,0 +1,51 @@
+import json
+import yaml
+
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class SSMSessionManagerDocumentEncryption(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure Session Manager data is encrypted in transit"
+        id = "CKV_AWS_107"
+        supported_resources = ["aws_ssm_document"]
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if conf.get("document_type") == ["Session"]:
+            doc_format = conf.get("document_format", ["JSON"])
+
+            if "content" in conf.keys():
+                content = conf["content"][0]
+                inputs = None
+
+                if doc_format == ["JSON"] and is_json(content):
+                    inputs = json.loads(content).get("inputs", {})
+                elif doc_format == ["YAML"] and is_yaml(content):
+                    inputs = yaml.safe_load(content).get("inputs", {})
+
+                if inputs and not inputs.get("kmsKeyId"):
+                    return CheckResult.FAILED
+
+        return CheckResult.PASSED
+
+
+def is_json(data):
+    try:
+        json.loads(data)
+    except ValueError:
+        return False
+    return True
+
+
+def is_yaml(data):
+    try:
+        yaml.safe_load(data)
+    except yaml.YAMLError:
+        return False
+    return True
+
+
+check = SSMSessionManagerDocumentEncryption()

--- a/tests/terraform/checks/resource/aws/example_SSMSessionManagerDocumentEncryption/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SSMSessionManagerDocumentEncryption/main.tf
@@ -1,0 +1,115 @@
+# pass
+
+resource "aws_ssm_document" "enabled" {
+  name          = "SSM-SessionManagerRunShell"
+  document_type = "Session"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.0",
+    "description": "Document to hold regional settings for Session Manager",
+    "sessionType": "Standard_Stream",
+    "inputs": {
+      "s3BucketName": "",
+      "s3KeyPrefix": "",
+      "s3EncryptionEnabled": true,
+      "cloudWatchLogGroupName": "",
+      "cloudWatchEncryptionEnabled": true,
+      "idleSessionTimeout": "20",
+      "cloudWatchStreamingEnabled": true,
+      "kmsKeyId": "${var.kms_key_id}",
+      "runAsEnabled": false,
+      "runAsDefaultUser": "",
+      "shellProfile": {
+        "windows": "",
+        "linux": ""
+      }
+    }
+  }
+DOC
+}
+
+resource "aws_ssm_document" "enabled_yaml" {
+  name          = "SSM-SessionManagerRunShell"
+  document_type = "Session"
+
+  document_format = "YAML"
+
+  content = <<DOC
+  schemaVersion: '1.0'
+  description: Document to hold regional settings for Session Manager
+  sessionType: Standard_Stream
+  inputs:
+    s3BucketName: ''
+    s3KeyPrefix: ''
+    s3EncryptionEnabled: true
+    cloudWatchLogGroupName: ''
+    cloudWatchEncryptionEnabled: true
+    cloudWatchStreamingEnabled: true
+    kmsKeyId: '${var.kms_key_id}'
+    runAsEnabled: true
+    runAsDefaultUser: ''
+    idleSessionTimeout: '20'
+    shellProfile:
+      windows: ''
+      linux: ''
+DOC
+}
+
+# failure
+
+resource "aws_ssm_document" "disabled" {
+  name          = "SSM-SessionManagerRunShell"
+  document_type = "Session"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.0",
+    "description": "Document to hold regional settings for Session Manager",
+    "sessionType": "Standard_Stream",
+    "inputs": {
+      "s3BucketName": "",
+      "s3KeyPrefix": "",
+      "s3EncryptionEnabled": true,
+      "cloudWatchLogGroupName": "",
+      "cloudWatchEncryptionEnabled": true,
+      "idleSessionTimeout": "20",
+      "cloudWatchStreamingEnabled": true,
+      "kmsKeyId": "",
+      "runAsEnabled": false,
+      "runAsDefaultUser": "",
+      "shellProfile": {
+        "windows": "",
+        "linux": ""
+      }
+    }
+  }
+DOC
+}
+
+resource "aws_ssm_document" "disabled_yaml" {
+  name          = "SSM-SessionManagerRunShell"
+  document_type = "Session"
+
+  document_format = "YAML"
+
+  content = <<DOC
+  schemaVersion: '1.0'
+  description: Document to hold regional settings for Session Manager
+  sessionType: Standard_Stream
+  inputs:
+    s3BucketName: ''
+    s3KeyPrefix: ''
+    s3EncryptionEnabled: true
+    cloudWatchLogGroupName: ''
+    cloudWatchEncryptionEnabled: true
+    cloudWatchStreamingEnabled: true
+    kmsKeyId: ''
+    runAsEnabled: true
+    runAsDefaultUser: ''
+    idleSessionTimeout: '20'
+    shellProfile:
+      windows: ''
+      linux: ''
+DOC
+}

--- a/tests/terraform/checks/resource/aws/test_SSMSessionManagerDocument.py
+++ b/tests/terraform/checks/resource/aws/test_SSMSessionManagerDocument.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.SSMSessionManagerDocumentEncryption import check
+from checkov.terraform.runner import Runner
+
+
+class TestSSMSessionManagerDocumentEncryption(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_SSMSessionManagerDocumentEncryption"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {"aws_ssm_document.enabled", "aws_ssm_document.enabled_yaml"}
+        failing_resources = {"aws_ssm_document.disabled", "aws_ssm_document.disabled_yaml"}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Adds the encryption in transit part of issue #192. I think it is better to have to different checks, this one and an other for checking if logging is enabled and encrypted, or should it be then 3 checks?