### PR TITLE
Reduce the Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-alpine
 
-RUN apt-get update && apt install -y \
-    git \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk add git
 
 RUN pip install -U checkov
-
 ENTRYPOINT ["checkov"]


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

If the image is based on Alpine instead of ubuntu the image size drops from 325 to 182 MB. Faster downloads and response for the vscode integration.