### PR TITLE
Add jsonencode parsing

### DIFF
--- a/checkov/arm/checks/resource/NSGRulePortAccessRestricted.py
+++ b/checkov/arm/checks/resource/NSGRulePortAccessRestricted.py
@@ -14,7 +14,7 @@ import re
 # https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networksecuritygroups/securityrules
 
 INTERNET_ADDRESSES = ["*", "0.0.0.0", "<nw>/0", "/0", "internet", "any"] # nosec
-PORT_RANGE = re.compile('\d+-\d+')
+PORT_RANGE = re.compile(r"\d+-\d+")
 
 class NSGRulePortAccessRestricted(BaseResourceCheck):
     def __init__(self, name, check_id, port):

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -25,7 +25,7 @@ from checkov.common.bridgecrew.wrapper import reduce_scan_reports, persist_check
 from checkov.common.models.consts import SUPPORTED_FILE_EXTENSIONS
 from checkov.version import version as checkov_version
 
-EMAIL_PATTERN = "[^@]+@[^@]+\.[^@]+"
+EMAIL_PATTERN = r"[^@]+@[^@]+\.[^@]+"
 
 ACCOUNT_CREATION_TIME = 180  # in seconds
 

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -113,7 +113,7 @@ class Report:
         print(xml_string)
 
     def get_junit_xml_string(self, ts):
-        return TestSuite.to_xml_string(ts)
+        return TestSuite.to_xml_report_string(ts)
 
     def print_failed_github_md(self):
         result = []

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -2,7 +2,7 @@ import json
 from collections import defaultdict
 
 from colorama import init
-from junit_xml import TestCase, TestSuite
+from junit_xml import TestCase, TestSuite, to_xml_report_string
 from termcolor import colored
 
 from checkov.common.models.enums import CheckResult
@@ -113,7 +113,7 @@ class Report:
         print(xml_string)
 
     def get_junit_xml_string(self, ts):
-        return TestSuite.to_xml_report_string(ts)
+        return to_xml_report_string(ts)
 
     def print_failed_github_md(self):
         result = []

--- a/checkov/serverless/base_registry.py
+++ b/checkov/serverless/base_registry.py
@@ -1,4 +1,4 @@
-from collections import Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 from checkov.common.checks.base_check_registry import BaseCheckRegistry

--- a/checkov/serverless/parsers/parser.py
+++ b/checkov/serverless/parsers/parser.py
@@ -24,7 +24,7 @@ STACK_TAGS_TOKEN = 'stackTags' #nosec
 TAGS_TOKEN = 'tags' #nosec
 SUPPORTED_PROVIDERS = ['aws']
 
-DEFAULT_VAR_PATTERN = r"\\${([^{}]+?)}"
+DEFAULT_VAR_PATTERN = r"\${([^{}]+?)}"
 QUOTED_WORD_SYNTAX = re.compile(r"(?:('|\").*?\1)")
 FILE_LOCATION_PATTERN = re.compile(r'^file\(([^?%*:|"<>]+?)\)')
 

--- a/checkov/serverless/parsers/parser.py
+++ b/checkov/serverless/parsers/parser.py
@@ -24,7 +24,7 @@ STACK_TAGS_TOKEN = 'stackTags' #nosec
 TAGS_TOKEN = 'tags' #nosec
 SUPPORTED_PROVIDERS = ['aws']
 
-DEFAULT_VAR_PATTERN = "\\${([^{}]+?)}"
+DEFAULT_VAR_PATTERN = r"\\${([^{}]+?)}"
 QUOTED_WORD_SYNTAX = re.compile(r"(?:('|\").*?\1)")
 FILE_LOCATION_PATTERN = re.compile(r'^file\(([^?%*:|"<>]+?)\)')
 

