### PR TITLE
Restrict string eval() calls in variable rendering

### DIFF
--- a/checkov/terraform/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/variable_rendering/evaluate_terraform.py
@@ -3,7 +3,7 @@ from typing import Any
 
 # condition ? true_val : false_val -> (condition, true_val, false_val)
 from checkov.terraform.parser_utils import find_var_blocks
-from checkov.terraform.variable_rendering.safe_eval_functions import evaluate
+from checkov.terraform.variable_rendering.safe_eval_functions import evaluate, BuiltinError
 
 CONDITIONAL_EXPR = r'([^\?]+)\?([^:]+)\:([^:]+)'
 
@@ -46,9 +46,13 @@ def evaluate_terraform(input_str, keep_interpolations=True):
 def _try_evaluate(input_str):
     try:
         return evaluate(input_str)
+    except BuiltinError:
+        raise
     except Exception:
         try:
             return evaluate(f'"{input_str}"')
+        except BuiltinError:
+            raise
         except Exception:
             return input_str
 

--- a/checkov/terraform/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/variable_rendering/evaluate_terraform.py
@@ -1,11 +1,9 @@
-import ast
 import re
-from copy import deepcopy
 from typing import Any
 
-from checkov.terraform.variable_rendering.safe_eval_functions import SAFE_EVAL_DICT, evaluate
 # condition ? true_val : false_val -> (condition, true_val, false_val)
 from checkov.terraform.parser_utils import find_var_blocks
+from checkov.terraform.variable_rendering.safe_eval_functions import evaluate
 
 CONDITIONAL_EXPR = r'([^\?]+)\?([^:]+)\:([^:]+)'
 
@@ -47,15 +45,9 @@ def evaluate_terraform(input_str, keep_interpolations=True):
 
 def _try_evaluate(input_str):
     try:
-        # t = ast.literal_eval(temp)
-        # res = eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT) # nosec
-        # # print(f"1: t = {t}, res = {res}")
         return evaluate(input_str)
     except Exception:
         try:
-            # t = ast.literal_eval(f'"{temp}"')
-            # res = eval(f'"{input_str}"', {"__builtins__": None}, SAFE_EVAL_DICT) # nosec
-            # # print(f"2: t = {t}, res = {res}")
             return evaluate(f'"{input_str}"')
         except Exception:
             return input_str

--- a/checkov/terraform/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/variable_rendering/safe_eval_functions.py
@@ -188,7 +188,7 @@ def get_allowed_functions():
 
 
 # get all builtin python names containing underscores
-builtins_names = filter(lambda b: "__" in b, dir(__builtins__))
+builtins_names = list(filter(lambda b: "__" in b, dir(__builtins__)))
 
 
 class BuiltinError(ValueError):

--- a/checkov/terraform/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/variable_rendering/safe_eval_functions.py
@@ -187,15 +187,20 @@ def get_allowed_functions():
     return list(SAFE_EVAL_DICT.keys())
 
 
+# get all builtin python names containing underscores
+builtins_names = filter(lambda b: "__" in b, dir(__builtins__))
+
+
+class BuiltinError(ValueError):
+    # Create a custom error class for usage in python builtins
+    pass
+
+
 def evaluate(input_str):
-    safe = True
     code = compile(input_str, "<string>", "eval")
     for name in code.co_names:
-        if name not in list(SAFE_EVAL_DICT.keys()):
-            safe = False
-            print(f"found bad name {name}, full input_str {input_str}")
-            break
-    if not safe:
-        return input_str
+        if name in builtins_names:
+            err_msg = f"got a builtin name in string value! builtin found: {name}, origin string: {input_str}"
+            raise BuiltinError(err_msg)
     return eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
 

--- a/checkov/terraform/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/variable_rendering/safe_eval_functions.py
@@ -1,11 +1,11 @@
-import ast
+import itertools
 import itertools
 import re
 import sys
 from functools import reduce
 from math import ceil, floor, log
 
