### PR TITLE
Handle empty templates

### DIFF
--- a/checkov/kubernetes/parser/parser.py
+++ b/checkov/kubernetes/parser/parser.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 def parse(filename):
     template = None
     template_lines = None
+    valid_templates = []
     try:
         if filename.endswith(".yaml") or filename.endswith(".yml"):
             (template, template_lines) = k8_yaml.load(filename)
@@ -21,12 +22,9 @@ def parse(filename):
             (template, template_lines) = k8_json.load(filename)
         if template:
             if isinstance(template, list):
-                for i in range(len(template)):
-                    if isinstance(template[i], dict):
-                        if not ('apiVersion' in template[i].keys() and 'kind' in template[i].keys()):
-                            return
-                    else:
-                        return
+                for t in template:
+                    if t and isinstance(t, dict) and 'apiVersion' in t.keys() and 'kind' in t.keys():
+                        valid_templates.append(t)
             else:
                 return
         else:
@@ -51,4 +49,4 @@ def parse(filename):
             logger.debug('Cannot read file contents: %s - is it a yaml?', filename)
         return
 
-    return template, template_lines
+    return valid_templates, template_lines

--- a/tests/kubernetes/runner/resources/example_multiple.yaml
+++ b/tests/kubernetes/runner/resources/example_multiple.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: microservice-skeleton/templates/pod_disruption_budget.yaml
+# Source: a/templates/pod_disruption_budget.yaml
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -13,7 +13,7 @@ spec:
       app: a
 
 ---
-# Source: microservice-skeleton/templates/service.yaml
+# Source: a/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -36,10 +36,10 @@ spec:
     app: a
 
 ---
-# Source: microservice-skeleton/templates/deployment.yaml
+# Source: a/templates/deployment.yaml
 ---
 
 ---
-# Source: microservice-skeleton/templates/cron_job.yaml
+# Source: a/templates/cron_job.yaml
 
 

--- a/tests/kubernetes/runner/resources/example_multiple.yaml
+++ b/tests/kubernetes/runner/resources/example_multiple.yaml
@@ -1,0 +1,45 @@
+---
+# Source: microservice-skeleton/templates/pod_disruption_budget.yaml
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: a
+  namespace: a
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: a
+
+---
+# Source: microservice-skeleton/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: a
+  labels:
+    app: a
+    owner: core
+    helm.sh/chart: a-0.0.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Tiller
+    version: "a"
+    CostProduct: a
+    CostTech: "k8s"
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  selector:
+    app: a
+
+---
+# Source: microservice-skeleton/templates/deployment.yaml
+---
+
+---
+# Source: microservice-skeleton/templates/cron_job.yaml
+
+

--- a/tests/kubernetes/runner/test_runner.py
+++ b/tests/kubernetes/runner/test_runner.py
@@ -127,6 +127,19 @@ class TestRunnerValid(unittest.TestCase):
 
         assert len(check_imports) == 0, f"Wrong imports were added: {check_imports}"
 
+    def test_parse_with_empty_blocks(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        scan_file_path = os.path.join(current_dir, "resources", "example_multiple.yaml")
+        file_rel_path = os.path.relpath(scan_file_path)
+        runner = Runner()
+        try:
+            report = runner.run(root_folder=None, external_checks_dir=None, files=[file_rel_path],
+                       runner_filter=RunnerFilter(framework='kubernetes'))
+            # just check that something was parsed and scanned
+            self.assertGreater(len(report.failed_checks) + len(report.passed_checks), 0)
+        except:
+            self.assertTrue(False, "Could not run K8 runner on configuration")
+
     def tearDown(self):
         pass
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Handles a case common with Helm where generated files look like the example below. The blank blocks made the parser exit and no scan was performed.

```
---
# Source: a/templates/pod_disruption_budget.yaml
---
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
...
---
# Source: a/templates/service.yaml
apiVersion: v1
kind: Service
...

---
# Source: a/templates/deployment.yaml
---

---
# Source: a/templates/cron_job.yaml
```