--- a/checkov/terraform/checks/resource/gcp/AbsGoogleIAMMemberDefaultServiceAccount.py
+++ b/checkov/terraform/checks/resource/gcp/AbsGoogleIAMMemberDefaultServiceAccount.py
@@ -5,7 +5,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 
 # Default Compute -compute@developer.gserviceaccount.com
 # Default App Spot @appspot.gserviceaccount.com
-DEFAULT_SA = re.compile(".*-compute@developer\.gserviceaccount\.com|.*@appspot\.gserviceaccount\.com")
+DEFAULT_SA = re.compile(r".*-compute@developer\.gserviceaccount\.com|.*@appspot\.gserviceaccount\.com")
 
 
 class AbsGoogleIAMMemberDefaultServiceAccount(BaseResourceCheck):

--- a/checkov/terraform/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/variable_rendering/evaluate_terraform.py
@@ -36,6 +36,7 @@ def evaluate_terraform(input_str, keep_interpolations=True):
     evaluated_value = evaluate_directives(evaluated_value)
     evaluated_value = evaluate_conditional_expression(evaluated_value)
     evaluated_value = evaluate_compare(evaluated_value)
+    evaluated_value = evaluate_json_types(evaluated_value)
     second_evaluated_value = _try_evaluate(evaluated_value)
 
     return evaluated_value if callable(second_evaluated_value) else second_evaluated_value
@@ -125,6 +126,14 @@ def evaluate_compare(input_str):
                 return apply_binary_op(evaluate_terraform(a), evaluate_terraform(b), op)
             except TypeError or SyntaxError:
                 return input_str
+
+    return input_str
+
+
+def evaluate_json_types(input_str: str) -> str:
+    # https://www.terraform.io/docs/language/functions/jsonencode.html
+    if input_str.startswith("jsonencode("):
+        return input_str.replace("true", "True").replace("false", "False").replace("null", "None")
 
     return input_str
 

--- a/checkov/terraform/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/variable_rendering/evaluate_terraform.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 from checkov.terraform.variable_rendering.safe_eval_functions import SAFE_EVAL_DICT
 # condition ? true_val : false_val -> (condition, true_val, false_val)
@@ -130,9 +131,9 @@ def evaluate_compare(input_str):
     return input_str
 
 
-def evaluate_json_types(input_str: str) -> str:
+def evaluate_json_types(input_str: Any) -> str:
     # https://www.terraform.io/docs/language/functions/jsonencode.html
-    if input_str.startswith("jsonencode("):
+    if isinstance(input_str, str) and input_str.startswith("jsonencode("):
         return input_str.replace("true", "True").replace("false", "False").replace("null", "None")
 
     return input_str

--- a/checkov/terraform/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/variable_rendering/safe_eval_functions.py
@@ -176,3 +176,6 @@ SAFE_EVAL_DICT['tomap'] = lambda arg: wrap_func(tomap, str(arg))
 SAFE_EVAL_DICT['tonumber'] = lambda arg: arg if type(arg) in [int, float] else wrap_func(tonumber, arg)
 SAFE_EVAL_DICT['toset'] = lambda origin: set(origin)
 SAFE_EVAL_DICT['tostring'] = lambda arg: arg if isinstance(arg, str) else wrap_func(tostring, str(arg))
+
+# encoding
+SAFE_EVAL_DICT['jsonencode'] = lambda arg: arg

--- a/tests/common/checks/test_base_check.py
+++ b/tests/common/checks/test_base_check.py
@@ -6,6 +6,8 @@ from checkov.common.models.enums import CheckResult
 
 
 class TestCheckTypeNotInSignature(BaseCheck):
+    # for pytest not to collect this class as tests
+    __test__ = False
 
     def __init__(self):
         name = "Example check"

--- a/tests/common/checks/test_base_check_registry.py
+++ b/tests/common/checks/test_base_check_registry.py
@@ -5,6 +5,8 @@ from checkov.common.checks.base_check_registry import BaseCheckRegistry
 
 
 class TestCheck(BaseCheck):
