### PR TITLE
Add type hints to terraform utils and provider

### DIFF
--- a/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
+++ b/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
@@ -6,7 +6,7 @@ from cloudsplaining.scan.policy_document import PolicyDocument
 from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.common.multi_signature import multi_signature
-from checkov.terraform.checks.utils.iam_cloudformation_document_to_policy_converter import \
+from checkov.cloudformation.checks.utils.iam_cloudformation_document_to_policy_converter import \
     convert_cloudformation_conf_to_iam_policy
 
 

--- a/checkov/cloudformation/checks/utils/iam_cloudformation_document_to_policy_converter.py
+++ b/checkov/cloudformation/checks/utils/iam_cloudformation_document_to_policy_converter.py
@@ -1,5 +1,9 @@
 import copy
-def convert_cloudformation_conf_to_iam_policy(conf):
+
+from checkov.cloudformation.parser.node import dict_node
+
+
+def convert_cloudformation_conf_to_iam_policy(conf: dict_node) -> dict_node:
     """
         converts terraform parsed configuration to iam policy document
     """
@@ -11,7 +15,7 @@ def convert_cloudformation_conf_to_iam_policy(conf):
                 statement["Action"] = str(statement.pop("Action")[0])
             if "Resource" in statement:
                 resources = statement.pop("Resource")
-                if isinstance(resources,list):
+                if isinstance(resources, list):
                     statement["Resource"] = str(resources[0])
                 else:
                     statement["Resource"] = str(resources)
@@ -19,7 +23,7 @@ def convert_cloudformation_conf_to_iam_policy(conf):
                 statement["NotAction"] = str(statement.pop("NotAction")[0])
             if "NotResource" in statement:
                 not_resources = statement.pop("NotResource")
-                if isinstance(not_resources,list):
+                if isinstance(not_resources, list):
                     statement["NotResource"] = str(not_resources[0])
                 else:
                     statement["NotResource"] = str(not_resources)

--- a/checkov/common/graph/graph_builder/graph_components/attribute_names.py
+++ b/checkov/common/graph/graph_builder/graph_components/attribute_names.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+from typing import List, Any
 
 
 @dataclass
@@ -18,8 +19,8 @@ class CustomAttributes:
     SOURCE_MODULE = "source_module_"
 
 
-def props(cls):
-    return [i for i in cls.__dict__.keys() if i[:1] != '_']
+def props(cls: Any) -> List[str]:
+    return [i for i in cls.__dict__.keys() if i[:1] != "_"]
 
 
 reserved_attribute_names = props(CustomAttributes)

--- a/checkov/common/graph/graph_builder/graph_components/edge.py
+++ b/checkov/common/graph/graph_builder/graph_components/edge.py
@@ -1,8 +1,8 @@
 class Edge:
-    def __init__(self, origin, dest, label):
+    def __init__(self, origin: int, dest: int, label: str) -> None:
         self.origin = origin
         self.dest = dest
         self.label = label
 
-    def __str__(self):
-        return f'[{self.origin} -({self.label})-> {self.dest}]'
+    def __str__(self) -> str:
+        return f"[{self.origin} -({self.label})-> {self.dest}]"

--- a/checkov/terraform/checks/provider/aws/__init__.py
+++ b/checkov/terraform/checks/provider/aws/__init__.py
@@ -2,4 +2,4 @@ from os.path import dirname, basename, isfile, join
 import glob
 
 modules = glob.glob(join(dirname(__file__), "*.py"))
-__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
+__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith("__init__.py")]

--- a/checkov/terraform/checks/provider/aws/credentials.py
+++ b/checkov/terraform/checks/provider/aws/credentials.py
@@ -1,19 +1,20 @@
 import re
+from typing import Dict, List, Any
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.provider.base_check import BaseProviderCheck
 from checkov.common.models.consts import access_key_pattern, secret_key_pattern
 
 
 class AWSCredentials(BaseProviderCheck):
-
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure no hard coded AWS access key and secret key exists in provider"
         id = "CKV_AWS_41"
-        supported_provider = ['aws']
+        supported_provider = ["aws"]
         categories = [CheckCategories.SECRETS]
         super().__init__(name=name, id=id, categories=categories, supported_provider=supported_provider)
 
-    def scan_provider_conf(self, conf):
+    def scan_provider_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
         """
         see: https://www.terraform.io/docs/providers/aws/index.html#static-credentials
         """
@@ -24,7 +25,7 @@ class AWSCredentials(BaseProviderCheck):
         return CheckResult.PASSED
 
     @staticmethod
-    def secret_found(conf, field, pattern):
+    def secret_found(conf: Dict[str, List[Any]], field: str, pattern: str) -> bool:
         if field in conf.keys():
             value = conf[field][0]
             if re.match(pattern, value) is not None:

--- a/checkov/terraform/checks/provider/base_check.py
+++ b/checkov/terraform/checks/provider/base_check.py
@@ -1,30 +1,22 @@
 from abc import abstractmethod
+from typing import List, Dict, Any
 
 from checkov.common.checks.base_check import BaseCheck
