### PR TITLE
do not copy line numbers during param replacement

### DIFF
--- a/checkov/cloudformation/context_parser.py
+++ b/checkov/cloudformation/context_parser.py
@@ -155,11 +155,18 @@ class ContextParser(object):
     def _set_in_dict(self, data_dict, map_list, value):
         v = self._get_from_dict(data_dict, map_list[:-1])
         # save the original marks so that we do not copy in the line numbers of the parameter element
-        start = v.start_mark
-        end = v.end_mark
+        # but not all ref types will have these attributes
+        start = None
+        end = None
+        if hasattr(v, 'start_mark'):
+            start = v.start_mark
+            end = v.end_mark
+
         v[map_list[-1]] = value
-        v[map_list[-1]].start_mark = start
-        v[map_list[-1]].end_mark = end
+
+        if hasattr(v[map_list[-1]], 'start_mark') and start and end:
+            v[map_list[-1]].start_mark = start
+            v[map_list[-1]].end_mark = end
 
     @staticmethod
     def _get_from_dict(data_dict, map_list):

--- a/checkov/cloudformation/context_parser.py
+++ b/checkov/cloudformation/context_parser.py
@@ -153,7 +153,13 @@ class ContextParser(object):
         return keys
 
     def _set_in_dict(self, data_dict, map_list, value):
-        self._get_from_dict(data_dict, map_list[:-1])[map_list[-1]] = value
+        v = self._get_from_dict(data_dict, map_list[:-1])
+        # save the original marks so that we do not copy in the line numbers of the parameter element
+        start = v.start_mark
+        end = v.end_mark
+        v[map_list[-1]] = value
+        v[map_list[-1]].start_mark = start
+        v[map_list[-1]].end_mark = end
 
     @staticmethod
     def _get_from_dict(data_dict, map_list):

--- a/tests/cloudformation/parser/cfn_with_ref.yaml
+++ b/tests/cloudformation/parser/cfn_with_ref.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "data-stage"
+
+Parameters:
+  ElasticsearchInstanceType:
+    Type: String
+    Default: r5.large.elasticsearch
+
+Resources:
+  ElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: !Join
+          - "-"
+          - - !Ref AWS::StackName
+            - "20200325"
+      ElasticsearchVersion: !Ref ElasticsearchVersion
+      ElasticsearchClusterConfig:
+        InstanceCount: '1'
+        InstanceType: !Ref ElasticsearchInstanceType

--- a/tests/cloudformation/parser/test_cfn_yaml.py
+++ b/tests/cloudformation/parser/test_cfn_yaml.py
@@ -118,6 +118,19 @@ class TestCfnYaml(unittest.TestCase):
 
         self.assertEqual(ContextParser.trim_lines(test5), [])
 
+    def test_parameter_import_lines(self):
+        # check that when a parameter is imported into a resource, the line numbers of the resource are preserved
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        file = f'{current_dir}/cfn_with_ref.yaml'
+        definitions, definitions_raw = parse(file)
+
+        cf_context_parser = ContextParser(file, definitions, definitions_raw)
+        resource = definitions['Resources']['ElasticsearchDomain']
+        entity_lines_range, entity_code_lines = cf_context_parser.extract_cf_resource_code_lines(resource)
+        self.assertEqual(entity_lines_range[0], 10)
+        self.assertEqual(entity_lines_range[1], 20)
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR fixes CFN param replacement. It would copy in the line numbers of the parameter dict entry. The result was that the resource lines would range from the start of the param to the end of the resource.

@tronxd I think there might be nuances between CFN and JSON parsing that need to be handled here. I am not sure. Please take a look.