### PR TITLE
add resource count to json output

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -43,6 +43,7 @@ class Report:
             "failed": len(self.failed_checks),
             "skipped": len(self.skipped_checks),
             "parsing_errors": len(self.parsing_errors),
+            "resource_count": self._count_resources(),
             "checkov_version": version
         }
 
@@ -147,6 +148,13 @@ class Report:
 
     def print_json(self):
         print(self.get_json())
+
+    def _count_resources(self):
+        unique_resources = set()
+        for record in self.passed_checks + self.failed_checks:
+            unique_resources.add(record.file_path + '.' + record.resource)
+        return len(unique_resources)
+
 
     @staticmethod
     def enrich_plan_report(report, enriched_resources):

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -155,7 +155,6 @@ class Report:
             unique_resources.add(record.file_path + '.' + record.resource)
         return len(unique_resources)
 
-
     @staticmethod
     def enrich_plan_report(report, enriched_resources):
         # This enriches reports with the appropriate filepath, line numbers, and codeblock

--- a/tests/common/runner_registry/test_runner_registry.py
+++ b/tests/common/runner_registry/test_runner_registry.py
@@ -22,6 +22,23 @@ class TestRunnerRegistry(unittest.TestCase):
         for report in reports:
             self.assertGreater(len(report.passed_checks), 1)
 
+    def test_resource_counts(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        test_files_dir = current_dir + "/example_multi_iac"
+        runner_filter = RunnerFilter(framework=None, checks=None, skip_checks=None)
+        runner_registry = RunnerRegistry(banner, runner_filter, tf_runner(), cfn_runner(), k8_runner())
+        reports = runner_registry.run(root_folder=test_files_dir)
+
+        # The number of resources that will get scan results. Note that this may change if we add policies covering new resource types.
+        counts_by_type = {
+            'kubernetes': 13,
+            'terraform': 3,
+            'cloudformation': 3
+        }
+
+        for report in reports:
+            self.assertEqual(counts_by_type[report.check_type], report.get_summary()['resource_count'])
+
     def test_empty_tf(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         test_files_dir = current_dir + "/example_empty_tf"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Adds a count of the total unique resources in each scan report (outputs in JSON only).