### PR TITLE
Update Seccomp check to work on non-list annotations

### DIFF
--- a/checkov/kubernetes/checks/Seccomp.py
+++ b/checkov/kubernetes/checks/Seccomp.py
@@ -2,6 +2,7 @@ import dpath
 
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.kubernetes.base_spec_check import BaseK8Check
+from checkov.common.util.type_forcers import force_list
 
 
 class Seccomp(BaseK8Check):
@@ -63,7 +64,7 @@ class Seccomp(BaseK8Check):
 
         if metadata:
             if metadata.get('annotations'):
-                for annotation in metadata["annotations"]:
+                for annotation in force_list(metadata["annotations"]):
                     for key in annotation:
                         if "seccomp.security.alpha.kubernetes.io/pod" in key:
                             if "docker/default" in annotation[key] or "runtime/default" in annotation[key]:

--- a/tests/kubernetes/checks/example_Seccomp/cronjob-seccomp-PASSED.yaml
+++ b/tests/kubernetes/checks/example_Seccomp/cronjob-seccomp-PASSED.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cronjob-passed
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            seccomp.security.alpha.kubernetes.io/pod: runtime/default
+        spec:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 3000
+            fsGroup: 2000
+          volumes:
+            - name: sec-ctx-vol
+              emptyDir: {}
+          containers:
+            - name: sec-ctx-demo
+              image: busybox
+              command: ["sh", "-c", "sleep 1h"]
+              volumeMounts:
+                - name: sec-ctx-vol
+                  mountPath: /data/demo
+              securityContext:
+                allowPrivilegeEscalation: false

--- a/tests/kubernetes/checks/test_Seccomp.py
+++ b/tests/kubernetes/checks/test_Seccomp.py
@@ -16,7 +16,7 @@ class TestSeccomp(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 5)
+        self.assertEqual(summary['passed'], 6)
         self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

In [get_skipped_checks](https://github.com/bridgecrewio/checkov/blob/f2268666d1b45655d98514d5bd7663e5238b3a65/checkov/kubernetes/runner.py#L232), the root-level `metadata["annotations"]` is transformed into a list.  This is later assumed to be a list in the Seccomp check.  However, annotations that appear at other levels of the tree may not be a list.

This ensures that `metadata["annotations"]`, wherever it might be, is a list.