### PR TITLE
CKV_AWS_143 - allow the check to handle dynamic values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM python:3.8-alpine
-
-RUN apk update && apk add --no-cache git util-linux
-
-RUN pip install --no-cache-dir -U checkov
-
-ENTRYPOINT ["checkov"]
+        From  base
+        LABEL foo="bar baz"
+        USER  me
+        HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1 
+        

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-        From  base
-        LABEL foo="bar baz"
-        USER  me
-        HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1 
-        
+FROM python:3.8-alpine
+
+RUN apk update && apk add --no-cache git util-linux
+
+RUN pip install --no-cache-dir -U checkov
+
+ENTRYPOINT ["checkov"]

--- a/checkov/terraform/checks/resource/aws/S3BucketObjectLock.py
+++ b/checkov/terraform/checks/resource/aws/S3BucketObjectLock.py
@@ -1,8 +1,7 @@
 from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
-
-class S3BucketObjectLock(BaseResourceCheck):
+class S3BucketObjectLock(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure that S3 bucket has lock configuration enabled by default"
         id = "CKV_AWS_143"
@@ -10,16 +9,10 @@ class S3BucketObjectLock(BaseResourceCheck):
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        if 'object_lock_configuration' in conf:
-            if 'object_lock_enabled' in conf['object_lock_configuration'][0]:
-                lock = conf['object_lock_configuration'][0]['object_lock_enabled']
-                if lock == "Enabled":
-                    return CheckResult.PASSED
-                else:
-                    return CheckResult.FAILED
-        else:
-            return CheckResult.PASSED
+    def get_inspected_key(self):
+        return 'object_lock_configuration/[0]/object_lock_enabled/[0]'
 
+    def get_expected_value(self):
+        return 'Enabled'
 
 check = S3BucketObjectLock()

--- a/tests/terraform/checks/resource/aws/test_S3BucketObjectLock.py
+++ b/tests/terraform/checks/resource/aws/test_S3BucketObjectLock.py
@@ -44,22 +44,7 @@ class TestS3BucketObjectLock(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-    def test_success_no_param(self):
-        hcl_res = hcl2.loads("""
-                resource "aws_s3_bucket" "test" {
-                      bucket = "my-tf-test-bucket"
-                      acl    = "private"
-                      tags = {
-                        Name        = "My bucket"
-                        Environment = "Dev"
-                      }
-                }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_s3_bucket']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
-
-    def test_dynamic_value(self):
+    def test_dynamic_value_object_lock(self):
         hcl_res = hcl2.loads("""
             resource "aws_s3_bucket" "test" {
               count         = local.enabled ? 1 : 0
@@ -87,6 +72,7 @@ class TestS3BucketObjectLock(unittest.TestCase):
         resource_conf = hcl_res['resource'][0]['aws_s3_bucket']['test']
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/terraform/checks/resource/aws/test_S3BucketObjectLock.py
+++ b/tests/terraform/checks/resource/aws/test_S3BucketObjectLock.py
@@ -12,7 +12,6 @@ class TestS3BucketObjectLock(unittest.TestCase):
                 resource "aws_s3_bucket" "test" {
                       bucket = "my-tf-test-bucket"
                       acl    = "private"
-                    
                       tags = {
                         Name        = "My bucket"
                         Environment = "Dev"
@@ -32,7 +31,6 @@ class TestS3BucketObjectLock(unittest.TestCase):
                 resource "aws_s3_bucket" "test" {
                       bucket = "my-tf-test-bucket"
                       acl    = "private"
-                    
                       tags = {
                         Name        = "My bucket"
                         Environment = "Dev"
@@ -51,7 +49,6 @@ class TestS3BucketObjectLock(unittest.TestCase):
                 resource "aws_s3_bucket" "test" {
                       bucket = "my-tf-test-bucket"
                       acl    = "private"
-                    
                       tags = {
                         Name        = "My bucket"
                         Environment = "Dev"
@@ -62,6 +59,34 @@ class TestS3BucketObjectLock(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_dynamic_value(self):
+        hcl_res = hcl2.loads("""
+            resource "aws_s3_bucket" "test" {
+              count         = local.enabled ? 1 : 0
+              bucket        = module.this.id
+              acl           = "private"
+              tags          = module.this.tags
+
+              dynamic "object_lock_configuration" {
+                for_each = var.object_lock_enabled == true ? [local.object_lock_params] : []
+
+                content {
+                    object_lock_enabled = "Enabled"
+
+                    rule {
+                    default_retention {
+                      mode  = object_lock_configuration.value.retention_mode
+                      days  = object_lock_configuration.value.retention_period_days
+                      years = object_lock_configuration.value.retention_period_years
+                    }
+                  }
+                }
+              }
+            }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_s3_bucket']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- The check CKV_AWS_143 was only setup to handle static values. Has now been modified to handle dynamic values.