### PR TITLE
Don't fail if command is set

### DIFF
--- a/checkov/kubernetes/checks/KubeControllerManagerBlockProfiles.py
+++ b/checkov/kubernetes/checks/KubeControllerManagerBlockProfiles.py
@@ -21,7 +21,7 @@ class KubeControllerManagerBlockProfiles(BaseK8Check):
                         value = command.split("=")[1]
                         if value == 'false':
                             return CheckResult.PASSED
-            return CheckResult.FAILED
+                return CheckResult.FAILED
         return CheckResult.PASSED
 
 

--- a/checkov/kubernetes/checks/KubeControllerManagerTerminatedPods.py
+++ b/checkov/kubernetes/checks/KubeControllerManagerTerminatedPods.py
@@ -23,7 +23,7 @@ class KubeControllerManagerTerminatedPods(BaseK8Check):
                             return CheckResult.PASSED
                         else:
                             return CheckResult.FAILED
-            return CheckResult.FAILED
+                return CheckResult.FAILED
         return CheckResult.PASSED
 
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


Currently checkov will fail if `command` is on your pod, even if it is not set to `kube-controller-manager`.  This PR will tell these checks to not fail unless the command contains `kube-controller-manager`.