### PR TITLE
Add CKV2_AWS_22 check to find IAM users with console access

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/IAMUserHasNoConsoleAccess.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/IAMUserHasNoConsoleAccess.yaml
@@ -1,0 +1,20 @@
+metadata:
+  id: "CKV2_AWS_22"
+  name: "Ensure an IAM User does not have access to the console"
+  category: "IAM"
+definition:
+  and:
+    - cond_type: filter
+      attribute: resource_type
+      value:
+        - aws_iam_user
+      operator: within
+    - resource_types:
+        - aws_iam_user
+      connected_resource_types:
+        - aws_iam_user_login_profile
+      operator: not_exists
+      cond_type: connection
+
+   
+

--- a/tests/graph/terraform/checks/resources/IAMUserHasNoConsoleAccess/expected.yaml
+++ b/tests/graph/terraform/checks/resources/IAMUserHasNoConsoleAccess/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "aws_iam_user.pass"
+fail:
+  - "aws_iam_user.fail"

--- a/tests/graph/terraform/checks/resources/IAMUserHasNoConsoleAccess/main.tf
+++ b/tests/graph/terraform/checks/resources/IAMUserHasNoConsoleAccess/main.tf
@@ -1,0 +1,16 @@
+# pass
+
+resource "aws_iam_user" "pass" {
+  name = "tech-user"
+}
+
+# fail
+
+resource "aws_iam_user" "fail" {
+  name = "human-user"
+}
+
+resource "aws_iam_user_login_profile" "fail" {
+  user    = aws_iam_user.fail.name
+  pgp_key = "keybase:human-user"
+}

--- a/tests/graph/terraform/checks/test_yaml_policies.py
+++ b/tests/graph/terraform/checks/test_yaml_policies.py
@@ -112,6 +112,9 @@ class TestYamlPolicies(unittest.TestCase):
     def test_IAMGroupHasAtLeastOneUser(self):
         self.go("IAMGroupHasAtLeastOneUser")
 
+    def test_IAMUserHasNoConsoleAccess(self):
+        self.go("IAMUserHasNoConsoleAccess")
+
     def test_IAMUsersAreMembersAtLeastOneGroup(self):
         self.go("IAMUsersAreMembersAtLeastOneGroup")
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This check is looking for IAM users, who have console access, which is usually discouraged and instead something like AWS SSO or SAML should be used to manage human user access to AWS.