### PR TITLE
fix(CKV_K8S_121): prevent exception when args don't exist

### DIFF
--- a/checkov/kubernetes/checks/PeerClientCertAuthTrue.py
+++ b/checkov/kubernetes/checks/PeerClientCertAuthTrue.py
@@ -18,12 +18,13 @@ class PeerClientCertAuthTrue(BaseK8Check):
             return "{}.{}.default".format(conf["kind"], conf["metadata"]["name"])
 
     def scan_spec_conf(self, conf, entity_type=None):
-        if conf.get("metadata")['name'] == 'etcd':
-            containers = conf.get('spec')['containers']
-            for container in containers:
-                if '--peer-client-cert-auth=true' not in container['args']:
-                    return CheckResult.FAILED
-            return CheckResult.PASSED
+        if conf.get("args") is not None:
+            if conf.get("metadata")['name'] == 'etcd':
+                containers = conf.get('spec')['containers']
+                for container in containers:
+                    if '--peer-client-cert-auth=true' not in container['args']:
+                        return CheckResult.FAILED
+                return CheckResult.PASSED
         return CheckResult.UNKNOWN
 
 

--- a/checkov/kubernetes/checks/PeerClientCertAuthTrue.py
+++ b/checkov/kubernetes/checks/PeerClientCertAuthTrue.py
@@ -18,13 +18,13 @@ class PeerClientCertAuthTrue(BaseK8Check):
             return "{}.{}.default".format(conf["kind"], conf["metadata"]["name"])
 
     def scan_spec_conf(self, conf, entity_type=None):
-        if conf.get("args") is not None:
-            if conf.get("metadata")['name'] == 'etcd':
-                containers = conf.get('spec')['containers']
-                for container in containers:
+        if conf.get("metadata")['name'] == 'etcd':
+            containers = conf.get('spec')['containers']
+            for container in containers:
+                if container.get("args") is not None:
                     if '--peer-client-cert-auth=true' not in container['args']:
                         return CheckResult.FAILED
-                return CheckResult.PASSED
+            return CheckResult.PASSED
         return CheckResult.UNKNOWN
 
 


### PR DESCRIPTION
Issue: Scan fails with exception on check `CKV_K8S_121`

Version: 2.0.88

Reproduce: scanned this file
```yml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    scheduler.alpha.kubernetes.io/critical-pod: ""
  creationTimestamp: null
  labels:
    component: etcd
    tier: control-plane
  name: etcd
  namespace: kube-system
spec:
  containers:
  - command:
    - etcd
    image: k8s.gcr.io/etcd-amd64:3.2.18
    imagePullPolicy: IfNotPresent
    livenessProbe:
      exec:
        command:
        - /bin/sh
        - -ec
        - ETCDCTL_API=3 etcdctl --endpoints=https://[192.168.22.9]:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt
          --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt --key=/etc/kubernetes/pki/etcd/healthcheck-client.key
          get foo
      failureThreshold: 8
      initialDelaySeconds: 15
      timeoutSeconds: 15
    name: etcd-should-fail
    resources: {}
    volumeMounts:
    - mountPath: /var/lib/etcd
      name: etcd-data
    - mountPath: /etc/kubernetes/pki/etcd
      name: etcd-certs
  hostNetwork: true
  priorityClassName: system-cluster-critical
  volumes:
  - hostPath:
      path: /var/lib/etcd
      type: DirectoryOrCreate
    name: etcd-data
  - hostPath:
      path: /etc/kubernetes/pki/etcd
      type: DirectoryOrCreate
    name: etcd-certs
status: {}
``` 