+    # for pytest not to collect this class as tests
+    __test__ = False
 
     def __init__(self, *supported_entities, id="CKV_T_1"):
         name = "Example check"

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -28,14 +28,14 @@ class TestBCApiUrl(unittest.TestCase):
         instance = BcPlatformIntegration()
         instance.setup_http_manager()
         instance.get_id_mapping()
-        self.assertEquals(None,instance.ckv_to_bc_id_mapping)
+        self.assertEqual(None,instance.ckv_to_bc_id_mapping)
 
     @mock.patch.dict(os.environ, {'BC_SKIP_MAPPING': 'FALSE'})
     def test_skip_mapping_false(self):
         instance = BcPlatformIntegration()
         instance.setup_http_manager()
         instance.get_id_mapping()
-        self.assertNotEquals(None,instance.ckv_to_bc_id_mapping)
+        self.assertNotEqual(None,instance.ckv_to_bc_id_mapping)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/graph/terraform/variable_rendering/test_string_evaluation.py
+++ b/tests/graph/terraform/variable_rendering/test_string_evaluation.py
@@ -55,7 +55,7 @@ class TestTerraformEvaluation(TestCase):
         expected = {"authority":"terraform.io", "scheme" : "https"}
         self.assertEqual(expected, evaluate_terraform(input_str))
 
-        input_str = 'regex("(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)", "2019-02-01")'
+        input_str = 'regex(r"(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)", "2019-02-01")'
         expected = ["2019","02","01"]
         self.assertEqual(expected, evaluate_terraform(input_str))
 
@@ -273,3 +273,20 @@ class TestTerraformEvaluation(TestCase):
         replaced = remove_interpolation(original_str)
         expected = 'merge(local.common_tags,local.common_data_tags,{\'Name\':\'Bob-local.static1-local.static2\'})'
         self.assertEqual(expected, replaced)
+
+    def test_jsonencode(self):
+        cases = [
+            ("jsonencode(['a', 42, true, null])", ["a", 42, True, None]),
+            ("jsonencode({'a': 'b'})", {"a": "b"}),
+            ("jsonencode({'a' = 'b'})", {"a": "b"}),
+            ("jsonencode({'a' = 42})", {"a": 42}),
+            ("jsonencode({'a' = true})", {"a": True}),
+            ("jsonencode({'a' = false})", {"a": False}),
+            ("jsonencode({'a' = null})", {"a": None}),
+            ("jsonencode({'a' = ['b', 'c']})", {"a": ["b", "c"]}),
+            ("jsonencode({'a' = jsonencode(['b', 'c'])})", {"a": ["b", "c"]}),
+        ]
+
+        for input_str, expected in cases:
+            with self.subTest(input_str):
+                assert evaluate_terraform(input_str) == expected

--- a/tests/terraform/checks/resource/test_base_resource_value_check.py
+++ b/tests/terraform/checks/resource/test_base_resource_value_check.py
@@ -7,6 +7,9 @@ from checkov.terraform.checks.resource.registry import resource_registry
 
 
 class TestAnyCheck(BaseResourceValueCheck):
+    # for pytest not to collect this class as tests
+    __test__ = False
+
     def __init__(self):
         super().__init__("Ensure it ain't broke", "test/TestAnyCheck", [], ["doesnt_matter"])
 
@@ -18,6 +21,9 @@ class TestAnyCheck(BaseResourceValueCheck):
 
 
 class TestStaticCheck(BaseResourceValueCheck):
+    # for pytest not to collect this class as tests
+    __test__ = False
+
     def __init__(self):
         super().__init__("Ensure it ain't broke", "test/TestStaticCheck", [], ["doesnt_matter"])
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I added the possibility to parse `jsonencode` functions, which will be helpful to create checks, when users use this function instead of text blocks.

I also fixed couple of deprecation warnings, one is still popping up, but I can't figure out where it comes from 😞 