### PR TITLE
Various checks fixes

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/EKSSecretsEncryption.py
+++ b/checkov/cloudformation/checks/resource/aws/EKSSecretsEncryption.py
@@ -17,8 +17,7 @@ class EKSSecretsEncryption(BaseResourceCheck):
         :param conf: AWS::EKS::Cluster configuration
         :return: <CheckResult>
         """
-        if 'EncryptionConfig' in conf['Properties'].keys() and 'Resources' in conf['Properties']['EncryptionConfig'][0] \
-                and 'secrets' in conf['Properties']['EncryptionConfig'][0]['Resources']:
+        if 'secrets' in conf.get('Properties', {}).get('EncryptionConfig', {}).get('Resources', {}):
             return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/checkov/cloudformation/checks/resource/aws/EKSSecretsEncryption.py
+++ b/checkov/cloudformation/checks/resource/aws/EKSSecretsEncryption.py
@@ -17,7 +17,9 @@ class EKSSecretsEncryption(BaseResourceCheck):
         :param conf: AWS::EKS::Cluster configuration
         :return: <CheckResult>
         """
-        if 'secrets' in conf.get('Properties', {}).get('EncryptionConfig', {}).get('Resources', {}):
+        encryption_config = list(conf.get('Properties', {}).get('EncryptionConfig', []))
+        encryption_config_resources = [p["Resources"] for p in encryption_config if "Resources" in p]
+        if isinstance(encryption_config_resources, list) and any('secrets' in r for r in encryption_config_resources):
             return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/checkov/kubernetes/base_spec_check.py
+++ b/checkov/kubernetes/base_spec_check.py
@@ -34,8 +34,8 @@ class BaseK8Check(BaseCheck):
         return wrapper
 
     @staticmethod
-    def get_inner_spec(conf):
+    def get_inner_entry(conf, entry_name):
         spec = {}
         if conf.get("spec") and conf.get("spec").get("template"):
-            spec = conf.get("spec").get("template").get("spec", {})
+            spec = conf.get("spec").get("template").get(entry_name, {})
         return spec

--- a/checkov/kubernetes/base_spec_check.py
+++ b/checkov/kubernetes/base_spec_check.py
@@ -32,3 +32,10 @@ class BaseK8Check(BaseCheck):
             return wrapped(self, conf)
 
         return wrapper
+
+    @staticmethod
+    def get_inner_spec(conf):
+        spec = {}
+        if conf.get("spec") and conf.get("spec").get("template"):
+            spec = conf.get("spec").get("template").get("spec", {})
+        return spec

