### PR TITLE
Fix wrong check imports and add test to prevent future mistakes

### DIFF
--- a/checkov/terraform/checks/resource/aws/KubernetesSecretsEncryptedUsingCMK.py
+++ b/checkov/terraform/checks/resource/aws/KubernetesSecretsEncryptedUsingCMK.py
@@ -1,26 +1,28 @@
-from checkov.arm.base_resource_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class KubernetesSecretsEncryptedUsingCMK(BaseResourceCheck):
     def __init__(self):
         name = "Ensure Kubernetes Secrets are encrypted using Customer Master Keys (CMKs) managed in AWS KMS"
-        id = "CKV_AWS_106"
-        supported_resources = ['aws_eks_cluster']
+        id = "CKV_AWS_151"
+        supported_resources = ["aws_eks_cluster"]
         categories = [CheckCategories.KUBERNETES]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if 'encryption_config' not in conf.keys():
+        if "encryption_config" not in conf.keys():
             return CheckResult.FAILED
         else:
-            encryption_config = conf.get('encryption_config')[0]
-            if 'resources' in encryption_config and 'provider' in encryption_config:
-                resources = encryption_config.get('resources')[0]
-                provider = encryption_config.get('provider')[0]
-                if type(resources) is list:
-                    if 'secrets' in resources and 'key_arn' in provider:
+            encryption_config = conf.get("encryption_config")[0]
+            if "resources" in encryption_config and "provider" in encryption_config:
+                resources = encryption_config.get("resources")[0]
+                provider = encryption_config.get("provider")[0]
+                if isinstance(resources, list):
+                    if "secrets" in resources and "key_arn" in provider:
                         return CheckResult.PASSED
+                    return CheckResult.UNKNOWN
+
         return CheckResult.FAILED
 
 

--- a/checkov/terraform/checks/resource/aws/LBDeletionProtection.py
+++ b/checkov/terraform/checks/resource/aws/LBDeletionProtection.py
@@ -1,18 +1,17 @@
-from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.models.enums import CheckCategories
 
 
 class LBDeletionProtection(BaseResourceValueCheck):
-
     def __init__(self):
         name = "Ensure that Load Balancer has deletion protection enabled"
-        id = "CKV_AWS_113"
-        supported_resources = ['aws_lb', 'aws_alb']
+        id = "CKV_AWS_150"
+        supported_resources = ["aws_lb", "aws_alb"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):
-        return 'enable_deletion_protection'
+        return "enable_deletion_protection"
 
 
 check = LBDeletionProtection()

--- a/checkov/terraform/checks/resource/aws/SecretManagerSecretEncrypted.py
+++ b/checkov/terraform/checks/resource/aws/SecretManagerSecretEncrypted.py
@@ -1,14 +1,13 @@
-from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
-from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
 from checkov.common.models.consts import ANY_VALUE
 
 
 class SecretManagerSecretEncrypted(BaseResourceValueCheck):
-
     def __init__(self):
-        name = "Ensure that Secret Manager secret is encrypted using KMS"
-        id = "CKV_AWS_152"
-        supported_resources = ['aws_secretsmanager_secret']
+        name = "Ensure that Secrets Manager secret is encrypted using KMS"
+        id = "CKV_AWS_149"
+        supported_resources = ["aws_secretsmanager_secret"]
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
@@ -16,7 +15,7 @@ class SecretManagerSecretEncrypted(BaseResourceValueCheck):
         return ANY_VALUE
 
     def get_inspected_key(self):
-        return 'kms_key_id'
+        return "kms_key_id"
 
 
 check = SecretManagerSecretEncrypted()

--- a/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
+++ b/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
@@ -4,7 +4,7 @@ from checkov.common.util.type_forcers import force_list
 import re
 
 INTERNET_ADDRESSES = ["*", "0.0.0.0", "<nw>/0", "/0", "internet", "any"] # nosec
-PORT_RANGE = re.compile('\d+-\d+')
+PORT_RANGE = re.compile(r'\d+-\d+')
 
 
 class NSGRulePortAccessRestricted(BaseResourceCheck):

