### PR TITLE
The check for Storage Account naming rules produced a false positive

### DIFF
--- a/checkov/terraform/checks/resource/azure/StorageAccountName.py
+++ b/checkov/terraform/checks/resource/azure/StorageAccountName.py
@@ -21,7 +21,7 @@ class StorageAccountName(BaseResourceCheck):
         :param conf: azurerm_storage_account configuration
         :return: <CheckResult>
         """
-        return CheckResult.PASSED if conf.get('name') and re.match(STO_NAME_REGEX, conf['name'][0]) else CheckResult.FAILED
+        return CheckResult.PASSED if conf.get('name') and (re.match(STO_NAME_REGEX, conf['name'][0]) != None) else CheckResult.FAILED
 
 
 check = StorageAccountName()

--- a/checkov/terraform/checks/resource/azure/StorageAccountName.py
+++ b/checkov/terraform/checks/resource/azure/StorageAccountName.py
@@ -21,7 +21,7 @@ class StorageAccountName(BaseResourceCheck):
         :param conf: azurerm_storage_account configuration
         :return: <CheckResult>
         """
-        return CheckResult.PASSED if conf.get('name') and (re.match(STO_NAME_REGEX, conf['name'][0]) != None) else CheckResult.FAILED
+        return CheckResult.PASSED if conf.get('name') and re.findall(STO_NAME_REGEX, conf['name'][0]) else CheckResult.FAILED
 
 
 check = StorageAccountName()


### PR DESCRIPTION
re.match returns an object or None so we have to check if the object is not None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
