### PR TITLE
Fix update_inner_attribute index error

### DIFF
--- a/checkov/terraform/graph_builder/graph_components/blocks.py
+++ b/checkov/terraform/graph_builder/graph_components/blocks.py
@@ -140,10 +140,11 @@ class Block:
         if type(nested_attributes) is list:
             if curr_key.isnumeric():
                 curr_key = int(curr_key)
-                if not isinstance(nested_attributes[curr_key], dict):
-                    nested_attributes[curr_key] = value_to_update
-                else:
-                    self.update_inner_attribute('.'.join(split_key[i:]), nested_attributes[curr_key], value_to_update)
+                if curr_key < len(nested_attributes):
+                    if not isinstance(nested_attributes[curr_key], dict):
+                        nested_attributes[curr_key] = value_to_update
+                    else:
+                        self.update_inner_attribute('.'.join(split_key[i:]), nested_attributes[curr_key], value_to_update)
             else:
                 for inner in nested_attributes:
                     self.update_inner_attribute(curr_key, inner, value_to_update)

--- a/tests/graph/terraform/graph_builder/graph_components/test_blocks.py
+++ b/tests/graph/terraform/graph_builder/graph_components/test_blocks.py
@@ -157,3 +157,17 @@ class TestBlocks(TestCase):
                                                      'transit_gateway_vpc_attachment_id': None,
                                                      'vpc_cidr': 'test',
                                                      'vpc_id': '${local.own_vpc.vpc_id}'}})
+
+    def test_update_inner_attribute_bad_index(self):
+        config = {'aws_security_group': {
+            'test': {}}}
+
+        nested_attributes = {'provisioner/remote-exec.connection': {'private_key': '${file(var.ssh_key_path)}', 'user': 'ec2-user'}, 'provisioner/remote-exec.connection.private_key': '${file(var.ssh_key_path)}', 'provisioner/remote-exec.connection.user': 'ec2-user', 'provisioner/remote-exec.inline': ['command'], 'provisioner/remote-exec.inline.0': 'command0', 'provisioner/remote-exec.inline.1': 'command1', 'provisioner/remote-exec.inline.2': 'command2', 'provisioner/remote-exec.inline.3': 'command3', 'provisioner/remote-exec.inline.4': 'command4'}
+        block = Block(name='aws_security_group.test', config=config, path='test_path', block_type=BlockType.RESOURCE,
+                      attributes=nested_attributes)
+
+        block.update_inner_attribute(attribute_key='provisioner/remote-exec.inline.3', nested_attributes=nested_attributes,
+                                     value_to_update='new_command_3')
+
+        self.assertEqual('new_command_3', block.attributes['provisioner/remote-exec.inline.3'],
+                         f"failed to update provisioner/remote-exec.inline.3, got {block.attributes['provisioner/remote-exec.inline.3']}")


### PR DESCRIPTION
When `nested_attributes` are a list, check that the current key is within the size of the list before accessing that index.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