--- a/checkov/terraform/checks/resource/azure/SQLServerNoPublicAccess.py
+++ b/checkov/terraform/checks/resource/azure/SQLServerNoPublicAccess.py
@@ -2,7 +2,7 @@ from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
 import re
 
-PORT_RANGE = re.compile('\d+-\d+')
+PORT_RANGE = re.compile(r'\d+-\d+')
 
 
 class SQLServerNoPublicAccess(BaseResourceCheck):

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccount.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccount.py
@@ -2,7 +2,7 @@ from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 import re
 
-DEFAULT_SERVICE_ACCOUNT = re.compile('\d+-compute@developer\.gserviceaccount\.com')
+DEFAULT_SERVICE_ACCOUNT = re.compile(r'\d+-compute@developer\.gserviceaccount\.com')
 
 
 class GoogleComputeDefaultServiceAccount(BaseResourceCheck):

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccountFullAccess.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccountFullAccess.py
@@ -2,7 +2,7 @@ from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 import re
 
-DEFAULT_SERVICE_ACCOUNT = re.compile('\d+-compute@developer\.gserviceaccount\.com')
+DEFAULT_SERVICE_ACCOUNT = re.compile(r'\d+-compute@developer\.gserviceaccount\.com')
 FULL_ACCESS_API = 'https://www.googleapis.com/auth/cloud-platform'
 
 

--- a/checkov/terraform/checks/resource/gcp/GoogleProjectAdminServiceAccount.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleProjectAdminServiceAccount.py
@@ -2,7 +2,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 from checkov.common.models.enums import CheckResult, CheckCategories
 import re
 
-USER_MANAGED_SERVICE_ACCOUNT = re.compile ('.*@.*\.iam\.gserviceaccount\.com$')
+USER_MANAGED_SERVICE_ACCOUNT = re.compile (r'.*@.*\.iam\.gserviceaccount\.com$')
 ADMIN_ROLE = re.compile ('.*(.*Admin|.*admin|editor|owner)')
 
 

--- a/tests/arm/runner/test_runner.py
+++ b/tests/arm/runner/test_runner.py
@@ -1,5 +1,8 @@
+import dis
+import inspect
 import os
 import unittest
+from pathlib import Path
 
 from checkov.runner_filter import RunnerFilter
 from checkov.arm.runner import Runner
@@ -95,6 +98,23 @@ class TestRunnerValid(unittest.TestCase):
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
+
+    def test_wrong_check_imports(self):
+        wrong_imports = ["cloudformation", "dockerfile", "helm", "kubernetes", "serverless", "terraform"]
+        check_imports = []
+
+        checks_path = Path(inspect.getfile(Runner)).parent.joinpath("checks")
+        for file in checks_path.rglob("*.py"):
+            with file.open() as f:
+                instructions = dis.get_instructions(f.read())
+                import_names = [instr.argval for instr in instructions if "IMPORT_NAME" == instr.opname]
+
+                for import_name in import_names:
+                    wrong_import = next((import_name for x in wrong_imports if x in import_name), None)
+                    if wrong_import:
+                        check_imports.append({file.name: wrong_import})
+
+        assert len(check_imports) == 0, f"Wrong imports were added: {check_imports}"
 
     def tearDown(self):
         pass

--- a/tests/kubernetes/runner/test_runner.py
+++ b/tests/kubernetes/runner/test_runner.py
@@ -1,5 +1,8 @@
+import dis
+import inspect
 import os
 import unittest
+from pathlib import Path
 
 from checkov.runner_filter import RunnerFilter
 from checkov.kubernetes.runner import Runner
@@ -106,6 +109,23 @@ class TestRunnerValid(unittest.TestCase):
                                 runner_filter=RunnerFilter(framework='kubernetes'))
         except:
             self.assertTrue(False, "Could not run K8 runner on configuration")
+
+    def test_wrong_check_imports(self):
+        wrong_imports = ["arm", "cloudformation", "dockerfile", "helm", "serverless", "terraform"]
+        check_imports = []
+
+        checks_path = Path(inspect.getfile(Runner)).parent.joinpath("checks")
+        for file in checks_path.rglob("*.py"):
+            with file.open() as f:
+                instructions = dis.get_instructions(f.read())
+                import_names = [instr.argval for instr in instructions if "IMPORT_NAME" == instr.opname]
+
+                for import_name in import_names:
+                    wrong_import = next((import_name for x in wrong_imports if x in import_name), None)
+                    if wrong_import:
+                        check_imports.append({file.name: wrong_import})
+
+        assert len(check_imports) == 0, f"Wrong imports were added: {check_imports}"
 
     def tearDown(self):
         pass

