### PR TITLE
add check redshift should be in vpc

### DIFF
--- a/checkov/terraform/checks/resource/aws/RedshiftInEc2ClassicMode.py
+++ b/checkov/terraform/checks/resource/aws/RedshiftInEc2ClassicMode.py
@@ -1,0 +1,21 @@
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class RedshiftInEc2ClassicMode(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Redshift is not deployed outside of a VPC"
+        id = "CKV_AWS_153"
+        supported_resources = ['aws_redshift_cluster']
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "cluster_subnet_group_name"
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = RedshiftInEc2ClassicMode()

--- a/checkov/terraform/checks/resource/aws/RedshiftInEc2ClassicMode.py
+++ b/checkov/terraform/checks/resource/aws/RedshiftInEc2ClassicMode.py
@@ -6,7 +6,7 @@ from checkov.terraform.checks.resource.base_resource_value_check import BaseReso
 class RedshiftInEc2ClassicMode(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure Redshift is not deployed outside of a VPC"
-        id = "CKV_AWS_153"
+        id = "CKV_AWS_154"
         supported_resources = ['aws_redshift_cluster']
         categories = [CheckCategories.LOGGING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/tests/terraform/checks/resource/aws/example_RedshiftInEc2ClassicMode/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RedshiftInEc2ClassicMode/main.tf
@@ -1,0 +1,16 @@
+resource "aws_redshift_cluster" "fail" {
+  cluster_identifier = "redshift-defaults-only"
+  node_type = "dc2.large"
+  master_password = "Test1234"
+  master_username = "test"
+  skip_final_snapshot = true
+}
+
+resource "aws_redshift_cluster" "pass" {
+  cluster_identifier = "redshift-defaults-only"
+  node_type = "dc2.large"
+  master_password = "Test1234"
+  master_username = "test"
+  skip_final_snapshot = true
+  cluster_subnet_group_name="subnet-ebd9cead"
+}

--- a/tests/terraform/checks/resource/aws/test_RedshiftInEc2ClassicMode.py
+++ b/tests/terraform/checks/resource/aws/test_RedshiftInEc2ClassicMode.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.RedshiftInEc2ClassicMode import check
+from checkov.terraform.runner import Runner
+
+class TestRedshiftInEc2ClassicMode(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_RedshiftInEc2ClassicMode"
+        report = runner.run(
+            root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
+        )
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_redshift_cluster.pass",        }
+        failing_resources = {
+            "aws_redshift_cluster.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

new check for redshift that checks that the cluster is created within a VPC.

addressing one of these failures https://github.com/iacsecurity/tool-compare