### PR TITLE
Add CKV_AWS_101 check to cloudformation

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/NeptuneClusterLogging.py
+++ b/checkov/cloudformation/checks/resource/aws/NeptuneClusterLogging.py
@@ -1,0 +1,24 @@
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.cloudformation.parser.node import dict_node
+from checkov.common.models.enums import CheckResult, CheckCategories
+
+
+class NeptuneClusterLogging(BaseResourceCheck):
+    def __init__(self) -> None:
+        name = "Ensure Neptune logging is enabled"
+        id = "CKV_AWS_101"
+        supported_resources = ["AWS::Neptune::DBCluster"]
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: dict_node) -> CheckResult:
+        log_types = ["audit"]
+
+        logs_exports = conf.get("Properties", {}).get("EnableCloudwatchLogsExports", [])
+        if all(elem in logs_exports for elem in log_types):
+            return CheckResult.PASSED
+
+        return CheckResult.FAILED
+
+
+check = NeptuneClusterLogging()

--- a/tests/cloudformation/checks/resource/aws/example_NeptuneClusterLogging/NeptuneClusterLogging-FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_NeptuneClusterLogging/NeptuneClusterLogging-FAILED.yml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  NeptuneDBCluster1:
+    Type: "AWS::Neptune::DBCluster"
+    Properties:
+      DBClusterIdentifier: DBClusterIdentifier
+  NeptuneDBCluster2:
+    Type: "AWS::Neptune::DBCluster"
+    Properties:
+      DBClusterIdentifier: DBClusterIdentifier
+      EnableCloudwatchLogsExports: []

--- a/tests/cloudformation/checks/resource/aws/example_NeptuneClusterLogging/NeptuneClusterLogging-FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_NeptuneClusterLogging/NeptuneClusterLogging-FAILED.yml
@@ -1,10 +1,10 @@
 AWSTemplateFormatVersion: 2010-09-09
 Resources:
-  NeptuneDBCluster1:
+  NeptuneDBClusterDefault:
     Type: "AWS::Neptune::DBCluster"
     Properties:
       DBClusterIdentifier: DBClusterIdentifier
-  NeptuneDBCluster2:
+  NeptuneDBClusterEmpty:
     Type: "AWS::Neptune::DBCluster"
     Properties:
       DBClusterIdentifier: DBClusterIdentifier

--- a/tests/cloudformation/checks/resource/aws/example_NeptuneClusterLogging/NeptuneClusterLogging-PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_NeptuneClusterLogging/NeptuneClusterLogging-PASSED.yml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Resources:
-  NeptuneDBCluster:
+  NeptuneDBClusterEnabled:
     Type: "AWS::Neptune::DBCluster"
     Properties:
       DBClusterIdentifier: DBClusterIdentifier

--- a/tests/cloudformation/checks/resource/aws/example_NeptuneClusterLogging/NeptuneClusterLogging-PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_NeptuneClusterLogging/NeptuneClusterLogging-PASSED.yml
@@ -1,0 +1,7 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  NeptuneDBCluster:
+    Type: "AWS::Neptune::DBCluster"
+    Properties:
+      DBClusterIdentifier: DBClusterIdentifier
+      EnableCloudwatchLogsExports: ["audit"]

--- a/tests/cloudformation/checks/resource/aws/test_NeptuneClusterLogging.py
+++ b/tests/cloudformation/checks/resource/aws/test_NeptuneClusterLogging.py
@@ -1,0 +1,25 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.NeptuneClusterLogging import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestNeptuneClusterLogging(unittest.TestCase):
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_NeptuneClusterLogging"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_NeptuneClusterLogging.py
+++ b/tests/cloudformation/checks/resource/aws/test_NeptuneClusterLogging.py
@@ -15,10 +15,24 @@ class TestNeptuneClusterLogging(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
+        passing_resources = {
+            "AWS::Neptune::DBCluster.NeptuneDBClusterEnabled",
+        }
+        failing_resources = {
+            "AWS::Neptune::DBCluster.NeptuneDBClusterDefault",
+            "AWS::Neptune::DBCluster.NeptuneDBClusterEmpty",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
         self.assertEqual(summary["passed"], 1)
         self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This check already exists for Terraform, so I also implemented it for CloudFormation. I also wanted to add `CKV_AWS_102`, but you can't create a public accessible Neptune Cluster via CloudFormation.