--- a/tests/serverless/runner/test_runner.py
+++ b/tests/serverless/runner/test_runner.py
@@ -1,5 +1,8 @@
+import dis
+import inspect
 import os
 import unittest
+from pathlib import Path
 
 from checkov.runner_filter import RunnerFilter
 from checkov.serverless.runner import Runner
@@ -95,6 +98,23 @@ class TestRunnerValid(unittest.TestCase):
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
+
+    def test_wrong_check_imports(self):
+        wrong_imports = ["arm", "cloudformation", "dockerfile", "helm", "kubernetes", "terraform"]
+        check_imports = []
+
+        checks_path = Path(inspect.getfile(Runner)).parent.joinpath("checks")
+        for file in checks_path.rglob("*.py"):
+            with file.open() as f:
+                instructions = dis.get_instructions(f.read())
+                import_names = [instr.argval for instr in instructions if "IMPORT_NAME" == instr.opname]
+
+                for import_name in import_names:
+                    wrong_import = next((import_name for x in wrong_imports if x in import_name), None)
+                    if wrong_import:
+                        check_imports.append({file.name: wrong_import})
+
+        assert len(check_imports) == 0, f"Wrong imports were added: {check_imports}"
 
     def tearDown(self):
         pass

--- a/tests/terraform/checks/resource/aws/example_KubernetesSecretsEncryptedUsingCMK/main.tf
+++ b/tests/terraform/checks/resource/aws/example_KubernetesSecretsEncryptedUsingCMK/main.tf
@@ -1,0 +1,46 @@
+# pass
+
+resource "aws_eks_cluster" "enabled" {
+  name     = "eks"
+  role_arn = var.role_arn
+
+  vpc_config {
+    subnet_ids = var.subnet_ids
+  }
+
+  encryption_config {
+    resources = ["secrets"]
+    provider {
+      key_arn = var.key_arn
+    }
+  }
+}
+
+# failure
+
+resource "aws_eks_cluster" "default" {
+  name     = "eks"
+  role_arn = var.role_arn
+
+  vpc_config {
+    subnet_ids = var.subnet_ids
+  }
+}
+
+# unknown
+
+resource "aws_eks_cluster" "not_secrets" {
+  name     = "eks"
+  role_arn = var.role_arn
+
+  vpc_config {
+    subnet_ids = var.subnet_ids
+  }
+
+  encryption_config {
+    resources = ["something"]
+    provider {
+      key_arn = var.key_arn
+    }
+  }
+}

