### PR TITLE
Add CKV_DOCKER_7 check for latest version tag reference

### DIFF
--- a/checkov/dockerfile/checks/ReferenceLatestTag.py
+++ b/checkov/dockerfile/checks/ReferenceLatestTag.py
@@ -1,0 +1,36 @@
+import re
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.dockerfile.base_dockerfile_check import BaseDockerfileCheck
+
+MULTI_STAGE_PATTERN = re.compile(r"(\S+)\s+as\s+(\S+)")
+
+
+class ReferenceLatestTag(BaseDockerfileCheck):
+    def __init__(self):
+        name = "Ensure the base image uses a non latest version tag"
+        id = "CKV_DOCKER_7"
+        supported_instructions = ["FROM"]
+        categories = [CheckCategories.CONVENTION]
+        super().__init__(name=name, id=id, categories=categories, supported_instructions=supported_instructions)
+
+    def scan_entity_conf(self, conf):
+        stages = []
+
+        for instruction, contents in conf.items():
+            if instruction == "FROM":
+                for content in contents:
+                    base_image = content["value"]
+                    multi_stage = re.match(MULTI_STAGE_PATTERN, base_image)
+                    if multi_stage:
+                        base_image = multi_stage[1]
+                        stages.append(multi_stage[2])
+
+                    if ":" not in base_image and base_image not in stages:
+                        return CheckResult.FAILED, contents[0]
+                    elif base_image.endswith(":latest"):
+                        return CheckResult.FAILED, contents[0]
+        return CheckResult.PASSED, None
+
+
+check = ReferenceLatestTag()

--- a/checkov/dockerfile/checks/ReferenceLatestTag.py
+++ b/checkov/dockerfile/checks/ReferenceLatestTag.py
@@ -27,9 +27,9 @@ class ReferenceLatestTag(BaseDockerfileCheck):
                         stages.append(multi_stage[2])
 
                     if ":" not in base_image and base_image not in stages:
-                        return CheckResult.FAILED, contents[0]
+                        return CheckResult.FAILED, content
                     elif base_image.endswith(":latest"):
-                        return CheckResult.FAILED, contents[0]
+                        return CheckResult.FAILED, content
         return CheckResult.PASSED, None
 
 

--- a/tests/dockerfile/checks/test_ReferenceLatestTag.py
+++ b/tests/dockerfile/checks/test_ReferenceLatestTag.py
@@ -1,0 +1,61 @@
+import unittest
+
+from dockerfile_parse import DockerfileParser
+
+from checkov.common.models.enums import CheckResult
+from checkov.dockerfile.checks.ReferenceLatestTag import check
+from checkov.dockerfile.parser import dfp_group_by_instructions
+
+
+class TestMaintainerExists(unittest.TestCase):
+    def test_failure_default_version_tag(self):
+        dfp = DockerfileParser()
+
+        dfp.content = """
+        FROM alpine
+        """
+
+        conf = dfp_group_by_instructions(dfp)[0]
+        scan_result = check.scan_entity_conf(conf)
+
+        self.assertEqual((CheckResult.FAILED), scan_result[0])
+
+    def test_failure_latest_version_tag(self):
+        dfp = DockerfileParser()
+
+        dfp.content = """
+        FROM alpine:latest
+        """
+
+        conf = dfp_group_by_instructions(dfp)[0]
+        scan_result = check.scan_entity_conf(conf)
+
+        self.assertEqual((CheckResult.FAILED), scan_result[0])
+
+    def test_success(self):
+        dfp = DockerfileParser()
+
+        dfp.content = """
+        FROM alpine:3
+        """
+
+        conf = dfp_group_by_instructions(dfp)[0]
+        scan_result = check.scan_entity_conf(conf)
+
+        self.assertEqual((CheckResult.PASSED, None), scan_result)
+
+    def test_success_multi_stage(self):
+        dfp = DockerfileParser()
+
+        dfp.content = """
+        FROM alpine:3 as base
+        COPY test.sh /test.sh
+        
+        FROM base
+        LABEL maintainer=checkov
+        """
+
+        conf = dfp_group_by_instructions(dfp)[0]
+        scan_result = check.scan_entity_conf(conf)
+
+        self.assertEqual((CheckResult.PASSED, None), scan_result)

--- a/tests/dockerfile/checks/test_ReferenceLatestTag.py
+++ b/tests/dockerfile/checks/test_ReferenceLatestTag.py
@@ -18,7 +18,8 @@ class TestMaintainerExists(unittest.TestCase):
         conf = dfp_group_by_instructions(dfp)[0]
         scan_result = check.scan_entity_conf(conf)
 
-        self.assertEqual((CheckResult.FAILED), scan_result[0])
+        self.assertEqual(CheckResult.FAILED, scan_result[0])
+        self.assertEqual("alpine", scan_result[1]["value"])
 
     def test_failure_latest_version_tag(self):
         dfp = DockerfileParser()
@@ -30,7 +31,8 @@ class TestMaintainerExists(unittest.TestCase):
         conf = dfp_group_by_instructions(dfp)[0]
         scan_result = check.scan_entity_conf(conf)
 
-        self.assertEqual((CheckResult.FAILED), scan_result[0])
+        self.assertEqual(CheckResult.FAILED, scan_result[0])
+        self.assertEqual("alpine:latest", scan_result[1]["value"])
 
     def test_success(self):
         dfp = DockerfileParser()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

It is always recommended to use a non latest version tag for your base image or multi stage builds, because of typical nature of the latest tag being used for the most up-to-date version, which can result in a major version upgrade.

Using a versioned tag makes also the build more reliable and consistent.