### PR TITLE
Fix logging 

### DIFF
--- a/checkov/logging_init.py
+++ b/checkov/logging_init.py
@@ -17,3 +17,4 @@ def init():
     logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
     logging.getLogger("urllib3.connectionpool").propagate = False
     logging.getLogger("urllib3").propagate = False
+    logging.getLogger().setLevel(LOG_LEVEL)

--- a/checkov/logging_init.py
+++ b/checkov/logging_init.py
@@ -13,8 +13,8 @@ def init():
     consoleHandler.setFormatter(logFormatter)
     consoleHandler.setLevel(LOG_LEVEL)
     rootLogger.addHandler(consoleHandler)
+    logging.getLogger().setLevel(LOG_LEVEL)
     logging.getLogger("urllib3").setLevel(logging.ERROR)
     logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
     logging.getLogger("urllib3.connectionpool").propagate = False
     logging.getLogger("urllib3").propagate = False
-    logging.getLogger().setLevel(LOG_LEVEL)

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -12,9 +12,6 @@ from checkov.terraform.context_parsers.registry import parser_registry
 # Allow the evaluation of empty variables
 from checkov.terraform.plan_parser import parse_tf_plan
 
-LOG_LEVEL = os.getenv('LOG_LEVEL', 'WARNING').upper()
-logging.basicConfig(level=LOG_LEVEL)
-
 
 class Runner(BaseRunner):
     check_type = "terraform_plan"

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -24,9 +24,6 @@ from checkov.terraform.tag_providers import get_resource_tags
 
 dpath.options.ALLOW_EMPTY_STRING_KEYS = True
 
-LOG_LEVEL = os.getenv('LOG_LEVEL', 'WARNING').upper()
-logging.basicConfig(level=LOG_LEVEL)
-
 CHECK_BLOCK_TYPES = frozenset(['resource', 'data', 'provider', 'module'])
 
 


### PR DESCRIPTION
The root logger always defaults to WARNING level. 
setting export LOG_LEVEL=debug was not displaying any debug message. Added 

Set the LOG_LEVEL with logging.getLogger().setLevel(LOG_LEVEL)
to make it work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