-from checkov.common.multi_signature import multi_signature
+from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.provider.registry import provider_registry
 
 
 class BaseProviderCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_provider):
-        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_provider,
-                         block_type="provider")
+    def __init__(self, name: str, id: str, categories: List[CheckCategories], supported_provider: List[str]) -> None:
+        super().__init__(
+            name=name, id=id, categories=categories, supported_entities=supported_provider, block_type="provider"
+        )
         self.supported_provider = supported_provider
         provider_registry.register(self)
 
-    def scan_entity_conf(self, conf, entity_type):
-        return self.scan_provider_conf(conf, entity_type)
+    def scan_entity_conf(self, conf: Dict[str, List[Any]], entity_type: str) -> CheckResult:
+        return self.scan_provider_conf(conf)
 
-    @multi_signature()
     @abstractmethod
-    def scan_provider_conf(self, conf, provider_type):
+    def scan_provider_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
         raise NotImplementedError()
-
-    @classmethod
-    @scan_provider_conf.add_signature(args=["self", "conf"])
-    def _scan_provider_conf_self_conf(cls, wrapped):
-        def wrapper(self, conf, provider_type=None):
-            # keep default argument for entity_type so old code, that doesn't set it, will work.
-            return wrapped(self, conf)
-
-        return wrapper

--- a/checkov/terraform/checks/provider/base_registry.py
+++ b/checkov/terraform/checks/provider/base_registry.py
@@ -1,14 +1,14 @@
+from typing import Dict, Any, Tuple
+
 from checkov.common.checks.base_check_registry import BaseCheckRegistry
 
 
 class Registry(BaseCheckRegistry):
-
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
-    def extract_entity_details(self, entity):
+    def extract_entity_details(self, entity: Dict[str, Any]) -> Tuple[str, str, Dict[str, Any]]:
         provider_type = list(entity.keys())[0]
         provider_name = list(entity.keys())[0]
         provider_configuration = entity[provider_name]
         return provider_type, provider_name, provider_configuration
-

--- a/checkov/terraform/checks/provider/linode/__init__.py
+++ b/checkov/terraform/checks/provider/linode/__init__.py
@@ -2,4 +2,4 @@ from os.path import dirname, basename, isfile, join
 import glob
 
 modules = glob.glob(join(dirname(__file__), "*.py"))
-__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
+__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith("__init__.py")]

--- a/checkov/terraform/checks/provider/linode/credentials.py
+++ b/checkov/terraform/checks/provider/linode/credentials.py
@@ -1,25 +1,26 @@
 import re
+from typing import Dict, List, Any
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.provider.base_check import BaseProviderCheck
 from checkov.common.models.consts import linode_token_pattern
 
 
 class LinodeCredentials(BaseProviderCheck):
-
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure no hard coded Linode tokens exist in provider"
         id = "CKV_LIN_1"
-        supported_provider = ['linode']
+        supported_provider = ["linode"]
         categories = [CheckCategories.SECRETS]
         super().__init__(name=name, id=id, categories=categories, supported_provider=supported_provider)
 
-    def scan_provider_conf(self, conf):
+    def scan_provider_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
         if self.secret_found(conf, "token", linode_token_pattern):
             return CheckResult.FAILED
         return CheckResult.PASSED
 
     @staticmethod
-    def secret_found(conf, field, pattern):
+    def secret_found(conf: Dict[str, List[Any]], field: str, pattern: str) -> bool:
         if field in conf.keys():
             value = conf[field][0]
             if re.match(pattern, value) is not None:

--- a/checkov/terraform/checks/utils/dependency_path_handler.py
+++ b/checkov/terraform/checks/utils/dependency_path_handler.py
@@ -1,5 +1,7 @@
-PATH_SEPARATOR ='->'
+from typing import List
+
+PATH_SEPARATOR = "->"
 
 
-def unify_dependency_path(dependency_path: list):
+def unify_dependency_path(dependency_path: List[str]) -> str:
     return PATH_SEPARATOR.join(dependency_path)

--- a/checkov/terraform/checks/utils/iam_terraform_document_to_policy_converter.py
+++ b/checkov/terraform/checks/utils/iam_terraform_document_to_policy_converter.py
@@ -1,5 +1,8 @@
 import copy
-def convert_terraform_conf_to_iam_policy(conf):
+from typing import Dict, List, Any
+
+
+def convert_terraform_conf_to_iam_policy(conf: Dict[str, List[Dict[str, Any]]]) -> Dict[str, List[Dict[str, Any]]]:
     """
         converts terraform parsed configuration to iam policy document
     """

--- a/checkov/terraform/checks/utils/utils.py
+++ b/checkov/terraform/checks/utils/utils.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from typing import Union, List, Any, Dict, Optional, Callable
 
 from checkov.common.graph.graph_builder import Edge
-from checkov.terraform.graph_builder.graph_components.attribute_names import CustomTerraformAttributes
+from checkov.terraform.graph_builder.graph_components.attribute_names import CustomAttributes
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 
 BLOCK_TYPES_STRINGS = ["var", "local", "module", "data"]
