### PR TITLE
fix:Check neg on attribute allow_blob_public_access for Azure storage account

### DIFF
--- a/checkov/terraform/checks/resource/azure/StorageAccountDisablePublicAccess.py
+++ b/checkov/terraform/checks/resource/azure/StorageAccountDisablePublicAccess.py
@@ -1,18 +1,20 @@
+from checkov.common.models.consts import ANY_VALUE
 from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
 
 
-class StorageAccountDisablePublicAccess(BaseResourceValueCheck):
+class StorageAccountDisablePublicAccess(BaseResourceNegativeValueCheck):
     def __init__(self):
         name = "Ensure that Storage accounts disallow public access"
         id = "CKV_AZURE_59"
         supported_resources = ['azurerm_storage_account']
         categories = [CheckCategories.NETWORKING]
-        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
-                         missing_block_result=CheckResult.PASSED)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):
-        return "enable_https_traffic_only"
+        return "allow_blob_public_access"
 
+    def get_forbidden_values(self):
+        return [True]
 
 check = StorageAccountDisablePublicAccess()


### PR DESCRIPTION
https://docs.bridgecrew.io/docs/ensure-that-storage-accounts-disallow-public-access, the “Ensure that storage accounts disallow public access” should flag on allow_blob_public_access = true, NOT enable_https_traffic_only.  You can see that the below 2 issues are flagging on the same line.

attribute checko was wrong and of the wrong type. not sure how the test passed.