### PR TITLE
Add docdb audit log check

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/DocDBAuditLogs.py
+++ b/checkov/cloudformation/checks/resource/aws/DocDBAuditLogs.py
@@ -1,0 +1,23 @@
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.cloudformation.parser.node import dict_node
+from checkov.common.models.enums import CheckResult, CheckCategories
+
+
+class DocDBAuditLogs(BaseResourceCheck):
+    def __init__(self) -> None:
+        name = "Ensure DocDB has audit logs enabled"
+        id = "CKV_AWS_104"
+        supported_resources = ["AWS::DocDB::DBClusterParameterGroup"]
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: dict_node) -> CheckResult:
+        params = conf.get("Properties", {}).get("Parameters", {})
+
+        if params.get("audit_logs") == "enabled":
+            return CheckResult.PASSED
+
+        return CheckResult.FAILED
+
+
+check = DocDBAuditLogs()

--- a/tests/cloudformation/checks/resource/aws/example_DocDBAuditLogs/DocDBAuditLogs-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBAuditLogs/DocDBAuditLogs-FAILED.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  DocDBParameterGroupDefault:
+    Type: AWS::DocDB::DBClusterParameterGroup
+    Properties: 
+      Description: docdb cluster parameter group
+      Family: docdb4.0
+      Name: test
+      Parameters: 
+        ttl_monitor: "enabled"
+  DocDBParameterGroupDisabled:
+    Type: AWS::DocDB::DBClusterParameterGroup
+    Properties:
+      Description: docdb cluster parameter group
+      Family: docdb4.0
+      Name: test
+      Parameters:
+        audit_logs: "disabled"

--- a/tests/cloudformation/checks/resource/aws/example_DocDBAuditLogs/DocDBAuditLogs-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBAuditLogs/DocDBAuditLogs-PASSED.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  DocDBParameterGroupEnabled:
+    Type: AWS::DocDB::DBClusterParameterGroup
+    Properties: 
+      Description: docdb cluster parameter group
+      Family: docdb4.0
+      Name: test
+      Parameters: 
+        audit_logs: "enabled"

--- a/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-FAILED.yaml
@@ -1,6 +1,11 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  MyDocDB:
+  DocDBDefault:
+    Type: AWS::DocDB::DBCluster
+    Properties:
+      MasterUsername: name
+      MasterUserPassword: password
+  DocDBDisabled:
     Type: AWS::DocDB::DBCluster
     Properties:
       MasterUsername: name

--- a/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBEncryption/DocDBEncryption-PASSED.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  MyDocDB:
+  DocDBEnabled:
     Type: AWS::DocDB::DBCluster
     Properties:
       MasterUsername: name

--- a/tests/cloudformation/checks/resource/aws/example_DocDBLogging/DocDBLogging-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBLogging/DocDBLogging-FAILED.yaml
@@ -1,20 +1,20 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  MyDocDB0:
+  DocDBProfiler:
     Type: AWS::DocDB::DBCluster
     Properties:
       MasterUsername: name
       MasterUserPassword: password
       StorageEncrypted: false
       EnableCloudwatchLogsExports: ["profiler"]
-  MyDocDB1:
+  DocDBAudit:
     Type: AWS::DocDB::DBCluster
     Properties:
       MasterUsername: name
       MasterUserPassword: password
       StorageEncrypted: false
       EnableCloudwatchLogsExports: ["audit"]
-  MyDocDB2:
+  DocDBDefault:
     Type: AWS::DocDB::DBCluster
     Properties:
       MasterUsername: name

--- a/tests/cloudformation/checks/resource/aws/example_DocDBLogging/DocDBLogging-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBLogging/DocDBLogging-PASSED.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  MyDocDB:
+  DocDBEnabled:
     Type: AWS::DocDB::DBCluster
     Properties:
       MasterUsername: name

--- a/tests/cloudformation/checks/resource/aws/example_DocDBTLS/DocDBTLS-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBTLS/DocDBTLS-FAILED.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  MyDocDBParamGroup:
+  DocDBParameterGroupDisabled:
     Type: AWS::DocDB::DBClusterParameterGroup
     Properties: 
       Description: docdb cluster parameter group

