### PR TITLE
only check for rotation on symmetric keys

### DIFF
--- a/checkov/terraform/checks/resource/aws/KMSRotation.py
+++ b/checkov/terraform/checks/resource/aws/KMSRotation.py
@@ -17,8 +17,7 @@ class KMSRotation(BaseResourceValueCheck):
         # Only symmetric keys support auto rotation. The attribute is optional and defaults to symmetric.
         spec = conf.get('customer_master_key_spec')
         if not spec or 'SYMMETRIC_DEFAULT' in spec:
-            res = super().scan_resource_conf(conf)
-            return res
+            return super().scan_resource_conf(conf)
         else:
             return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/aws/KMSRotation.py
+++ b/checkov/terraform/checks/resource/aws/KMSRotation.py
@@ -1,5 +1,5 @@
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class KMSRotation(BaseResourceValueCheck):
@@ -12,6 +12,15 @@ class KMSRotation(BaseResourceValueCheck):
 
     def get_inspected_key(self):
         return "enable_key_rotation"
+
+    def scan_resource_conf(self, conf):
+        # Only symmetric keys support auto rotation. The attribute is optional and defaults to symmetric.
+        spec = conf.get('customer_master_key_spec')
+        if not spec or 'SYMMETRIC_DEFAULT' in spec:
+            res = super().scan_resource_conf(conf)
+            return res
+        else:
+            return CheckResult.PASSED
 
 
 check = KMSRotation()

--- a/tests/terraform/checks/resource/aws/example_KMSRotation/main.tf
+++ b/tests/terraform/checks/resource/aws/example_KMSRotation/main.tf
@@ -1,0 +1,42 @@
+resource "aws_kms_key" "pass1" {
+  description             = "KMS key 1"
+  deletion_window_in_days = 10
+  enable_key_rotation = true
+}
+
+resource "aws_kms_key" "pass2" {
+  description             = "KMS key 1"
+  deletion_window_in_days = 10
+  customer_master_key_spec = "RSA_2096"
+}
+
+resource "aws_kms_key" "pass3" {
+  description             = "KMS key 1"
+  deletion_window_in_days = 10
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation = true
+}
+
+resource "aws_kms_key" "fail1" {
+  description             = "KMS key 1"
+  deletion_window_in_days = 10
+}
+
+resource "aws_kms_key" "fail2" {
+  description             = "KMS key 1"
+  deletion_window_in_days = 10
+  enable_key_rotation = false
+}
+
+resource "aws_kms_key" "fail3" {
+  description             = "KMS key 1"
+  deletion_window_in_days = 10
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation = false
+}
+
+resource "aws_kms_key" "fail4" {
+  description             = "KMS key 1"
+  deletion_window_in_days = 10
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes KMS rotation to only check for rotation on symmetric keys

https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks