### PR TITLE
Improve string evaluation in variable rendering

### DIFF
--- a/checkov/terraform/variable_rendering/renderer.py
+++ b/checkov/terraform/variable_rendering/renderer.py
@@ -192,7 +192,6 @@ class VariableRenderer:
         The function updates the value of changed_attribute_key with changed_attribute_value for vertex
         """
         str_to_evaluate = str(changed_attribute_value) if changed_attribute_key in ATTRIBUTES_NO_EVAL else f'"{str(changed_attribute_value)}"'
-        # if isinstance(changed_attribute_value, list) and len(changed_attribute_value) == 1 and isinstance(changed_attribute_value[0], str) and len(changed_attribute_value[0]) != len(str_to_evaluate):
         str_to_evaluate = str_to_evaluate.replace("\\\\", "\\")
         evaluated_attribute_value = str_to_evaluate if changed_attribute_key in ATTRIBUTES_NO_EVAL else evaluate_terraform(str_to_evaluate)
         self.local_graph.update_vertex_attribute(vertex, changed_attribute_key, evaluated_attribute_value, change_origin_id, attribute_at_dest)

--- a/checkov/terraform/variable_rendering/renderer.py
+++ b/checkov/terraform/variable_rendering/renderer.py
@@ -191,8 +191,12 @@ class VariableRenderer:
         """
         The function updates the value of changed_attribute_key with changed_attribute_value for vertex
         """
-        evaluated_attribute_value = str(changed_attribute_value) if changed_attribute_key in ATTRIBUTES_NO_EVAL else evaluate_terraform(f'"{str(changed_attribute_value)}"')
+        str_to_evaluate = str(changed_attribute_value) if changed_attribute_key in ATTRIBUTES_NO_EVAL else f'"{str(changed_attribute_value)}"'
+        # if isinstance(changed_attribute_value, list) and len(changed_attribute_value) == 1 and isinstance(changed_attribute_value[0], str) and len(changed_attribute_value[0]) != len(str_to_evaluate):
+        str_to_evaluate = str_to_evaluate.replace("\\\\", "\\")
+        evaluated_attribute_value = str_to_evaluate if changed_attribute_key in ATTRIBUTES_NO_EVAL else evaluate_terraform(str_to_evaluate)
         self.local_graph.update_vertex_attribute(vertex, changed_attribute_key, evaluated_attribute_value, change_origin_id, attribute_at_dest)
+
 
     def evaluate_vertices_attributes(self):
         for vertex in self.local_graph.vertices:

--- a/checkov/terraform/variable_rendering/renderer.py
+++ b/checkov/terraform/variable_rendering/renderer.py
@@ -196,7 +196,6 @@ class VariableRenderer:
         evaluated_attribute_value = str_to_evaluate if changed_attribute_key in ATTRIBUTES_NO_EVAL else evaluate_terraform(str_to_evaluate)
         self.local_graph.update_vertex_attribute(vertex, changed_attribute_key, evaluated_attribute_value, change_origin_id, attribute_at_dest)
 
-
     def evaluate_vertices_attributes(self):
         for vertex in self.local_graph.vertices:
             decoded_attributes = vertex.get_decoded_attribute_dict()


### PR DESCRIPTION
When using `str(string_val)` that contains `\`, the operation duplicates it. 
This fix will prevent from this duplication to occur.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
