### PR TITLE
Allows resource=* for ecr:GetAuthorizationToken

### DIFF
--- a/checkov/terraform/checks/data/aws/IAMCredentialsExposure.py
+++ b/checkov/terraform/checks/data/aws/IAMCredentialsExposure.py
@@ -9,7 +9,11 @@ class CloudSplainingCredentialsExposure(BaseCloudsplainingIAMCheck):
         super().__init__(name=name, id=id)
 
     def cloudsplaining_analysis(self, policy):
-        return policy.credentials_exposure
+        excluded_actions = {
+            "ecr:GetAuthorizationToken"
+        }
+        credentials_exposure_actions = policy.credentials_exposure
+        return [x for x in credentials_exposure_actions if x not in excluded_actions]
 
 
 check = CloudSplainingCredentialsExposure()

--- a/checkov/terraform/checks/data/aws/IAMCredentialsExposure.py
+++ b/checkov/terraform/checks/data/aws/IAMCredentialsExposure.py
@@ -2,6 +2,9 @@ from checkov.terraform.checks.data.BaseCloudsplainingIAMCheck import BaseCloudsp
 
 
 class CloudSplainingCredentialsExposure(BaseCloudsplainingIAMCheck):
+    excluded_actions = {
+        "ecr:GetAuthorizationToken"
+    }
 
     def __init__(self):
         name = "Ensure IAM policies does not allow credentials exposure"
@@ -9,11 +12,11 @@ class CloudSplainingCredentialsExposure(BaseCloudsplainingIAMCheck):
         super().__init__(name=name, id=id)
 
     def cloudsplaining_analysis(self, policy):
-        excluded_actions = {
-            "ecr:GetAuthorizationToken"
-        }
         credentials_exposure_actions = policy.credentials_exposure
-        return [x for x in credentials_exposure_actions if x not in excluded_actions]
+        return [
+            x for x in credentials_exposure_actions
+            if x not in CloudSplainingCredentialsExposure.excluded_actions
+        ]
 
 
 check = CloudSplainingCredentialsExposure()

--- a/tests/terraform/checks/data/aws/test_CloudSplainingCredentialsExposure.py
+++ b/tests/terraform/checks/data/aws/test_CloudSplainingCredentialsExposure.py
@@ -53,6 +53,27 @@ class TestcloudsplainingPrivilegeEscalation(unittest.TestCase):
         scan_result = check.scan_data_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_allowed_credential_actions(self):
+        hcl_res = hcl2.loads("""
+            data "aws_iam_policy_document" "example" {
+              statement {
+                sid = "1"
+                effect = "Allow"
+
+                actions = [
+                    "ecr:GetAuthorizationToken",
+                ]
+            
+                resources = [
+                  "*",
+                ]
+              }
+            }
+        """)
+        resource_conf = hcl_res['data'][0]['aws_iam_policy_document']['example']
+        scan_result = check.scan_data_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
     def test_deny(self):
         hcl_res = hcl2.loads("""
              data "aws_iam_policy_document" "DenyOutsideCallers" {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

There's not really a good way to constrain the AWS `ecr:GetAuthorizationToken` action by resource. The API just returns a token for use with e.g., Docker but the only argument it takes (and could use for constraint context) is deprecated (https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_GetAuthorizationToken.html#API_GetAuthorizationToken_RequestSyntax) and not usually passed by recent clients. The repo constraints are applied over other actions made via subsequent requests using the token.

This patch allows IAM policy statements like the following to pass without throwing `CKV_AWS_107` (credential exposure):

```
              statement {
                actions = [
                    "ecr:GetAuthorizationToken",
                ]
            
                resources = [
                  "*",
                ]
              }
```

Usually such statements are accompanied by something similar to:

```
  statement {
    actions = [
      "ecr:GetDownloadUrlForLayer",
      "ecr:BatchGetImage",
      "ecr:BatchCheckLayerAvailability"
    ]
    resources = [
      aws_ecr_repository.foo.arn
    ]
  }
```

Even though there's no constraint against the GetToken request itself, the returned token can only be used with the ECR service to authorize use of the Docker 'registry' APIs. The usage of the token is also automatically further constrained by whatever `ecr:` actions are granted to the entity that requested the token. E.g., callers using tokens derived from the example policy above would only be able to use them to download from `aws_ecr_repository.foo`. They wouldn't be able to write to that repo nor would they be able to read from other repos in the same account.