### PR TITLE
Skip scanning excluded paths in platform integration

### DIFF
--- a/checkov/arm/runner.py
+++ b/checkov/arm/runner.py
@@ -32,7 +32,7 @@ class Runner(BaseRunner):
 
         if root_folder:
             for root, d_names, f_names in os.walk(root_folder):
-                filter_ignored_directories(d_names)
+                filter_ignored_directories(d_names, runner_filter.excluded_paths)
                 for file in f_names:
                     file_ending = os.path.splitext(file)[1]
                     if file_ending in ARM_POSSIBLE_ENDINGS:

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -33,7 +33,7 @@ class Runner(BaseRunner):
 
         if root_folder:
             for root, d_names, f_names in os.walk(root_folder):
-                filter_ignored_directories(d_names)
+                filter_ignored_directories(d_names, runner_filter.excluded_paths)
                 for file in f_names:
                     file_ending = os.path.splitext(file)[1]
                     if file_ending in CF_POSSIBLE_ENDINGS:

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -70,6 +70,7 @@ class BcPlatformIntegration(object):
         self.platform_integration_configured = False
         self.http = None
         self.customer_name = ""
+        self.excluded_paths = []
 
     def setup_http_manager(self, ca_certificate=os.getenv('BC_CA_BUNDLE', None)):
         """
@@ -138,7 +139,6 @@ class BcPlatformIntegration(object):
         self.get_id_mapping()
 
         self.platform_integration_configured = True
-        self.get_excluded_paths()
 
     def get_s3_role(self, bc_api_key, repo_id):
         request = self.http.request("POST", self.integrations_api_url, body=json.dumps({"repoId": repo_id}),
@@ -173,6 +173,9 @@ class BcPlatformIntegration(object):
             return
 
         for root_path, d_names, f_names in os.walk(root_dir):
+            if any(re.findall(re.compile(exp), root_path) for exp in self.excluded_paths):
+                logging.info(f"skipping persisting excluded directory {root_path}")
+                continue
             for file_path in f_names:
                 _, file_extension = os.path.splitext(file_path)
                 if file_extension in SUPPORTED_FILE_EXTENSIONS:
@@ -415,30 +418,24 @@ class BcPlatformIntegration(object):
                 sleep(1)
 
     def get_excluded_paths(self):
-        # const
-        # repoSettingSchema = await this.settingsMgrApiLambda.invoke('vcsSettings/getScheme',
-        #                                                            {customerName, fullRepoName});
-        request = None
-        response = None
+        repo_settings_api_url = os.path.join(self.bc_api_url, "vcs/settings/scheme")
         try:
-
-            request = self.http.request("GET", os.path.join(self.bc_api_url, "vcs/settings/scheme"),
-                                   body=json.dumps({"customerName": self.customer_name, "fullRepoName": self.repo_id}),
-                                   headers={"Authorization": self.bc_api_key, "Content-Type": "text/plain"})
+            fields = {"customerName": self.customer_name, "fullRepoName": self.repo_id}
+            request = self.http.request("GET", repo_settings_api_url,
+                                        fields=fields,
+                                        headers={"Authorization": self.bc_api_key, "Content-Type": "application/json"})
             response = json.loads(request.data.decode("utf8"))
-            url = response.get("url", None)
-            return url
+            if 'scannedFiles' in response:
+                for section in response.get('scannedFiles').get('sections'):
+                    if self.repo_id in section.get('repos') and section.get('rule').get('excludePaths'):
+                        self.excluded_paths.extend(section.get('rule').get('excludePaths'))
+            return self.excluded_paths
         except HTTPError as e:
-            logging.error(f"Failed to commit repository {self.repo_path}\n{e}")
+            logging.error(f"Failed to get vcs settings for repo {self.repo_path}\n{e}")
             raise e
         except JSONDecodeError as e:
-            logging.error(f"Response of {self.integrations_api_url} is not a valid JSON\n{e}")
+            logging.error(f"Response of {repo_settings_api_url} is not a valid JSON\n{e}")
             raise e
-        finally:
-            if request.status == 201 and response["result"] == "Success":
-                logging.info(f"Finalize repository {self.repo_id} in bridgecrew's platform")
-            else:
-                raise Exception(f"Failed to finalize repository {self.repo_id} in bridgecrew's platform\n{response}")
 
 
 bc_integration = BcPlatformIntegration()

--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -1,14 +1,13 @@
 import os
 import re
 from abc import ABC, abstractmethod
+from typing import List
 
 from checkov.runner_filter import RunnerFilter
 
 IGNORED_DIRECTORIES_ENV = os.getenv('CKV_IGNORED_DIRECTORIES', "node_modules,.terraform,.serverless")
-EXCLUDED_PATHS_REGEXP = os.getenv('CKV_EXCLUDED_PATHS_REGEXP', "") + ","
 
 ignored_directories = IGNORED_DIRECTORIES_ENV.split(",")
-excluded_paths_regex = [re.compile(e) for e in EXCLUDED_PATHS_REGEXP.split(",")]
 
 
 class BaseRunner(ABC):
@@ -19,6 +18,7 @@ class BaseRunner(ABC):
         pass
 
 
-def filter_ignored_directories(d_names):
+def filter_ignored_directories(d_names, excluded_paths: List[str]):
+    excluded_paths = [] if excluded_paths is None else excluded_paths
     [d_names.remove(d) for d in list(d_names) if d in ignored_directories or d.startswith(".")
-     or any(re.match(exp, d) for exp in excluded_paths_regex)]
+     or any(re.findall(re.compile(exp), d) for exp in excluded_paths)]

--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -1,11 +1,14 @@
 import os
+import re
 from abc import ABC, abstractmethod
 
 from checkov.runner_filter import RunnerFilter
 
 IGNORED_DIRECTORIES_ENV = os.getenv('CKV_IGNORED_DIRECTORIES', "node_modules,.terraform,.serverless")
+EXCLUDED_PATHS_REGEXP = os.getenv('CKV_EXCLUDED_PATHS_REGEXP', "") + ","
 
 ignored_directories = IGNORED_DIRECTORIES_ENV.split(",")
+excluded_paths_regex = [re.compile(e) for e in EXCLUDED_PATHS_REGEXP.split(",")]
 
 
 class BaseRunner(ABC):
@@ -17,4 +20,5 @@ class BaseRunner(ABC):
 
 
 def filter_ignored_directories(d_names):
-    [d_names.remove(d) for d in list(d_names) if d in ignored_directories or d.startswith(".")]
+    [d_names.remove(d) for d in list(d_names) if d in ignored_directories or d.startswith(".")
+     or any(re.match(exp, d) for exp in excluded_paths_regex)]

--- a/checkov/dockerfile/runner.py
+++ b/checkov/dockerfile/runner.py
@@ -33,7 +33,7 @@ class Runner(BaseRunner):
 
         if root_folder:
             for root, d_names, f_names in os.walk(root_folder):
-                filter_ignored_directories(d_names)
+                filter_ignored_directories(d_names, runner_filter.excluded_paths)
                 for file in f_names:
                     if file in DOCKER_FILE_MASK:
                         files_list.append(os.path.join(root, file))

--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -27,7 +27,7 @@ class Runner(BaseRunner):
     system_deps = True
 
     @staticmethod
-    def find_chart_directories(root_folder, files):
+    def find_chart_directories(root_folder, files, excluded_paths):
         chart_directories = []
         if files:
             logging.info('Running with --file argument; checking for Helm Chart.yaml files')
@@ -37,7 +37,7 @@ class Runner(BaseRunner):
 
         if root_folder:
             for root, d_names, f_names in os.walk(root_folder):
-                filter_ignored_directories(d_names)
+                filter_ignored_directories(d_names, excluded_paths)
                 if 'Chart.yaml' in f_names:
                     chart_directories.append(root)
 
@@ -97,7 +97,7 @@ class Runner(BaseRunner):
             for directory in external_checks_dir:
                 registry.load_external_checks(directory)
 
-        chart_directories = self.find_chart_directories(root_folder, files)
+        chart_directories = self.find_chart_directories(root_folder, files, runner_filter.excluded_paths)
 
         report = Report(self.check_type)
     

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -34,7 +34,7 @@ class Runner(BaseRunner):
 
         if root_folder:
             for root, d_names, f_names in os.walk(root_folder):
-                filter_ignored_directories(d_names)
+                filter_ignored_directories(d_names, runner_filter.excluded_paths)
 
                 for file in f_names:
                     file_ending = os.path.splitext(file)[1]

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -85,6 +85,7 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
                                                         skip_fixes=args.skip_fixes,
                                                         skip_suppressions=args.skip_suppressions,
                                                         source=source, source_version=source_version, repo_branch=args.branch)
+            excluded_paths = bc_integration.get_excluded_paths()
         except Exception as e:
             logger.error('An error occurred setting up the Bridgecrew platform integration. Please check your API token and try again.', exc_info=True)
             return

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -86,6 +86,7 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
                                                         skip_suppressions=args.skip_suppressions,
                                                         source=source, source_version=source_version, repo_branch=args.branch)
             excluded_paths = bc_integration.get_excluded_paths()
+            runner_filter.excluded_paths = excluded_paths
         except Exception as e:
             logger.error('An error occurred setting up the Bridgecrew platform integration. Please check your API token and try again.', exc_info=True)
             return

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -21,6 +21,7 @@ class RunnerFilter(object):
         evaluate_variables: bool = True,
         runners: Optional[List[str]] = None,
         skip_framework: Optional[str] = None,
+        excluded_directories: Optional[List[str]] = None
     ) -> None:
         if checks is None:
             checks = []
@@ -54,6 +55,7 @@ class RunnerFilter(object):
         self.download_external_modules = download_external_modules
         self.external_modules_download_path = external_modules_download_path
         self.evaluate_variables = evaluate_variables
+        self.excluded_paths = excluded_directories
 
     def should_run_check(self, check_id: str) -> bool:
         if RunnerFilter.is_external_check(check_id):

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -64,7 +64,7 @@ class Runner(BaseRunner):
                 if "node_modules" in d_names:
                     d_names.remove("node_modules")
 
-                filter_ignored_directories(d_names)
+                filter_ignored_directories(d_names, runner_filter.excluded_paths)
                 for file in f_names:
                     if file in SLS_FILE_MASK:
                         full_path = os.path.join(root, file)

--- a/checkov/terraform/graph_manager.py
+++ b/checkov/terraform/graph_manager.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 from checkov.terraform.graph_builder.local_graph import LocalGraph
 from checkov.terraform.parser import Parser
@@ -10,11 +11,11 @@ class GraphManager:
         self.source = source
 
     def build_graph_from_source_directory(self, source_dir, render_variables=True, local_graph_class=LocalGraph,
-                                          parsing_errors=None, download_external_modules=False):
+                                          parsing_errors=None, download_external_modules=False, excluded_paths: List[str]=None):
         parser = Parser()
         logging.info('Parsing HCL files in source dir')
         module, module_dependency_map, tf_definitions = \
-            parser.parse_hcl_module(source_dir, self.source, download_external_modules, parsing_errors)
+            parser.parse_hcl_module(source_dir, self.source, download_external_modules, parsing_errors, excluded_paths=excluded_paths)
 
         logging.info('Building graph from parsed module')
         local_graph = local_graph_class(module, module_dependency_map)

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -80,7 +80,7 @@ class Runner(BaseRunner):
                     self.graph_manager.build_graph_from_source_directory(root_folder,
                                                                          local_graph_class=self.graph_class,
                                                                          download_external_modules=runner_filter.download_external_modules,
-                                                                         parsing_errors=parsing_errors)
+                                                                         parsing_errors=parsing_errors, excluded_paths=runner_filter.excluded_paths)
             elif files:
                 files = [os.path.abspath(file) for file in files]
                 root_folder = os.path.split(os.path.commonprefix(files))[0]

--- a/tests/common/runners/test_base_runner.py
+++ b/tests/common/runners/test_base_runner.py
@@ -7,8 +7,7 @@ from checkov.common.runners.base_runner import filter_ignored_directories
 class TestBaseRunner(unittest.TestCase):
 
     def test_filter_ignored_directories_regex(self):
-        os.environ["CKV_EXCLUDED_PATHS_REGEXP"] = "tests"
         d_names = ['bin', 'integration_tests', 'tests', 'docs', '.github', 'checkov', 'venv', '.git', 'kubernetes', '.idea']
-        expected = ['bin', 'docs', '.github', 'checkov', 'venv', '.git', 'kubernetes', '.idea']
-        actual = filter_ignored_directories(d_names)
-        self.assertEqual(expected, actual)
+        expected = ['bin', 'docs', 'checkov', 'venv', 'kubernetes']
+        filter_ignored_directories(d_names, ["tests"])
+        self.assertEqual(expected, d_names)

--- a/tests/common/runners/test_base_runner.py
+++ b/tests/common/runners/test_base_runner.py
@@ -1,0 +1,14 @@
+import os
+import unittest
+
+from checkov.common.runners.base_runner import filter_ignored_directories
+
+
+class TestBaseRunner(unittest.TestCase):
+
+    def test_filter_ignored_directories_regex(self):
+        os.environ["CKV_EXCLUDED_PATHS_REGEXP"] = "tests"
+        d_names = ['bin', 'integration_tests', 'tests', 'docs', '.github', 'checkov', 'venv', '.git', 'kubernetes', '.idea']
+        expected = ['bin', 'docs', '.github', 'checkov', 'venv', '.git', 'kubernetes', '.idea']
+        actual = filter_ignored_directories(d_names)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
In platform-integration, added a function that calls for the repository settings and look for excluded paths. 
Added the excluded path as another member to the runner filter and use it to match paths in `filter_ignored_directories` function. 
This also prevents persisting the excluded paths to s3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.