--- a/tests/terraform/checks/resource/aws/example_LBDeletionProtection/main.tf
+++ b/tests/terraform/checks/resource/aws/example_LBDeletionProtection/main.tf
@@ -6,7 +6,7 @@ resource "aws_lb" "enabled" {
   name               = "alb"
   subnets            = var.public_subnet_ids
 
-  drop_invalid_header_fields = true
+  enable_deletion_protection = true
 }
 
 resource "aws_alb" "enabled" {
@@ -15,7 +15,7 @@ resource "aws_alb" "enabled" {
   name               = "alb"
   subnets            = var.public_subnet_ids
 
-  drop_invalid_header_fields = true
+  enable_deletion_protection = true
 }
 
 # failure
@@ -40,7 +40,7 @@ resource "aws_lb" "disabled" {
   name               = "alb"
   subnets            = var.public_subnet_ids
 
-  drop_invalid_header_fields = false
+  enable_deletion_protection = false
 }
 
 resource "aws_alb" "disabled" {
@@ -49,14 +49,5 @@ resource "aws_alb" "disabled" {
   name               = "alb"
   subnets            = var.public_subnet_ids
 
-  drop_invalid_header_fields = false
-}
-
-# unknown
-
-resource "aws_lb" "network" {
-  internal           = false
-  load_balancer_type = "network"
-  name               = "nlb"
-  subnets            = var.public_subnet_ids
+  enable_deletion_protection = false
 }

--- a/tests/terraform/checks/resource/aws/example_SecretManagerSecretEncrypted/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SecretManagerSecretEncrypted/main.tf
@@ -1,0 +1,13 @@
+# pass
+
+resource "aws_secretsmanager_secret" "enabled" {
+  name = "secret"
+
+  kms_key_id = var.kms_key_id
+}
+
+# failure
+
+resource "aws_secretsmanager_secret" "default" {
+  name = "secret"
+}

--- a/tests/terraform/checks/resource/aws/test_KubernetesSecretsEncryptedUsingCMK.py
+++ b/tests/terraform/checks/resource/aws/test_KubernetesSecretsEncryptedUsingCMK.py
@@ -1,71 +1,38 @@
+import os
 import unittest
 
-import hcl2
-
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.KubernetesSecretsEncryptedUsingCMK import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestKubernetesSecretsEncryptedUsingCMK(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
 
-    def test_failure1(self):
-        hcl_res = hcl2.loads("""
-            resource "aws_eks_cluster" "test" {
-              name     = "example"
-              role_arn = aws_iam_role.example.arn
-            
-              vpc_config {
-                    subnet_ids = [aws_subnet.example1.id, aws_subnet.example2.id]
-                }
-              }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_eks_cluster']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        test_files_dir = current_dir + "/example_KubernetesSecretsEncryptedUsingCMK"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-    def test_failure2(self):
-        hcl_res = hcl2.loads("""
-            resource "aws_eks_cluster" "test" {
-              name     = "example"
-              role_arn = aws_iam_role.example.arn
+        passing_resources = {
+            "aws_eks_cluster.enabled",
+        }
+        failing_resources = {
+            "aws_eks_cluster.default",
+        }
 
-              vpc_config {
-                    subnet_ids = [aws_subnet.example1.id, aws_subnet.example2.id]
-                }
-             encryption_config {
-                            resources = ["test"]
-                            provider {
-                                key_arn = "test"
-                             }
-                      }   
-              }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_eks_cluster']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-                    resource "aws_eks_cluster" "test" {
-                      name     = "example"
-                      role_arn = aws_iam_role.example.arn
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
 
-                      vpc_config {
-                        subnet_ids = [aws_subnet.example1.id, aws_subnet.example2.id]
-                      }
-                      
-                      encryption_config {
-                            resources = ["secrets"]
-                            provider {
-                                key_arn = "test"
-                             }
-                      }
-                    }
-                """)
-        resource_conf = hcl_res['resource'][0]['aws_eks_cluster']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/resource/aws/test_LBDeletionProtection.py
+++ b/tests/terraform/checks/resource/aws/test_LBDeletionProtection.py
@@ -1,54 +1,42 @@
+import os
 import unittest
 
-import hcl2
-
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.LBDeletionProtection import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestLBDeletionProtection(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
 
-    def test_failure(self):
-        hcl_res = hcl2.loads("""
-                resource "aws_lb" "test_failed" {
-                    name               = "test-lb-tf"
-                    internal           = false
-                    load_balancer_type = "network"
-                    subnets            = aws_subnet.public.*.id
-                    enable_deletion_protection = false
-                }
-                """)
-        resource_conf = hcl_res['resource'][0]['aws_lb']['test_failed']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        test_files_dir = current_dir + "/example_LBDeletionProtection"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-    def test_failure_missing_attribute(self):
-        hcl_res = hcl2.loads("""
-                   resource "aws_lb" "test_failed" {
-                       name               = "test-lb-tf"
-                       internal           = false
-                       load_balancer_type = "network"
-                       subnets            = aws_subnet.public.*.id
-                   }
-                   """)
-        resource_conf = hcl_res['resource'][0]['aws_lb']['test_failed']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passing_resources = {
+            "aws_lb.enabled",
+            "aws_alb.enabled",
+        }
+        failing_resources = {
+            "aws_lb.default",
+            "aws_alb.default",
+            "aws_lb.disabled",
+            "aws_alb.disabled",
+        }
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-               resource "aws_lb" "test_success" {
-                    name               = "test-lb-tf"
-                    internal           = false
-                    load_balancer_type = "network"
-                    subnets            = aws_subnet.public.*.id
-                    enable_deletion_protection = true
-                }
-                """)
-        resource_conf = hcl_res['resource'][0]['aws_lb']['test_success']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/resource/aws/test_SecretManagerSecretEncrypted.py
+++ b/tests/terraform/checks/resource/aws/test_SecretManagerSecretEncrypted.py
@@ -1,33 +1,38 @@
+import os
 import unittest
-import hcl2
 
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.SecretManagerSecretEncrypted import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
-class TestSSMSecretEncrypted(unittest.TestCase):
+class TestSecretManagerSecretEncrypted(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
 
-    def test_failure(self):
-        hcl_res = hcl2.loads("""
-            resource "aws_secretsmanager_secret" "example" {
-              name = "example"
-            }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_secretsmanager_secret']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        test_files_dir = current_dir + "/example_SecretManagerSecretEncrypted"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-            resource "aws_secretsmanager_secret" "example" {
-              name = "example"
-              kms_key_id = "arn:kuku:kisi"
-            }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_secretsmanager_secret']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passing_resources = {
+            "aws_secretsmanager_secret.enabled",
+        }
+        failing_resources = {
+            "aws_secretsmanager_secret.default",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -55,8 +55,19 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
         self.assertEqual(report.get_exit_code(soft_fail=True), 0)
 
-        self.assertEqual(report.get_summary()["failed"], 12)
+        self.assertEqual(report.get_summary()["failed"], 15)
         self.assertEqual(report.get_summary()["passed"], 0)
+
+        failed_check_ids = set([c.check_id for c in report.failed_checks])
+        expected_failed_check_ids = {
+            "CKV_AWS_37",
+            "CKV_AWS_38",
+            "CKV_AWS_39",
+            "CKV_AWS_58",
+            "CKV_AWS_151",
+        }
+
+        assert failed_check_ids == expected_failed_check_ids
 
     def test_runner_root_module_resources_no_values(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -74,8 +85,19 @@ class TestRunnerValid(unittest.TestCase):
         # 4 checks fail on test data for single eks resource as of present
         # If more eks checks are added then this number will need to increase correspondingly to reflect
         # This reasoning holds for all current pass/fails in these tests
-        self.assertEqual(report.get_summary()["failed"], 4)
+        self.assertEqual(report.get_summary()["failed"], 5)
         self.assertEqual(report.get_summary()["passed"], 0)
+
+        failed_check_ids = set([c.check_id for c in report.failed_checks])
+        expected_failed_check_ids = {
+            "CKV_AWS_37",
+            "CKV_AWS_38",
+            "CKV_AWS_39",
+            "CKV_AWS_58",
+            "CKV_AWS_151",
+        }
+
+        assert failed_check_ids == expected_failed_check_ids
 
     def test_runner_data_resource_partial_values(self):
         # In rare circumstances a data resource with partial values in the plan could cause false negatives
@@ -101,8 +123,19 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
         self.assertEqual(report.get_exit_code(soft_fail=True), 0)
 
-        self.assertEqual(report.get_summary()["failed"], 4)
+        self.assertEqual(report.get_summary()["failed"], 5)
         self.assertEqual(report.get_summary()["passed"], 0)
+
+        failed_check_ids = set([c.check_id for c in report.failed_checks])
+        expected_failed_check_ids = {
+            "CKV_AWS_37",
+            "CKV_AWS_38",
+            "CKV_AWS_39",
+            "CKV_AWS_58",
+            "CKV_AWS_151",
+        }
+
+        assert failed_check_ids == expected_failed_check_ids
 
     def test_runner_root_dir(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

During work on a new check I realized there was a gab between the last check number and the previous one, which actually surprised me, because there is a test which tries to prevent it. After further investigation, I found the culprit and I even discovered that one of the checks imported the wrong parent check class. Therefore I added a test, which checks, to prevent future mistakes. And the test even found two other miss configured checks 💪 

I also adjusted the check `KubernetesSecretsEncryptedUsingCMK` to return an `UNKNOWN` result, if the encryption config is pointing to an other resource, which at the moment is not possible, because the only possible value is `secrets`.
