### PR TITLE
Further reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-alpine
 
-RUN apk update && apk add git
+RUN apk --no-cache add git
 
-RUN pip install -U checkov
+RUN pip install --no-cache-dir -U checkov
 ENTRYPOINT ["checkov"]


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

In #1022 the image size went from 325MB to 182MB by switching from Debian to Alpine. 
I was able to reduce this even further to 165MB by disabling the caches of the APK and Pip installs. 

17MB is not as big of a reduction as the 143MB from #1022, but still it should make the download/usage a little faster. 😄 