### PR TITLE
check  AWS secrets in Lambda env variable only for AWS and GENERAL regex

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -18,7 +18,7 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
                 if 'Variables' in environment.keys():
                     variables = environment['Variables']
                     for value in variables.values():
-                        if string_has_secrets(str(value)):
+                        if string_has_secrets(str(value), AWS):
                             return CheckResult.FAILED
 
         return CheckResult.PASSED

--- a/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -1,6 +1,6 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
-from checkov.common.util.secrets import string_has_secrets, AWS
+from checkov.common.util.secrets import string_has_secrets, AWS, GENERAL
 
 class LambdaEnvironmentCredentials(BaseResourceCheck):
     def __init__(self):

--- a/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -18,7 +18,7 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
                 if 'Variables' in environment.keys():
                     variables = environment['Variables']
                     for value in variables.values():
-                        if string_has_secrets(str(value), AWS):
+                        if string_has_secrets(str(value), AWS,GENERAL):
                             return CheckResult.FAILED
 
         return CheckResult.PASSED

--- a/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -18,7 +18,7 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
                 if 'Variables' in environment.keys():
                     variables = environment['Variables']
                     for value in variables.values():
-                        if string_has_secrets(str(value), AWS,GENERAL):
+                        if string_has_secrets(str(value),AWS,GENERAL):
                             return CheckResult.FAILED
 
         return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -22,7 +22,7 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
                         # variables can be a string, which in this case it points to a variable
                         for values in list(force_list(conf['environment'][0]['variables'])[0].values()):
                             for value in list(filter(lambda value: isinstance(value, str), force_list(values))):
-                                if string_has_secrets(value, AWS):
+                                if string_has_secrets(value, AWS,General):
                                     return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -22,7 +22,7 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
                         # variables can be a string, which in this case it points to a variable
                         for values in list(force_list(conf['environment'][0]['variables'])[0].values()):
                             for value in list(filter(lambda value: isinstance(value, str), force_list(values))):
-                                if string_has_secrets(value):
+                                if string_has_secrets(value, AWS):
                                     return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -22,7 +22,7 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
                         # variables can be a string, which in this case it points to a variable
                         for values in list(force_list(conf['environment'][0]['variables'])[0].values()):
                             for value in list(filter(lambda value: isinstance(value, str), force_list(values))):
-                                if string_has_secrets(value, AWS,General):
+                                if string_has_secrets(value,AWS,GENERAL):
                                     return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/terraform/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -1,6 +1,6 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
-from checkov.common.util.secrets import string_has_secrets, AWS
+from checkov.common.util.secrets import string_has_secrets, AWS, GENERAL
 from checkov.common.util.type_forcers import force_list
 
 


### PR DESCRIPTION
The following regex  hits aws kms key id and creates FP for AWS resources.

_secrets_regexes = {
    'azure': [
            "(\"|')?([0-9A-Fa-f]{4}-){4}[0-9A-Fa-f]{12}(\"|')?",  # client_secret
            "(\"|')?[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}(\"|')?", # client_id and many other forms of IDs

environment": [
              {
             "variables": {
              "kms_key_id": "arn:aws:kms:eu-west-1:123456789:key/c0baad75-d0d3-24e3-95d1-1e4e38a44c4a"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
