### PR TITLE
CF - Check - ECRImageScanning

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ECRImageScanning.py
+++ b/checkov/cloudformation/checks/resource/aws/ECRImageScanning.py
@@ -5,7 +5,7 @@ from checkov.cloudformation.checks.resource.base_resource_value_check import Bas
 class ECRImageScanning(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure ECR image scanning on push is enabled"
-        id = "CKV_AWS_161"
+        id = "CKV_AWS_162"
         supported_resources = ["AWS::ECR::Repository"]
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/checkov/cloudformation/checks/resource/aws/ECRImageScanning.py
+++ b/checkov/cloudformation/checks/resource/aws/ECRImageScanning.py
@@ -5,9 +5,9 @@ from checkov.cloudformation.checks.resource.base_resource_value_check import Bas
 class ECRImageScanning(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure ECR image scanning on push is enabled"
-        id = "CKV_AWS_162"
+        id = "CKV_AWS_163"
         supported_resources = ["AWS::ECR::Repository"]
-        categories = [CheckCategories.ENCRYPTION]
+        categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):

--- a/checkov/cloudformation/checks/resource/aws/ECRImageScanning.py
+++ b/checkov/cloudformation/checks/resource/aws/ECRImageScanning.py
@@ -1,4 +1,17 @@
-#############################################################################
-### CloudFormation Currently (Feb 2020) does not support ECR Image Scanning #
-### https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/245
-#############################################################################
+from checkov.common.models.enums import CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class ECRImageScanning(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure ECR image scanning on push is enabled"
+        id = "CKV_AWS_161"
+        supported_resources = ["AWS::ECR::Repository"]
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "Properties/ImageScanningConfiguration/ScanOnPush"
+
+
+check = ECRImageScanning()

--- a/checkov/terraform/checks/resource/aws/ECRImageScanning.py
+++ b/checkov/terraform/checks/resource/aws/ECRImageScanning.py
@@ -5,7 +5,7 @@ from checkov.common.models.enums import CheckCategories
 class ECRImageScanning(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure ECR image scanning on push is enabled"
-        id = "CKV_AWS_162"
+        id = "CKV_AWS_163"
         supported_resources = ['aws_ecr_repository']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/checkov/terraform/checks/resource/aws/ECRImageScanning.py
+++ b/checkov/terraform/checks/resource/aws/ECRImageScanning.py
@@ -5,7 +5,7 @@ from checkov.common.models.enums import CheckCategories
 class ECRImageScanning(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure ECR image scanning on push is enabled"
-        id = "CKV_AWS_161"
+        id = "CKV_AWS_162"
         supported_resources = ['aws_ecr_repository']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/tests/cloudformation/checks/resource/aws/example_ECRImageScanning/FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ECRImageScanning/FAILED.yml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  ImageScanFalse:
+    Type: AWS::ECR::Repository
+    Properties: 
+      RepositoryName: "test"
+      ImageScanningConfiguration:
+        ScanOnPush: false
+  ImageScanNotSet:
+    Type: AWS::ECR::Repository
+    Properties: 
+      RepositoryName: "test"
+

--- a/tests/cloudformation/checks/resource/aws/example_ECRImageScanning/PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ECRImageScanning/PASSED.yml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  ImageScanTrue:
+    Type: AWS::ECR::Repository
+    Properties: 
+      RepositoryName: "test"
+      ImageScanningConfiguration:
+        ScanOnPush: true

--- a/tests/cloudformation/checks/resource/aws/test_ECRImageScanning.py
+++ b/tests/cloudformation/checks/resource/aws/test_ECRImageScanning.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.ECRImageScanning import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestECRImageScanning(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ECRImageScanning"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        for record in report.failed_checks:
+            self.assertEqual(record.check_id, check.id)
+        
+        for record in report.passed_checks:
+            self.assertEqual(record.check_id, check.id)
+
+        passing_resources = {
+            "AWS::ECR::Repository.ImageScanTrue"
+        }
+
+        failing_resources = {
+            "AWS::ECR::Repository.ImageScanFalse",
+            "AWS::ECR::Repository.ImageScanNotSet"
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello,

Implementing this check as already done for Terraform. There was a placeholder because a previous version of CloudFormation did not include this functionality.

* Resolved Check ID conflict. Made sure TF and CF check for this could both live with the same ID.

TF Check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/ECRImageScanning.py
CF Doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecr-repository-imagescanningconfiguration.html

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