@@ -110,10 +110,10 @@ def get_vertex_reference_from_alias(
 ) -> Optional[VertexReference]:
     block_type = ""
     if block_type_str in aliases:
-        block_type = aliases[block_type_str][CustomTerraformAttributes.BLOCK_TYPE]
+        block_type = aliases[block_type_str][CustomAttributes.BLOCK_TYPE]
     aliased_provider = ".".join(val)
     if aliased_provider in aliases:
-        block_type = aliases[aliased_provider][CustomTerraformAttributes.BLOCK_TYPE]
+        block_type = aliases[aliased_provider][CustomAttributes.BLOCK_TYPE]
     if block_type:
         return VertexReference(block_type=block_type, sub_parts=val, origin_value="")
     return None

--- a/checkov/terraform/checks/utils/utils.py
+++ b/checkov/terraform/checks/utils/utils.py
@@ -5,48 +5,56 @@ import logging
 import os
 import re
 from copy import deepcopy
+from typing import Union, List, Any, Dict, Optional, Callable
 
-from checkov.terraform.graph_builder.graph_components.attribute_names import CustomAttributes
+from checkov.common.graph.graph_builder import Edge
+from checkov.terraform.graph_builder.graph_components.attribute_names import CustomTerraformAttributes
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 
-BLOCK_TYPES_STRINGS = ['var', 'local', 'module', 'data']
-FUNC_CALL_PREFIX_PATTERN = r'([.a-zA-Z]+)\('
-INTERPOLATION_PATTERN = '[${}]'
-INTERPOLATION_EXPR = r'\$\{([^\}]*)\}'
-BRACKETS_PATTERN = r'[\[\]\)\(\{\}]+'
-INDEX_PATTERN = r'\[([0-9]+)\]'
-IDENTIFIER_PATTERN = r'^[^\d\W]\w*\Z'
-MAP_ATTRIBUTE_PATTERN = r'\[\"([^\d\W]\w*)\"\]'
+BLOCK_TYPES_STRINGS = ["var", "local", "module", "data"]
+FUNC_CALL_PREFIX_PATTERN = r"([.a-zA-Z]+)\("
+INTERPOLATION_PATTERN = "[${}]"
+INTERPOLATION_EXPR = r"\$\{([^\}]*)\}"
+BRACKETS_PATTERN = r"[\[\]\)\(\{\}]+"
+INDEX_PATTERN = r"\[([0-9]+)\]"
+IDENTIFIER_PATTERN = r"^[^\d\W]\w*\Z"
+MAP_ATTRIBUTE_PATTERN = r"\[\"([^\d\W]\w*)\"\]"
 
 
 class VertexReference:
-    def __init__(self, block_type, sub_parts, origin_value):
+    def __init__(self, block_type: Union[str, BlockType], sub_parts: List[str], origin_value: str) -> None:
         self.block_type = block_type_str_to_enum(block_type) if type(block_type) is str else block_type
         self.sub_parts = sub_parts
         self.origin_value = origin_value
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, VertexReference):
             return NotImplemented
-        return self.block_type == other.block_type and self.sub_parts == other.sub_parts and self.origin_value == other.origin_value
+        return (
+            self.block_type == other.block_type
+            and self.sub_parts == other.sub_parts
+            and self.origin_value == other.origin_value
+        )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.block_type} sub_parts = {self.sub_parts}, origin = {self.origin_value}"
 
 
-def get_vertices_references(str_value, aliases, resources_types):
+def get_vertices_references(
+    str_value: str, aliases: Dict[str, Dict[str, BlockType]], resources_types: List[str]
+) -> List[VertexReference]:
     vertices_references = []
     words_in_str_value = str_value.split()
 
     for word in words_in_str_value:
-        if word.startswith('.') or word.startswith('/.'):
+        if word.startswith(".") or word.startswith("/."):
             # check if word is a relative path
             continue
 
         interpolations = re.split(INTERPOLATION_EXPR, word)
         for interpolation_content in interpolations:
-            for w in interpolation_content.split(','):
-                word_sub_parts = w.split('.')
+            for w in interpolation_content.split(","):
+                word_sub_parts = w.split(".")
                 if len(word_sub_parts) <= 1 or word_sub_parts[0].isnumeric():
                     # if the word doesn't contain a '.' char, or if the first part before the dot is a number
                     continue
@@ -54,121 +62,134 @@ def get_vertices_references(str_value, aliases, resources_types):
                 suspected_block_type = word_sub_parts[0]
                 if suspected_block_type in BLOCK_TYPES_STRINGS:
                     # matching cases like 'var.x'
-                    vertex_reference = VertexReference(block_type=suspected_block_type, sub_parts=word_sub_parts[1:],
-                                                       origin_value=w)
+                    vertex_reference = VertexReference(
+                        block_type=suspected_block_type, sub_parts=word_sub_parts[1:], origin_value=w
+                    )
                     if vertex_reference not in vertices_references:
                         vertices_references.append(vertex_reference)
                     continue
 
