### PR TITLE
Fix Docker checks CKV_DOCKER_6,CKV_DOCKER_8

### DIFF
--- a/checkov/dockerfile/checks/MaintainerExists.py
+++ b/checkov/dockerfile/checks/MaintainerExists.py
@@ -11,10 +11,7 @@ class MaintainerExists(BaseDockerfileCheck):
         super().__init__(name=name, id=id, categories=categories, supported_instructions=supported_instructions)
 
     def scan_entity_conf(self, conf):
-        for instruction, content in conf.items():
-            if instruction == "MAINTAINER":
-                return CheckResult.FAILED, content[0]
-        return CheckResult.PASSED, None
+        return CheckResult.FAILED, conf[0]
 
 
 check = MaintainerExists()

--- a/checkov/dockerfile/checks/RootUser.py
+++ b/checkov/dockerfile/checks/RootUser.py
@@ -11,16 +11,11 @@ class RootUser(BaseDockerfileCheck):
         super().__init__(name=name, id=id, categories=categories, supported_instructions=supported_instructions)
 
     def scan_entity_conf(self, conf):
-        contents = conf.get("USER")
+        last_user = conf[-1]
+        if last_user["value"] == "root":
+            return CheckResult.FAILED, last_user
 
-        if contents:
-            last_user = contents[-1]
-            if last_user["value"] == "root":
-                return CheckResult.FAILED, last_user
-
-            return CheckResult.PASSED, last_user
-
-        return CheckResult.UNKNOWN, None
+        return CheckResult.PASSED, last_user
 
 
 check = RootUser()

--- a/tests/dockerfile/checks/example_MaintainerExists/failure/Dockerfile
+++ b/tests/dockerfile/checks/example_MaintainerExists/failure/Dockerfile
@@ -1,0 +1,3 @@
+FROM  base
+
+MAINTAINER checkov

--- a/tests/dockerfile/checks/example_RootUser/failure/Dockerfile
+++ b/tests/dockerfile/checks/example_RootUser/failure/Dockerfile
@@ -1,0 +1,3 @@
+FROM base
+
+USER root

--- a/tests/dockerfile/checks/example_RootUser/success/Dockerfile
+++ b/tests/dockerfile/checks/example_RootUser/success/Dockerfile
@@ -1,0 +1,6 @@
+FROM base
+
+USER root
+COPY test.sh /test.sh
+
+USER checkov


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #1101.

After realizing how the checks were tested I changed my to use the same way as the terraform checks to really let the parse through the runner.

The Maintainer check looks quite silly, this is because of the runner functionality. When `supported_instructions` is set to something other than `*`, he will just send the chosen instruction to the `scan_entity_conf()` method. Therefore there is no need to check anything and I can directly return the `FAILED` status 😄 