### PR TITLE
Ignore resources with a count of zero

### DIFF
--- a/checkov/terraform/checks/resource/base_resource_check.py
+++ b/checkov/terraform/checks/resource/base_resource_check.py
@@ -1,24 +1,31 @@
+import json
 from abc import abstractmethod
+from typing import Dict, List, Callable, Optional
 
 from checkov.common.checks.base_check import BaseCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.common.multi_signature import multi_signature
 from checkov.terraform.checks.resource.registry import resource_registry
 
 
 class BaseResourceCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_resources):
-        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_resources,
-                         block_type="resource")
+    def __init__(self, name: str, id: str, categories: List[CheckCategories], supported_resources: List[str]) -> None:
+        super().__init__(
+            name=name, id=id, categories=categories, supported_entities=supported_resources, block_type="resource"
+        )
         self.supported_resources = supported_resources
         resource_registry.register(self)
 
-    def scan_entity_conf(self, conf, entity_type):
+    def scan_entity_conf(self, conf: Dict[str, List], entity_type: str) -> CheckResult:
+        if conf.get("count") == [0]:
+            return CheckResult.UNKNOWN
+
         self.handle_dynamic_values(conf)
         return self.scan_resource_conf(conf, entity_type)
 
     @multi_signature()
     @abstractmethod
-    def scan_resource_conf(self, conf, entity_type):
+    def scan_resource_conf(self, conf: Dict[str, List], entity_type: str) -> CheckResult:
         """
         self.evaluated_keys should be set with a JSONPath of the attribute inspected.
         If not relevant it should be set to an empty array so the previous check's value gets overridden in the report.
@@ -27,14 +34,14 @@ class BaseResourceCheck(BaseCheck):
 
     @classmethod
     @scan_resource_conf.add_signature(args=["self", "conf"])
-    def _scan_resource_conf_self_conf(cls, wrapped):
-        def wrapper(self, conf, entity_type=None):
+    def _scan_resource_conf_self_conf(cls, wrapped: Callable) -> Callable:
+        def wrapper(self: "BaseResourceCheck", conf: Dict[str, List], entity_type: Optional[str] = None) -> CheckResult:
             # keep default argument for entity_type so old code, that doesn't set it, will work.
             return wrapped(self, conf)
 
         return wrapper
 
-    def handle_dynamic_values(self, conf):
+    def handle_dynamic_values(self, conf: Dict[str, List]) -> None:
         for dynamic_element in conf.get("dynamic", {}):
             if isinstance(dynamic_element, str):
                 try:
@@ -42,4 +49,4 @@ class BaseResourceCheck(BaseCheck):
                 except Exception:
                     dynamic_element = {}
             for element_name in dynamic_element.keys():
-                conf[element_name] = dynamic_element[element_name].get('content', [])
+                conf[element_name] = dynamic_element[element_name].get("content", [])

--- a/checkov/terraform/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/variable_rendering/evaluate_terraform.py
@@ -93,7 +93,11 @@ def strip_double_quotes(input_str):
     return input_str
 
 
-def evaluate_conditional_expression(input_str):
+def evaluate_conditional_expression(input_str: str) -> str:
+    variable_ref = re.match(r"^\${(.*)}$", input_str)
+    if variable_ref:
+        input_str = variable_ref.groups()[0]
+
     condition = re.match(CONDITIONAL_EXPR, input_str)
     while condition:
         groups = condition.groups()

--- a/tests/graph/terraform/runner/test_graph_builder.py
+++ b/tests/graph/terraform/runner/test_graph_builder.py
@@ -52,7 +52,7 @@ class TestGraphBuilder(TestCase):
         runner = Runner()
         report = runner.run(root_folder=resources_path)
         self.assertLessEqual(3, len(report.failed_checks))
-        self.assertLessEqual(40, len(report.passed_checks))
+        self.assertLessEqual(34, len(report.passed_checks))
         self.assertEqual(0, len(report.skipped_checks))
 
         found_versioning_failure = False

--- a/tests/terraform/checks/example_WildcardEntities/main.tf
+++ b/tests/terraform/checks/example_WildcardEntities/main.tf
@@ -4,6 +4,10 @@ locals {
   bucket_name          = var.bucket_name
 }
 
+variable "user_exists" {
+  default = false
+}
+
 resource "aws_cognito_user_group" "user_group" {
   name         = "${var.customer_name}_group"
   description  = "${var.customer_name} user group"

--- a/tests/terraform/checks/resource/test_base_resource_check.py
+++ b/tests/terraform/checks/resource/test_base_resource_check.py
@@ -1,0 +1,43 @@
+import pytest
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class TestStaticCheck(BaseResourceCheck):
+    # for pytest not to collect this class as tests
+    __test__ = False
+
+    def __init__(self):
+        name = "Test something"
+        id = "CKV_TEST_1"
+        supported_resources = ["ckv_test"]
+        categories = [CheckCategories.CONVENTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if "check_result" in conf.keys():
+            check_result = conf["check_result"][0]
+            if check_result:
+                return CheckResult.PASSED
+
+            return CheckResult.FAILED
+
+        return CheckResult.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "conf,expected",
+    [
+        ({"check_result": [True]}, CheckResult.PASSED),
+        ({"check_result": [False]}, CheckResult.FAILED),
+        ({"foo": ["bar"]}, CheckResult.UNKNOWN),
+        ({"count": [0], "check_result": [True]}, CheckResult.UNKNOWN),
+        ({"count": [1], "check_result": [True]}, CheckResult.PASSED),
+    ],
+    ids=["pass", "fail", "unknown", "count_zero", "count_one"],
+)
+def test_scan_entity_conf(conf, expected):
+    result = TestStaticCheck().scan_entity_conf(conf, "ckv_test")
+
+    assert result == expected


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #1078.

It was a pretty interesting issue. The first problem was that the `input_str` in `evaluate_conditional_expression` was surrounded with `${}`. After fixing that, I realized that `checkov` doesn't care, when a resource is actually not deployed `count = 0`, which is in general ok, but result in a lot of false positive, when third party modules are used.

I also added type hints for code parts I touched, will do so for other parts, when I have to fix something :)