-                vertex_reference = get_vertex_reference_from_alias(suspected_block_type, aliases, word_sub_parts)
-                if vertex_reference and vertex_reference not in vertices_references:
-                    vertex_reference.origin_value = w
+                vertex_reference_alias = get_vertex_reference_from_alias(suspected_block_type, aliases, word_sub_parts)
+                if vertex_reference_alias and vertex_reference_alias not in vertices_references:
+                    vertex_reference_alias.origin_value = w
                     # matching cases where the word is referring an alias
-                    vertices_references.append(vertex_reference)
+                    vertices_references.append(vertex_reference_alias)
                     continue
 
                 # matching cases like 'aws_vpc.main'
                 if word_sub_parts[0] in resources_types:
-                    block_name = word_sub_parts[0] + '.' + word_sub_parts[1]
+                    block_name = word_sub_parts[0] + "." + word_sub_parts[1]
                     word_sub_parts = [block_name] + word_sub_parts[2:]
-                    vertex_reference = VertexReference(block_type=BlockType.RESOURCE, sub_parts=word_sub_parts,
-                                                       origin_value=w)
+                    vertex_reference = VertexReference(
+                        block_type=BlockType.RESOURCE, sub_parts=word_sub_parts, origin_value=w
+                    )
                     if vertex_reference not in vertices_references:
                         vertices_references.append(vertex_reference)
 
     return vertices_references
 
 
-def block_type_str_to_enum(block_type_str):
-    if block_type_str == 'var':
+def block_type_str_to_enum(block_type_str: str) -> BlockType:
+    if block_type_str == "var":
         return BlockType.VARIABLE
-    if block_type_str == 'local':
+    if block_type_str == "local":
         return BlockType.LOCALS
     return BlockType(block_type_str)
 
 
-def block_type_enum_to_str(block_type):
+def block_type_enum_to_str(block_type: BlockType) -> str:
     if block_type == BlockType.VARIABLE:
-        return 'var'
+        return "var"
     if block_type == BlockType.LOCALS:
-        return 'local'
+        return "local"
     return block_type
 
 
-def get_vertex_reference_from_alias(block_type_str, aliases, val):
-    block_type = ''
+def get_vertex_reference_from_alias(
+    block_type_str: str, aliases: Dict[str, Dict[str, BlockType]], val: List[str]
+) -> Optional[VertexReference]:
+    block_type = ""
     if block_type_str in aliases:
-        block_type = aliases[block_type_str][CustomAttributes.BLOCK_TYPE]
+        block_type = aliases[block_type_str][CustomTerraformAttributes.BLOCK_TYPE]
     aliased_provider = ".".join(val)
     if aliased_provider in aliases:
-        block_type = aliases[aliased_provider][CustomAttributes.BLOCK_TYPE]
+        block_type = aliases[aliased_provider][CustomTerraformAttributes.BLOCK_TYPE]
     if block_type:
-        return VertexReference(block_type=block_type, sub_parts=val,
-                               origin_value='')
+        return VertexReference(block_type=block_type, sub_parts=val, origin_value="")
     return None
 
 
-def remove_function_calls_from_str(str_value):
+def remove_function_calls_from_str(str_value: str) -> str:
     # remove start of function calls:: 'length(aws_vpc.main) > 0 ? aws_vpc.main[0].cidr_block : ${var.x}' --> 'aws_vpc.main) > 0 ? aws_vpc.main[0].cidr_block : ${var.x}'
-    str_value = re.sub(FUNC_CALL_PREFIX_PATTERN, '', str_value)
+    str_value = re.sub(FUNC_CALL_PREFIX_PATTERN, "", str_value)
     # remove ')'
-    return re.sub(r'[)]+', '', str_value)
+    return re.sub(r"[)]+", "", str_value)
 
 
-def remove_index_pattern_from_str(str_value):
-    str_value = re.sub(INDEX_PATTERN, '', str_value)
+def remove_index_pattern_from_str(str_value: str) -> str:
+    str_value = re.sub(INDEX_PATTERN, "", str_value)
     str_value = str_value.replace("[", " [ ")
     str_value = str_value.replace("]", " ] ")
     return str_value
 
 
-def remove_interpolation(str_value, replace_str=' '):
+def remove_interpolation(str_value: str, replace_str: str = " ") -> str:
     return re.sub(INTERPOLATION_PATTERN, replace_str, str_value)
 
 
-def replace_map_attribute_access_with_dot(str_value):
+def replace_map_attribute_access_with_dot(str_value: str) -> str:
     split_by_identifiers = re.split(MAP_ATTRIBUTE_PATTERN, str_value)
     new_split = []
     for split_part in split_by_identifiers:
-        if split_part.startswith('.'):
+        if split_part.startswith("."):
             split_part = split_part[1:]
-        if split_part.endswith('.'):
+        if split_part.endswith("."):
             split_part = split_part[:-1]
         new_split.append(split_part)
 
