### PR TITLE
allow the user to specify a CA bundle when running bridgecrew

### DIFF
--- a/checkov/common/bridgecrew/integration_features/base_integration_feature.py
+++ b/checkov/common/bridgecrew/integration_features/base_integration_feature.py
@@ -15,6 +15,7 @@ class BaseIntegrationFeature(ABC):
 
     def __init__(self, bc_integration, order):
         self.bc_integration = bc_integration
+        bc_integration.setup_http_manager()
         self.order = order
         integration_feature_registry.register(self)
 

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -67,13 +67,15 @@ class BcPlatformIntegration(object):
         self.ckv_to_bc_id_mapping = None
         self.use_s3_integration = False
         self.platform_integration_configured = False
-        self.setup_http_manager(os.getenv('BC_CA_BUNDLE', None))
+        self.http = None
 
-    def setup_http_manager(self, ca_certificate=None):
+    def setup_http_manager(self, ca_certificate=os.getenv('BC_CA_BUNDLE', None)):
         """
         bridgecrew uses both the urllib3 and requests libraries, while checkov uses the requests library.
         :param ca_certificate: an optional CA bundle to be used by both libraries.
         """
+        if self.http:
+            return
         if ca_certificate:
             os.environ['REQUESTS_CA_BUNDLE'] = ca_certificate
             try:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -43,6 +43,11 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(description='Infrastructure as code static analysis')
     add_parser_args(parser)
     args = parser.parse_args(argv)
+
+    # bridgecrew uses both the urllib3 and requests libraries, while checkov uses the requests library.
+    # Allow the user to specify a CA bundle to be used by both libraries.
+    bc_integration.setup_http_manager(args.ca_certificate)
+
     # Disable runners with missing system dependencies
     args.skip_framework = runnerDependencyHandler.disable_incompatible_runners(args.skip_framework)
 
@@ -183,7 +188,9 @@ def add_parser_args(parser):
     parser.add_argument('--evaluate-variables',
                         help="evaluate the values of variables and locals",
                         default=True)
-
+    parser.add_argument('-ca', '--ca-certificate',
+                        help='custom CA bundle file',
+                        default=os.environ.get('BC_CA_BUNDLE', None))
 
 def get_external_checks_dir(args):
     external_checks_dir = args.external_checks_dir

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -189,8 +189,7 @@ def add_parser_args(parser):
                         help="evaluate the values of variables and locals",
                         default=True)
     parser.add_argument('-ca', '--ca-certificate',
-                        help='custom CA bundle file',
-                        default=os.environ.get('BC_CA_BUNDLE', None))
+                        help='custom CA (bundle) file', default=None)
 
 def get_external_checks_dir(args):
     external_checks_dir = args.external_checks_dir

--- a/checkov/terraform/context_parsers/base_parser.py
+++ b/checkov/terraform/context_parsers/base_parser.py
@@ -21,6 +21,7 @@ class BaseContextParser(ABC):
     context = {}
 
     def __init__(self, definition_type):
+        #bc_integration.setup_http_manager()
         self.logger = logging.getLogger("{}".format(self.__module__))
         if definition_type.upper() not in ContextCategories.__members__:
             self.logger.error("Terraform context parser type not supported yet")

--- a/docs/2.Basics/CLI Command Reference.md
+++ b/docs/2.Basics/CLI Command Reference.md
@@ -25,3 +25,4 @@ nav_order: 2
 | `--bc-api-key BC_API_KEY` | Bridgecrew API key. |
 | `--repo-id REPO_ID` | The identity string of the repository. It should be in the form: `<repo_owner>/<repo_name>` |
 | `-b BRANCH`, `--branch BRANCH` | The selected branch of the persisted repository. Only has effect when using the `--bc-api-key` flag. |
+| `-ca CA_CERTIFICATE`, `--ca-certificate CA_CERTIFICATE` | Custom CA (bundle) file. |

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -25,16 +25,16 @@ class TestBCApiUrl(unittest.TestCase):
 
     @mock.patch.dict(os.environ, {'BC_SKIP_MAPPING': 'TRUE'})
     def test_skip_mapping(self):
-
         instance = BcPlatformIntegration()
+        instance.setup_http_manager()
         instance.get_id_mapping()
         self.assertEquals(None,instance.ckv_to_bc_id_mapping)
 
     @mock.patch.dict(os.environ, {'BC_SKIP_MAPPING': 'FALSE'})
     def test_skip_mapping_false(self):
         instance = BcPlatformIntegration()
+        instance.setup_http_manager()
         instance.get_id_mapping()
-
         self.assertNotEquals(None,instance.ckv_to_bc_id_mapping)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Software (like GlobalProtect) generates 'ignore self signed certificate in certificate chain' errors when executing bridgecrew; and/or bridgecrew might be installed into a Python without any CA certificates.

This commit allows users to specify a CA bundle (including the 'Palo Alto Networks Inc Root CA' used by GlobalProtect, for example) via a --ca-certificate argument or a BC_CA_BUNDLE environment variable.

Hint: To generate a CA bundle, copy the CA bundle provided by the certifi module (locate via 'python -m certifi') and, if applicable, append other CA certificates (including the 'Palo Alto Networks Inc Root CA' used by GlobalProtect, for example).

This commit also replaces the global http variable with a self.http instance variable (representing a urllib3.ProxyManager or urllib3.PoolManager resource) used for network requests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.