### PR TITLE
Add CKV_DOCKER_6 check for existence of MAINTAINER

### DIFF
--- a/checkov/dockerfile/checks/MaintainerExists.py
+++ b/checkov/dockerfile/checks/MaintainerExists.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.dockerfile.base_dockerfile_check import BaseDockerfileCheck
+
+
+class MaintainerExists(BaseDockerfileCheck):
+    def __init__(self):
+        name = "Ensure that LABEL maintainer is used instead of MAINTAINER (deprecated)"
+        id = "CKV_DOCKER_6"
+        supported_instructions = ["MAINTAINER"]
+        categories = [CheckCategories.CONVENTION]
+        super().__init__(name=name, id=id, categories=categories, supported_instructions=supported_instructions)
+
+    def scan_entity_conf(self, conf):
+        for instruction, content in conf.items():
+            if instruction == "MAINTAINER":
+                return CheckResult.FAILED, conf[instruction][0]
+        return CheckResult.PASSED, None
+
+
+check = MaintainerExists()

--- a/checkov/dockerfile/checks/MaintainerExists.py
+++ b/checkov/dockerfile/checks/MaintainerExists.py
@@ -13,7 +13,7 @@ class MaintainerExists(BaseDockerfileCheck):
     def scan_entity_conf(self, conf):
         for instruction, content in conf.items():
             if instruction == "MAINTAINER":
-                return CheckResult.FAILED, conf[instruction][0]
+                return CheckResult.FAILED, content[0]
         return CheckResult.PASSED, None
 
 

--- a/tests/dockerfile/checks/test_MaintainerExists.py
+++ b/tests/dockerfile/checks/test_MaintainerExists.py
@@ -1,0 +1,34 @@
+import unittest
+
+from dockerfile_parse import DockerfileParser
+
+from checkov.common.models.enums import CheckResult
+from checkov.dockerfile.checks.MaintainerExists import check
+from checkov.dockerfile.parser import dfp_group_by_instructions
+
+
+class TestMaintainerExists(unittest.TestCase):
+    def test_failure(self):
+        dfp = DockerfileParser()
+
+        dfp.content = """
+        From  base
+        MAINTAINER checkov
+        """
+
+        conf = dfp_group_by_instructions(dfp)[0]
+        scan_result = check.scan_entity_conf(conf)
+
+        self.assertEqual((CheckResult.FAILED), scan_result[0])
+
+    def test_success(self):
+        dfp = DockerfileParser()
+
+        dfp.content = """\
+        From  base
+        """
+
+        conf = dfp_group_by_instructions(dfp)[0]
+        scan_result = check.scan_entity_conf(conf)
+
+        self.assertEqual((CheckResult.PASSED, None), scan_result)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Happy to see Docker support by checkov. Also happy to help here with some best or worst practice 😄 

I'm still seeing from time to time the usage of the infamous `MAINTAINER` instruction. I hope someday it will be removed completely.

https://docs.docker.com/engine/reference/builder/#maintainer-deprecated 