-    return '.'.join(new_split)
+    return ".".join(new_split)
 
 
-DEFAULT_CLEANUP_FUNCTIONS = [remove_function_calls_from_str, remove_index_pattern_from_str,
-                             replace_map_attribute_access_with_dot, remove_interpolation]
+DEFAULT_CLEANUP_FUNCTIONS: List[Callable[[str], str]] = [
+    remove_function_calls_from_str,
+    remove_index_pattern_from_str,
+    replace_map_attribute_access_with_dot,
+    remove_interpolation,
+]
 
 
-def get_referenced_vertices_in_value(value, aliases, resources_types, cleanup_functions=None):
+def get_referenced_vertices_in_value(
+    value: Union[str, List[str], Dict[str, str]],
+    aliases: Dict[str, Dict[str, BlockType]],
+    resources_types: List[str],
+    cleanup_functions: Optional[List[Callable[[str], str]]] = None,
+) -> List[VertexReference]:
     if cleanup_functions is None:
         cleanup_functions = DEFAULT_CLEANUP_FUNCTIONS
     references_vertices = []
-    value_type = type(value)
 
-    if value_type is list:
+    if isinstance(value, list):
         for sub_value in value:
-            references_vertices += get_referenced_vertices_in_value(sub_value, aliases, resources_types,
-                                                                    cleanup_functions)
+            references_vertices += get_referenced_vertices_in_value(
+                sub_value, aliases, resources_types, cleanup_functions
+            )
 
-    if value_type is dict:
-        for sub_key in value:
-            references_vertices += get_referenced_vertices_in_value(value[sub_key], aliases, resources_types,
-                                                                    cleanup_functions)
+    if isinstance(value, dict):
+        for sub_value in value.values():
+            references_vertices += get_referenced_vertices_in_value(
+                sub_value, aliases, resources_types, cleanup_functions
+            )
 
-    if value_type is str:
+    if isinstance(value, str):
         if cleanup_functions:
             for func in cleanup_functions:
-                value = func.__call__(value)
+                value = func(value)
         references_vertices = get_vertices_references(value, aliases, resources_types)
 
     return references_vertices
 
 
-def encode_graph_property_value(value):
+def encode_graph_property_value(value: Union[bool, int, float, str, Dict[str, Any]]) -> str:
     if isinstance(value, bool):
         # Encode boolean into Terraform's lower case convention
         value = str(value).lower()
@@ -177,11 +198,11 @@ def encode_graph_property_value(value):
     return json.dumps(value, indent=4, default=str)
 
 
-def decode_graph_property_value(value, leave_str=False):
+def decode_graph_property_value(value: Any, leave_str: bool = False) -> Any:
     if type(value) not in (str, bytes, bytearray):
         return value
-    if 'python_object' in value:
-        raise Exception(f'checkov does not allow arbitrary code execution, found here: {value}')
+    if "python_object" in value:
+        raise Exception(f"checkov does not allow arbitrary code execution, found here: {value}")
     if value.startswith('"') and value.endswith('"'):
         value = value[1:-1]
     if not leave_str:
@@ -191,21 +212,22 @@ def decode_graph_property_value(value, leave_str=False):
             try:
                 value = json.loads(value)
             except (ValueError, AttributeError):
-                logging.debug(f'Failed to decode graph value {value}')
+                logging.debug(f"Failed to decode graph value {value}")
     return value
 
 
-def calculate_hash(data):
+def calculate_hash(data: Union[bool, int, float, str, Dict[str, Any]]) -> str:
     encoded_attributes = encode_graph_property_value(data)
     sha256 = hashlib.sha256()
-    sha256.update(repr(encoded_attributes).encode('utf-8'))
+    sha256.update(repr(encoded_attributes).encode("utf-8"))
 
     return sha256.hexdigest()
 
 
-def run_function_multithreaded(func, data, max_group_size, num_of_workers=None):
-    groups_of_data = [data[i:i + max_group_size] for i in
-                      range(0, len(data), max_group_size)]
+def run_function_multithreaded(
+    func: Callable[..., Any], data: List[List[Edge]], max_group_size: int, num_of_workers: Optional[int] = None
+) -> None:
+    groups_of_data = [data[i : i + max_group_size] for i in range(0, len(data), max_group_size)]
     if not num_of_workers:
         num_of_workers = len(groups_of_data)
     if num_of_workers > 0:
@@ -213,7 +235,7 @@ def run_function_multithreaded(func, data, max_group_size, num_of_workers=None):
             futures = {executor.submit(func, data_group): data_group for data_group in groups_of_data}
             wait_result = concurrent.futures.wait(futures)
             if wait_result.not_done:
-                raise Exception(f'failed to perform {func.__name__}')
+                raise Exception(f"failed to perform {func.__name__}")
             for future in futures:
                 try:
                     future.result()
@@ -221,9 +243,11 @@ def run_function_multithreaded(func, data, max_group_size, num_of_workers=None):
                     raise e
 
 
-def update_dictionary_attribute(config, key_to_update, new_value):
-    key_parts = key_to_update.split('.')
-    if type(config) is dict:
+def update_dictionary_attribute(
+    config: Union[List[Any], Dict[str, Any]], key_to_update: str, new_value: Any
+) -> Union[List[Any], Dict[str, Any]]:
+    key_parts = key_to_update.split(".")
+    if isinstance(config, dict):
         if config.get(key_parts[0]) is not None:
             key = key_parts[0]
             if len(key_parts) == 1:
