### PR TITLE
handle case when from_port and to_port are both 0 (all ports)

### DIFF
--- a/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
@@ -67,6 +67,9 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
         from_port = force_int(force_list(conf.get('from_port',[{-1}]))[0])
         to_port = force_int(force_list(conf.get('to_port',[{-1}]))[0])
 
+        if from_port == 0 and to_port == 0:
+            to_port = 65535
+
         if from_port is not None and to_port is not None and (from_port <= self.port <= to_port):
             conf_cidr_blocks = conf.get('cidr_blocks', [[]])
             if len(conf_cidr_blocks) > 0:

--- a/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngress22.py
+++ b/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngress22.py
@@ -34,6 +34,32 @@ class TestSecurityGroupUnrestrictedIngress22(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_0_0(self):
+        hcl_res = hcl2.loads("""
+        resource "aws_security_group" "bar-sg" {
+          name   = "sg-bar"
+          vpc_id = aws_vpc.main.id
+
+          ingress {
+            from_port = 0
+            to_port   = 0
+            protocol  = "tcp"
+            cidr_blocks = ["192.168.0.0/16", "0.0.0.0/0"]
+            description = "foo"
+          }
+
+          egress {
+            from_port = 0
+            to_port   = 0
+            protocol  = "-1"
+            cidr_blocks = ["0.0.0.0/0"]
+          }
+        }  
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_failure_ipv6(self):
         hcl_res = hcl2.loads("""
         resource "aws_security_group" "bar-sg" {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Handles the port checks when you specify `0` for both from_port and to_port.