### PR TITLE
[CKV_AZURE_109] Update KeyVaultEnablesFirewallRulesSettings.py to expect a properly formated value

### DIFF
--- a/checkov/terraform/checks/resource/azure/KeyVaultEnablesFirewallRulesSettings.py
+++ b/checkov/terraform/checks/resource/azure/KeyVaultEnablesFirewallRulesSettings.py
@@ -14,7 +14,7 @@ class KeyVaultEnablesFirewallRulesSettings(BaseResourceValueCheck):
         return "network_acls/[0]/default_action"
 
     def get_expected_value(self):
-        return "deny"
+        return "Deny"
 
 
 check = KeyVaultEnablesFirewallRulesSettings()

--- a/tests/terraform/checks/resource/azure/test_KeyVaultEnablesFirewallRulesSettings.py
+++ b/tests/terraform/checks/resource/azure/test_KeyVaultEnablesFirewallRulesSettings.py
@@ -73,7 +73,7 @@ class TestKeyVaultEnablesFirewallRulesSettings(unittest.TestCase):
                     ]
                   }
                   network_acls {
-                    default_action = "deny" 
+                    default_action = "Deny" 
                   }
                 }
                 """)
@@ -111,7 +111,7 @@ class TestKeyVaultEnablesFirewallRulesSettings(unittest.TestCase):
                     ]
                   }
                   network_acls {
-                    default_action = "allow" 
+                    default_action = "Allow" 
                   }
                 }
                 """)


### PR DESCRIPTION
Hello,

I noticed this rule changed recently (it made no sense before). However, this rule is not working properly. It expects a "deny". However, azurerm expects "Deny". If "deny" is given to azurerm it will fail.


I'm not sure if there is anything else I should update. Please bring it to my attention and I will make the changes.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
