### PR TITLE
Matrix tests for python 3.7, 3.8, 3.9, artifacts left on 3.7 for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,16 +6,21 @@ on:
     - master
 jobs:
   integration-tests:
+    strategy:
+      fail-fast: true
+      matrix:
+        python: [3.7, 3.8, 3.9]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python }}
       - uses: dschep/install-pipenv-action@v1
       - uses: azure/setup-helm@v1
       - name: Build & install checkov package
         run: |
+          pipenv --python ${{ matrix.python }}
           pipenv run pip install pytest
           pipenv run python setup.py sdist bdist_wheel
           pipenv run pip install --upgrade pip==20.2

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -18,16 +18,21 @@ jobs:
           cfn-lint tests/cloudformation/checks/resource/aws/**/* -i W
 
   unit-tests:
+    strategy:
+      fail-fast: true
+      matrix:
+        python: [3.7, 3.8, 3.9]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.7
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python }}
       - uses: dschep/install-pipenv-action@v1
       - name: Install dependencies
         run: |
+          pipenv --python ${{ matrix.python }}
           pipenv install --dev
       - name: Unit tests
         env:
@@ -38,16 +43,21 @@ jobs:
           pipenv run python -m coverage html
 
   integration-tests:
+    strategy:
+      fail-fast: true
+      matrix:
+        python: [3.7, 3.8, 3.9]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python }}
       - uses: azure/setup-helm@v1
       - uses: dschep/install-pipenv-action@v1
       - name: Build & install checkov package
         run: |
+          pipenv --python ${{ matrix.python }}
           pipenv run pip install pytest
           pipenv run python setup.py sdist bdist_wheel
           pipenv run pip install --upgrade pip==20.2


### PR DESCRIPTION
Adding matrix testing for python versions as discussed in #745.
Should successful tests will allow us to move Pipfile from:

```
[requires]
python_version = "3.7"
```
to

```
[requires]
python_version => "3.7"
Giving more flexibility.
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
