### PR TITLE
Fix illegal index access in check AbsSecurityGroupUnrestrictedIngress

### DIFF
--- a/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
@@ -71,8 +71,8 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
             cidr_blocks = force_list(conf.get('cidr_blocks', [[]])[0])
             if "0.0.0.0/0" in cidr_blocks:
                 return True
-            ipv6_cidr_blocks = force_list(conf.get('ipv6_cidr_blocks', [[]])[0])
-            if any(ip in ['::/0', '0000:0000:0000:0000:0000:0000:0000:0000/0'] for ip in ipv6_cidr_blocks):
+            ipv6_cidr_blocks = conf.get('ipv6_cidr_blocks', [])
+            if len(ipv6_cidr_blocks) > 0 and any(ip in ['::/0', '0000:0000:0000:0000:0000:0000:0000:0000/0'] for ip in ipv6_cidr_blocks[0]):
                 return True
 
         return False


### PR DESCRIPTION
added validation in check `AbsSecurityGroupUnrestrictedIngress` to make sure there is no illegal access to `ipv6_cidr_blocks`[0] when it is empty.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
