### PR TITLE
Enable CF Cloudsplaining Checks Where Policies Are Embedded In Resources

### DIFF
--- a/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
+++ b/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
@@ -12,30 +12,54 @@ from checkov.terraform.checks.utils.iam_cloudformation_document_to_policy_conver
 
 class BaseCloudsplainingIAMCheck(BaseResourceCheck):
     def __init__(self, name, id):
-        super().__init__(name=name, id=id, categories=CheckCategories.IAM, supported_resources=["AWS::IAM::Policy", "AWS::IAM::ManagedPolicy"])
+        super().__init__(name=name, id=id, categories=CheckCategories.IAM,
+            supported_resources=["AWS::IAM::Policy", "AWS::IAM::ManagedPolicy", "AWS::IAM::Group",
+            "AWS::IAM::Role", "AWS::IAM::User"])
 
     def scan_resource_conf(self, conf):
         if 'Properties' in conf.keys():
             props_conf = conf['Properties']
-            key = 'PolicyDocument'
-            if key in props_conf.keys():
-                converted_conf = props_conf[key]
-                try:
-                    converted_conf = convert_cloudformation_conf_to_iam_policy(converted_conf)
-                    key = 'Statement'
-                    if key in converted_conf:
-                        policy = PolicyDocument(converted_conf)
-                        violations = self.cloudsplaining_analysis(policy)
-                        if violations:
-                            logging.debug("detailed cloudsplainging finding: {}",json.dumps(violations))
-                            return CheckResult.FAILED
-                except Exception as e:
-                    # this might occur with templated iam policies where ARN is not in place or similar
-                    logging.debug("could not run cloudsplaining analysis on policy {}", conf)
-                    return CheckResult.UNKNOWN
-        return CheckResult.PASSED
+            policies_key = 'Policies'
+
+            # Obtain a list of 1 or more policies regardless of resource schema
+            if policies_key in props_conf.keys():
+                policy_conf = props_conf[policies_key]
+            else:
+                policy_conf = [props_conf]
+
+            # Scan all policies
+            for policy in policy_conf:
+                policy_doc_key = 'PolicyDocument'
+                if policy_doc_key in policy.keys():
+                    policy_doc = policy[policy_doc_key]
+                    try:
+                        converted_policy_doc = convert_cloudformation_conf_to_iam_policy(policy_doc)
+                        statement_key = 'Statement'
+                        if statement_key in converted_policy_doc:
+                            policy_statement = PolicyDocument(converted_policy_doc)
+                            violations = self.cloudsplaining_analysis(policy_statement)
+                            if violations:
+                                logging.debug("detailed cloudsplainging finding: {}",json.dumps(violations))
+                                return CheckResult.FAILED
+                    except Exception as e:
+                        # this might occur with templated iam policies where ARN is not in place or similar
+                        logging.debug("could not run cloudsplaining analysis on policy {}", conf)
+                        return CheckResult.UNKNOWN
+            return CheckResult.PASSED
 
     @multi_signature()
     @abstractmethod
     def cloudsplaining_analysis(self, policy):
         raise NotImplementedError()
