### PR TITLE
Check: elasticsearch has node to node encrypted coms

### DIFF
--- a/checkov/terraform/checks/resource/aws/ElasticsearchDomainNodeToNodeEncryption.py
+++ b/checkov/terraform/checks/resource/aws/ElasticsearchDomainNodeToNodeEncryption.py
@@ -1,0 +1,18 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class ElasticsearchDomainNodeToNodeEncryption(BaseResourceValueCheck):
+
+    def __init__(self):
+        name = "Ensure Elasticsearch Domain enforces Node To Node Encryption"
+        id = "CKV_AWS_157"
+        supported_resources = ['aws_elasticsearch_domain']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "node_to_node_encryption/[0]/enabled"
+
+
+check = ElasticsearchDomainNodeToNodeEncryption()

--- a/tests/terraform/checks/resource/aws/example_ElasticsearchDomainNodeToNodeEncryption/main.tf
+++ b/tests/terraform/checks/resource/aws/example_ElasticsearchDomainNodeToNodeEncryption/main.tf
@@ -1,0 +1,145 @@
+resource "aws_elasticsearch_domain" "missing" {
+  domain_name           = "cloudrail-non-enc-in-tran"
+  elasticsearch_version = "6.0"
+
+  cluster_config {
+    instance_type = "i3.large.elasticsearch"
+  }
+
+}
+
+resource "aws_elasticsearch_domain" "pass" {
+  domain_name           = var.es_domain
+  elasticsearch_version = var.es_version
+
+  advanced_security_options {
+    enabled = var.advanced_security_options
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.examplea.arn
+    log_type                 = var.log_publishing_options_type
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  cluster_config {
+    instance_type            = var.instance_type
+    instance_count           = var.instance_count
+    dedicated_master_enabled = var.dedicated_master_enabled
+    dedicated_master_count   = var.dedicated_master_count
+    dedicated_master_type    = var.dedicated_master_type
+    zone_awareness_enabled   = var.es_zone_awareness
+    zone_awareness_config {
+      availability_zone_count = 2
+    }
+
+    warm_enabled = false
+    warm_count = 2
+    warm_type  = "ultrawarm1.medium.elasticsearch"
+  }
+
+  vpc_options {
+    subnet_ids = var.subnets
+    security_group_ids = [
+      aws_security_group.examplea.id
+    ]
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = var.ebs_volume_size
+    volume_type = var.ebs_volume_type
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = var.snapshot_start_hour
+  }
+
+  encrypt_at_rest {
+    enabled = true
+    kms_key_id = var.kms_key_id
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  tags = var.common_tags
+}
+
+resource "aws_elasticsearch_domain" "fail" {
+  domain_name           = var.es_domain
+  elasticsearch_version = var.es_version
+
+
+  advanced_options = {
+  }
+
+  advanced_security_options {
+    enabled = var.advanced_security_options  
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.examplea.arn
+    log_type                 = var.log_publishing_options_type
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  cluster_config {
+    instance_type            = var.instance_type
+    instance_count           = var.instance_count
+    dedicated_master_enabled = var.dedicated_master_enabled
+    dedicated_master_count   = var.dedicated_master_count
+    dedicated_master_type    = var.dedicated_master_type
+    zone_awareness_enabled   = var.es_zone_awareness
+    zone_awareness_config {
+      availability_zone_count = 2
+      // Number of Availability Zones for the domain to use with zone_awareness_enabled. Defaults to 2. Valid values: 2 or 3.
+
+    }
+
+    warm_enabled = false
+    //2-150
+    warm_count = 2
+    warm_type  = "ultrawarm1.medium.elasticsearch"
+  }
+
+  vpc_options {
+    subnet_ids = var.subnets
+    security_group_ids = [
+      aws_security_group.examplea.id
+    ]
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = var.ebs_volume_size
+    volume_type = var.ebs_volume_type
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = var.snapshot_start_hour
+  }
+
+  encrypt_at_rest {
+    enabled = true
+    //default is aws/es
+    kms_key_id = var.kms_key_id
+  }
+
+  //add check 
+  node_to_node_encryption {
+    enabled = false
+  }
+
+
+  tags = var.common_tags
+}

--- a/tests/terraform/checks/resource/aws/test_ElasticsearchDomainNodeToNodeEncryption.py
+++ b/tests/terraform/checks/resource/aws/test_ElasticsearchDomainNodeToNodeEncryption.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.ElasticsearchDomainNodeToNodeEncryption import check
+from checkov.terraform.runner import Runner
+
+
+class TestElasticsearchDomainNodeToNodeEncryption(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ElasticsearchDomainNodeToNodeEncryption"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_elasticsearch_domain.pass"
+        }
+
+        failing_resources = {
+            "aws_elasticsearch_domain.fail",
+            "aws_elasticsearch_domain.missing",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Ensure that node to node communication is encrypted - is not by default.
Addresses missing checks as tested here: https://github.com/iacsecurity/tool-compare