### PR TITLE
Replace string evaluation exception with warning

### DIFF
--- a/checkov/terraform/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/variable_rendering/evaluate_terraform.py
@@ -3,7 +3,7 @@ from typing import Any
 
 # condition ? true_val : false_val -> (condition, true_val, false_val)
 from checkov.terraform.parser_utils import find_var_blocks
-from checkov.terraform.variable_rendering.safe_eval_functions import evaluate, PythonCodeError
+from checkov.terraform.variable_rendering.safe_eval_functions import evaluate
 
 CONDITIONAL_EXPR = r'([^\?]+)\?([^:]+)\:([^:]+)'
 
@@ -46,13 +46,9 @@ def evaluate_terraform(input_str, keep_interpolations=True):
 def _try_evaluate(input_str):
     try:
         return evaluate(input_str)
-    except PythonCodeError:
-        raise
     except Exception:
         try:
             return evaluate(f'"{input_str}"')
-        except PythonCodeError:
-            raise
         except Exception:
             return input_str
 

--- a/checkov/terraform/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/variable_rendering/safe_eval_functions.py
@@ -1,7 +1,6 @@
 import itertools
-import itertools
+import logging
 import re
-import sys
 from functools import reduce
 from math import ceil, floor, log
 
@@ -183,18 +182,9 @@ SAFE_EVAL_DICT['tostring'] = lambda arg: arg if isinstance(arg, str) else wrap_f
 SAFE_EVAL_DICT['jsonencode'] = lambda arg: arg
 
 
-def get_allowed_functions():
-    return list(SAFE_EVAL_DICT.keys())
-
-
-class PythonCodeError(ValueError):
-    # Create a custom error class for usage in python builtins
-    pass
-
-
 def evaluate(input_str):
     if "__" in input_str:
-        err_msg = f"got a substring with double underscore, which is not allowed. origin string: {input_str}"
-        raise PythonCodeError(err_msg)
+        logging.warning(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")
+        return input_str
     return eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
 

--- a/tests/graph/terraform/variable_rendering/test_string_evaluation.py
+++ b/tests/graph/terraform/variable_rendering/test_string_evaluation.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 
 from checkov.terraform.variable_rendering.evaluate_terraform import evaluate_terraform, replace_string_value, \
     remove_interpolation
-from checkov.terraform.variable_rendering.safe_eval_functions import PythonCodeError
 
 
 class TestTerraformEvaluation(TestCase):
@@ -296,43 +295,28 @@ class TestTerraformEvaluation(TestCase):
     def test_block_file_write(self):
         temp_file_path = "/tmp/file_shouldnt_create"
         input_str = "[x for x in {}.__class__.__bases__[0].__subclasses__() if x.__name__ == 'catch_warnings'][0]()._module.__builtins__['__import__']('os').system('date >> /tmp/file_shouldnt_create')"
-        try:
-            evaluate_terraform(input_str)
-            self.fail("expected to raise PythonCodeError")
-        except PythonCodeError as e:
-            print(e)
-            self.assertFalse(os.path.exists(temp_file_path))
-            pass
+        evaluated = evaluate_terraform(input_str)
+        self.assertEqual(input_str, evaluated)
+        self.assertFalse(os.path.exists(temp_file_path))
 
     def test_block_file_write2(self):
         temp_file_path = "/tmp/file_shouldnt_create_vuln"
         input_str = "(lambda: [x for x in {}.__class__.__bases__[0].__subclasses__() if x.__name__ == 'catch_warnings'][0]()._module.__builtins__['__import__']('os').system('date >> /tmp/file_shouldnt_create_vuln'))()"
-        try:
-            evaluate_terraform(input_str)
-            self.fail("expected to raise PythonCodeError")
-        except PythonCodeError as e:
-            print(e)
-            self.assertFalse(os.path.exists(temp_file_path))
-            pass
+        evaluated = evaluate_terraform(input_str)
+        self.assertEqual(input_str, evaluated)
+        self.assertFalse(os.path.exists(temp_file_path))
 
     def test_block_file_write_lower(self):
         temp_file_path = "/tmp/file_shouldnt_create"
         input_str = "[x for x in parsint.__bases__[0].__subclasses__()][134]()._module.__builtins__['__IMPORT__'.lower()]('os').system('date >> /tmp/file_shouldnt_create')"
-        try:
-            ret = evaluate_terraform(input_str)
-            self.fail("expected to raise PythonCodeError")
-        except PythonCodeError as e:
-            print(e)
-            self.assertFalse(os.path.exists(temp_file_path))
-            pass
+        evaluated = evaluate_terraform(input_str)
+        self.assertEqual(input_str, evaluated)
+        self.assertFalse(os.path.exists(temp_file_path))
 
     def test_block_math_expr(self):
         input_str = "__import__('math').sqrt(25)"
-        try:
-            evaluate_terraform(input_str)
-            self.fail("expected to raise PythonCodeError")
-        except PythonCodeError as e:
-            pass
+        evaluated = evaluate_terraform(input_str)
+        self.assertEqual(input_str, evaluated)
 
     def test_block_segmentation_fault(self):
         # in this test, the following code is causing segmentation fault if evaluated
@@ -351,9 +335,5 @@ class TestTerraformEvaluation(TestCase):
     )()
 )()
 """
-        try:
-            evaluate_terraform(input_str)
-            self.fail("expected to raise PythonCodeError")
-        except PythonCodeError as e:
-            print(e)
-            pass
+        evaluated = evaluate_terraform(input_str)
+        self.assertEqual(input_str.replace("\n", ""), evaluated)


### PR DESCRIPTION
Replaced throwing and exception in case of `__` is in an evaluated string with logging a warning and returning the origin string.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
