### PR TITLE
fix ckv_aws_63 to handle conf dict properly

### DIFF
--- a/checkov/terraform/checks/resource/aws/IAMStarActionPolicyDocument.py
+++ b/checkov/terraform/checks/resource/aws/IAMStarActionPolicyDocument.py
@@ -16,7 +16,7 @@ class IAMStarActionPolicyDocument(BaseResourceCheck):
     def scan_resource_conf(self, conf):
         if 'policy' in conf.keys():
             try:
-                policy_block = json.loads(conf['policy'][0])
+                policy_block = conf['policy'][0]
                 if 'Statement' in policy_block.keys():
                     for statement in force_list(policy_block['Statement']):
                         if 'Action' in statement and \


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Upon testing the following resource:

```hcl
resource "aws_iam_policy" "policy" {
  name        = "my_policy-${var.aws_account_id}"
  path        = "/"
  description = "My test policy"
  policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "*"
      ],
      "Effect": "Allow",
      "Resource": "arn:aws:iam::${var.aws_account_id}:role/admin"
    }
  ]
}
EOF
}
```
Checkov 2.x returns a false positive because it fails to parse the IAM policy properly. This is due to https://github.com/bridgecrewio/checkov/commit/44100303db08412b9ad28505d59de8b21aff2c30 as of Checkov 2.0 which changes the `conf` to a dict, in turn breaking the `json.loads` here in this check.