### PR TITLE
do equals comparisons as strings

### DIFF
--- a/checkov/terraform/checks_infra/solvers/attribute_solvers/equals_attribute_solver.py
+++ b/checkov/terraform/checks_infra/solvers/attribute_solvers/equals_attribute_solver.py
@@ -10,4 +10,4 @@ class EqualsAttributeSolver(BaseAttributeSolver):
                          attribute=attribute, value=value)
 
     def _get_operation(self, vertex, attribute):
-        return vertex.get(attribute) == self.value
+        return str(vertex.get(attribute)) == str(self.value)

--- a/tests/graph/terraform/checks/resources/ALBRedirectsHTTPToHTTPS/expected.yaml
+++ b/tests/graph/terraform/checks/resources/ALBRedirectsHTTPToHTTPS/expected.yaml
@@ -4,3 +4,4 @@ pass:
   - "aws_lb.lb_good_3"
 fail:
   - "aws_lb.lb_bad_1"
+  - "aws_lb.lb_bad_2"

--- a/tests/graph/terraform/checks/resources/ALBRedirectsHTTPToHTTPS/expected.yaml
+++ b/tests/graph/terraform/checks/resources/ALBRedirectsHTTPToHTTPS/expected.yaml
@@ -1,5 +1,6 @@
 pass:
   - "aws_lb.lb_good_1"
   - "aws_lb.lb_good_2"
+  - "aws_lb.lb_good_3"
 fail:
   - "aws_lb.lb_bad_1"

--- a/tests/graph/terraform/checks/resources/ALBRedirectsHTTPToHTTPS/main.tf
+++ b/tests/graph/terraform/checks/resources/ALBRedirectsHTTPToHTTPS/main.tf
@@ -4,6 +4,9 @@ resource "aws_lb" "lb_good_1" {
 resource "aws_lb" "lb_good_2" {
 }
 
+resource "aws_lb" "lb_good_3" {
+}
+
 resource "aws_lb" "lb_bad_1" {
 }
 
@@ -20,6 +23,23 @@ resource "aws_lb_listener" "listener_good_1" {
 resource "aws_lb_listener" "listener_good_2" {
   load_balancer_arn = aws_lb.lb_good_2.arn
   port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+
+  }
+}
+
+resource "aws_lb_listener" "listener_good_3" {
+  load_balancer_arn = aws_lb.lb_good_3.arn
+  port              = 80  #as an int
   protocol          = "HTTP"
 
   default_action {

--- a/tests/graph/terraform/checks/resources/ALBRedirectsHTTPToHTTPS/main.tf
+++ b/tests/graph/terraform/checks/resources/ALBRedirectsHTTPToHTTPS/main.tf
@@ -10,6 +10,10 @@ resource "aws_lb" "lb_good_3" {
 resource "aws_lb" "lb_bad_1" {
 }
 
+resource "aws_lb" "lb_bad_2" {
+}
+
+
 resource "aws_lb_listener" "listener_good_1" {
   load_balancer_arn = aws_lb.lb_good_1.arn
   port = "443"
@@ -63,3 +67,14 @@ resource "aws_lb_listener" "listener_bad_1" {
     type = "some-action"
   }
 }
+
+resource "aws_lb_listener" "listener_bad_2" {
+  load_balancer_arn = aws_lb.lb_bad_2.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "some-action"
+  }
+}
+


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR handles type conversion for Equals (and NotEquals) graph checks. For example, the HTTP -> HTTPS redirect check fails if you specify the port as an int. But this is valid in TF.

@rotemavni does this need to be updated somewhere in the platform?