### PR TITLE
added normalisation of api-key and repo-id for file and dir scan

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -357,6 +357,34 @@ class BcPlatformIntegration(object):
             if self.is_integration_configured():
                 self._upload_run(args, scan_reports)
 
+# Added this to generate a default repo_id for cli scans for upload to the platform 
+# whilst also persisting a cli repo_id into the object
+    def persist_bc_api_key(self, args):
+        if args.bc_api_key:
+            self.bc_api_key=args.bc_api_key
+        else: 
+            # get the key from file
+            self.bc_api_key=read_key()
+        return self.bc_api_key    
+
+# Added this to generate a default repo_id for cli scans for upload to the platform 
+# whilst also persisting a cli repo_id into the object
+    def persist_repo_id(self, args):
+        if args.repo_id is None:
+            if BC_FROM_BRANCH:
+                self.repo_id = BC_FROM_BRANCH
+            if args.directory:
+                basename = path.basename(os.path.abspath(args.directory[0]))
+                self.repo_id = "cli_repo/" + basename
+            if args.file:
+                # Get the base path of the file based on it's absolute path
+                basename = os.path.basename(os.path.dirname(os.path.abspath(args.file[0])))
+                self.repo_id = "cli_repo/" + basename
+ 
+        else: 
+            self.repo_id=args.repo_id
+        return self.repo_id    
+
     def get_repository(self, args):
         if BC_FROM_BRANCH:
             return BC_FROM_BRANCH

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -85,8 +85,8 @@ class RunnerRegistry(object):
                 print(json.dumps(report_jsons[0], indent=4))
             else:
                 print(json.dumps(report_jsons, indent=4))
-        if config.output == "cli":
-            bc_integration.get_report_to_platform(config,scan_reports)
+        #if config.output == "cli":
+            #bc_integration.get_report_to_platform(config,scan_reports)
 
         exit_code = 1 if 1 in exit_codes else 0
         return exit_code

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -54,6 +54,11 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
     # bridgecrew uses both the urllib3 and requests libraries, while checkov uses the requests library.
     # Allow the user to specify a CA bundle to be used by both libraries.
     bc_integration.setup_http_manager(config.ca_certificate)
+    
+    # if a repo is passed in it'll save it.  Otherwise a default will be created based on the file or dir
+    config.repo_id=bc_integration.persist_repo_id(config)
+    # if a bc_api_key is passed it'll save it.  Otherwise it will check ~/.bridgecrew/credentials
+    config.bc_api_key=bc_integration.persist_bc_api_key(config)
 
     # Disable runners with missing system dependencies
     config.skip_framework = runnerDependencyHandler.disable_incompatible_runners(config.skip_framework)


### PR DESCRIPTION
Due to fixing some of the oddities in the onboarding, the multiple sources of where a bc_api_key could be retrieved from AND the multiple ways a repo_id could be either passed in or defaulted to made it difficult to track what it would be when and where.

Added functions to bc_integration to make that decision early in main.

Also when using the cli with out a github integration the flow was going down a custom path.  Getting the above correct should mean it always uses the same paths regardless for file or directory specified scan.  

This is just adding and commenting out.  If it works consistently there is a bunch of stuff in bc_integration that can be striped out.

This needs a new test in the workflow but I cannot add a secret in order to test the api_key part so I'll submit a new PR with the tests once that is in place.  Please review but don't approve until I can submit the tests for this in advance.  