Checkov result:
```
ERROR:checkov.kubernetes.checks.PeerClientCertAuthTrue:Failed to run check: Ensure that the --peer-client-cert-auth argument is set to true for configuration: {'apiVersion': 'v1', 'kind': 'Pod', 'metadata': {'annotations': [{'scheduler.alpha.kubernetes.io/critical-pod': '', '__startline__': 5, '__endline__': 6}], 'creationTimestamp': None, 'labels': {'component': 'etcd', 'tier': 'control-plane', '__startline__': 8, '__endline__': 10}, 'name': 'etcd', 'namespace': 'kube-system', '__startline__': 4, '__endline__': 12}, 'spec': {'containers': [{'command': ['etcd'], 'image': 'k8s.gcr.io/etcd-amd64:3.2.18', 'imagePullPolicy': 'IfNotPresent', 'livenessProbe': {'exec': {'command': ['/bin/sh', '-ec', 'ETCDCTL_API=3 etcdctl --endpoints=https://[192.168.22.9]:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt --key=/etc/kubernetes/pki/etcd/healthcheck-client.key get foo'], '__startline__': 20, '__endline__': 26}, 'failureThreshold': 8, 'initialDelaySeconds': 15, 'timeoutSeconds': 15, '__startline__': 19, '__endline__': 29}, 'name': 'etcd-should-fail', 'resources': {'__startline__': 30, '__endline__': 30}, 'volumeMounts': [{'mountPath': '/var/lib/etcd', 'name': 'etcd-data', '__startline__': 32, '__endline__': 34}, {'mountPath': '/etc/kubernetes/pki/etcd', 'name': 'etcd-certs', '__startline__': 34, '__endline__': 36}], '__startline__': 14, '__endline__': 36, 'apiVersion': 'v1', 'kind': 'containers', 'parent': 'Pod.etcd.kube-system (container 0)', 'parent_metadata': {'annotations': [{'scheduler.alpha.kubernetes.io/critical-pod': '', '__startline__': 5, '__endline__': 6}], 'creationTimestamp': None, 'labels': {'component': 'etcd', 'tier': 'control-plane', '__startline__': 8, '__endline__': 10}, 'name': 'etcd', 'namespace': 'kube-system', '__startline__': 4, '__endline__': 12}}], 'hostNetwork': True, 'priorityClassName': 'system-cluster-critical', 'volumes': [{'hostPath': {'path': '/var/lib/etcd', 'type': 'DirectoryOrCreate', '__startline__': 40, '__endline__': 42}, 'name': 'etcd-data', '__startline__': 39, '__endline__': 43}, {'hostPath': {'path': '/etc/kubernetes/pki/etcd', 'type': 'DirectoryOrCreate', '__startline__': 44, '__endline__': 46}, 'name': 'etcd-certs', '__startline__': 43, '__endline__': 47}], '__startline__': 13, '__endline__': 47}, 'status': {'__startline__': 47, '__endline__': 47}, '__startline__': 1, '__endline__': 47} at file: ../tf-folder/ckv2.yml
2021-05-02 11:33:54,356 [MainThread  ] [ERROR]  Failed to run check: Ensure that the --peer-client-cert-auth argument is set to true for configuration: {'apiVersion': 'v1', 'kind': 'Pod', 'metadata': {'annotations': [{'scheduler.alpha.kubernetes.io/critical-pod': '', '__startline__': 5, '__endline__': 6}], 'creationTimestamp': None, 'labels': {'component': 'etcd', 'tier': 'control-plane', '__startline__': 8, '__endline__': 10}, 'name': 'etcd', 'namespace': 'kube-system', '__startline__': 4, '__endline__': 12}, 'spec': {'containers': [{'command': ['etcd'], 'image': 'k8s.gcr.io/etcd-amd64:3.2.18', 'imagePullPolicy': 'IfNotPresent', 'livenessProbe': {'exec': {'command': ['/bin/sh', '-ec', 'ETCDCTL_API=3 etcdctl --endpoints=https://[192.168.22.9]:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt --key=/etc/kubernetes/pki/etcd/healthcheck-client.key get foo'], '__startline__': 20, '__endline__': 26}, 'failureThreshold': 8, 'initialDelaySeconds': 15, 'timeoutSeconds': 15, '__startline__': 19, '__endline__': 29}, 'name': 'etcd-should-fail', 'resources': {'__startline__': 30, '__endline__': 30}, 'volumeMounts': [{'mountPath': '/var/lib/etcd', 'name': 'etcd-data', '__startline__': 32, '__endline__': 34}, {'mountPath': '/etc/kubernetes/pki/etcd', 'name': 'etcd-certs', '__startline__': 34, '__endline__': 36}], '__startline__': 14, '__endline__': 36, 'apiVersion': 'v1', 'kind': 'containers', 'parent': 'Pod.etcd.kube-system (container 0)', 'parent_metadata': {'annotations': [{'scheduler.alpha.kubernetes.io/critical-pod': '', '__startline__': 5, '__endline__': 6}], 'creationTimestamp': None, 'labels': {'component': 'etcd', 'tier': 'control-plane', '__startline__': 8, '__endline__': 10}, 'name': 'etcd', 'namespace': 'kube-system', '__startline__': 4, '__endline__': 12}}], 'hostNetwork': True, 'priorityClassName': 'system-cluster-critical', 'volumes': [{'hostPath': {'path': '/var/lib/etcd', 'type': 'DirectoryOrCreate', '__startline__': 40, '__endline__': 42}, 'name': 'etcd-data', '__startline__': 39, '__endline__': 43}, {'hostPath': {'path': '/etc/kubernetes/pki/etcd', 'type': 'DirectoryOrCreate', '__startline__': 44, '__endline__': 46}, 'name': 'etcd-certs', '__startline__': 43, '__endline__': 47}], '__startline__': 13, '__endline__': 47}, 'status': {'__startline__': 47, '__endline__': 47}, '__startline__': 1, '__endline__': 47} at file: ../tf-folder/ckv2.yml
Traceback (most recent call last):
  File "/usr/local/bin/checkov", line 5, in <module>
    exit(run())
  File "/usr/local/lib/python3.9/site-packages/checkov/main.py", line 122, in run
    scan_reports = runner_registry.run(external_checks_dir=external_checks_dir, files=args.file,
  File "/usr/local/lib/python3.9/site-packages/checkov/common/runners/runner_registry.py", line 34, in run
    scan_report = runner.run(root_folder, external_checks_dir=external_checks_dir, files=files,
  File "/usr/local/lib/python3.9/site-packages/checkov/kubernetes/runner.py", line 163, in run
    results = registry.scan(k8_file, entity_conf, skipped_checks, runner_filter)
  File "/usr/local/lib/python3.9/site-packages/checkov/kubernetes/base_registry.py", line 28, in scan
    result = check.run(scanned_file=scanned_file, entity_configuration=entity_configuration,
  File "/usr/local/lib/python3.9/site-packages/checkov/common/checks/base_check.py", line 62, in run
    raise e
  File "/usr/local/lib/python3.9/site-packages/checkov/common/checks/base_check.py", line 42, in run
    check_result['result'] = self.scan_entity_conf(entity_configuration, entity_type)
  File "/usr/local/lib/python3.9/site-packages/checkov/kubernetes/base_spec_check.py", line 20, in scan_entity_conf
    return self.scan_spec_conf(conf, entity_type)
  File "/usr/local/lib/python3.9/site-packages/checkov/kubernetes/checks/PeerClientCertAuthTrue.py", line 24, in scan_spec_conf
    if '--peer-client-cert-auth=true' not in container['args']:
KeyError: 'args'
```

Fix: Ensure `args` exist in order to continue the check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
