### PR TITLE
Make SQL firewall rule congruent with documentation

### DIFF
--- a/checkov/arm/checks/resource/SQLServerNoPublicAccess.py
+++ b/checkov/arm/checks/resource/SQLServerNoPublicAccess.py
@@ -24,7 +24,9 @@ class SQLServerNoPublicAccess(BaseResourceCheck):
                                 resource["type"] == "firewallrules":
                             if "properties" in resource:
                                 if "startIpAddress" in resource["properties"] and \
-                                        resource["properties"]["startIpAddress"] in ['0.0.0.0', '0.0.0.0/0']:  # nosec
+                                        resource["properties"]["startIpAddress"] in ['0.0.0.0', '0.0.0.0/0'] and \
+                                            "endIpAddress" in resource["properties"] and \
+                                                resource["properties"]["endIpAddress"] == '255.255.255.255':  # nosec
                                     return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/arm/checks/resource/SQLServerNoPublicAccess.py
+++ b/checkov/arm/checks/resource/SQLServerNoPublicAccess.py
@@ -23,10 +23,10 @@ class SQLServerNoPublicAccess(BaseResourceCheck):
                                 resource["type"] == "firewallRules" or \
                                 resource["type"] == "firewallrules":
                             if "properties" in resource:
-                                if "startIpAddress" in resource["properties"] and \
-                                        resource["properties"]["startIpAddress"] in ['0.0.0.0', '0.0.0.0/0'] and \
-                                            "endIpAddress" in resource["properties"] and \
-                                                resource["properties"]["endIpAddress"] == '255.255.255.255':  # nosec
+                                if ("startIpAddress" in resource["properties"] and  # nosec
+                                        resource["properties"]["startIpAddress"] in ['0.0.0.0', '0.0.0.0/0'] and
+                                        "endIpAddress" in resource["properties"] and
+                                        resource["properties"]["endIpAddress"] == '255.255.255.255'):
                                     return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/azure/SQLServerNoPublicAccess.py
+++ b/checkov/terraform/checks/resource/azure/SQLServerNoPublicAccess.py
@@ -15,7 +15,8 @@ class SQLServerNoPublicAccess(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if 'start_ip_address' in conf and conf['start_ip_address'][0] in ['0.0.0.0', '0.0.0.0/0']: # nosec
+        if 'start_ip_address' in conf and conf['start_ip_address'][0] in ['0.0.0.0', '0.0.0.0/0'] and \
+            'end_ip_address' in conf and conf['end_ip_address'][0] == '255.255.255.255': # nosec
             return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/azure/SQLServerNoPublicAccess.py
+++ b/checkov/terraform/checks/resource/azure/SQLServerNoPublicAccess.py
@@ -15,8 +15,8 @@ class SQLServerNoPublicAccess(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if 'start_ip_address' in conf and conf['start_ip_address'][0] in ['0.0.0.0', '0.0.0.0/0'] and \
-            'end_ip_address' in conf and conf['end_ip_address'][0] == '255.255.255.255': # nosec
+        if ('start_ip_address' in conf and conf['start_ip_address'][0] in ['0.0.0.0', '0.0.0.0/0'] and  # nosec
+                'end_ip_address' in conf and conf['end_ip_address'][0] == '255.255.255.255'):
             return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/tests/arm/checks/resource/example_SQLServerNoPublicAccess/sqlServerNoPublicAccess-TDE-FAILED.json
+++ b/tests/arm/checks/resource/example_SQLServerNoPublicAccess/sqlServerNoPublicAccess-TDE-FAILED.json
@@ -92,7 +92,7 @@
           "apiVersion": "2015-05-01-preview",
           "location": "[parameters('location')]",
           "properties": {
-            "endIpAddress": "0.0.0.0",
+            "endIpAddress": "255.255.255.255",
             "startIpAddress": "0.0.0.0"
           },
           "dependsOn": [

--- a/tests/arm/checks/resource/example_SQLServerNoPublicAccess/sqlServerNoPublicAccess-TDE-PASSED.json
+++ b/tests/arm/checks/resource/example_SQLServerNoPublicAccess/sqlServerNoPublicAccess-TDE-PASSED.json
@@ -92,8 +92,8 @@
           "apiVersion": "2015-05-01-preview",
           "location": "[parameters('location')]",
           "properties": {
-            "endIpAddress": "10.255.255.255",
-            "startIpAddress": "10.0.0.0"
+            "endIpAddress": "0.0.0.0",
+            "startIpAddress": "0.0.0.0"
           },
           "dependsOn": [
             "[variables('sqlServerName')]"

--- a/tests/terraform/checks/resource/azure/test_SQLServerNoPublicAccess.py
+++ b/tests/terraform/checks/resource/azure/test_SQLServerNoPublicAccess.py
@@ -22,6 +22,20 @@ class TestSQLServerNoPublicAccess(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_success_allow_azure_services(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_mysql_firewall_rule" "example" {
+              name                = "office"
+              resource_group_name = azurerm_resource_group.example.name
+              server_name         = azurerm_mysql_server.example.name
+              start_ip_address    = "0.0.0.0"
+              end_ip_address      = "0.0.0.0"
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_mysql_firewall_rule']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
     def test_success(self):
         hcl_res = hcl2.loads("""
             resource "azurerm_mysql_firewall_rule" "example" {


### PR DESCRIPTION
See https://docs.bridgecrew.io/docs/bc_azr_networking_4#fix---buildtime.

Without this change, the rule CKV_AZURE_11 erroneously flags a firewall rule that allows access _only_ from Azure internal services as allowing access from the entire Internet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
