### PR TITLE
Fix lb checks for gateway lb

### DIFF
--- a/checkov/terraform/checks/resource/aws/ALBDropHttpHeaders.py
+++ b/checkov/terraform/checks/resource/aws/ALBDropHttpHeaders.py
@@ -11,7 +11,7 @@ class ALBDropHttpHeaders(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if conf.get("load_balancer_type") == ["network"]:
+        if conf.get("load_balancer_type") in (["gateway"], ["network"]):
             return CheckResult.UNKNOWN
         return super().scan_resource_conf(conf)
 

--- a/checkov/terraform/checks/resource/aws/ELBv2AccessLogs.py
+++ b/checkov/terraform/checks/resource/aws/ELBv2AccessLogs.py
@@ -6,12 +6,17 @@ class ELBv2AccessLogs(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure the ELBv2 (Application/Network) has access logging enabled"
         id = "CKV_AWS_91"
-        supported_resources = ['aws_lb', 'aws_alb']
+        supported_resources = ["aws_lb", "aws_alb"]
         categories = [CheckCategories.LOGGING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):
-        return 'access_logs/0/enabled/0'
+        return "access_logs/0/enabled/0"
+
+    def scan_resource_conf(self, conf):
+        if conf.get("load_balancer_type") == ["gateway"]:
+            return CheckResult.UNKNOWN
+        return super().scan_resource_conf(conf)
 
 
 check = ELBv2AccessLogs()

--- a/tests/terraform/checks/resource/aws/example_ALBDropHttpHeaders/main.tf
+++ b/tests/terraform/checks/resource/aws/example_ALBDropHttpHeaders/main.tf
@@ -60,3 +60,12 @@ resource "aws_lb" "default" {
   name               = "nlb"
   subnets            = var.public_subnet_ids
 }
+
+resource "aws_lb" "gateway" {
+  load_balancer_type = "gateway"
+  name               = "glb"
+
+  subnet_mapping {
+    subnet_id = var.subnet_id
+  }
+}

--- a/tests/terraform/checks/resource/aws/example_ELBv2AccessLogs/main.tf
+++ b/tests/terraform/checks/resource/aws/example_ELBv2AccessLogs/main.tf
@@ -1,0 +1,91 @@
+# pass
+
+resource "aws_lb" "enabled" {
+  load_balancer_type = "network"
+  name               = "nlb"
+  subnets            = var.public_subnet_ids
+
+  access_logs {
+    bucket  = var.bucket_name
+    enabled = true
+  }
+}
+
+resource "aws_alb" "enabled" {
+  load_balancer_type = "application"
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+
+  access_logs {
+    bucket  = var.bucket_name
+    enabled = true
+  }
+}
+
+# failure
+
+resource "aws_lb" "default" {
+  load_balancer_type = "network"
+  name               = "nlb"
+  subnets            = var.public_subnet_ids
+}
+
+resource "aws_alb" "default" {
+  load_balancer_type = "application"
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+}
+
+resource "aws_lb" "only_bucket" {
+  load_balancer_type = "network"
+  name               = "nlb"
+  subnets            = var.public_subnet_ids
+
+  access_logs {
+    bucket = var.bucket_name
+  }
+}
+
+resource "aws_alb" "only_bucket" {
+  load_balancer_type = "application"
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+
+  access_logs {
+    bucket = var.bucket_name
+  }
+}
+
+resource "aws_lb" "disabled" {
+  load_balancer_type = "network"
+  name               = "nlb"
+  subnets            = var.public_subnet_ids
+
+  access_logs {
+    bucket  = var.bucket_name
+    enabled = false
+  }
+}
+
+resource "aws_alb" "disabled" {
+  load_balancer_type = "application"
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+
+  access_logs {
+    bucket  = var.bucket_name
+    enabled = false
+  }
+}
+
+# unknown
+
+resource "aws_lb" "gateway" {
+  name = "glb"
+  load_balancer_type = "gateway"
+
+  subnet_mapping {
+    subnet_id = var.subnet_id
+  }
+}
+

--- a/tests/terraform/checks/resource/aws/test_ELBv2AccessLogs.py
+++ b/tests/terraform/checks/resource/aws/test_ELBv2AccessLogs.py
@@ -1,119 +1,44 @@
+import os
 import unittest
-import hcl2
 
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.ELBv2AccessLogs import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
-class TestELBAccessLogs(unittest.TestCase):
+class TestELBv2AccessLogs(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
 
-    def test_failure_lb_1(self):
-        hcl_res = hcl2.loads("""
-          resource "aws_lb" "test" {
-            name               = "test-lb-tf"
+        test_files_dir = current_dir + "/example_ELBv2AccessLogs"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-            access_logs {
-              bucket  = aws_s3_bucket.lb_logs.bucket
-            }
-          }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_lb']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passing_resources = {
+            "aws_lb.enabled",
+            "aws_alb.enabled",
+        }
+        failing_resources = {
+            "aws_lb.default",
+            "aws_alb.default",
+            "aws_lb.only_bucket",
+            "aws_alb.only_bucket",
+            "aws_lb.disabled",
+            "aws_alb.disabled",
+        }
 
-    def test_failure_lb_2(self):
-        hcl_res = hcl2.loads("""
-          resource "aws_lb" "test" {
-            name               = "test-lb-tf"
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
 
-            access_logs {
-              bucket  = aws_s3_bucket.lb_logs.bucket
-              enabled = false
-            }
-          }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_lb']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 6)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
 
-    def test_failure_lb_3(self):
-        hcl_res = hcl2.loads("""
-          resource "aws_lb" "test" {
-            name               = "test-lb-tf"
-          }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_lb']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)        
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
-    def test_failure_alb_1(self):
-        hcl_res = hcl2.loads("""
-          resource "aws_alb" "test" {
-            name               = "test-lb-tf"
 
-            access_logs {
-              bucket  = aws_s3_bucket.lb_logs.bucket
-            }
-          }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_alb']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
-
-    def test_failure_alb_2(self):
-        hcl_res = hcl2.loads("""
-          resource "aws_alb" "test" {
-            name               = "test-lb-tf"
-
-            access_logs {
-              bucket  = aws_s3_bucket.lb_logs.bucket
-              enabled = false
-            }
-          }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_alb']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
-
-    def test_failure_alb_3(self):
-        hcl_res = hcl2.loads("""
-          resource "aws_alb" "test" {
-            name               = "test-lb-tf"
-          }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_alb']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
-
-    def test_success_lb(self):
-        hcl_res = hcl2.loads("""
-          resource "aws_lb" "test" {
-            name               = "test-lb-tf"
-
-            access_logs {
-              bucket  = aws_s3_bucket.lb_logs.bucket
-              enabled = true
-            }
-          }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_lb']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
-
-    def test_success_alb(self):
-        hcl_res = hcl2.loads("""
-          resource "aws_alb" "test" {
-            name               = "test-lb-tf"
-
-            access_logs {
-              bucket  = aws_s3_bucket.lb_logs.bucket
-              enabled = true
-            }
-          }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_alb']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

AWS Gateway Load Balancers are very similar to NLBs that's why there are no HTTP headers to drop and they don't support logging at all.

https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/monitoring.html
_However, the Gateway Load Balancer does not generate access logs since it is a transparent layer 3 load balancer that does not terminate flows._