### PR TITLE
DockerSocketVolume check if "hostPath" in volumes is not None

### DIFF
--- a/checkov/kubernetes/checks/DockerSocketVolume.py
+++ b/checkov/kubernetes/checks/DockerSocketVolume.py
@@ -46,7 +46,7 @@ class DockerSocketVolume(BaseK8Check):
         if spec:
             if "volumes" in spec and spec.get("volumes"):
                 for v in spec["volumes"]:
-                    if "hostPath" in v:
+                    if v.get("hostPath"):
                         if "path" in v["hostPath"]:
                             if v["hostPath"]["path"] == "/var/run/docker.sock":
                                 return CheckResult.FAILED


### PR DESCRIPTION
Used `v.get("hostPath")` to validate `hostPath` exists and that it is not None.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
