### PR TITLE
Fix CKV2_AWS_19 check to incorporate NAT Gateways

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/EIPAllocatedToVPCAttachedEC2.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/EIPAllocatedToVPCAttachedEC2.yaml
@@ -51,3 +51,21 @@ definition:
           - aws_eip_association
         attribute: instance_id
         operator: exists
+    - and:
+      - resource_types:
+          - aws_eip
+        connected_resource_types:
+          - aws_nat_gateway
+        operator: exists
+        cond_type: connection
+      - cond_type: filter
+        attribute: resource_type
+        value:
+          - aws_eip
+        operator: within
+      - cond_type: attribute
+        resource_types:
+          - aws_eip
+        attribute: vpc
+        operator: equals
+        value: true

--- a/tests/graph/terraform/checks/resources/EIPAllocatedToVPCAttachedEC2/expected.yaml
+++ b/tests/graph/terraform/checks/resources/EIPAllocatedToVPCAttachedEC2/expected.yaml
@@ -1,5 +1,6 @@
 pass:
   - "aws_eip.ok_eip"
   - "aws_eip.ok_eip_assoc"
+  - "aws_eip.ok_eip_nat"
 fail:
   - "aws_eip.not_ok_eip"

--- a/tests/graph/terraform/checks/resources/EIPAllocatedToVPCAttachedEC2/main.tf
+++ b/tests/graph/terraform/checks/resources/EIPAllocatedToVPCAttachedEC2/main.tf
@@ -39,3 +39,14 @@ resource "aws_instance" "ec2_assoc" {
 resource "aws_eip" "ok_eip_assoc" {
   vpc = true
 }
+
+# via aws_nat_gateway
+
+resource "aws_eip" "ok_eip_nat" {
+  vpc = true
+}
+
+resource "aws_nat_gateway" "ok_eip_nat" {
+  allocation_id = aws_eip.ok_eip_nat.id
+  subnet_id     = "aws_subnet.public.id"
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I'm not sure, if the name of the check `Ensure that all EIP addresses allocated to a VPC are attached to EC2 instances` is still accurate, because now it also checks if the EIP is attached to NAT Gateway.