### PR TITLE
CF - Extend Cloudsplaining to ManagedIAMPolicy

### DIFF
--- a/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
+++ b/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
@@ -13,7 +13,7 @@ from checkov.terraform.checks.utils.iam_cloudformation_document_to_policy_conver
 class BaseCloudsplainingIAMCheck(BaseResourceCheck):
     def __init__(self, name, id):
         # todo: managedpolicy
-        super().__init__(name=name, id=id, categories=CheckCategories.IAM, supported_resources=["AWS::IAM::Policy"])
+        super().__init__(name=name, id=id, categories=CheckCategories.IAM, supported_resources=["AWS::IAM::Policy", "AWS::IAM::ManagedPolicy"])
 
     def scan_resource_conf(self, conf):
         if 'Properties' in conf.keys():

--- a/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
+++ b/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
@@ -12,7 +12,6 @@ from checkov.terraform.checks.utils.iam_cloudformation_document_to_policy_conver
 
 class BaseCloudsplainingIAMCheck(BaseResourceCheck):
     def __init__(self, name, id):
-        # todo: managedpolicy
         super().__init__(name=name, id=id, categories=CheckCategories.IAM, supported_resources=["AWS::IAM::Policy", "AWS::IAM::ManagedPolicy"])
 
     def scan_resource_conf(self, conf):

--- a/tests/cloudformation/checks/resource/aws/cloudsplaining/IAMPolicyAttachedToGroupOrRoles-FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/cloudsplaining/IAMPolicyAttachedToGroupOrRoles-FAILED.yml
@@ -15,3 +15,17 @@ Resources:
         - example_role
       Users:
         - admin
+  ExampleManagedPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      ManagedPolicyName: root
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: '*'
+            Resource: '*'
+      Roles:
+        - example_role
+      Users:
+        - admin

--- a/tests/cloudformation/checks/resource/aws/cloudsplaining/IAMPolicyAttachedToGroupOrRoles-PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/cloudsplaining/IAMPolicyAttachedToGroupOrRoles-PASSED.yml
@@ -13,3 +13,15 @@ Resources:
             Resource: 'foo'
       Roles:
         - example_role
+  ExampleManagedPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      ManagedPolicyName: root
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: 's3:Get*'
+            Resource: 'foo'
+      Roles:
+        - example_role

--- a/tests/cloudformation/checks/resource/aws/test_IAMPermissionsManagement.py
+++ b/tests/cloudformation/checks/resource/aws/test_IAMPermissionsManagement.py
@@ -16,8 +16,8 @@ class TestIAMPermisionssManagement(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
         self.assertEqual(report.failed_checks[0].check_id, check.id)
-        self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
Hello,

Whilst going through my CloudFormation coverage checks I see we have implemented Cloudsplaining which looks like it can play a larger role for IAM checks in CF and TF and across all ways of embedding policies. I think this is great work to get the integration working!

This is just addressing the TODO to extend to ManagedIAMPolicies and is an initial start in the area of extending this wider.

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