-from checkov.terraform.parser_functions import tonumber, FUNCTION_FAILED, create_map, tobool, tolist, tomap, tostring
+from checkov.terraform.parser_functions import tonumber, FUNCTION_FAILED, create_map, tobool, tomap, tostring
 
 """
 This file contains a custom implementation of the builtin `eval` function.
@@ -188,19 +188,14 @@ def get_allowed_functions():
 
 
 def evaluate(input_str):
-    # ast.parse(input_str, filename='<unknown>', mode='exec')
-    # code = compile(input_string, "<string>", "eval")
-    ok = True
+    safe = True
     code = compile(input_str, "<string>", "eval")
     for name in code.co_names:
         if name not in list(SAFE_EVAL_DICT.keys()):
-            ok = False
-            print(f"found bad name {name}, in builtin? {name in sys.builtin_module_names}")
+            safe = False
+            print(f"found bad name {name}, full input_str {input_str}")
             break
-    if not ok:
+    if not safe:
         return input_str
     return eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
-    # for allowed_func in list(SAFE_EVAL_DICT.keys()):
-    #     if input_str.startswith(f"{allowed_func}(") and input_str.endswith(")"):
-    #         return eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT) # nosec
-    # return ast.literal_eval(input_str)
+

--- a/checkov/terraform/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/variable_rendering/safe_eval_functions.py
@@ -197,10 +197,9 @@ class BuiltinError(ValueError):
 
 
 def evaluate(input_str):
-    code = compile(input_str, "<string>", "eval")
-    for name in code.co_names:
-        if name in builtins_names:
-            err_msg = f"got a builtin name in string value! builtin found: {name}, origin string: {input_str}"
+    for builtin_name in builtins_names:
+        if builtin_name in input_str:
+            err_msg = f"got a builtin name in string value! builtin found: {builtin_name}, origin string: {input_str}"
             raise BuiltinError(err_msg)
     return eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
 

--- a/checkov/terraform/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/variable_rendering/safe_eval_functions.py
@@ -1,5 +1,7 @@
+import ast
 import itertools
 import re
+import sys
 from functools import reduce
 from math import ceil, floor, log
 
@@ -179,3 +181,26 @@ SAFE_EVAL_DICT['tostring'] = lambda arg: arg if isinstance(arg, str) else wrap_f
 
 # encoding
 SAFE_EVAL_DICT['jsonencode'] = lambda arg: arg
+
+
+def get_allowed_functions():
+    return list(SAFE_EVAL_DICT.keys())
+
+
+def evaluate(input_str):
+    # ast.parse(input_str, filename='<unknown>', mode='exec')
+    # code = compile(input_string, "<string>", "eval")
+    ok = True
+    code = compile(input_str, "<string>", "eval")
+    for name in code.co_names:
+        if name not in list(SAFE_EVAL_DICT.keys()):
+            ok = False
+            print(f"found bad name {name}, in builtin? {name in sys.builtin_module_names}")
+            break
+    if not ok:
+        return input_str
+    return eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
+    # for allowed_func in list(SAFE_EVAL_DICT.keys()):
+    #     if input_str.startswith(f"{allowed_func}(") and input_str.endswith(")"):
+    #         return eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT) # nosec
+    # return ast.literal_eval(input_str)

--- a/tests/graph/terraform/variable_rendering/test_string_evaluation.py
+++ b/tests/graph/terraform/variable_rendering/test_string_evaluation.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase
 
 from checkov.terraform.variable_rendering.evaluate_terraform import evaluate_terraform, replace_string_value, \
@@ -290,3 +291,9 @@ class TestTerraformEvaluation(TestCase):
         for input_str, expected in cases:
             with self.subTest(input_str):
                 assert evaluate_terraform(input_str) == expected
+
+    def test_block_python_code(self):
+        temp_file_path = "/tmp/file_shouldnt_create"
+        input_str = "[x for x in {}.__class__.__bases__[0].__subclasses__() if x.__name__ == 'catch_warnings'][0]()._module.__builtins__['__import__']('os').system('date >> /tmp/file_shouldnt_create')"
+        evaluate_terraform(input_str)
+        self.assertFalse(os.path.exists(temp_file_path))

--- a/tests/graph/terraform/variable_rendering/test_string_evaluation.py
+++ b/tests/graph/terraform/variable_rendering/test_string_evaluation.py
@@ -309,14 +309,26 @@ class TestTerraformEvaluation(TestCase):
         evaluated = evaluate_terraform(input_str)
         self.assertEqual(input_str, evaluated)
 
-    def test_block_console_output(self):
-        input_str = """"
-        (lambda fc=(lambda n: [c for c in ().__class__.__bases__[0].__subclasses__()
-    if c.__name__ == n][0]): fc("function")(fc("code")(0,0,0,0,"KABOOM",(),
-    (),(),"","",0,""),{})())()
-        """
+    def test_block_segmentation_fault(self):
+        # in this test, the following code is causing segmentation fault if evaluated
+        input_str = """
+(lambda fc=(
+    lambda n: [
+        c for c in
+            ().__class__.__bases__[0].__subclasses__()
+            if c.__name__ == n
+        ][0]
+    ):
+    fc("function")(
+        fc("code")(
+            0,0,0,0,0,b'test',(),(),(),"","",0,b'test'
+        ),{}
+    )()
+)()
+"""
         try:
             evaluate_terraform(input_str)
+            self.fail("expected to raise BuiltinError")
+        except BuiltinError as e:
+            print(e)
             pass
-        except Exception:
-            self.fail(f"code shouldn't execute and raise exceptions")

--- a/tests/graph/terraform/variable_rendering/test_string_evaluation.py
+++ b/tests/graph/terraform/variable_rendering/test_string_evaluation.py
@@ -292,8 +292,25 @@ class TestTerraformEvaluation(TestCase):
             with self.subTest(input_str):
                 assert evaluate_terraform(input_str) == expected
 
-    def test_block_python_code(self):
+    def test_block_file_write(self):
         temp_file_path = "/tmp/file_shouldnt_create"
         input_str = "[x for x in {}.__class__.__bases__[0].__subclasses__() if x.__name__ == 'catch_warnings'][0]()._module.__builtins__['__import__']('os').system('date >> /tmp/file_shouldnt_create')"
         evaluate_terraform(input_str)
         self.assertFalse(os.path.exists(temp_file_path))
+
+    def test_block_math_expr(self):
+        input_str = "__import__('math').sqrt(25)"
+        evaluated = evaluate_terraform(input_str)
+        self.assertEqual(input_str, evaluated)
+
+    def test_block_console_output(self):
+        input_str = """"
+        (lambda fc=(lambda n: [c for c in ().__class__.__bases__[0].__subclasses__()
+    if c.__name__ == n][0]): fc("function")(fc("code")(0,0,0,0,"KABOOM",(),
+    (),(),"","",0,""),{})())()
+        """
+        try:
+            evaluate_terraform(input_str)
+            pass
+        except Exception:
+            self.fail(f"code shouldn't execute and raise exceptions")


### PR DESCRIPTION
In the variable rendering process we are trying to evaluate strings which might contain terraform function calls or python expressions.
In order to make sure the call to python's `eval` function is as safe as possible without losing the ability to evaluate terraform functions we can use the `compile` function to generate a code object, and check if that code object contains any names that are within python's builtin names (containing `__`).
If such a name exists, the string is not evaluated and a custom `BuiltinError` is raised.
Added unit tests to check some interesting cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
