### PR TITLE
Add CKV_AWS_160 check for Timestream DB KMS encryption

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/TimestreamDatabaseKMSKey.py
+++ b/checkov/cloudformation/checks/resource/aws/TimestreamDatabaseKMSKey.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories
+
+
+class TimestreamDatabaseKMSKey(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that Timestream database is encrypted with KMS CMK"
+        id = "CKV_AWS_160"
+        supported_resources = ["AWS::Timestream::Database"]
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "Properties/KmsKeyId"
+
+    def get_expected_value(self) -> Any:
+        return ANY_VALUE
+
+
+check = TimestreamDatabaseKMSKey()

--- a/checkov/terraform/checks/resource/aws/TimestreamDatabaseKMSKey.py
+++ b/checkov/terraform/checks/resource/aws/TimestreamDatabaseKMSKey.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from checkov.common.models.consts import ANY_VALUE
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class TimestreamDatabaseKMSKey(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that Timestream database is encrypted with KMS CMK"
+        id = "CKV_AWS_160"
+        supported_resources = ["aws_timestreamwrite_database"]
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "kms_key_id"
+
+    def get_expected_value(self) -> Any:
+        return ANY_VALUE
+
+
+check = TimestreamDatabaseKMSKey()

--- a/tests/cloudformation/checks/resource/aws/example_TimestreamDatabaseKMSKey/TimestreamDatabaseKMSKey-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_TimestreamDatabaseKMSKey/TimestreamDatabaseKMSKey-FAILED.yaml
@@ -1,0 +1,6 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  TimestreamDatabaseDefault:
+    Type: AWS::Timestream::Database
+    Properties:
+      DatabaseName: timestream

--- a/tests/cloudformation/checks/resource/aws/example_TimestreamDatabaseKMSKey/TimestreamDatabaseKMSKey-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_TimestreamDatabaseKMSKey/TimestreamDatabaseKMSKey-PASSED.yaml
@@ -1,0 +1,7 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  TimestreamDatabaseEnabled:
+    Type: AWS::Timestream::Database
+    Properties:
+      DatabaseName: timestream
+      KmsKeyId: kms-key-id

--- a/tests/cloudformation/checks/resource/aws/test_TimestreamDatabaseKMSKey.py
+++ b/tests/cloudformation/checks/resource/aws/test_TimestreamDatabaseKMSKey.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.TimestreamDatabaseKMSKey import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestRedShiftSSL(unittest.TestCase):
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_TimestreamDatabaseKMSKey"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::Timestream::Database.TimestreamDatabaseEnabled",
+        }
+        failing_resources = {
+            "AWS::Timestream::Database.TimestreamDatabaseDefault",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/example_TimestreamDatabaseKMSKey/main.tf
+++ b/tests/terraform/checks/resource/aws/example_TimestreamDatabaseKMSKey/main.tf
@@ -1,0 +1,13 @@
+# pass
+
+resource "aws_timestreamwrite_database" "enabled" {
+  database_name = "timestream"
+
+  kms_key_id = var.kms_key_id
+}
+
+# failure
+
+resource "aws_timestreamwrite_database" "default" {
+  database_name = "timestream"
+}

--- a/tests/terraform/checks/resource/aws/test_TimestreamDatabaseKMSKey.py
+++ b/tests/terraform/checks/resource/aws/test_TimestreamDatabaseKMSKey.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.TimestreamDatabaseKMSKey import check
+from checkov.terraform.runner import Runner
+
+
+class TestTimestreamDatabaseKMSKey(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_TimestreamDatabaseKMSKey"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_timestreamwrite_database.enabled",
+        }
+        failing_resources = {
+            "aws_timestreamwrite_database.default",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Terraform support for Timestream came out quite recently and of course you can encrypt it with your own KMS key 😉 and I also added the same check as an CloudFormation check, why not 😄 