### PR TITLE
Avoid evaluation strings with double underscores in var rendering

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Clone Cfngoat - vulnerable cloudformation
         run: git clone https://github.com/bridgecrewio/cfngoat
       - name: Clone Kubernetes-goat - vulnerable kubernetes
-        run: git clone https://github.com/bridgecrewio/kubernetes-goa
+        run: git clone https://github.com/bridgecrewio/kubernetes-goat
       - name: Create checkov reports
         env:
           LOG_LEVEL: INFO

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -63,26 +63,11 @@ jobs:
           pipenv run python setup.py sdist bdist_wheel
           pipenv run pip install dist/checkov-*.whl
       - name: Clone Terragoat - vulnerable terraform
-        uses: actions/checkout@master
-        with:
-          repository: bridgecrewio/terragoat  # clone https://github.com/bridgecrewio/terragoat/
-          clean: false
-          token: ''
-          path: 'terragoat'
+        run: git clone https://github.com/bridgecrewio/terragoat
       - name: Clone Cfngoat - vulnerable cloudformation
-        uses: actions/checkout@master
-        with:
-          repository: bridgecrewio/cfngoat  # clone https://github.com/bridgecrewio/cfngoat/
-          clean: false
-          token: ''
-          path: 'cfngoat'
+        run: git clone https://github.com/bridgecrewio/cfngoat
       - name: Clone Kubernetes-goat - vulnerable kubernetes
-        uses: actions/checkout@master
-        with:
-          repository: madhuakula/kubernetes-goat  # clone https://github.com/madhuakula/kubernetes-goat
-          clean: false
-          token: ''
-          path: 'kubernetes-goat'
+        run: git clone https://github.com/bridgecrewio/kubernetes-goa
       - name: Create checkov reports
         env:
           LOG_LEVEL: INFO

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -66,21 +66,18 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: bridgecrewio/terragoat  # clone https://github.com/bridgecrewio/terragoat/
-          token: ${{ secrets.GITHUB_TOKEN }}
           clean: false
           path: 'terragoat'
       - name: Clone Cfngoat - vulnerable cloudformation
         uses: actions/checkout@master
         with:
           repository: bridgecrewio/cfngoat  # clone https://github.com/bridgecrewio/cfngoat/
-          token: ${{ secrets.GITHUB_TOKEN }}
           clean: false
           path: 'cfngoat'
       - name: Clone Kubernetes-goat - vulnerable kubernetes
         uses: actions/checkout@master
         with:
           repository: madhuakula/kubernetes-goat  # clone https://github.com/madhuakula/kubernetes-goat
-          token: ${{ secrets.GITHUB_TOKEN }}
           clean: false
           path: 'kubernetes-goat'
       - name: Create checkov reports

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Clone Cfngoat - vulnerable cloudformation
         run: git clone https://github.com/bridgecrewio/cfngoat
       - name: Clone Kubernetes-goat - vulnerable kubernetes
-        run: git clone https://github.com/bridgecrewio/kubernetes-goat
+        run: git clone https://github.com/madhuakula/kubernetes-goat
       - name: Create checkov reports
         env:
           LOG_LEVEL: INFO

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -67,18 +67,21 @@ jobs:
         with:
           repository: bridgecrewio/terragoat  # clone https://github.com/bridgecrewio/terragoat/
           clean: false
+          token: ''
           path: 'terragoat'
       - name: Clone Cfngoat - vulnerable cloudformation
         uses: actions/checkout@master
         with:
           repository: bridgecrewio/cfngoat  # clone https://github.com/bridgecrewio/cfngoat/
           clean: false
+          token: ''
           path: 'cfngoat'
       - name: Clone Kubernetes-goat - vulnerable kubernetes
         uses: actions/checkout@master
         with:
           repository: madhuakula/kubernetes-goat  # clone https://github.com/madhuakula/kubernetes-goat
           clean: false
+          token: ''
           path: 'kubernetes-goat'
       - name: Create checkov reports
         env:

--- a/checkov/terraform/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/variable_rendering/evaluate_terraform.py
@@ -3,7 +3,7 @@ from typing import Any
 
 # condition ? true_val : false_val -> (condition, true_val, false_val)
 from checkov.terraform.parser_utils import find_var_blocks
-from checkov.terraform.variable_rendering.safe_eval_functions import evaluate, BuiltinError
+from checkov.terraform.variable_rendering.safe_eval_functions import evaluate, PythonCodeError
 
 CONDITIONAL_EXPR = r'([^\?]+)\?([^:]+)\:([^:]+)'
 
@@ -46,12 +46,12 @@ def evaluate_terraform(input_str, keep_interpolations=True):
 def _try_evaluate(input_str):
     try:
         return evaluate(input_str)
-    except BuiltinError:
+    except PythonCodeError:
         raise
     except Exception:
         try:
             return evaluate(f'"{input_str}"')
-        except BuiltinError:
+        except PythonCodeError:
             raise
         except Exception:
             return input_str

--- a/checkov/terraform/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/variable_rendering/safe_eval_functions.py
@@ -187,19 +187,14 @@ def get_allowed_functions():
     return list(SAFE_EVAL_DICT.keys())
 
 
-# get all builtin python names containing underscores
-builtins_names = list(filter(lambda b: "__" in b, dir(__builtins__)))
-
-
-class BuiltinError(ValueError):
+class PythonCodeError(ValueError):
     # Create a custom error class for usage in python builtins
     pass
 
 
 def evaluate(input_str):
-    for builtin_name in builtins_names:
-        if builtin_name in input_str:
-            err_msg = f"got a builtin name in string value! builtin found: {builtin_name}, origin string: {input_str}"
-            raise BuiltinError(err_msg)
+    if "__" in input_str:
+        err_msg = f"got a substring with double underscore, which is not allowed. origin string: {input_str}"
+        raise PythonCodeError(err_msg)
     return eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
 


### PR DESCRIPTION
In terraform variable rendering, replaced looking for builtin names with looking for `__` substring. 
Added some more UTs for this use case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