+    
+    # def cloudsplaining_scan(self, cf_policy_document):
+    #     converted_policy_document = convert_cloudformation_conf_to_iam_policy(cf_policy_document)
+    #     key = 'Statement'
+    #     if key in converted_policy_document:
+    #         policy = PolicyDocument(converted_policy_document)
+    #         violations = self.cloudsplaining_analysis(policy)
+    #         if violations:
+    #             logging.debug("detailed cloudsplainging finding: {}",json.dumps(violations))
+    #             return False
+    #     return True
+

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMGroup/FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMGroup/FAILED.yml
@@ -1,0 +1,43 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: IAM Group with multiple policies
+Resources:
+  PolicyOnePassPolicyTwoFailAdmin:
+    Type: 'AWS::IAM::Group'
+    Properties:
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:Get*'
+              Resource: 
+              - 'foo'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: '*'
+              Resource: '*'    
+  PolicyOneFailPolicyTwoFailPermissionsWildcard:
+    Type: 'AWS::IAM::Group'
+    Properties:
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 'iam:ChangePassword'
+              Resource: '*'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:PutBucketAcl'
+              Resource: '*'

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMGroup/PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMGroup/PASSED.yaml
@@ -1,0 +1,45 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: IAM Groups with multiple policies
+Resources:
+  NotPermissionsScopedAndWildcard:
+    Type: 'AWS::IAM::Group'
+    Properties:
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:Get*'
+              Resource: 
+              - 'foo'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:Get*'
+              Resource: 
+              - '*'        
+  AdminDenyAndPermissionsScoped:
+    Type: 'AWS::IAM::Group'
+    Properties:
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Deny
+              Action: '*'
+              Resource: '*'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 'iam:ChangePassword'
+              Resource: 
+              - 'foo'

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMRole/FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMRole/FAILED.yml
@@ -1,0 +1,61 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: IAM Roles with multiple policies
+Resources:
+  PolicyOnePassPolicyTwoFailAdmin:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:Get*'
+              Resource: 
+              - 'foo'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: '*'
+              Resource: '*'    
+  PolicyOneFailPolicyTwoFailPermissionsWildcard:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 'iam:ChangePassword'
+              Resource: '*'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:PutBucketAcl'
+              Resource: '*'

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMRole/PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMRole/PASSED.yaml
@@ -1,0 +1,63 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: IAM Roles with multiple policies
+Resources:
+  NotPermissionsScopedAndWildcard:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:Get*'
+              Resource: 
+              - 'foo'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:Get*'
+              Resource: 
+              - '*'        
+  AdminDenyAndPermissionsScoped:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Deny
+              Action: '*'
+              Resource: '*'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 'iam:ChangePassword'
+              Resource: 
+              - 'foo'

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMUser/FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMUser/FAILED.yml
@@ -1,0 +1,43 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: IAM Users with multiple policies
+Resources:
+  PolicyOnePassPolicyTwoFailAdmin:
+    Type: 'AWS::IAM::User'
+    Properties:
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:Get*'
+              Resource: 
+              - 'foo'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: '*'
+              Resource: '*'    
+  PolicyOneFailPolicyTwoFailPermissionsWildcard:
+    Type: 'AWS::IAM::User'
+    Properties:
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 'iam:ChangePassword'
+              Resource: '*'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:PutBucketAcl'
+              Resource: '*'

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMUser/PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMUser/PASSED.yaml
@@ -1,0 +1,45 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: IAM Users with multiple policies
+Resources:
+  NotPermissionsScopedAndWildcard:
+    Type: 'AWS::IAM::User'
+    Properties:
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:Get*'
+              Resource: 
+              - 'foo'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 's3:Get*'
+              Resource: 
+              - '*'        
+  AdminDenyAndPermissionsScoped:
+    Type: 'AWS::IAM::User'
+    Properties:
+      Policies:
+      - PolicyName: a
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Deny
+              Action: '*'
+              Resource: '*'
+      - PolicyName: b
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: 
+              - 'iam:ChangePassword'
+              Resource: 
+              - 'foo'

--- a/tests/cloudformation/checks/resource/aws/test_CloudsplainingIAMGroup.py
+++ b/tests/cloudformation/checks/resource/aws/test_CloudsplainingIAMGroup.py
@@ -1,0 +1,29 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.IAMPermissionsManagement import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+# This test is the same as for IAMPermissionsManagement but uses IAM Group test data
+# with multiple Policies to ensure that this resource type is tested but it would be
+# overkill to use all possible resources for each policy related check
+
+class TestCloudsplainingIAMGroup(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/Cloudsplaining_IAMGroup"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+        self.assertEqual(report.failed_checks[0].check_id, check.id)
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_CloudsplainingIAMRole.py
+++ b/tests/cloudformation/checks/resource/aws/test_CloudsplainingIAMRole.py
@@ -1,0 +1,29 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.IAMPermissionsManagement import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+# This test is the same as for IAMPermissionsManagement but uses IAM Role test data
+# with multiple Policies to ensure that this resource type is tested but it would be
+# overkill to use all possible resources for each policy related check
+
+class TestCloudsplainingIAMRole(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/Cloudsplaining_IAMRole"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+        self.assertEqual(report.failed_checks[0].check_id, check.id)
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_CloudsplainingIAMUser.py
+++ b/tests/cloudformation/checks/resource/aws/test_CloudsplainingIAMUser.py
@@ -1,0 +1,29 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.IAMPermissionsManagement import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+# This test is the same as for IAMPermissionsManagement but uses IAM User test data
+# with multiple Policies to ensure that this resource type is tested but it would be
+# overkill to use all possible resources for each policy related check
+
+class TestCloudsplainingIAMUser(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/Cloudsplaining_IAMUser"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+        self.assertEqual(report.failed_checks[0].check_id, check.id)
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello all,

Continuing on with the work we are doing with Cloudsplaining I have made it so that we are able to access and analyse policies that are embedded as part of other CF Resources - IAM Groups, Roles and Users.

As I've also been increasing the Cloudsplaining test coverage we can see that this does not disrupt the anything existing but it does enable both scanning of the new resource types and ensures that it will work where there are 1 or more policies in the policy lists for these resources.

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
