### PR TITLE
Fix file paths for calculating fixes when there are graph records

### DIFF
--- a/checkov/common/output/graph_record.py
+++ b/checkov/common/output/graph_record.py
@@ -7,7 +7,7 @@ class GraphRecord(Record):
     def __init__(self, record, breadcrumbs):
         super().__init__(record.check_id, record.check_name, record.check_result, record.code_block, record.file_path,
                          record.file_line_range, record.resource, record.evaluations, record.check_class,
-                         record.repo_file_path, record.entity_tags, record.caller_file_path,
+                         record.file_abs_path, record.entity_tags, record.caller_file_path,
                          record.caller_file_line_range)
         self.fixed_definition = record.fixed_definition
         self.breadcrumbs = breadcrumbs

--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -38,6 +38,7 @@ class Record:
         self.check_result = check_result
         self.code_block = code_block
         self.file_path = file_path
+        self.file_abs_path = file_abs_path
         self.repo_file_path = f'/{os.path.relpath(file_abs_path)}' # matches file paths given in the BC platform.
         self.file_line_range = file_line_range
         self.resource = resource


### PR DESCRIPTION
`GraphRecord` objects invoke the super `Record` constructor by unpacking `Record`'s properties and passing them as params. The `Record` constructor calculates a file's path relative to the root / working directory, which allows it to match up files with the platform for calculating suppressions. To do this, it uses the absolute path that gets passed into the constructor and stores the result in `repo_file_path`.

However, it does not store the absolute path. This means that for `GraphRecord` objects, there is no known absolute path available. So it passes in `repo_file_path`. This results in calculating a relative path to `repo_file_path` (e.g., `/file.tf` ) from the file being sanned (`<working dir>/file.tf`), which results in a path that looks like `'/../../../../../../storage.tf'`. But this isn't an actual path, so the fixes logic bombs out when it tries to read this file to send it to the API.

So this PR simply saves the absolute path that gets passed in originally so that `GraphRecord` can pass it to `Record`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
