### PR TITLE
Set correct file path for BC cli s3 file upload

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -229,7 +229,7 @@ class BcPlatformIntegration(object):
     def _persist_file(self, full_file_path, relative_file_path):
         tries = 4
         curr_try = 0
-        file_object_key = os.path.join(self.repo_path, relative_file_path)
+        file_object_key = os.path.join(self.repo_path, relative_file_path).replace("\\", "/")
         while curr_try < tries:
             try:
                 self.s3_client.upload_file(full_file_path, self.bucket, file_object_key)


### PR DESCRIPTION
Replace all backslash created by os.path.join on windows with forward slash.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
