### PR TITLE
Add CKV_DOCKER_8 check for last USER being root

### DIFF
--- a/checkov/dockerfile/checks/RootUser.py
+++ b/checkov/dockerfile/checks/RootUser.py
@@ -1,0 +1,26 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.dockerfile.base_dockerfile_check import BaseDockerfileCheck
+
+
+class RootUser(BaseDockerfileCheck):
+    def __init__(self):
+        name = "Ensure the last USER is not root"
+        id = "CKV_DOCKER_8"
+        supported_instructions = ["USER"]
+        categories = [CheckCategories.APPLICATION_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_instructions=supported_instructions)
+
+    def scan_entity_conf(self, conf):
+        contents = conf.get("USER")
+
+        if contents:
+            last_user = contents[-1]
+            if last_user["value"] == "root":
+                return CheckResult.FAILED, last_user
+
+            return CheckResult.PASSED, last_user
+
+        return CheckResult.UNKNOWN, None
+
+
+check = RootUser()

--- a/tests/dockerfile/checks/test_RootUser.py
+++ b/tests/dockerfile/checks/test_RootUser.py
@@ -1,0 +1,39 @@
+import unittest
+
+from dockerfile_parse import DockerfileParser
+
+from checkov.common.models.enums import CheckResult
+from checkov.dockerfile.checks.RootUser import check
+from checkov.dockerfile.parser import dfp_group_by_instructions
+
+
+class TestUserExists(unittest.TestCase):
+    def test_failure(self):
+        dfp = DockerfileParser()
+
+        dfp.content = """
+        FROM base
+        USER root
+        """
+
+        conf = dfp_group_by_instructions(dfp)[0]
+        scan_result = check.scan_entity_conf(conf)
+
+        self.assertEqual(CheckResult.FAILED, scan_result[0])
+        self.assertEqual("root", scan_result[1]["value"])
+
+    def test_success(self):
+        dfp = DockerfileParser()
+
+        dfp.content = """
+        FROM base
+        USER root
+        COPY test.sh /test.sh
+        USER checkov
+        """
+
+        conf = dfp_group_by_instructions(dfp)[0]
+        scan_result = check.scan_entity_conf(conf)
+
+        self.assertEqual(CheckResult.PASSED, scan_result[0])
+        self.assertEqual("checkov", scan_result[1]["value"])


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Quite often you need to use the `USER root` instruction to install packages or change permissions. Therefore the last `USER` instruction should not be root to make the container start with a non root user by default.