### PR TITLE
Add CKV_AWS_152 check for cross-zone load balancing

### DIFF
--- a/checkov/terraform/checks/resource/aws/LBCrossZone.py
+++ b/checkov/terraform/checks/resource/aws/LBCrossZone.py
@@ -1,0 +1,24 @@
+from typing import Dict, List
+
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories, CheckResult
+
+
+class LBCrossZone(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that Load Balancer (Network/Gateway) has cross-zone load balancing enabled"
+        id = "CKV_AWS_152"
+        supported_resources = ["aws_lb", "aws_alb"]
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: Dict[str, List]) -> CheckResult:
+        if conf.get("load_balancer_type", ["application"]) == ["application"]:
+            return CheckResult.UNKNOWN
+        return super().scan_resource_conf(conf)
+
+    def get_inspected_key(self) -> str:
+        return "enable_cross_zone_load_balancing"
+
+
+check = LBCrossZone()

--- a/tests/terraform/checks/resource/aws/example_LBCrossZone/main.tf
+++ b/tests/terraform/checks/resource/aws/example_LBCrossZone/main.tf
@@ -1,0 +1,74 @@
+# pass
+
+resource "aws_lb" "enabled" {
+  internal           = false
+  load_balancer_type = "network"
+  name               = "nlb"
+  subnets            = var.public_subnet_ids
+
+  enable_cross_zone_load_balancing = true
+}
+
+resource "aws_alb" "enabled" {
+  load_balancer_type = "gateway"
+  name               = "glb"
+
+  enable_cross_zone_load_balancing = true
+
+  subnet_mapping {
+    subnet_id = var.subnet_id
+  }
+}
+
+# failure
+
+resource "aws_lb" "default" {
+  internal           = false
+  load_balancer_type = "network"
+  name               = "nlb"
+  subnets            = var.public_subnet_ids
+}
+
+resource "aws_alb" "default" {
+  load_balancer_type = "gateway"
+  name               = "glb"
+
+  subnet_mapping {
+    subnet_id = var.subnet_id
+  }
+}
+
+resource "aws_lb" "disabled" {
+  internal           = false
+  load_balancer_type = "network"
+  name               = "nlb"
+  subnets            = var.public_subnet_ids
+
+  enable_cross_zone_load_balancing = false
+}
+
+resource "aws_alb" "disabled" {
+  load_balancer_type = "gateway"
+  name               = "glb"
+
+  enable_cross_zone_load_balancing = false
+
+  subnet_mapping {
+    subnet_id = var.subnet_id
+  }
+}
+
+# unknown
+
+resource "aws_lb" "application" {
+  internal           = false
+  load_balancer_type = "application"
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+}
+
+resource "aws_lb" "default_type" {
+  internal           = false
+  name               = "alb"
+  subnets            = var.public_subnet_ids
+}

--- a/tests/terraform/checks/resource/aws/test_LBCrossZone.py
+++ b/tests/terraform/checks/resource/aws/test_LBCrossZone.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.LBCrossZone import check
+from checkov.terraform.runner import Runner
+
+
+class TestLBCrossZone(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_LBCrossZone"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_lb.enabled",
+            "aws_alb.enabled",
+        }
+        failing_resources = {
+            "aws_lb.default",
+            "aws_alb.default",
+            "aws_lb.disabled",
+            "aws_alb.disabled",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -183,7 +183,7 @@ class TestRunnerValid(unittest.TestCase):
             for check in checks:
                 unique_checks.add(check.id)
         aws_checks = sorted(list(filter(lambda check_id: '_AWS_' in check_id, unique_checks)), reverse=True, key=lambda s: int(s.split('_')[-1]))
-        for i in range(1, len(aws_checks) + 1 + 4):
+        for i in range(1, len(aws_checks) + 4):
             if f'CKV_AWS_{i}' == 'CKV_AWS_4':
                 # CKV_AWS_4 was deleted due to https://github.com/bridgecrewio/checkov/issues/371
                 continue
@@ -192,9 +192,6 @@ class TestRunnerValid(unittest.TestCase):
                 continue
             if f'CKV_AWS_{i}' == 'CKV_AWS_95':
                 # CKV_AWS_95 is currently implemented just on cfn
-                continue
-            if f"CKV_AWS_{i}" == "CKV_AWS_152":
-                # TODO: remove when a new check with this number is added
                 continue
             self.assertIn(f'CKV_AWS_{i}', aws_checks, msg=f'The new AWS violation should have the ID "CKV_AWS_{i}"')
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Cross-zone load balancing is disabled by default for Network and Gateway load balancers. For Application LB is enabled by default and can't be changed.
