### PR TITLE
Ignore data sources with a count of zero

### DIFF
--- a/checkov/terraform/checks/data/base_check.py
+++ b/checkov/terraform/checks/data/base_check.py
@@ -1,29 +1,33 @@
 from abc import abstractmethod
+from typing import Dict, List, Callable, Optional
 
 from checkov.common.checks.base_check import BaseCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.common.multi_signature import multi_signature
 from checkov.terraform.checks.data.registry import data_registry
 
 
 class BaseDataCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_data):
-        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_data,
-                         block_type="data")
+    def __init__(self, name: str, id: str, categories: List[CheckCategories], supported_data: List[str]) -> None:
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_data, block_type="data")
         self.supported_data = supported_data
         data_registry.register(self)
 
-    def scan_entity_conf(self, conf, entity_type):
+    def scan_entity_conf(self, conf: Dict[str, List], entity_type: str) -> CheckResult:
+        if conf.get("count") == [0]:
+            return CheckResult.UNKNOWN
+
         return self.scan_data_conf(conf, entity_type)
 
     @multi_signature()
     @abstractmethod
-    def scan_data_conf(self, conf, entity_type):
+    def scan_data_conf(self, conf: Dict[str, List], entity_type: str) -> CheckResult:
         raise NotImplementedError()
 
     @classmethod
     @scan_data_conf.add_signature(args=["self", "conf"])
-    def _scan_data_conf_self_conf(cls, wrapped):
-        def wrapper(self, conf, entity_type=None):
+    def _scan_data_conf_self_conf(cls, wrapped: Callable) -> Callable:
+        def wrapper(self: "BaseDataCheck", conf: Dict[str, List], entity_type: Optional[str] = None) -> CheckResult:
             # keep default argument for entity_type so old code, that doesn't set it, will work.
             return wrapped(self, conf)
 

--- a/tests/graph/terraform/runner/test_graph_builder.py
+++ b/tests/graph/terraform/runner/test_graph_builder.py
@@ -52,7 +52,7 @@ class TestGraphBuilder(TestCase):
         runner = Runner()
         report = runner.run(root_folder=resources_path)
         self.assertLessEqual(3, len(report.failed_checks))
-        self.assertLessEqual(34, len(report.passed_checks))
+        self.assertLessEqual(13, len(report.passed_checks))
         self.assertEqual(0, len(report.skipped_checks))
 
         found_versioning_failure = False

--- a/tests/terraform/checks/data/test_base_data_check.py
+++ b/tests/terraform/checks/data/test_base_data_check.py
@@ -1,0 +1,43 @@
+import pytest
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.data.base_check import BaseDataCheck
+
+
+class TestStaticCheck(BaseDataCheck):
+    # for pytest not to collect this class as tests
+    __test__ = False
+
+    def __init__(self):
+        name = "Test something"
+        id = "CKV_TEST_2"
+        supported_data = ["ckv_test"]
+        categories = [CheckCategories.CONVENTION]
+        super().__init__(name=name, id=id, categories=categories, supported_data=supported_data)
+
+    def scan_data_conf(self, conf):
+        if "check_result" in conf.keys():
+            check_result = conf["check_result"][0]
+            if check_result:
+                return CheckResult.PASSED
+
+            return CheckResult.FAILED
+
+        return CheckResult.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "conf,expected",
+    [
+        ({"check_result": [True]}, CheckResult.PASSED),
+        ({"check_result": [False]}, CheckResult.FAILED),
+        ({"foo": ["bar"]}, CheckResult.UNKNOWN),
+        ({"count": [0], "check_result": [True]}, CheckResult.UNKNOWN),
+        ({"count": [1], "check_result": [True]}, CheckResult.PASSED),
+    ],
+    ids=["pass", "fail", "unknown", "count_zero", "count_one"],
+)
+def test_scan_entity_conf(conf, expected):
+    result = TestStaticCheck().scan_entity_conf(conf, "ckv_test")
+
+    assert result == expected


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes partially #1068.

Since the data sources have a different base check, I also added here the possibility to ignore data sources with `count = 0`