--- a/tests/cloudformation/checks/resource/aws/example_DocDBTLS/DocDBTLS-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DocDBTLS/DocDBTLS-PASSED.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  MyDocDBParamGroup0:
+  DocDBParameterGroupEnabled:
     Type: AWS::DocDB::DBClusterParameterGroup
     Properties: 
       Description: docdb cluster parameter group
@@ -9,7 +9,7 @@ Resources:
       Parameters: 
         tls: "enabled"
         ttl_monitor: "enabled"
-  MyDocDBParamGroup1:
+  DocDBParameterGroupDefault:
     Type: AWS::DocDB::DBClusterParameterGroup
     Properties: 
       Description: docdb cluster parameter group

--- a/tests/cloudformation/checks/resource/aws/test_DocDBAuditLogs.py
+++ b/tests/cloudformation/checks/resource/aws/test_DocDBAuditLogs.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.DocDBAuditLogs import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestDocDBAuditLogs(unittest.TestCase):
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_DocDBAuditLogs"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::DocDB::DBClusterParameterGroup.DocDBParameterGroupEnabled",
+        }
+        failing_resources = {
+            "AWS::DocDB::DBClusterParameterGroup.DocDBParameterGroupDefault",
+            "AWS::DocDB::DBClusterParameterGroup.DocDBParameterGroupDisabled",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_DocDBEncryption.py
+++ b/tests/cloudformation/checks/resource/aws/test_DocDBEncryption.py
@@ -7,20 +7,33 @@ from checkov.runner_filter import RunnerFilter
 
 
 class TestDocDBEncryption(unittest.TestCase):
-
     def test_summary(self):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
         test_files_dir = current_dir + "/example_DocDBEncryption"
-        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 1)
-        self.assertEqual(summary['skipped'], 0)
-        self.assertEqual(summary['parsing_errors'], 0)
+        passing_resources = {
+            "AWS::DocDB::DBCluster.DocDBEnabled",
+        }
+        failing_resources = {
+            "AWS::DocDB::DBCluster.DocDBDefault",
+            "AWS::DocDB::DBCluster.DocDBDisabled",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_DocDBLogging.py
+++ b/tests/cloudformation/checks/resource/aws/test_DocDBLogging.py
@@ -7,20 +7,34 @@ from checkov.runner_filter import RunnerFilter
 
 
 class TestDocDBLogging(unittest.TestCase):
-
     def test_summary(self):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
         test_files_dir = current_dir + "/example_DocDBLogging"
-        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 3)
-        self.assertEqual(summary['skipped'], 0)
-        self.assertEqual(summary['parsing_errors'], 0)
+        passing_resources = {
+            "AWS::DocDB::DBCluster.DocDBEnabled",
+        }
+        failing_resources = {
+            "AWS::DocDB::DBCluster.DocDBDefault",
+            "AWS::DocDB::DBCluster.DocDBAudit",
+            "AWS::DocDB::DBCluster.DocDBProfiler",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_DocDBTLS.py
+++ b/tests/cloudformation/checks/resource/aws/test_DocDBTLS.py
@@ -7,20 +7,33 @@ from checkov.runner_filter import RunnerFilter
 
 
 class TestDocDBTLS(unittest.TestCase):
-
     def test_summary(self):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
         test_files_dir = current_dir + "/example_DocDBTLS"
-        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 2)
-        self.assertEqual(summary['failed'], 1)
-        self.assertEqual(summary['skipped'], 0)
-        self.assertEqual(summary['parsing_errors'], 0)
+        passing_resources = {
+            "AWS::DocDB::DBClusterParameterGroup.DocDBParameterGroupEnabled",
+            "AWS::DocDB::DBClusterParameterGroup.DocDBParameterGroupDefault",
+        }
+        failing_resources = {
+            "AWS::DocDB::DBClusterParameterGroup.DocDBParameterGroupDisabled",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Implement `CKV_AWS_104` check equivalent for CloudFormation.

I also added tests for passed/failed resources to the other DocDB check tests to make clear, what should pass or fail.