--- a/checkov/kubernetes/checks/DockerSocketVolume.py
+++ b/checkov/kubernetes/checks/DockerSocketVolume.py
@@ -39,7 +39,8 @@ class DockerSocketVolume(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_entry(conf, "spec")
+            inner_spec = self.get_inner_entry(conf, "spec")
+            spec = inner_spec if inner_spec else spec
 
         # Evaluate volumes
         if spec:

--- a/checkov/kubernetes/checks/DockerSocketVolume.py
+++ b/checkov/kubernetes/checks/DockerSocketVolume.py
@@ -39,10 +39,7 @@ class DockerSocketVolume(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            if "spec" in conf:
-                if "template" in conf["spec"]:
-                    if "spec" in conf["spec"]["template"]:
-                        spec = conf["spec"]["template"]["spec"]
+            spec = self.get_inner_spec(conf)
 
         # Evaluate volumes
         if spec:

--- a/checkov/kubernetes/checks/DockerSocketVolume.py
+++ b/checkov/kubernetes/checks/DockerSocketVolume.py
@@ -39,7 +39,7 @@ class DockerSocketVolume(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_spec(conf)
+            spec = self.get_inner_entry(conf, "spec")
 
         # Evaluate volumes
         if spec:

--- a/checkov/kubernetes/checks/PodSecurityContext.py
+++ b/checkov/kubernetes/checks/PodSecurityContext.py
@@ -37,7 +37,8 @@ class PodSecurityContext(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_entry(conf, "spec")
+            inner_spec = self.get_inner_entry(conf, "spec")
+            spec = inner_spec if inner_spec else spec
 
         if spec:
             if "securityContext" in spec:

--- a/checkov/kubernetes/checks/PodSecurityContext.py
+++ b/checkov/kubernetes/checks/PodSecurityContext.py
@@ -37,10 +37,7 @@ class PodSecurityContext(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            if "spec" in conf:
-                if "template" in conf["spec"]:
-                    if "spec" in conf["spec"]["template"]:
-                        spec = conf["spec"]["template"]["spec"]
+            spec = self.get_inner_spec(conf)
 
         if spec:
             if "securityContext" in spec:

--- a/checkov/kubernetes/checks/PodSecurityContext.py
+++ b/checkov/kubernetes/checks/PodSecurityContext.py
@@ -37,7 +37,7 @@ class PodSecurityContext(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_spec(conf)
+            spec = self.get_inner_entry(conf, "spec")
 
         if spec:
             if "securityContext" in spec:

--- a/checkov/kubernetes/checks/RootContainers.py
+++ b/checkov/kubernetes/checks/RootContainers.py
@@ -40,10 +40,7 @@ class RootContainers(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            if "spec" in conf:
-                if "template" in conf["spec"]:
-                    if "spec" in conf["spec"]["template"]:
-                        spec = conf["spec"]["template"]["spec"]
+            spec = self.get_inner_spec(conf)
 
         # Collect results
         if spec:
@@ -53,7 +50,7 @@ class RootContainers(BaseK8Check):
             results["pod"]["runAsNonRoot"] = check_runAsNonRoot(spec)
             results["pod"]["runAsUser"] = check_runAsUser(spec)
 
-            if "containers" in spec:
+            if spec.get("containers"):
                 for c in spec["containers"]:
                     cresults = {}
                     cresults["runAsNonRoot"] = check_runAsNonRoot(c)

--- a/checkov/kubernetes/checks/RootContainers.py
+++ b/checkov/kubernetes/checks/RootContainers.py
@@ -40,7 +40,8 @@ class RootContainers(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_entry(conf, "spec")
+            inner_spec = self.get_inner_entry(conf, "spec")
+            spec = inner_spec if inner_spec else spec
 
         # Collect results
         if spec:

--- a/checkov/kubernetes/checks/RootContainers.py
+++ b/checkov/kubernetes/checks/RootContainers.py
@@ -40,7 +40,7 @@ class RootContainers(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_spec(conf)
+            spec = self.get_inner_entry(conf, "spec")
 
         # Collect results
         if spec:

--- a/checkov/kubernetes/checks/RootContainersHighUID.py
+++ b/checkov/kubernetes/checks/RootContainersHighUID.py
@@ -38,7 +38,7 @@ class RootContainersHighUID(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_spec(conf)
+            spec = self.get_inner_entry(conf, "spec")
 
         # Collect results
         if spec:

--- a/checkov/kubernetes/checks/RootContainersHighUID.py
+++ b/checkov/kubernetes/checks/RootContainersHighUID.py
@@ -38,10 +38,7 @@ class RootContainersHighUID(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            if "spec" in conf:
-                if "template" in conf["spec"]:
-                    if "spec" in conf["spec"]["template"]:
-                        spec = conf["spec"]["template"]["spec"]
+            spec = self.get_inner_spec(conf)
 
         # Collect results
         if spec:
@@ -50,7 +47,7 @@ class RootContainersHighUID(BaseK8Check):
             results["container"] = []
             results["pod"]["runAsUser"] = check_runAsUser(spec)
 
-            if "containers" in spec:
+            if spec.get("containers"):
                 for c in spec["containers"]:
                     cresults = {}
                     cresults["runAsUser"] = check_runAsUser(c)

--- a/checkov/kubernetes/checks/RootContainersHighUID.py
+++ b/checkov/kubernetes/checks/RootContainersHighUID.py
@@ -38,7 +38,8 @@ class RootContainersHighUID(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_entry(conf, "spec")
+            inner_spec = self.get_inner_entry(conf, "spec")
+            spec = inner_spec if inner_spec else spec
 
         # Collect results
         if spec:

--- a/checkov/kubernetes/checks/Seccomp.py
+++ b/checkov/kubernetes/checks/Seccomp.py
@@ -57,10 +57,8 @@ class Seccomp(BaseK8Check):
                             if "metadata" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 metadata = conf["spec"]["jobTemplate"]["spec"]["template"]["metadata"]
         else:
-            if "spec" in conf:
-                if "template" in conf["spec"]:
-                    if "metadata" in conf["spec"]["template"]:
-                        metadata = conf["spec"]["template"]["metadata"]
+            if conf.get("spec") and conf.get("spec").get("template"):
+                metadata = conf.get("spec").get("template").get("metadata", {})
 
         if metadata:
             if metadata.get('annotations'):

--- a/checkov/kubernetes/checks/Seccomp.py
+++ b/checkov/kubernetes/checks/Seccomp.py
@@ -57,7 +57,8 @@ class Seccomp(BaseK8Check):
                             if "metadata" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 metadata = conf["spec"]["jobTemplate"]["spec"]["template"]["metadata"]
         else:
-            metadata = self.get_inner_entry(conf, "metadata")
+            inner_metadata = self.get_inner_entry(conf, "metadata")
+            metadata = inner_metadata if inner_metadata else metadata
 
         if metadata:
             if metadata.get('annotations'):

--- a/checkov/kubernetes/checks/Seccomp.py
+++ b/checkov/kubernetes/checks/Seccomp.py
@@ -57,8 +57,7 @@ class Seccomp(BaseK8Check):
                             if "metadata" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 metadata = conf["spec"]["jobTemplate"]["spec"]["template"]["metadata"]
         else:
-            if conf.get("spec") and conf.get("spec").get("template"):
-                metadata = conf.get("spec").get("template").get("metadata", {})
+            metadata = self.get_inner_entry(conf, "metadata")
 
         if metadata:
             if metadata.get('annotations'):

--- a/checkov/kubernetes/checks/ServiceAccountTokens.py
+++ b/checkov/kubernetes/checks/ServiceAccountTokens.py
@@ -37,10 +37,7 @@ class ServiceAccountTokens(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            if "spec" in conf:
-                if "template" in conf["spec"]:
-                    if "spec" in conf["spec"]["template"]:
-                        spec = conf["spec"]["template"]["spec"]
+            spec = self.get_inner_spec(conf)
 
         # Collect results
         if spec:

--- a/checkov/kubernetes/checks/ServiceAccountTokens.py
+++ b/checkov/kubernetes/checks/ServiceAccountTokens.py
@@ -37,7 +37,8 @@ class ServiceAccountTokens(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_entry(conf, "spec")
+            inner_spec = self.get_inner_entry(conf, "spec")
+            spec = inner_spec if inner_spec else spec
 
         # Collect results
         if spec:

--- a/checkov/kubernetes/checks/ServiceAccountTokens.py
+++ b/checkov/kubernetes/checks/ServiceAccountTokens.py
@@ -37,7 +37,7 @@ class ServiceAccountTokens(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_spec(conf)
+            spec = self.get_inner_entry(conf, "spec")
 
         # Collect results
         if spec:

--- a/checkov/kubernetes/checks/ShareHostIPC.py
+++ b/checkov/kubernetes/checks/ShareHostIPC.py
@@ -36,7 +36,7 @@ class ShareHostIPC(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_spec(conf)
+            spec = self.get_inner_entry(conf, "spec")
         if spec:
             if "hostIPC" in spec:
                 if spec["hostIPC"]:

--- a/checkov/kubernetes/checks/ShareHostIPC.py
+++ b/checkov/kubernetes/checks/ShareHostIPC.py
@@ -36,7 +36,8 @@ class ShareHostIPC(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_entry(conf, "spec")
+            inner_spec = self.get_inner_entry(conf, "spec")
+            spec = inner_spec if inner_spec else spec
         if spec:
             if "hostIPC" in spec:
                 if spec["hostIPC"]:

--- a/checkov/kubernetes/checks/ShareHostIPC.py
+++ b/checkov/kubernetes/checks/ShareHostIPC.py
@@ -36,10 +36,7 @@ class ShareHostIPC(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            if "spec" in conf:
-                if "template" in conf["spec"]:
-                    if "spec" in conf["spec"]["template"]:
-                        spec = conf["spec"]["template"]["spec"]
+            spec = self.get_inner_spec(conf)
         if spec:
             if "hostIPC" in spec:
                 if spec["hostIPC"]:

--- a/checkov/kubernetes/checks/ShareHostPID.py
+++ b/checkov/kubernetes/checks/ShareHostPID.py
@@ -36,10 +36,7 @@ class ShareHostPID(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            if "spec" in conf:
-                if "template" in conf["spec"]:
-                    if "spec" in conf["spec"]["template"]:
-                        spec = conf["spec"]["template"]["spec"]
+            spec = self.get_inner_spec(conf)
         if spec:
             if "hostPID" in spec:
                 if spec["hostPID"]:

--- a/checkov/kubernetes/checks/ShareHostPID.py
+++ b/checkov/kubernetes/checks/ShareHostPID.py
@@ -36,7 +36,7 @@ class ShareHostPID(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_spec(conf)
+            spec = self.get_inner_entry(conf, "spec")
         if spec:
             if "hostPID" in spec:
                 if spec["hostPID"]:

--- a/checkov/kubernetes/checks/ShareHostPID.py
+++ b/checkov/kubernetes/checks/ShareHostPID.py
@@ -36,7 +36,8 @@ class ShareHostPID(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_entry(conf, "spec")
+            inner_spec = self.get_inner_entry(conf, "spec")
+            spec = inner_spec if inner_spec else spec
         if spec:
             if "hostPID" in spec:
                 if spec["hostPID"]:

--- a/checkov/kubernetes/checks/SharedHostNetworkNamespace.py
+++ b/checkov/kubernetes/checks/SharedHostNetworkNamespace.py
@@ -36,10 +36,7 @@ class SharedHostNetworkNamespace(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            if "spec" in conf:
-                if "template" in conf["spec"]:
-                    if "spec" in conf["spec"]["template"]:
-                        spec = conf["spec"]["template"]["spec"]
+            spec = self.get_inner_spec(conf)
         if spec:
             if "hostNetwork" in spec:
                 if spec["hostNetwork"]:

--- a/checkov/kubernetes/checks/SharedHostNetworkNamespace.py
+++ b/checkov/kubernetes/checks/SharedHostNetworkNamespace.py
@@ -36,7 +36,8 @@ class SharedHostNetworkNamespace(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_entry(conf, "spec")
+            inner_spec = self.get_inner_entry(conf, "spec")
+            spec = inner_spec if inner_spec else spec
         if spec:
             if "hostNetwork" in spec:
                 if spec["hostNetwork"]:

--- a/checkov/kubernetes/checks/SharedHostNetworkNamespace.py
+++ b/checkov/kubernetes/checks/SharedHostNetworkNamespace.py
@@ -36,7 +36,7 @@ class SharedHostNetworkNamespace(BaseK8Check):
                             if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
-            spec = self.get_inner_spec(conf)
+            spec = self.get_inner_entry(conf, "spec")
         if spec:
             if "hostNetwork" in spec:
                 if spec["hostNetwork"]:

--- a/checkov/kubernetes/checks/WildcardRoles.py
+++ b/checkov/kubernetes/checks/WildcardRoles.py
@@ -17,8 +17,7 @@ class WildcardRoles(BaseK8Check):
             return "{}.{}.default".format(conf["kind"], conf["metadata"]["name"])
 
     def scan_spec_conf(self, conf):
-        if "rules" in conf:
-            #print(conf)
+        if isinstance(conf.get("rules"), list) and len(conf.get("rules")) > 0:
             if "apiGroups" in conf["rules"][0]:
                 if any("*" in s for s in conf["rules"][0]["apiGroups"]):
                     return CheckResult.FAILED

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -87,7 +87,7 @@ class Runner(BaseRunner):
                         continue
 
                     # Skip entity without metadata["name"]
-                    if "metadata" in entity_conf:
+                    if "metadata" in entity_conf and entity_conf.get("metadata"):
                         if isinstance(entity_conf["metadata"], int) or not "name" in entity_conf["metadata"]:
                             continue
                     else:
@@ -134,14 +134,14 @@ class Runner(BaseRunner):
 
                     entity_conf = definitions[k8_file][i]
 
-                    if entity_conf["kind"] == "List":
+                    if entity_conf["kind"] == "List" or not entity_conf["kind"]:
                         continue
 
                     if isinstance(entity_conf["kind"], int):
                         continue
                     # Skip entity without metadata["name"] or parent_metadata["name"]
                     if not any(x in entity_conf["kind"] for x in ["containers", "initContainers"]):
-                        if "metadata" in entity_conf:
+                        if "metadata" in entity_conf and entity_conf.get("metadata"):
                             if isinstance(entity_conf["metadata"], int) or not "name" in entity_conf["metadata"]:
                                 continue
                         else:

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -87,7 +87,7 @@ class Runner(BaseRunner):
                         continue
 
                     # Skip entity without metadata["name"]
-                    if "metadata" in entity_conf and entity_conf.get("metadata"):
+                    if entity_conf.get("metadata"):
                         if isinstance(entity_conf["metadata"], int) or not "name" in entity_conf["metadata"]:
                             continue
                     else:
@@ -134,14 +134,14 @@ class Runner(BaseRunner):
 
                     entity_conf = definitions[k8_file][i]
 
-                    if entity_conf["kind"] == "List" or not entity_conf["kind"]:
+                    if entity_conf["kind"] == "List" or not entity_conf.get("kind"):
                         continue
 
                     if isinstance(entity_conf["kind"], int):
                         continue
                     # Skip entity without metadata["name"] or parent_metadata["name"]
                     if not any(x in entity_conf["kind"] for x in ["containers", "initContainers"]):
-                        if "metadata" in entity_conf and entity_conf.get("metadata"):
+                        if entity_conf.get("metadata"):
                             if isinstance(entity_conf["metadata"], int) or not "name" in entity_conf["metadata"]:
                                 continue
                         else:

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -100,6 +100,8 @@ class Runner(BaseRunner):
 
             if CFN_RESOURCES_TOKEN in sls_file_data and isinstance(sls_file_data[CFN_RESOURCES_TOKEN], dict_node):
                 cf_sub_template = sls_file_data[CFN_RESOURCES_TOKEN]
+                if not cf_sub_template.get('Resources'):
+                    continue
                 cf_context_parser = CfnContextParser(sls_file, cf_sub_template, definitions_raw[sls_file])
                 logging.debug("Template Dump for {}: {}".format(sls_file, sls_file_data, indent=2))
                 cf_context_parser.evaluate_default_refs()

--- a/tests/cloudformation/checks/resource/aws/example_EKSSecretEncryption/EKSSecretEncryption-FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_EKSSecretEncryption/EKSSecretEncryption-FAILED.yml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  Resource0:
+    Type: 'AWS::EKS::Cluster'
+    Properties:
+      Name: prod
+      Version: '1.14'
+      RoleArn: >-
+        arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonEKS-EXAMPLEBQ4PI
+      ResourcesVpcConfig:
+        SecurityGroupIds:
+          - sg-6979fe18
+        SubnetIds:
+          - subnet-6782e71e
+          - subnet-e7e761ac
+  Resource1:
+    Type: 'AWS::EKS::Cluster'
+    Properties:
+      Name: prod
+      Version: '1.14'
+      RoleArn: >-
+        arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonEKS-EXAMPLEBQ4PI
+      ResourcesVpcConfig:
+        SecurityGroupIds:
+          - sg-6979fe18
+        SubnetIds:
+          - subnet-6782e71e
+          - subnet-e7e761ac
+      EncryptionConfig:
+        Resources:
+          - not_secrets

--- a/tests/cloudformation/checks/resource/aws/example_EKSSecretEncryption/EKSSecretEncryption-FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_EKSSecretEncryption/EKSSecretEncryption-FAILED.yml
@@ -27,5 +27,5 @@ Resources:
           - subnet-6782e71e
           - subnet-e7e761ac
       EncryptionConfig:
-        Resources:
+        - Resources:
           - not_secrets

--- a/tests/cloudformation/checks/resource/aws/example_EKSSecretEncryption/EKSSecretEncryption-PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_EKSSecretEncryption/EKSSecretEncryption-PASSED.yml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  myCluster:
+    Type: 'AWS::EKS::Cluster'
+    Properties:
+      Name: prod
+      Version: '1.14'
+      RoleArn: >-
+        arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonEKS-EXAMPLEBQ4PI
+      ResourcesVpcConfig:
+        SecurityGroupIds:
+          - sg-6979fe18
+        SubnetIds:
+          - subnet-6782e71e
+          - subnet-e7e761ac
+      EncryptionConfig:
+        Resources:
+          - secrets

--- a/tests/cloudformation/checks/resource/aws/example_EKSSecretEncryption/EKSSecretEncryption-PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_EKSSecretEncryption/EKSSecretEncryption-PASSED.yml
@@ -14,5 +14,5 @@ Resources:
           - subnet-6782e71e
           - subnet-e7e761ac
       EncryptionConfig:
-        Resources:
+        - Resources:
           - secrets

--- a/tests/cloudformation/checks/resource/aws/test_EKSSecretEncryption.py
+++ b/tests/cloudformation/checks/resource/aws/test_EKSSecretEncryption.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.EKSSecretsEncryption import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestEKSSecretEncryption(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_EKSSecretEncryption"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/graph/terraform/graph_builder/graph_components/test_blocks.py
+++ b/tests/graph/terraform/graph_builder/graph_components/test_blocks.py
@@ -52,20 +52,3 @@ class TestBlocks(TestCase):
         err = block.update_inner_attribute(attribute_key="labels.app.kubernetes.io/name", nested_attributes=attributes,
                                            value_to_update="dummy value")
         self.assertEqual(None, err)
-
-    def test_update_complex_key2(self):
-        config = {'labels': [{'app.kubernetes.io/name': '${local.name}', 'app.kubernetes.io/instance': 'hpa',
-                              'app.kubernetes.io/version': '1.0.0', 'app.kubernetes.io/managed-by': 'terraform'}]}
-        attributes = {'var.owning_account': {'route_to': None, 'route_to_cidr_blocks': '${local.allowed_cidrs}',
-                                             'static_routes': None, 'subnet_ids': '${local.own_vpc.private_subnet_ids}',
-                                             'subnet_route_table_ids': '${local.own_vpc.private_route_table_ids}',
-                                             'transit_gateway_vpc_attachment_id': None,
-                                             'vpc_cidr': '${local.own_vpc.vpc_cidr}',
-                                             'vpc_id': '${local.own_vpc.vpc_id}'}}
-        block = Block(name='test_local_name', config=config, path='', block_type=BlockType.LOCALS,
-                      attributes=attributes)
-        value_to_update = [
-            "${{'connected_accounts':'${var.connections}','eks':'${data.terraform_remote_state.eks}','existing_transit_gateway_id':'${module.transit_gateway.transit_gateway_id}','existing_transit_gateway_route_table_id':'${module.transit_gateway.transit_gateway_route_table_id}','expose_eks_sg':True,'vpcs':'${data.terraform_remote_state.vpc}'}[\"prod\"].outputs}"]
-        err = block.update_inner_attribute(attribute_key="var.owning_account.vpc_cidr", nested_attributes=attributes,
-                                           value_to_update=value_to_update)
-        self.assertEqual(None, err)

--- a/tests/kubernetes/checks/example_WildcardRoles/role-passed-2.yaml
+++ b/tests/kubernetes/checks/example_WildcardRoles/role-passed-2.yaml
@@ -1,0 +1,7 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-should-pass-2
+  namespace: test
+rules:

--- a/tests/kubernetes/checks/test_WildcardRoles.py
+++ b/tests/kubernetes/checks/test_WildcardRoles.py
@@ -17,7 +17,8 @@ class TestWildcardRoles(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            'Role.test-should-pass-3.test'
+            'Role.test-should-pass-3.test',
+            'Role.test-should-pass-2.test'
         }
         failing_resources = {
             'Role.test-should-fail-1.test',
@@ -25,7 +26,7 @@ class TestWildcardRoles(unittest.TestCase):
             'ClusterRole.test-should-fail-3.test'
         }
 
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 3)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
1. Fixed cloudformation `CKV_AWS_58` - there access to conf was list-like rather than dict-like. Added UT as well.

2. Handled multiple cases in K8 where specs elements existed as `None` which caused errors while trying to access nested elements. Handled it by implementing `get_inner_spec` method in `base_spec_check`.

3. Fixed serveless runner accessing `cf_sub_template['Resources'].items()` when `cf_sub_template['Resources']` doesn't exists.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
