### PR TITLE
Fix dynamo encryption check for default encryption

### DIFF
--- a/checkov/terraform/checks/resource/aws/DynamoDBTablesEncrypted.py
+++ b/checkov/terraform/checks/resource/aws/DynamoDBTablesEncrypted.py
@@ -1,8 +1,8 @@
 from checkov.common.models.enums import CheckCategories
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
 
 
-class DynamoDBTablesEncrypted(BaseResourceValueCheck):
+class DynamoDBTablesEncrypted(BaseResourceNegativeValueCheck):
     def __init__(self):
         name = "Ensure DynamoDB Tables are encrypted using KMS"
         id = "CKV_AWS_119"
@@ -12,6 +12,9 @@ class DynamoDBTablesEncrypted(BaseResourceValueCheck):
 
     def get_inspected_key(self):
         return "server_side_encryption/[0]/enabled"
+
+    def get_forbidden_values(self):
+        return [False, "false"]
 
 
 check = DynamoDBTablesEncrypted()

--- a/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
+++ b/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
@@ -32,8 +32,7 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
         skipped_check_ids = set([c.check_id for c in report.skipped_checks])
         expected_failed_check_ids = {
             "CKV_AWS_19",
-            "CKV_AWS_63",
-            "CKV_AWS_119"
+            "CKV_AWS_63"
         }
         expected_skipped_check_ids = {
             "CKV_AWS_20",
@@ -90,24 +89,6 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
                     (15, '  }\n'),
                     (16, '  provider = aws.current_region\n'),
                     (17, '}')
-                )
-            ),
-            (
-                "dynamodb.tf",
-                (1, 12),
-                (
-                    (1, 'resource "aws_dynamodb_table" "cross-environment-violations" {\n'),
-                    (2, '  # checkov:skip=CKV_AWS_28: ignoring backups for now\n'),
-                    (3, '  name           = "CrossEnvironmentViolations"\n'),
-                    (4, '  read_capacity  = 20\n'),
-                    (5, '  write_capacity = 20\n'),
-                    (6, '  hash_key       = "id"\n'),
-                    (7, '  attribute {\n'),
-                    (8, '    name = "id"\n'),
-                    (9, '    type = "S"\n'),
-                    (10, '  }\n'),
-                    (11, '  provider = aws.current_region\n'),
-                    (12, '}')
                 )
             )
         }

--- a/tests/terraform/checks/resource/aws/test_DynamoDBTablesEncrypted.py
+++ b/tests/terraform/checks/resource/aws/test_DynamoDBTablesEncrypted.py
@@ -31,7 +31,7 @@ class TestELBAccessLogs(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-    def test_failure2(self):
+    def test_default_pass(self):
         hcl_res = hcl2.loads("""
             resource "aws_dynamodb_table" "basic-dynamodb-table" {
               name           = "GameScores"
@@ -49,7 +49,7 @@ class TestELBAccessLogs(unittest.TestCase):
         """)
         resource_conf = hcl_res['resource'][0]['aws_dynamodb_table']['basic-dynamodb-table']
         scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        self.assertEqual(CheckResult.PASSED, scan_result)
 
     def test_success(self):
         hcl_res = hcl2.loads("""


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Dynamo tables are encrypted by default, so this check should only look for `enabled = false`.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table
