### PR TITLE
fix CKV2_AWS_16 check to only consider DynamoDB tables

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/AutoScalingEnableOnDynamoDBTables.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/AutoScalingEnableOnDynamoDBTables.yaml
@@ -3,30 +3,40 @@ metadata:
   id: "CKV2_AWS_16"
   category: "GENERAL_SECURITY"
 definition:
-  and:
-    - cond_type: filter
-      attribute: resource_type
-      value:
-        - aws_appautoscaling_policy
-      operator: within
+  or:
+    - and:
+      - cond_type: filter
+        attribute: resource_type
+        value:
+          - aws_dynamodb_table
+        operator: within
+      - cond_type: connection
+        resource_types:
+          - aws_dynamodb_table
+        connected_resource_types:
+          - aws_appautoscaling_target
+        operator: exists
+      - cond_type: connection
+        resource_types:
+          - aws_appautoscaling_target
+        connected_resource_types:
+          - aws_appautoscaling_policy
+        operator: exists
+      - cond_type: attribute
+        resource_types:
+          - aws_dynamodb_table
+        attribute: billing_mode
+        operator: equals
+        value: PROVISIONED
+      - cond_type: attribute
+        resource_types:
+          - aws_appautoscaling_target
+        attribute: service_namespace
+        operator: equals
+        value: dynamodb
     - cond_type: attribute
       resource_types:
-        - aws_appautoscaling_target
-      attribute: scalable_dimension
-      operator: contains
-      value: table
-    - cond_type: attribute
-      resource_types:
-        - aws_appautoscaling_target
-      attribute: service_namespace
+        - aws_dynamodb_table
+      attribute: billing_mode
       operator: equals
-      value: dynamodb
-    - cond_type: connection
-      resource_types:
-        - aws_appautoscaling_policy
-      connected_resource_types:
-        - aws_appautoscaling_target
-      operator: exists
-
-
-
+      value: PAY_PER_REQUEST

--- a/tests/graph/terraform/checks/resources/AutoScalingEnableOnDynamoDBTables/expected.yaml
+++ b/tests/graph/terraform/checks/resources/AutoScalingEnableOnDynamoDBTables/expected.yaml
@@ -1,4 +1,6 @@
 pass:
-  - "aws_appautoscaling_policy.ok_connect_dynamo_table"
+  - "aws_dynamodb_table.pass"
+  - "aws_dynamodb_table.pass_on_demand"
 fail:
-  - "aws_appautoscaling_policy.not_ok_connect_dynamo_table"
+  - "aws_dynamodb_table.fail"
+  - "aws_dynamodb_table.fail_no_policy"

--- a/tests/graph/terraform/checks/resources/AutoScalingEnableOnDynamoDBTables/main.tf
+++ b/tests/graph/terraform/checks/resources/AutoScalingEnableOnDynamoDBTables/main.tf
@@ -1,21 +1,36 @@
-resource "aws_appautoscaling_target" "dynamoDB" {
-  resource_id        = "table/${aws_dynamodb_table.example.name}"
+# pass
+
+resource "aws_dynamodb_table" "pass" {
+  name           = "user"
+  hash_key       = "user-id"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 10
+  write_capacity = 10
+
+  attribute {
+    name = "user-id"
+    type = "S"
+  }
+}
+
+resource "aws_appautoscaling_target" "pass" {
+  resource_id        = "table/${aws_dynamodb_table.pass.name}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
   min_capacity       = 1
   max_capacity       = 15
 }
 
-resource "aws_appautoscaling_policy" "ok_connect_dynamo_table" {
-  name               = "cpu-auto-scaling"
-  service_namespace  = aws_appautoscaling_target.dynamoDB.service_namespace
-  scalable_dimension = aws_appautoscaling_target.dynamoDB.scalable_dimension
-  resource_id        = aws_appautoscaling_target.dynamoDB.resource_id
+resource "aws_appautoscaling_policy" "pass" {
+  name               = "rcu-auto-scaling"
+  service_namespace  = aws_appautoscaling_target.pass.service_namespace
+  scalable_dimension = aws_appautoscaling_target.pass.scalable_dimension
+  resource_id        = aws_appautoscaling_target.pass.resource_id
   policy_type        = "TargetTrackingScaling"
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
-      predefined_metric_type = "RDSReaderAverageCPUUtilization"
+      predefined_metric_type = "DynamoDBReadCapacityUtilization"
     }
 
     target_value       = 75
@@ -24,28 +39,78 @@ resource "aws_appautoscaling_policy" "ok_connect_dynamo_table" {
   }
 }
 
-resource "aws_appautoscaling_target" "not_dynamo" {
-  service_namespace  = "rds"
-  scalable_dimension = "rds:cluster:ReadReplicaCount"
-  resource_id        = "cluster:${aws_rds_cluster.example.id}"
+resource "aws_dynamodb_table" "pass_on_demand" {
+  name           = "user"
+  hash_key       = "user-id"
+  billing_mode   = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "user-id"
+    type = "S"
+  }
+}
+
+# fail
+
+resource "aws_dynamodb_table" "fail" {
+  name           = "user"
+  hash_key       = "user-id"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 10
+  write_capacity = 10
+
+  attribute {
+    name = "user-id"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table" "fail_no_policy" {
+  name           = "user"
+  hash_key       = "user-id"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 10
+  write_capacity = 10
+
+  attribute {
+    name = "user-id"
+    type = "S"
+  }
+}
+
+resource "aws_appautoscaling_target" "fail_no_policy" {
+  resource_id        = "table/${aws_dynamodb_table.fail_no_policy.name}"
+  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
+  service_namespace  = "dynamodb"
   min_capacity       = 1
   max_capacity       = 15
 }
 
-resource "aws_appautoscaling_policy" "not_ok_connect_dynamo_table" {
-  name               = "cpu-auto-scaling"
-  service_namespace  = aws_appautoscaling_target.not_dynamo.service_namespace
-  scalable_dimension = aws_appautoscaling_target.not_dynamo.scalable_dimension
-  resource_id        = aws_appautoscaling_target.not_dynamo.resource_id
-  policy_type        = "TargetTrackingScaling"
+# unknown
 
-  target_tracking_scaling_policy_configuration {
-    predefined_metric_specification {
-      predefined_metric_type = "RDSReaderAverageCPUUtilization"
+resource "aws_appautoscaling_target" "ecs" {
+  max_capacity       = 4
+  min_capacity       = 1
+  resource_id        = "service/clusterName/serviceName"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "ecs" {
+  name               = "scale-down"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.ecs.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
     }
-
-    target_value       = 75
-    scale_in_cooldown  = 300
-    scale_out_cooldown = 300
   }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #1251 
the check now only considers autoscaling related to DynamoDB tables, which will not raise false positives related to other non DynamoDB tables. I also changed the flagging to be connected with the DynamoDB table and not `aws_appautoscaling_policy`. Additionally a DynamoDB table which is provisioned with `billing_mode = "PAY_PER_REQUEST"` will pass the check too, because it has already autoscaling embedded in it 😉  
