### PR TITLE
Add rds iam auth check

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/RDSClusterIAMAuthentication.py
+++ b/checkov/cloudformation/checks/resource/aws/RDSClusterIAMAuthentication.py
@@ -1,0 +1,17 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class RDSClusterIAMAuthentication(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure RDS cluster has IAM authentication enabled"
+        id = "CKV_AWS_162"
+        supported_resources = ["AWS::RDS::DBCluster"]
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "Properties/EnableIAMDatabaseAuthentication"
+
+
+check = RDSClusterIAMAuthentication()

--- a/checkov/cloudformation/checks/resource/aws/RDSIAMAuthentication.py
+++ b/checkov/cloudformation/checks/resource/aws/RDSIAMAuthentication.py
@@ -1,0 +1,26 @@
+from checkov.cloudformation.parser.node import dict_node
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class RDSIAMAuthentication(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure RDS database has IAM authentication enabled"
+        id = "CKV_AWS_161"
+        supported_resources = ["AWS::RDS::DBInstance"]
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "Properties/EnableIAMDatabaseAuthentication"
+
+    def scan_resource_conf(self, conf: dict_node) -> CheckResult:
+        # IAM authentication is only supported for MySQL and PostgreSQL
+        engine = conf.get("Properties", {}).get("Engine", {})
+        if engine not in ("mysql", "postgres"):
+            return CheckResult.UNKNOWN
+
+        return super().scan_resource_conf(conf)
+
+
+check = RDSIAMAuthentication()

--- a/checkov/terraform/checks/resource/aws/RDSClusterIAMAuthentication.py
+++ b/checkov/terraform/checks/resource/aws/RDSClusterIAMAuthentication.py
@@ -1,0 +1,17 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class RDSClusterIAMAuthentication(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure RDS cluster has IAM authentication enabled"
+        id = "CKV_AWS_162"
+        supported_resources = ["aws_rds_cluster"]
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "iam_database_authentication_enabled"
+
+
+check = RDSClusterIAMAuthentication()

--- a/checkov/terraform/checks/resource/aws/RDSIAMAuthentication.py
+++ b/checkov/terraform/checks/resource/aws/RDSIAMAuthentication.py
@@ -1,0 +1,26 @@
+from typing import Dict, List, Any
+
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories, CheckResult
+
+
+class RDSIAMAuthentication(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure RDS database has IAM authentication enabled"
+        id = "CKV_AWS_161"
+        supported_resources = ["aws_db_instance"]
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "iam_database_authentication_enabled"
+
+    def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
+        # IAM authentication is only supported for MySQL and PostgreSQL
+        if conf.get("engine") not in (["mysql"], ["postgres"]):
+            return CheckResult.UNKNOWN
+
+        return super().scan_resource_conf(conf)
+
+
+check = RDSIAMAuthentication()

--- a/tests/cloudformation/checks/resource/aws/example_RDSClusterIAMAuthentication/RDSClusterIAMAuthentication-FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSClusterIAMAuthentication/RDSClusterIAMAuthentication-FAIL.yaml
@@ -1,0 +1,14 @@
+Resources:
+  Default:
+    Type: 'AWS::RDS::DBCluster'
+    Properties:
+      Engine: 'aurora'
+      MasterUsername: 'username'
+      MasterUserPassword: 'password'
+  Disabled:
+    Type: 'AWS::RDS::DBCluster'
+    Properties:
+      Engine: 'aurora'
+      MasterUsername: 'username'
+      MasterUserPassword: 'password'
+      EnableIAMDatabaseAuthentication: false

--- a/tests/cloudformation/checks/resource/aws/example_RDSClusterIAMAuthentication/RDSClusterIAMAuthentication-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSClusterIAMAuthentication/RDSClusterIAMAuthentication-PASSED.yaml
@@ -1,0 +1,8 @@
+Resources:
+  Enabled:
+    Type: 'AWS::RDS::DBCluster'
+    Properties:
+      Engine: 'aurora'
+      MasterUsername: 'username'
+      MasterUserPassword: 'password'
+      EnableIAMDatabaseAuthentication: true

--- a/tests/cloudformation/checks/resource/aws/example_RDSIAMAuthentication/RDSIAMAuthentication-FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSIAMAuthentication/RDSIAMAuthentication-FAIL.yaml
@@ -1,0 +1,31 @@
+Resources:
+  DefaultMysql:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBInstanceClass: 'db.t3.micro'
+      Engine: 'mysql'
+      MasterUsername: 'username'
+      MasterUserPassword: 'password'
+  DefaultPostgres:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBInstanceClass: 'db.t3.micro'
+      Engine: 'postgres'
+      MasterUsername: 'username'
+      MasterUserPassword: 'password'
+  DisabledMysql:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBInstanceClass: 'db.t3.micro'
+      Engine: 'mysql'
+      MasterUsername: 'username'
+      MasterUserPassword: 'password'
+      EnableIAMDatabaseAuthentication: false
+  DisabledPostgres:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBInstanceClass: 'db.t3.micro'
+      Engine: 'postgres'
+      MasterUsername: 'username'
+      MasterUserPassword: 'password'
+      EnableIAMDatabaseAuthentication: false

--- a/tests/cloudformation/checks/resource/aws/example_RDSIAMAuthentication/RDSIAMAuthentication-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSIAMAuthentication/RDSIAMAuthentication-PASSED.yaml
@@ -1,0 +1,17 @@
+Resources:
+  EnabledMysql:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBInstanceClass: 'db.t3.micro'
+      Engine: 'mysql'
+      MasterUsername: 'username'
+      MasterUserPassword: 'password'
+      EnableIAMDatabaseAuthentication: true
+  EnabledPostgres:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBInstanceClass: 'db.t3.micro'
+      Engine: 'postgres'
+      MasterUsername: 'username'
+      MasterUserPassword: 'password'
+      EnableIAMDatabaseAuthentication: true

--- a/tests/cloudformation/checks/resource/aws/example_RDSIAMAuthentication/RDSIAMAuthentication-UNKNOWN.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSIAMAuthentication/RDSIAMAuthentication-UNKNOWN.yaml
@@ -1,0 +1,8 @@
+Resources:
+  Mariadb:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBInstanceClass: 'db.t3.micro'
+      Engine: 'mariadb'
+      MasterUsername: 'username'
+      MasterUserPassword: 'password'

--- a/tests/cloudformation/checks/resource/aws/test_RDSClusterIAMAuthentication.py
+++ b/tests/cloudformation/checks/resource/aws/test_RDSClusterIAMAuthentication.py
@@ -1,0 +1,37 @@
+import unittest
+from pathlib import Path
+
+from checkov.cloudformation.checks.resource.aws.RDSClusterIAMAuthentication import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestRDSClusterIAMAuthentication(unittest.TestCase):
+    def test_summary(self):
+        test_files_dir = Path(__file__).parent / "example_RDSClusterIAMAuthentication"
+
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::RDS::DBCluster.Enabled",
+        }
+        failing_resources = {
+            "AWS::RDS::DBCluster.Default",
+            "AWS::RDS::DBCluster.Disabled",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_RDSIAMAuthentication.py
+++ b/tests/cloudformation/checks/resource/aws/test_RDSIAMAuthentication.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+
+from checkov.cloudformation.checks.resource.aws.RDSIAMAuthentication import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestRDSIAMAuthentication(unittest.TestCase):
+    def test_summary(self):
+        test_files_dir = Path(__file__).parent / "example_RDSIAMAuthentication"
+
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::RDS::DBInstance.EnabledMysql",
+            "AWS::RDS::DBInstance.EnabledPostgres",
+        }
+        failing_resources = {
+            "AWS::RDS::DBInstance.DefaultMysql",
+            "AWS::RDS::DBInstance.DefaultPostgres",
+            "AWS::RDS::DBInstance.DisabledMysql",
+            "AWS::RDS::DBInstance.DisabledPostgres",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cloudformation/parser/test_cfn_yaml.py
+++ b/tests/cloudformation/parser/test_cfn_yaml.py
@@ -17,7 +17,7 @@ class TestCfnYaml(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 1)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/terraform/checks/resource/aws/example_RDSClusterIAMAuthentication/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSClusterIAMAuthentication/main.tf
@@ -1,0 +1,22 @@
+# pass
+
+resource "aws_rds_cluster" "enabled" {
+  master_username         = "username"
+  master_password         = "password"
+
+  iam_database_authentication_enabled = true
+}
+
+# failure
+
+resource "aws_rds_cluster" "default" {
+  master_username         = "username"
+  master_password         = "password"
+}
+
+resource "aws_rds_cluster" "disabled" {
+  master_username         = "username"
+  master_password         = "password"
+
+  iam_database_authentication_enabled = false
+}

--- a/tests/terraform/checks/resource/aws/example_RDSIAMAuthentication/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSIAMAuthentication/main.tf
@@ -1,0 +1,69 @@
+# pass
+
+resource "aws_db_instance" "enabled_mysql" {
+  allocated_storage = 5
+  engine            = "postgres"
+  instance_class    = "db.t3.small"
+  password          = "password"
+  username          = "username"
+
+  iam_database_authentication_enabled = true
+}
+
+resource "aws_db_instance" "enabled_postgres" {
+  allocated_storage = 5
+  engine            = "postgres"
+  instance_class    = "db.t3.small"
+  password          = "password"
+  username          = "username"
+
+  iam_database_authentication_enabled = true
+}
+
+# failure
+
+resource "aws_db_instance" "default_mysql" {
+  allocated_storage = 5
+  engine            = "mysql"
+  instance_class    = "db.t3.small"
+  password          = "password"
+  username          = "username"
+}
+
+resource "aws_db_instance" "default_postgres" {
+  allocated_storage = 5
+  engine            = "postgres"
+  instance_class    = "db.t3.small"
+  password          = "password"
+  username          = "username"
+}
+
+resource "aws_db_instance" "disabled_mysql" {
+  allocated_storage = 5
+  engine            = "postgres"
+  instance_class    = "db.t3.small"
+  password          = "password"
+  username          = "username"
+
+  iam_database_authentication_enabled = false
+}
+
+resource "aws_db_instance" "disabled_postgres" {
+  allocated_storage = 5
+  engine            = "postgres"
+  instance_class    = "db.t3.small"
+  password          = "password"
+  username          = "username"
+
+  iam_database_authentication_enabled = false
+}
+
+# unknown
+
+resource "aws_db_instance" "mariadb" {
+  allocated_storage = 5
+  engine            = "mariadb"
+  instance_class    = "db.t3.small"
+  password          = "password"
+  username          = "username"
+}

--- a/tests/terraform/checks/resource/aws/test_RDSClusterIAMAuthentication.py
+++ b/tests/terraform/checks/resource/aws/test_RDSClusterIAMAuthentication.py
@@ -1,0 +1,37 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.RDSClusterIAMAuthentication import check
+from checkov.terraform.runner import Runner
+
+
+class TestRDSClusterIAMAuthentication(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_RDSClusterIAMAuthentication"
+
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_rds_cluster.enabled",
+        }
+        failing_resources = {
+            "aws_rds_cluster.default",
+            "aws_rds_cluster.disabled",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_RDSIAMAuthentication.py
+++ b/tests/terraform/checks/resource/aws/test_RDSIAMAuthentication.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.RDSIAMAuthentication import check
+from checkov.terraform.runner import Runner
+
+
+class TestRDSIAMAuthentication(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_RDSIAMAuthentication"
+
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_db_instance.enabled_mysql",
+            "aws_db_instance.enabled_postgres",
+        }
+        failing_resources = {
+            "aws_db_instance.default_mysql",
+            "aws_db_instance.default_postgres",
+            "aws_db_instance.disabled_mysql",
+            "aws_db_instance.disabled_postgres",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I first tried to put both checks into the same, but the handling is quite awkward, so I split them into two. In general it is recommended to use IAM authentication for RDS databases and cluster, because you don't need to inject the password anymore and have to temporarily invoke a session to connect to the database.