### PR TITLE
Add a major version image that is stable for the docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,9 @@ jobs:
         id: get_version
         run: |
           checkov_version=$(curl -sL https://api.github.com/repos/bridgecrewio/checkov/tags | jq -r '.[0]["name"]' )
+          checkov_major_version=$(echo "${checkov_version}" | head -c1)
           echo ::set-env name=RELEASE_VERSION::$(echo $checkov_version)
+          echo ::set-env name=RELEASE_MAJOR_VERSION::$(echo $checkov_major_version)
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       - name: Publish to Registry
@@ -188,7 +190,7 @@ jobs:
           name: bridgecrew/checkov
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: "latest,${{ env.RELEASE_VERSION }}"
+          tags: "latest,${{ env.RELEASE_VERSION }},${{ env.RELEASE_MAJOR_VERSION }}"
   publish-checkov-k8s-dockerhub:
     runs-on: ubuntu-latest
     needs: publish-package
@@ -197,7 +199,9 @@ jobs:
       - name: update checkov-k8s version
         run: |
           checkov_version=$(curl -sL https://api.github.com/repos/bridgecrewio/checkov/tags | jq -r '.[0]["name"]' )
+          checkov_major_version=$(echo "${checkov_version}" | head -c1)
           echo ::set-env name=RELEASE_VERSION::$(echo $checkov_version)
+          echo ::set-env name=RELEASE_MAJOR_VERSION::$(echo $checkov_major_version)
           echo $RELEASE_VERSION
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
@@ -207,5 +211,5 @@ jobs:
           name: bridgecrew/checkov-k8s
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: "latest,${{ env.RELEASE_VERSION }}"
+          tags: "latest,${{ env.RELEASE_VERSION }},${{ env.RELEASE_MAJOR_VERSION }}"
           dockerfile: kubernetes/Dockerfile


### PR DESCRIPTION
Hi,

We're using checkov quite a lot to check our Terraform configurations. It's great to see this repository getting a lot of releases and updates we hugely benefit from it!

However it is quite cumbersome to embed any version apart from `latest` in our deployment pipeline templates due to the high release cadence on the docker images. I've, naively, tried to update the Github actions here to additionally update not only the `latest` tag but create another tag with just the major version, this could be used to pull the latest release inside of a given major version.

I'm not quite sure with the tagging strategy but this script will of course break if the semver versioning I've seen sometimes is broken in the tags so it might not fit the repository entirely, happy to take suggestions on what to change :)

This would be a huge quality of life improvement for me and probably others!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.