### PR TITLE
update git URL regex to match tag/tags

### DIFF
--- a/checkov/common/goget/github/get_git.py
+++ b/checkov/common/goget/github/get_git.py
@@ -2,7 +2,7 @@ import logging
 import re
 import shutil
 
-TAG_PATTERN = re.compile(r'\?(ref=)(?P<tag>v\d+.\d+.\d+)')
+TAG_PATTERN = re.compile(r'\?(ref=)(?P<tag>(.*))')
 try:
     from git import Repo
     git_import_error = None
@@ -22,6 +22,8 @@ class GitGetter(BaseGetter):
         search_tag = re.search(TAG_PATTERN, url)
         if search_tag:
             self.tag = search_tag.groupdict().get('tag')
+            #remove tag/ or tags/ from ref= to get actual branch name
+            self.tag = re.sub('tag.*/','', self.tag)   
         url = re.sub(TAG_PATTERN, '', url)
 
         super().__init__(url)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
fix for #994 
debug outputs 

I added following prints to see parse result in my local env.

URL tag:
Tag is here


```
 checkov  -d .  --download-external-modules true
URL tag: <re.Match object; span=(54, 70), match='?ref=tags/0.19.2'>
Tag is here 0.19.2
Cloning branch: 0.19.2 Clone dir: /Users/ismail/dev/terraform-aws-vpc-flow-logs-s3-bucket/.external_modules/git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2
URL tag: <re.Match object; span=(54, 69), match='?ref=tag/0.19.2'>
Tag is here 0.19.2
Cloning branch: 0.19.2 Clone dir: /Users/ismail/dev/terraform-aws-vpc-flow-logs-s3-bucket/.external_modules/git::https://github.com/cloudposse/terraform-null-label.git?ref=tag/0.19.2
URL tag: <re.Match object; span=(55, 70), match='?ref=tags/0.7.0'>
Tag is here 0.7.0
Cloning branch: 0.7.0 Clone dir: /Users/ismail/dev/terraform-aws-vpc-flow-logs-s3-bucket/.external_modules/git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=tags/0.7.0
URL tag: <re.Match object; span=(54, 70), match='?ref=tags/0.19.2'>
Tag is here 0.19.2
Cloning branch: 0.19.2 Clone dir: /Users/ismail/dev/terraform-aws-vpc-flow-logs-s3-bucket/.external_modules/git::https:/github.com/cloudposse/terraform-aws-kms-key.git?ref=tags/0.7.0/.external_modules/git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2
URL tag: <re.Match object; span=(62, 78), match='?ref=tags/0.14.0'>
Tag is here 0.14.0
Cloning branch: 0.14.0 Clone dir: /Users/ismail/dev/terraform-aws-vpc-flow-logs-s3-bucket/.external_modules/git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.14.0
Tag2 is here

```