@@ -232,22 +256,22 @@ def update_dictionary_attribute(config, key_to_update, new_value):
                 config[key] = new_value
                 return config
             else:
-                config[key] = update_dictionary_attribute(config[key], '.'.join(key_parts[1:]), new_value)
+                config[key] = update_dictionary_attribute(config[key], ".".join(key_parts[1:]), new_value)
         else:
             for key in config:
                 config[key] = update_dictionary_attribute(config[key], key_to_update, new_value)
-    if type(config) is list:
+    if isinstance(config, list):
         for i in range(len(config)):
             config[i] = update_dictionary_attribute(config[i], key_to_update, new_value)
 
     return config
 
 
-def join_trimmed_strings(char_to_join, str_lst, num_to_trim):
-    return char_to_join.join(str_lst[:len(str_lst) - num_to_trim])
+def join_trimmed_strings(char_to_join: str, str_lst: List[str], num_to_trim: int) -> str:
+    return char_to_join.join(str_lst[: len(str_lst) - num_to_trim])
 
 
-def filter_sub_keys(key_list):
+def filter_sub_keys(key_list: List[str]) -> List[str]:
     filtered_key_list = []
     for key in key_list:
         if not any(other_key != key and other_key.startswith(key) for other_key in key_list):
@@ -255,17 +279,17 @@ def filter_sub_keys(key_list):
     return filtered_key_list
 
 
-def generate_possible_strings_from_wildcards(origin_string, max_entries=10):
+def generate_possible_strings_from_wildcards(origin_string: str, max_entries: int = 10) -> List[str]:
     max_entries = int(os.environ.get("MAX_WILDCARD_ARR_SIZE", max_entries))
     generated_strings = [origin_string]
     if not origin_string:
         return []
-    if '*' not in origin_string:
+    if "*" not in origin_string:
         return generated_strings
 
     locations_of_wildcards = []
     for i, char in enumerate(origin_string):
-        if char == '*':
+        if char == "*":
             locations_of_wildcards.append(i)
     locations_of_wildcards.reverse()
 
@@ -273,17 +297,17 @@ def generate_possible_strings_from_wildcards(origin_string, max_entries=10):
         new_generated_strings = []
         for s in generated_strings:
             before_wildcard = s[:wildcard_index]
-            after_wildcard = s[wildcard_index + 1:]
+            after_wildcard = s[wildcard_index + 1 :]
             for i in range(max_entries):
                 new_generated_strings.append(before_wildcard + str(i) + after_wildcard)
         generated_strings = new_generated_strings
 
     # if origin_string == "ingress.*.cidr_blocks", check for "ingress.cidr_blocks" too
-    generated_strings.append(''.join(origin_string.split('.*')))
+    generated_strings.append("".join(origin_string.split(".*")))
     return generated_strings
 
 
