### PR TITLE
add new tag check for autoscaling groups only

### DIFF
--- a/checkov/terraform/checks/resource/aws/AutoScalingTagging.py
+++ b/checkov/terraform/checks/resource/aws/AutoScalingTagging.py
@@ -1,0 +1,22 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class AutoScalingTagging(BaseResourceCheck):
+    def __init__(self):
+        name = "Autoscaling groups should supply tags to launch configurations"
+        id = "CKV_AWS_153"
+        supported_resources = ['aws_autoscaling_group']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        """
+            Looks for tag or tags
+        """
+
+        if "tag" in conf.keys() or "tags" in conf.keys():
+            return CheckResult.PASSED
+        return  CheckResult.FAILED
+
+check = AutoScalingTagging()

--- a/tests/terraform/checks/resource/aws/example_AutoScalingTagging/main.tf
+++ b/tests/terraform/checks/resource/aws/example_AutoScalingTagging/main.tf
@@ -1,0 +1,58 @@
+resource "aws_autoscaling_group" "passtag" {
+  name                      = "foobar3-terraform-test"
+  max_size                  = 5
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  desired_capacity          = 4
+  force_delete              = true
+  placement_group           = aws_placement_group.test.id
+  launch_configuration      = aws_launch_configuration.foobar.name
+  vpc_zone_identifier       = [aws_subnet.example1.id, aws_subnet.example2.id]
+
+  tag {
+    key                 = "foo"
+    value               = "bar"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "lorem"
+    value               = "ipsum"
+    propagate_at_launch = false
+  }
+}
+
+
+resource "aws_autoscaling_group" "passtags" {
+  name                 = "foobar3-terraform-test"
+  max_size             = 5
+  min_size             = 2
+  launch_configuration = aws_launch_configuration.foobar.name
+  vpc_zone_identifier  = [aws_subnet.example1.id, aws_subnet.example2.id]
+
+  tags = concat(
+    [
+      {
+        "key"                 = "interpolation1"
+        "value"               = "value3"
+        "propagate_at_launch" = true
+      },
+      {
+        "key"                 = "interpolation2"
+        "value"               = "value4"
+        "propagate_at_launch" = true
+      },
+    ],
+    var.extra_tags,
+  )
+}
+
+
+resource "aws_autoscaling_group" "fail" {
+  name                 = "foobar3-terraform-test"
+  max_size             = 5
+  min_size             = 2
+  launch_configuration = aws_launch_configuration.foobar.name
+  vpc_zone_identifier  = [aws_subnet.example1.id, aws_subnet.example2.id]
+}

--- a/tests/terraform/checks/resource/aws/test_AutoScalingTagging.py
+++ b/tests/terraform/checks/resource/aws/test_AutoScalingTagging.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.AutoScalingTagging import check
+from checkov.terraform.runner import Runner
+
+class TestAutoScalingTagging(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_AutoScalingTagging"
+        report = runner.run(
+            root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
+        )
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_autoscaling_group.passtag",
+            "aws_autoscaling_group.passtags",  
+        }
+        failing_resources = {
+            "aws_autoscaling_group.fail"
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Tag are used differently in this resource and should pass attribute to launch configs for tagging