### PR TITLE
Improve collect skip comments performance

### DIFF
--- a/checkov/logging_init.py
+++ b/checkov/logging_init.py
@@ -7,12 +7,11 @@ import os
 def init():
     LOG_LEVEL = os.environ.get('LOG_LEVEL', 'WARNING').upper()
     logging.basicConfig(level=LOG_LEVEL)
-    logFormatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
-    rootLogger = logging.getLogger()
-    consoleHandler = logging.StreamHandler(sys.stderr)
-    consoleHandler.setFormatter(logFormatter)
-    consoleHandler.setLevel(LOG_LEVEL)
-    rootLogger.addHandler(consoleHandler)
+    log_formatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
+    root_logger = logging.getLogger()
+    stream_handler = root_logger.handlers[0]
+    stream_handler.setFormatter(log_formatter)
+    root_logger.setLevel(LOG_LEVEL)
     logging.getLogger().setLevel(LOG_LEVEL)
     logging.getLogger("urllib3").setLevel(logging.ERROR)
     logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)

--- a/checkov/terraform/context_parsers/base_parser.py
+++ b/checkov/terraform/context_parsers/base_parser.py
@@ -70,7 +70,7 @@ class BaseContextParser(ABC):
 
     @staticmethod
     def is_optional_comment_line(line: str) -> bool:
-        line_without_whitespace = "".join(line[1].split())
+        line_without_whitespace = "".join(line.split())
         return 'checkov:skip=' in line_without_whitespace or 'bridgecrew:skip=' in line_without_whitespace
 
     def _collect_skip_comments(self, definition_blocks: List[Dict[str, Any]]) -> Dict[str, Any]:

--- a/checkov/terraform/context_parsers/base_parser.py
+++ b/checkov/terraform/context_parsers/base_parser.py
@@ -7,10 +7,10 @@ from typing import List, Dict, Any, Tuple, Optional
 
 import dpath.util
 
+from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.comment.enum import COMMENT_REGEX
 from checkov.common.models.enums import ContextCategories
 from checkov.terraform.context_parsers.registry import parser_registry
-from checkov.common.bridgecrew.platform_integration import bc_integration
 
 OPEN_CURLY = "{"
 CLOSE_CURLY = "}"
@@ -68,6 +68,11 @@ class BaseContextParser(ABC):
             file_lines = [(ind + 1, line) for (ind, line) in list(enumerate(file.readlines()))]
             return file_lines
 
+    @staticmethod
+    def is_optional_comment_line(line: str) -> bool:
+        line_without_whitespace = "".join(line[1].split())
+        return 'checkov:skip=' in line_without_whitespace or 'bridgecrew:skip=' in line_without_whitespace
+
     def _collect_skip_comments(self, definition_blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
         """
         Collects checkov skip comments to all definition blocks
@@ -76,6 +81,10 @@ class BaseContextParser(ABC):
         """
         bc_id_mapping = bc_integration.get_id_mapping()
         parsed_file_lines = self.filtered_lines
+        optional_comment_lines = [
+            line for line in parsed_file_lines
+            if self.is_optional_comment_line(line[1])
+        ]
         comments = [
             (
                 line_num,
@@ -84,20 +93,21 @@ class BaseContextParser(ABC):
                     "suppress_comment": match.group(3)[1:] if match.group(3) else "No comment provided",
                 },
             )
-            for (line_num, x) in parsed_file_lines
+            for (line_num, x) in optional_comment_lines
             for match in [re.search(COMMENT_REGEX, x)]
             if match
         ]
         for entity_block in definition_blocks:
             skipped_checks = []
             entity_context_path = self.get_entity_context_path(entity_block)
-            context_search = dpath.search(self.context, entity_context_path, yielded=True)
-            for _, entity_context in context_search:
-                for (skip_check_line_num, skip_check) in comments:
-                    if entity_context["start_line"] < skip_check_line_num < entity_context["end_line"]:
-                        if bc_id_mapping and skip_check["id"] in bc_id_mapping:
-                            skip_check["id"] = bc_id_mapping[skip_check["id"]]
-                        skipped_checks.append(skip_check)
+            entity_context = self.context
+            for k in entity_context_path:
+                entity_context = entity_context[k]
+            for (skip_check_line_num, skip_check) in comments:
+                if entity_context["start_line"] < skip_check_line_num < entity_context["end_line"]:
+                    if bc_id_mapping and skip_check["id"] in bc_id_mapping:
+                        skip_check["id"] = bc_id_mapping[skip_check["id"]]
+                    skipped_checks.append(skip_check)
             dpath.new(self.context, entity_context_path + ["skipped_checks"], skipped_checks)
         return self.context
 
@@ -121,7 +131,7 @@ class BaseContextParser(ABC):
         return end_line_num
 
     def run(
-        self, tf_file: str, definition_blocks: List[Dict[str, Any]], collect_skip_comments: bool = True
+            self, tf_file: str, definition_blocks: List[Dict[str, Any]], collect_skip_comments: bool = True
     ) -> Dict[str, Any]:
         # TF files for loaded modules have this formation:  <file>[<referrer>#<index>]
         # Chop off everything after the file name for our purposes here
@@ -162,7 +172,7 @@ class BaseContextParser(ABC):
                     dpath.new(self.context, entity_context_path + ["start_line"], start_line)
                     dpath.new(self.context, entity_context_path + ["end_line"], end_line)
                     dpath.new(
-                        self.context, entity_context_path + ["code_lines"], self.file_lines[start_line - 1 : end_line]
+                        self.context, entity_context_path + ["code_lines"], self.file_lines[start_line - 1: end_line]
                     )
                     potential_block_start_lines.remove((line_num, line))
                     break

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -594,6 +594,7 @@ Load JSON or HCL, depending on filename.
     file_name = os.path.basename(file_path)
 
     try:
+        logging.debug(f"Parsing {file_path}")
         with open(file, "r") as f:
             if file_name.endswith(".json"):
                 return json.load(f)
@@ -605,7 +606,7 @@ Load JSON or HCL, depending on filename.
                 else:
                     return non_malformed_definitions
     except Exception as e:
-        logging.debug(f'failed while parsing file {file}', exc_info=e)
+        logging.debug(f'failed while parsing file {file_path}', exc_info=e)
         parsing_errors[file_path] = e
         return None
 

--- a/checkov/terraform/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/variable_rendering/evaluate_terraform.py
@@ -200,6 +200,9 @@ def evaluate_directives(input_str):
     evaluated_string_parts = []
     for str_part in matching_directives:
         evaluated_string_parts.append(evaluate_terraform(str_part))
+
+    # Handle evaluation results which are integer / boolean
+    evaluated_string_parts = [v if isinstance(v, str) else str(v) for v in evaluated_string_parts]
     return ''.join(evaluated_string_parts)
 
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. Avoid double logging for no reason
2. Filter optional comment lines to reduce number of calls to re.match()
3. Use direct access instead of dpath.search inside the context to reduce run time
4. Handle case of non-str in evaluated_string_parts to succeed in joining to new string