-def attribute_has_nested_attributes(attribute_key, attributes):
+def attribute_has_nested_attributes(attribute_key: str, attributes: Dict[str, Any]) -> bool:
     """
     :param attribute_key: key inside the  `attributes` dictionary
     :param attributes:
@@ -294,7 +318,7 @@ def attribute_has_nested_attributes(attribute_key, attributes):
     copy_of_attributes = deepcopy(attributes)
     copy_of_attributes.pop(attribute_key)
     prefixes_with_attribute_key = [a for a in copy_of_attributes.keys() if a.startswith(attribute_key)]
-    if not any(re.findall(r'\.\d+', a) for a in prefixes_with_attribute_key):
+    if not any(re.findall(r"\.\d+", a) for a in prefixes_with_attribute_key):
         # if there aro no numeric parts in the key such as key1.0.key2
         return isinstance(attributes[attribute_key], dict)
     return isinstance(attributes[attribute_key], list) or isinstance(attributes[attribute_key], dict)

--- a/checkov/terraform/graph_builder/graph_components/attribute_names.py
+++ b/checkov/terraform/graph_builder/graph_components/attribute_names.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass
 
-from checkov.common.graph.graph_builder import CustomAttributes, props
+from checkov.common.graph.graph_builder import CustomAttributes as CommonCustomAttributes, props
 
 
 @dataclass
-class CustomTerraformAttributes(CustomAttributes):
+class CustomAttributes(CommonCustomAttributes):
     ENCRYPTION = "encryption_"
     ENCRYPTION_DETAILS = "encryption_details_"
 
 
-reserved_attribute_names = props(CustomTerraformAttributes)
+reserved_attribute_names = props(CustomAttributes)

--- a/checkov/terraform/graph_builder/graph_components/attribute_names.py
+++ b/checkov/terraform/graph_builder/graph_components/attribute_names.py
@@ -4,10 +4,9 @@ from checkov.common.graph.graph_builder import CustomAttributes, props
 
 
 @dataclass
-class CustomAttributes(CustomAttributes):
-    SOURCE_MODULE = "source_module_"
+class CustomTerraformAttributes(CustomAttributes):
     ENCRYPTION = "encryption_"
     ENCRYPTION_DETAILS = "encryption_details_"
 
 
-reserved_attribute_names = props(CustomAttributes)
+reserved_attribute_names = props(CustomTerraformAttributes)

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from checkov.common.graph.graph_builder import reserved_attribute_names, EncryptionValues
 from checkov.common.graph.graph_builder import Edge
 from checkov.terraform.checks.utils.dependency_path_handler import unify_dependency_path
-from checkov.terraform.graph_builder.graph_components.attribute_names import CustomAttributes
+from checkov.terraform.graph_builder.graph_components.attribute_names import CustomTerraformAttributes
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 from checkov.terraform.graph_builder.graph_components.generic_resource_encryption import \
     ENCRYPTION_BY_RESOURCE_TYPE
@@ -107,7 +107,7 @@ class LocalGraph:
         aliases = {}
         for vertex in self.vertices:
             if 'alias' in vertex.attributes:
-                aliases[vertex.name] = {CustomAttributes.BLOCK_TYPE: vertex.block_type}
+                aliases[vertex.name] = {CustomTerraformAttributes.BLOCK_TYPE: vertex.block_type}
         return aliases
 
     def get_module_vertices_mapping(self):
@@ -398,7 +398,7 @@ class LocalGraph:
                     m = self.vertices[list(m.source_module)[0]]
                     source_module_data.append(m.get_export_data())
                 source_module_data.reverse()
-                vertex.breadcrumbs[CustomAttributes.SOURCE_MODULE] = source_module_data
+                vertex.breadcrumbs[CustomTerraformAttributes.SOURCE_MODULE] = source_module_data
 
     @staticmethod
     def _determine_if_module_connection(breadcrumbs_list, vertex_in_breadcrumbs):
@@ -424,6 +424,6 @@ class LocalGraph:
             if encryption_conf:
                 is_encrypted, reason = encryption_conf.is_encrypted(attributes)
                 # TODO: Does not support possible dependency (i.e. S3 Object being encrypted due to S3 Bucket config)
-                vertex.attributes[CustomAttributes.ENCRYPTION] = \
+                vertex.attributes[CustomTerraformAttributes.ENCRYPTION] = \
                     EncryptionValues.ENCRYPTED.value if is_encrypted else EncryptionValues.UNENCRYPTED.value
-                vertex.attributes[CustomAttributes.ENCRYPTION_DETAILS] = reason
+                vertex.attributes[CustomTerraformAttributes.ENCRYPTION_DETAILS] = reason

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from checkov.common.graph.graph_builder import reserved_attribute_names, EncryptionValues
 from checkov.common.graph.graph_builder import Edge
 from checkov.terraform.checks.utils.dependency_path_handler import unify_dependency_path
-from checkov.terraform.graph_builder.graph_components.attribute_names import CustomTerraformAttributes
+from checkov.terraform.graph_builder.graph_components.attribute_names import CustomAttributes
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 from checkov.terraform.graph_builder.graph_components.generic_resource_encryption import \
     ENCRYPTION_BY_RESOURCE_TYPE
@@ -107,7 +107,7 @@ class LocalGraph:
         aliases = {}
         for vertex in self.vertices:
             if 'alias' in vertex.attributes:
-                aliases[vertex.name] = {CustomTerraformAttributes.BLOCK_TYPE: vertex.block_type}
+                aliases[vertex.name] = {CustomAttributes.BLOCK_TYPE: vertex.block_type}
         return aliases
 
     def get_module_vertices_mapping(self):
@@ -398,7 +398,7 @@ class LocalGraph:
                     m = self.vertices[list(m.source_module)[0]]
                     source_module_data.append(m.get_export_data())
                 source_module_data.reverse()
-                vertex.breadcrumbs[CustomTerraformAttributes.SOURCE_MODULE] = source_module_data
+                vertex.breadcrumbs[CustomAttributes.SOURCE_MODULE] = source_module_data
 
     @staticmethod
     def _determine_if_module_connection(breadcrumbs_list, vertex_in_breadcrumbs):
@@ -424,6 +424,6 @@ class LocalGraph:
             if encryption_conf:
                 is_encrypted, reason = encryption_conf.is_encrypted(attributes)
                 # TODO: Does not support possible dependency (i.e. S3 Object being encrypted due to S3 Bucket config)
-                vertex.attributes[CustomTerraformAttributes.ENCRYPTION] = \
+                vertex.attributes[CustomAttributes.ENCRYPTION] = \
                     EncryptionValues.ENCRYPTED.value if is_encrypted else EncryptionValues.UNENCRYPTED.value
-                vertex.attributes[CustomTerraformAttributes.ENCRYPTION_DETAILS] = reason
+                vertex.attributes[CustomAttributes.ENCRYPTION_DETAILS] = reason

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,5 @@
+[mypy]
+files = checkov
+
 [mypy-dpath.*]
 ignore_missing_imports = True

--- a/tests/graph/terraform/graph_builder/test_local_graph.py
+++ b/tests/graph/terraform/graph_builder/test_local_graph.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from checkov.common.graph.db_connectors.networkx.networkx_db_connector import NetworkxConnector
 from checkov.common.graph.graph_builder import EncryptionValues, EncryptionTypes
-from checkov.terraform.graph_builder.graph_components.attribute_names import CustomTerraformAttributes
+from checkov.terraform.graph_builder.graph_components.attribute_names import CustomAttributes
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 from checkov.terraform.graph_builder.graph_components.blocks import Block
 from checkov.terraform.graph_builder.graph_components.generic_resource_encryption import ENCRYPTION_BY_RESOURCE_TYPE
@@ -113,10 +113,10 @@ class TestLocalGraph(TestCase):
         all_attributes = [vertex.get_attribute_dict() for vertex in local_graph.vertices]
         for attribute_dict in all_attributes:
             [resource_type, resource_name] = decode_graph_property_value(
-                attribute_dict[CustomTerraformAttributes.ID]).split(".")
+                attribute_dict[CustomAttributes.ID]).split(".")
             if resource_type in ENCRYPTION_BY_RESOURCE_TYPE:
-                is_encrypted = attribute_dict[CustomTerraformAttributes.ENCRYPTION]
-                details = attribute_dict[CustomTerraformAttributes.ENCRYPTION_DETAILS]
+                is_encrypted = attribute_dict[CustomAttributes.ENCRYPTION]
+                details = attribute_dict[CustomAttributes.ENCRYPTION_DETAILS]
                 self.assertEqual(is_encrypted, EncryptionValues.ENCRYPTED.value if resource_name.startswith("encrypted")
                                  else EncryptionValues.UNENCRYPTED.value, f'failed for "{resource_type}.{resource_name}"')
                 if is_encrypted == EncryptionValues.ENCRYPTED.value:
@@ -127,8 +127,8 @@ class TestLocalGraph(TestCase):
                 else:
                     self.assertEqual(details, "")
             else:
-                self.assertIsNone(attribute_dict.get(CustomTerraformAttributes.ENCRYPTION))
-                self.assertIsNone(attribute_dict.get(CustomTerraformAttributes.ENCRYPTION_DETAILS))
+                self.assertIsNone(attribute_dict.get(CustomAttributes.ENCRYPTION))
+                self.assertIsNone(attribute_dict.get(CustomAttributes.ENCRYPTION_DETAILS))
 
     def test_vertices_from_local_graph(self):
         resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME,

--- a/tests/graph/terraform/graph_builder/test_local_graph.py
+++ b/tests/graph/terraform/graph_builder/test_local_graph.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from checkov.common.graph.db_connectors.networkx.networkx_db_connector import NetworkxConnector
 from checkov.common.graph.graph_builder import EncryptionValues, EncryptionTypes
-from checkov.terraform.graph_builder.graph_components.attribute_names import CustomAttributes
+from checkov.terraform.graph_builder.graph_components.attribute_names import CustomTerraformAttributes
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 from checkov.terraform.graph_builder.graph_components.blocks import Block
 from checkov.terraform.graph_builder.graph_components.generic_resource_encryption import ENCRYPTION_BY_RESOURCE_TYPE
@@ -113,10 +113,10 @@ class TestLocalGraph(TestCase):
         all_attributes = [vertex.get_attribute_dict() for vertex in local_graph.vertices]
         for attribute_dict in all_attributes:
             [resource_type, resource_name] = decode_graph_property_value(
-                attribute_dict[CustomAttributes.ID]).split(".")
+                attribute_dict[CustomTerraformAttributes.ID]).split(".")
             if resource_type in ENCRYPTION_BY_RESOURCE_TYPE:
-                is_encrypted = attribute_dict[CustomAttributes.ENCRYPTION]
-                details = attribute_dict[CustomAttributes.ENCRYPTION_DETAILS]
+                is_encrypted = attribute_dict[CustomTerraformAttributes.ENCRYPTION]
+                details = attribute_dict[CustomTerraformAttributes.ENCRYPTION_DETAILS]
                 self.assertEqual(is_encrypted, EncryptionValues.ENCRYPTED.value if resource_name.startswith("encrypted")
                                  else EncryptionValues.UNENCRYPTED.value, f'failed for "{resource_type}.{resource_name}"')
                 if is_encrypted == EncryptionValues.ENCRYPTED.value:
@@ -127,8 +127,8 @@ class TestLocalGraph(TestCase):
                 else:
                     self.assertEqual(details, "")
             else:
-                self.assertIsNone(attribute_dict.get(CustomAttributes.ENCRYPTION))
-                self.assertIsNone(attribute_dict.get(CustomAttributes.ENCRYPTION_DETAILS))
+                self.assertIsNone(attribute_dict.get(CustomTerraformAttributes.ENCRYPTION))
+                self.assertIsNone(attribute_dict.get(CustomTerraformAttributes.ENCRYPTION_DETAILS))
 
     def test_vertices_from_local_graph(self):
         resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME,


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Next batch of type hints, this time for `terrafom.checks.provider` and `terrafom.checks.utils`.

I also moved `convert_cloudformation_conf_to_iam_policy.py` to the cloudformation code base, which is probably the correct place to have it 😉 

Other than that, I also renamed `CustomAttributes` to `CustomTerraformAttributes` in the terraform code base to better differentiate the difference between the original one and the subclass.