### PR TITLE
Fix CKV_AWS_131 check for network load balancers

### DIFF
--- a/checkov/terraform/checks/resource/aws/ALBDropHttpHeaders.py
+++ b/checkov/terraform/checks/resource/aws/ALBDropHttpHeaders.py
@@ -3,21 +3,20 @@ from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class ALBDropHttpHeaders(BaseResourceValueCheck):
-
     def __init__(self):
         name = "Ensure that ALB drops HTTP headers"
         id = "CKV_AWS_131"
-        supported_resources = ['aws_lb', 'aws_alb']
+        supported_resources = ["aws_lb", "aws_alb"]
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if conf.get('load_balancer_type') == 'network':
+        if conf.get("load_balancer_type") == ["network"]:
             return CheckResult.UNKNOWN
         return super().scan_resource_conf(conf)
 
     def get_inspected_key(self):
-        return 'drop_invalid_header_fields'
+        return "drop_invalid_header_fields"
 
 
 check = ALBDropHttpHeaders()

--- a/tests/terraform/checks/resource/aws/example_ALBDropHttpHeaders/main.tf
+++ b/tests/terraform/checks/resource/aws/example_ALBDropHttpHeaders/main.tf
@@ -1,0 +1,62 @@
+# pass
+
+resource "aws_lb" "enabled" {
+  internal           = false
+  load_balancer_type = "application"
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+
+  drop_invalid_header_fields = true
+}
+
+resource "aws_alb" "enabled" {
+  internal           = false
+  load_balancer_type = "application"
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+
+  drop_invalid_header_fields = true
+}
+
+# failure
+
+resource "aws_lb" "default" {
+  internal           = false
+  load_balancer_type = "application"
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+}
+
+resource "aws_alb" "default" {
+  internal           = false
+  load_balancer_type = "application"
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+}
+
+resource "aws_lb" "disabled" {
+  internal           = false
+  load_balancer_type = "application"
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+
+  drop_invalid_header_fields = false
+}
+
+resource "aws_alb" "disabled" {
+  internal           = false
+  load_balancer_type = "application"
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+
+  drop_invalid_header_fields = false
+}
+
+# unknown
+
+resource "aws_lb" "default" {
+  internal           = false
+  load_balancer_type = "network"
+  name               = "nlb"
+  subnets            = var.public_subnet_ids
+}

--- a/tests/terraform/checks/resource/aws/test_ALBDropHttpHeaders.py
+++ b/tests/terraform/checks/resource/aws/test_ALBDropHttpHeaders.py
@@ -1,54 +1,42 @@
+import os
 import unittest
 
-import hcl2
-
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.ALBDropHttpHeaders import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
-class TestLBDeletionProtection(unittest.TestCase):
+class TestALBDropHttpHeaders(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
 
-    def test_failure(self):
-        hcl_res = hcl2.loads("""
-                resource "aws_alb" "test_failed" {
-                    name               = "test-lb-tf"
-                    internal           = false
-                    load_balancer_type = "network"
-                    subnets            = aws_subnet.public.*.id
-                    drop_invalid_header_fields = false
-                }
-                """)
-        resource_conf = hcl_res['resource'][0]['aws_alb']['test_failed']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        test_files_dir = current_dir + "/example_ALBDropHttpHeaders"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-    def test_failure_missing_attribute(self):
-        hcl_res = hcl2.loads("""
-                   resource "aws_alb" "test_failed" {
-                       name               = "test-lb-tf"
-                       internal           = false
-                       load_balancer_type = "network"
-                       subnets            = aws_subnet.public.*.id
-                   }
-                   """)
-        resource_conf = hcl_res['resource'][0]['aws_alb']['test_failed']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passing_resources = {
+            "aws_lb.enabled",
+            "aws_alb.enabled",
+        }
+        failing_resources = {
+            "aws_lb.default",
+            "aws_alb.default",
+            "aws_lb.disabled",
+            "aws_alb.disabled",
+        }
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-               resource "aws_alb" "test_success" {
-                    name               = "test-lb-tf"
-                    internal           = false
-                    load_balancer_type = "network"
-                    subnets            = aws_subnet.public.*.id
-                    drop_invalid_header_fields = true
-                }
-                """)
-        resource_conf = hcl_res['resource'][0]['aws_alb']['test_success']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

The check sadly had missing square brackets, that's why it reported incorrectly for network load balancers. The tests were also incorrect so I fixed and changed them to use the runner instead.