### PR TITLE
Support json statements in cfn IAMRoleAllowsPublicAssume

### DIFF
--- a/tests/cloudformation/checks/resource/aws/example_IAMRoleAllowsPublicAssume/FAILED-2.yml
+++ b/tests/cloudformation/checks/resource/aws/example_IAMRoleAllowsPublicAssume/FAILED-2.yml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+Resources:
+  AWSStarPrincipal2:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument:
+          |
+          {
+            "Statement": [
+              {
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                }
+              }
+            ]
+          }
+
+  AWSStarPrincipalInList2:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument:
+          |
+          {
+            "Statement": [
+              {
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": ["arn:aws:iam::123456789101:root", "*"]
+                }
+              }
+            ]
+          }

--- a/tests/cloudformation/checks/resource/aws/example_IAMRoleAllowsPublicAssume/PASSED-2.yml
+++ b/tests/cloudformation/checks/resource/aws/example_IAMRoleAllowsPublicAssume/PASSED-2.yml
@@ -1,0 +1,33 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+Resources:
+  ServiceRole2:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument: |
+          {
+            "Statement": [
+              {
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "ec2.amazonaws.com"
+                }
+              }
+            ]
+          }
+  DenyIgnore2:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument: |
+          {
+           "Statement": [
+             {
+               "Action": "sts:AssumeRole",
+               "Effect": "Deny",
+               "Principal": {
+                 "AWS": "*"
+               }
+             }
+           ]
+          }

--- a/tests/cloudformation/checks/resource/aws/test_IAMRoleAllowsPublicAssume.py
+++ b/tests/cloudformation/checks/resource/aws/test_IAMRoleAllowsPublicAssume.py
@@ -25,18 +25,22 @@ class TestIAMRoleAllowsPublicAssume(unittest.TestCase):
         passing_resources = {
             "AWS::IAM::Role.ServiceRole",
             "AWS::IAM::Role.DenyIgnore",
+            "AWS::IAM::Role.ServiceRole2",
+            "AWS::IAM::Role.DenyIgnore2",
         }
 
         failing_resources = {
             "AWS::IAM::Role.AWSStarPrincipal",
             "AWS::IAM::Role.AWSStarPrincipalInList",
+            "AWS::IAM::Role.AWSStarPrincipal2",
+            "AWS::IAM::Role.AWSStarPrincipalInList2",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary['passed'], 2)
-        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['passed'], 4)
+        self.assertEqual(summary['failed'], 4)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
         self.assertEqual(passing_resources, passed_check_resources)


### PR DESCRIPTION
In cloudformation `IAMRoleAllowsPublicAssume`, handle a case where the assume_role_policy_doc is a json statement

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
