### PR TITLE
Fix `NoneType` error for empty ipv6_cidr_blocks

### DIFF
--- a/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
@@ -75,6 +75,7 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
             if "0.0.0.0/0" in cidr_blocks:
                 return True
             ipv6_cidr_blocks = conf.get('ipv6_cidr_blocks', [])
-            if len(ipv6_cidr_blocks) > 0 and any(ip in ['::/0', '0000:0000:0000:0000:0000:0000:0000:0000/0'] for ip in ipv6_cidr_blocks[0]):
+            if len(ipv6_cidr_blocks) > 0 and ipv6_cidr_blocks[0] is not None and \
+                    any(ip in ['::/0', '0000:0000:0000:0000:0000:0000:0000:0000/0'] for ip in ipv6_cidr_blocks[0]):
                 return True
         return False


### PR DESCRIPTION
We saw the following error when executing Checkov on https://github.com/terraform-aws-modules/terraform-aws-eks
```
ERROR:checkov.terraform.checks.resource.aws.SecurityGroupUnrestrictedIngress3389:Failed to run check: Ensure no security groups allow ingress from 0.0.0.0:0 to port 3389 for configuration: {'cidr_blocks': [None], 'description': ['Allow workers pods to receive communication from the cluster control plane.'], 'from_port': [1025], 'ipv6_cidr_blocks': [None], 'prefix_list_ids': [None], 'protocol': ['tcp'], 'self': [False], 'to_port': [65535], 'type': ['ingress'], 'start_line': [853], 'end_line': [863]} at file: /tf/tfplan.json
2021-04-26 09:33:04,809 [MainThread  ] [ERROR]  Failed to run check: Ensure no security groups allow ingress from 0.0.0.0:0 to port 3389 for configuration: {'cidr_blocks': [None], 'description': ['Allow workers pods to receive communication from the cluster control plane.'], 'from_port': [1025], 'ipv6_cidr_blocks': [None], 'prefix_list_ids': [None], 'protocol': ['tcp'], 'self': [False], 'to_port': [65535], 'type': ['ingress'], 'start_line': [853], 'end_line': [863]} at file: /tf/tfplan.json
Traceback (most recent call last):
  File "/usr/local/bin/checkov", line 5, in <module>
    run()
  File "/usr/local/lib/python3.8/site-packages/checkov/main.py", line 114, in run
    scan_reports = runner_registry.run(external_checks_dir=external_checks_dir, files=args.file,
  File "/usr/local/lib/python3.8/site-packages/checkov/common/runners/runner_registry.py", line 34, in run
    scan_report = runner.run(root_folder, external_checks_dir=external_checks_dir, files=files,
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/plan_runner.py", line 62, in run
    self.check_tf_definition(report, runner_filter)
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/plan_runner.py", line 78, in check_tf_definition
    self.run_block(definition[block_type], full_file_path, report, scanned_file,
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/plan_runner.py", line 94, in run_block
    results = registry.scan(scanned_file, entity, [], runner_filter)
  File "/usr/local/lib/python3.8/site-packages/checkov/common/checks/base_check_registry.py", line 110, in scan
    result = self.run_check(check, entity_configuration, entity_name, entity_type, scanned_file, skip_info)
  File "/usr/local/lib/python3.8/site-packages/checkov/common/checks/base_check_registry.py", line 116, in run_check
    result = check.run(scanned_file=scanned_file, entity_configuration=entity_configuration,
  File "/usr/local/lib/python3.8/site-packages/checkov/common/checks/base_check.py", line 62, in run
    raise e
  File "/usr/local/lib/python3.8/site-packages/checkov/common/checks/base_check.py", line 42, in run
    check_result['result'] = self.scan_entity_conf(entity_configuration, entity_type)
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/checks/resource/base_resource_check.py", line 17, in scan_entity_conf
    return self.scan_resource_conf(conf, entity_type)
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/checks/resource/base_resource_check.py", line 33, in wrapper
    return wrapped(self, conf)
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py", line 58, in scan_resource_conf
    if self.contains_violation(conf):
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py", line 78, in contains_violation
    if len(ipv6_cidr_blocks) > 0 and any(ip in ['::/0', '0000:0000:0000:0000:0000:0000:0000:0000/0'] for ip in ipv6_cidr_blocks[0]):
TypeError: 'NoneType' object is not iterable
```

By checking if the type is None before iterating on it we can prevent this error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
