### PR TITLE
allow boolean or string for Dynamo point in time recovery

### DIFF
--- a/checkov/terraform/checks/resource/aws/DynamodbRecovery.py
+++ b/checkov/terraform/checks/resource/aws/DynamodbRecovery.py
@@ -13,5 +13,8 @@ class DynamodbRecovery(BaseResourceValueCheck):
     def get_inspected_key(self):
         return "point_in_time_recovery/[0]/enabled"
 
+    def get_expected_values(self):
+        return [self.get_expected_value(), 'true']  # terraformer exports this as the string 'true'
+
 
 check = DynamodbRecovery()


### PR DESCRIPTION
Terraformer exports Dynamo point_in_time_recovery.enabled as a string, `'true'`, and not a boolean. This breaks the check.

We need to update Terraformer for this, but this is the fastest workaround. The check is valid, because Terraformer allows this value to be a string.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
