### PR TITLE
refactor external module loading

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -35,10 +35,16 @@ class Undetermined(TypedDict):
 
 
 class TerraformLocalGraph(LocalGraph):
-    def __init__(self, module: Module, module_dependency_map: Dict[str, List[List[str]]]) -> None:
-        super(TerraformLocalGraph, self).__init__()
+    def __init__(
+        self,
+        module: Module,
+        module_dependency_map: Dict[str, List[List[str]]],
+        external_modules_source_map: Optional[Dict[str, str]] = None
+    ) -> None:
+        super().__init__()
         self.module = module
         self.module_dependency_map = module_dependency_map
+        self.external_modules_source_map = external_modules_source_map or {}
         self.map_path_to_module: Dict[str, List[int]] = {}
         self.relative_paths_cache = {}
         self.abspath_cache: Dict[str, str] = {}
@@ -268,6 +274,8 @@ class TerraformLocalGraph(LocalGraph):
         dest_module_path = Path()
         if is_local_path(curr_module_dir, dest_module_source):
             dest_module_path = Path(curr_module_dir) / dest_module_source
+        elif dest_module_source in self.external_modules_source_map:
+            return self.external_modules_source_map[dest_module_source]
         else:
             try:
                 if dest_module_source not in self.relative_paths_cache:

--- a/checkov/terraform/graph_manager.py
+++ b/checkov/terraform/graph_manager.py
@@ -24,7 +24,7 @@ class TerraformGraphManager(GraphManager):
         vars_files: Optional[List[str]] = None
     ) -> Tuple[LocalGraph, Dict[str, Dict[str, Any]]]:
         logging.info('Parsing HCL files in source dir')
-        module, module_dependency_map, tf_definitions = \
+        module, module_dependency_map, external_modules_source_map, tf_definitions = \
             self.parser.parse_hcl_module(
                 source_dir=source_dir,
                 source=self.source,
@@ -36,7 +36,7 @@ class TerraformGraphManager(GraphManager):
             )
 
         logging.info('Building graph from parsed module')
-        local_graph = local_graph_class(module, module_dependency_map)
+        local_graph = local_graph_class(module, module_dependency_map, external_modules_source_map)
         local_graph.build_graph(render_variables=render_variables)
 
         return local_graph, tf_definitions

--- a/checkov/terraform/module_loading/content.py
+++ b/checkov/terraform/module_loading/content.py
@@ -1,10 +1,16 @@
 import tempfile
-from typing import Optional, Union
+from types import TracebackType
+from typing import Optional, Union, Type
 
 
 class ModuleContent(object):
-    def __init__(self, dir: Optional[Union[tempfile.TemporaryDirectory, str]], next_url=None, failed_url=None) -> None:
-        self.dir = dir.replace('//', '/') if dir else None
+    def __init__(
+        self,
+        dir: Optional[Union[tempfile.TemporaryDirectory, str]],
+        next_url: Optional[str] = None,
+        failed_url: Optional[str] = None,
+    ) -> None:
+        self.dir = dir.replace("//", "/") if dir else None
         self.next_url = next_url
         self.failed_url = failed_url
 
@@ -23,7 +29,7 @@ Returns the directory path containing module resources.
         else:
             return self.dir
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         """
 Clean up any temporary resources, if applicable.
         """
@@ -31,10 +37,15 @@ Clean up any temporary resources, if applicable.
             self.dir.cleanup()
 
     def __repr__(self) -> str:
-        return self.path()
+        return self.path() or ""
 
-    def __enter__(self):
+    def __enter__(self) -> "ModuleContent":
         return self
 
-    def __exit__(self, exc, value, tb):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         self.cleanup()

--- a/checkov/terraform/module_loading/loaders/bitbucket_loader.py
+++ b/checkov/terraform/module_loading/loaders/bitbucket_loader.py
@@ -2,13 +2,10 @@ from checkov.terraform.module_loading.loaders.git_loader import GenericGitLoader
 
 
 class BitbucketLoader(GenericGitLoader):
-    def _is_matching_loader(self):
+    def _is_matching_loader(self) -> bool:
         # https://www.terraform.io/docs/modules/sources.html#bitbucket
-        if 'bitbucket.org' in self.module_source:
-            if not self.module_source.startswith('https://') or not self.module_source.startswith('http://'):
-                self.module_source = 'https://' + self.module_source
-            if not self.module_source.endswith('.git'):
-                self.module_source = self.module_source + '.git'
+        if self.module_source.startswith("bitbucket.org"):
+            self.module_source = f"git::https://{self.module_source}"
             return True
         return False
 

--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -1,4 +1,7 @@
 import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
 
 from checkov.common.goget.github.get_git import GitGetter
 from checkov.terraform.module_loading.content import ModuleContent
@@ -6,23 +9,98 @@ from checkov.terraform.module_loading.content import ModuleContent
 from checkov.terraform.module_loading.loader import ModuleLoader
 
 
+@dataclass(frozen=True)
+class ModuleSource:
+    protocol: str
+    root_module: str
+    inner_module: str
+    version: str
+
+
 class GenericGitLoader(ModuleLoader):
-    def _is_matching_loader(self):
+    def _is_matching_loader(self) -> bool:
         # https://www.terraform.io/docs/modules/sources.html#generic-git-repository
-        return self.module_source.startswith('git::')
+        return self.module_source.startswith("git::")
 
     def _load_module(self) -> ModuleContent:
         try:
-            module_source = self.module_source.replace('git::', '')
+            self._process_generic_git_repo()
+
+            module_source = self.module_source.replace("git::", "")
             git_getter = GitGetter(module_source, create_clone_and_result_dirs=False)
             git_getter.temp_dir = self.dest_dir
-            return_dir = git_getter.do_get()
+            git_getter.do_get()
+
+            return_dir = self.dest_dir
             if self.inner_module:
                 return_dir = os.path.join(self.dest_dir, self.inner_module)
             return ModuleContent(dir=return_dir)
         except Exception as e:
-            self.logger.error(f'failed to get {self.module_source} because of {e}')
+            self.logger.error(f"failed to get {self.module_source} because of {e}")
             return ModuleContent(dir=None, failed_url=self.module_source)
+
+    def _find_module_path(self) -> str:
+        module_source = self._parse_module_source()
+        module_path = Path(self.current_dir).joinpath(
+            self.external_modules_folder_name,
+            module_source.root_module,
+            module_source.version,
+            module_source.inner_module,
+        )
+
+        if self.inner_module:
+            module_path = module_path / self.inner_module
+
+        return str(module_path)
+
+    def _parse_module_source(self) -> ModuleSource:
+        module_source_components = self.module_source.split("//")
+
+        if "?ref=" in module_source_components[-1]:
+            module_version_components = module_source_components[-1].rsplit("?ref=", maxsplit=1)
+            module_source_components[-1] = module_version_components[0]
+            version = module_version_components[1]
+        else:
+            version = "HEAD"
+
+        if len(module_source_components) == 2:
+            inner_module = ""
+        elif len(module_source_components) == 3:
+            inner_module = module_source_components[2]
+        else:
+            raise Exception("invalid git url")
+
+        root_module = module_source_components[1]
+        if root_module.endswith(".git"):
+            root_module = root_module[:-4]
+
+        return ModuleSource(
+            protocol=module_source_components[0], root_module=root_module, inner_module=inner_module, version=version,
+        )
+
+    def _process_generic_git_repo(self) -> None:
+        module_source = self._parse_module_source()
+
+        if module_source.inner_module:
+            self.dest_dir = str(
+                Path(self.current_dir).joinpath(
+                    self.external_modules_folder_name, module_source.root_module, module_source.version
+                )
+            )
+            self.inner_module = module_source.inner_module
+            self.module_source = f"{module_source.protocol}//{module_source.root_module}"
+            if module_source.version != "HEAD":
+                self.module_source += f"?ref={module_source.version}"
+        else:
+            self.dest_dir = str(
+                Path(self.current_dir).joinpath(
+                    self.external_modules_folder_name, module_source.root_module, module_source.version
+                )
+            )
+
+        username = re.match(r"^git::ssh://(.*?@).*", self.module_source)
+        if username:
+            self.dest_dir = self.dest_dir.replace(username[1], "")
 
 
 loader = GenericGitLoader()

--- a/checkov/terraform/module_loading/loaders/github_loader.py
+++ b/checkov/terraform/module_loading/loaders/github_loader.py
@@ -1,14 +1,13 @@
-from checkov.common.goget.github.get_git import GitGetter
-from checkov.terraform.module_loading.content import ModuleContent
-
-from checkov.terraform.module_loading.loader import ModuleLoader
 from checkov.terraform.module_loading.loaders.git_loader import GenericGitLoader
 
 
 class GithubLoader(GenericGitLoader):
-    def _is_matching_loader(self):
+    def _is_matching_loader(self) -> bool:
         # https://www.terraform.io/docs/modules/sources.html#github
-        return 'github.com' in self.module_source
+        if self.module_source.startswith("github.com"):
+            self.module_source = f"git::https://{self.module_source}"
+            return True
+        return False
 
 
 loader = GithubLoader()

--- a/checkov/terraform/module_loading/loaders/local_path_loader.py
+++ b/checkov/terraform/module_loading/loaders/local_path_loader.py
@@ -10,8 +10,12 @@ class LocalPathLoader(ModuleLoader):
         self.is_external = False
 
     def _is_matching_loader(self) -> bool:
-        return self.module_source.startswith("./") or self.module_source.startswith("../") \
-               or self.module_source.startswith(self.current_dir)
+        return (
+            self.module_source.startswith("./")
+            or self.module_source.startswith("../")
+            or self.module_source.startswith(self.current_dir)
+            or self.module_source.startswith("/")
+        )
 
     def _load_module(self) -> ModuleContent:
         module_path = os.path.normpath(os.path.join(self.current_dir, self.module_source))
@@ -21,6 +25,10 @@ class LocalPathLoader(ModuleLoader):
             raise FileNotFoundError(module_path)
 
         return ModuleContent(module_path)
+
+    def _find_module_path(self) -> str:
+        # to determine the exact path here would mimic _load_module()
+        return ""
 
 
 loader = LocalPathLoader()

--- a/checkov/terraform/module_loading/loaders/registry_loader.py
+++ b/checkov/terraform/module_loading/loaders/registry_loader.py
@@ -1,26 +1,35 @@
 import os
 from http import HTTPStatus
+from typing import List
 
 import requests
 
 from checkov.terraform.module_loading.content import ModuleContent
 from checkov.terraform.module_loading.loader import ModuleLoader
-from checkov.terraform.module_loading.loaders.versions_parser import order_versions_in_descending_order, get_version_constraints
+from checkov.terraform.module_loading.loaders.versions_parser import (
+    order_versions_in_descending_order,
+    get_version_constraints,
+)
 
 
 class RegistryLoader(ModuleLoader):
     REGISTRY_URL_PREFIX = "https://registry.terraform.io/v1/modules"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
-        self.available_versions = []
+        self.available_versions: List[str] = []
 
     def _is_matching_loader(self) -> bool:
+        # Since the registry loader is the first one to be checked,
+        # it shouldn't process any github modules
+        if self.module_source.startswith(("github.com", "bitbucket.org")):
+            return False
+
         self._process_inner_registry_module()
         if os.path.exists(self.dest_dir):
             return True
 
-        get_version_url = os.path.join(self.REGISTRY_URL_PREFIX, self.module_source, 'versions')
+        get_version_url = os.path.join(self.REGISTRY_URL_PREFIX, self.module_source, "versions")
         if not get_version_url.startswith(self.REGISTRY_URL_PREFIX):
             # Local paths don't get the prefix appended
             return False
@@ -28,8 +37,9 @@ class RegistryLoader(ModuleLoader):
         if response.status_code != HTTPStatus.OK:
             return False
         else:
-            self.available_versions = [v.get('version') for v in
-                                       response.json().get('modules', [{}])[0].get('versions', {})]
+            self.available_versions = [
+                v.get("version") for v in response.json().get("modules", [{}])[0].get("versions", {})
+            ]
             return True
 
     def _load_module(self) -> ModuleContent:
@@ -38,16 +48,20 @@ class RegistryLoader(ModuleLoader):
 
         best_version = self._find_best_version()
 
-        request_download_url = os.path.join(self.REGISTRY_URL_PREFIX, self.module_source, best_version, 'download')
+        request_download_url = os.path.join(self.REGISTRY_URL_PREFIX, self.module_source, best_version, "download")
         response = requests.get(url=request_download_url)
         if response.status_code != HTTPStatus.OK and response.status_code != HTTPStatus.NO_CONTENT:
             return ModuleContent(dir=None)
         else:
-            return ModuleContent(dir=None, next_url=response.headers.get('X-Terraform-Get', ''))
+            return ModuleContent(dir=None, next_url=response.headers.get("X-Terraform-Get", ""))
 
-    def _find_best_version(self):
+    def _find_module_path(self) -> str:
+        # to determine the exact path here would be almost a duplicate of the git_loader functionality
+        return ""
+
+    def _find_best_version(self) -> str:
         versions_by_size = order_versions_in_descending_order(self.available_versions)
-        if self.version == 'latest':
+        if self.version == "latest":
             self.version = versions_by_size[0]
         version_constraints = get_version_constraints(self.version)
         num_of_matches = 0
@@ -61,17 +75,17 @@ class RegistryLoader(ModuleLoader):
                 return version
             else:
                 num_of_matches = 0
-        return 'latest'
+        return "latest"
 
-    def _process_inner_registry_module(self):
+    def _process_inner_registry_module(self) -> None:
         # Check if the source has '//' in it. If it does, it indicates a reference for an inner module.
         # Example: "terraform-aws-modules/security-group/aws//modules/http-80" =>
         #    module_source = terraform-aws-modules/security-group/aws
         #    dest_dir = modules/http-80
-        module_source_components = self.module_source.split('//')
+        module_source_components = self.module_source.split("//")
         if len(module_source_components) > 1:
             self.module_source = module_source_components[0]
-            self.dest_dir = self.dest_dir.split('//')[0]
+            self.dest_dir = self.dest_dir.split("//")[0]
             self.inner_module = module_source_components[1]
 
 

--- a/checkov/terraform/module_loading/loaders/versions_parser.py
+++ b/checkov/terraform/module_loading/loaders/versions_parser.py
@@ -1,4 +1,6 @@
 import re
+from typing import List
+
 from packaging import version
 VERSION_REGEX = re.compile(r'^(?P<operator>=|!=|>=|>|<=|<|~>)*(?P<version>.+)$')
 
@@ -33,7 +35,7 @@ class VersionConstraint:
         return res
 
 
-def get_version_constraints(raw_version):
+def get_version_constraints(raw_version: str) -> List[VersionConstraint]:
     """
     :param raw_version: A string representation of a version, e.g: "~> v1.2.3"
     :return: VersionConstraint instance
@@ -47,7 +49,7 @@ def get_version_constraints(raw_version):
     return version_constraints
 
 
-def order_versions_in_descending_order(versions_strings):
+def order_versions_in_descending_order(versions_strings: List[str]) -> List[str]:
     """
     :param versions_strings: array of string versions: ["v1.2.3", "v1.2.4"...]
     :return: A sorted array of versions in descending order

--- a/tests/terraform/graph/db_connector/test_networkx_connector.py
+++ b/tests/terraform/graph/db_connector/test_networkx_connector.py
@@ -12,7 +12,7 @@ class TestNetworkxConnector(TestCase):
     def test_creating_graph(self):
         resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME, '../resources/encryption'))
         hcl_config_parser = Parser()
-        module, module_dependency_map, _ = hcl_config_parser.parse_hcl_module(resources_dir, 'AWS')
+        module, module_dependency_map, _, _ = hcl_config_parser.parse_hcl_module(resources_dir, 'AWS')
         local_graph = TerraformLocalGraph(module, module_dependency_map)
         local_graph._create_vertices()
         nxc = NetworkxConnector()

--- a/tests/terraform/graph/graph_builder/test_local_graph.py
+++ b/tests/terraform/graph/graph_builder/test_local_graph.py
@@ -53,7 +53,7 @@ class TestLocalGraph(TestCase):
         resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME,
                                                       '../resources/variable_rendering/render_from_module_vpc'))
         hcl_config_parser = Parser()
-        module, module_dependency_map, tf_definitions = hcl_config_parser.parse_hcl_module(resources_dir,
+        module, module_dependency_map, _, tf_definitions = hcl_config_parser.parse_hcl_module(resources_dir,
                                                                                            source=self.source)
         local_graph = TerraformLocalGraph(module, module_dependency_map)
         local_graph._create_vertices()
@@ -105,7 +105,7 @@ class TestLocalGraph(TestCase):
     def test_encryption_aws(self):
         resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME, '../resources/encryption'))
         hcl_config_parser = Parser()
-        module, module_dependency_map, _ = hcl_config_parser.parse_hcl_module(resources_dir,
+        module, module_dependency_map, _, _ = hcl_config_parser.parse_hcl_module(resources_dir,
                                                                               self.source)
         local_graph = TerraformLocalGraph(module, module_dependency_map)
         local_graph._create_vertices()
@@ -133,7 +133,7 @@ class TestLocalGraph(TestCase):
         resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME,
                                                       '../resources/variable_rendering/render_from_module_vpc'))
         hcl_config_parser = Parser()
-        module, module_dependency_map, _ = hcl_config_parser.parse_hcl_module(resources_dir,
+        module, module_dependency_map, _, _ = hcl_config_parser.parse_hcl_module(resources_dir,
                                                                               self.source)
         local_graph = TerraformLocalGraph(module, module_dependency_map)
         local_graph._create_vertices()
@@ -144,7 +144,7 @@ class TestLocalGraph(TestCase):
     def test_module_dependencies(self):
         resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME, '../resources/modules/stacks'))
         hcl_config_parser = Parser()
-        module, module_dependency_map, _ = hcl_config_parser.parse_hcl_module(resources_dir, self.source)
+        module, module_dependency_map, _, _ = hcl_config_parser.parse_hcl_module(resources_dir, self.source)
         self.assertEqual(module_dependency_map[f'{resources_dir}/prod'], [[]])
         self.assertEqual(module_dependency_map[f'{resources_dir}/stage'], [[]])
         self.assertEqual(module_dependency_map[f'{resources_dir}/test'], [[]])
@@ -162,7 +162,7 @@ class TestLocalGraph(TestCase):
     def test_blocks_from_local_graph_module(self):
         resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME, '../resources/modules/stacks'))
         hcl_config_parser = Parser()
-        module, module_dependency_map, _ = hcl_config_parser.parse_hcl_module(resources_dir,
+        module, module_dependency_map, _, _ = hcl_config_parser.parse_hcl_module(resources_dir,
                                                                               self.source)
         self.assertEqual(len(list(filter(lambda block: block.block_type == BlockType.RESOURCE and block.name == 'aws_s3_bucket.inner_s3', module.blocks))), 3)
         self.assertEqual(len(list(filter(lambda block: block.block_type == BlockType.MODULE and block.name == 'inner_module_call', module.blocks))), 3)
@@ -172,7 +172,7 @@ class TestLocalGraph(TestCase):
     def test_vertices_from_local_graph_module(self):
         resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME, '../resources/modules/stacks'))
         hcl_config_parser = Parser()
-        module, module_dependency_map, _ = hcl_config_parser.parse_hcl_module(resources_dir,
+        module, module_dependency_map, _, _ = hcl_config_parser.parse_hcl_module(resources_dir,
                                                                               self.source)
         local_graph = TerraformLocalGraph(module, module_dependency_map)
         local_graph.build_graph(render_variables=True)
@@ -182,7 +182,7 @@ class TestLocalGraph(TestCase):
     def test_variables_same_name_different_modules(self):
         resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME, '../resources/modules/same_var_names'))
         hcl_config_parser = Parser()
-        module, module_dependency_map, _ = hcl_config_parser.parse_hcl_module(resources_dir,
+        module, module_dependency_map, _, _ = hcl_config_parser.parse_hcl_module(resources_dir,
                                                                               self.source)
         local_graph = TerraformLocalGraph(module, module_dependency_map)
         local_graph.build_graph(render_variables=True)

--- a/tests/terraform/graph/graph_builder/test_terraform_graph_parser.py
+++ b/tests/terraform/graph/graph_builder/test_terraform_graph_parser.py
@@ -48,14 +48,14 @@ class TestParser(TestCase):
         cur_dir = os.path.dirname(os.path.realpath(__file__))
         tf_dir = f'{cur_dir}/../resources/tf_parsing_comparison/tf_regular'
         old_tf_dir = f'{cur_dir}/../resources/tf_parsing_comparison/tf_old'
-        _, _, tf_definitions = Parser().parse_hcl_module(tf_dir, 'AWS')
-        _, _, old_tf_definitions = Parser().parse_hcl_module(old_tf_dir, 'AWS')
+        _, _, _, tf_definitions = Parser().parse_hcl_module(tf_dir, 'AWS')
+        _, _, _, old_tf_definitions = Parser().parse_hcl_module(old_tf_dir, 'AWS')
         self.assertDictEqual(tf_definitions[f'{tf_dir}/main.tf'], old_tf_definitions[f'{old_tf_dir}/main.tf'])
 
     def test_hcl_parsing_old_booleans_correctness(self):
         cur_dir = os.path.dirname(os.path.realpath(__file__))
         tf_dir = f'{cur_dir}/../resources/tf_parsing_comparison/tf_regular'
-        _, _, tf_definitions = Parser().parse_hcl_module(tf_dir, 'AWS')
+        _, _, _, tf_definitions = Parser().parse_hcl_module(tf_dir, 'AWS')
         expected = [
             {'aws_cloudtrail': {
                 'tfer--cashdash_trail': {'enable_log_file_validation': [True], 'enable_logging': [True], 'include_global_service_events': [True],
@@ -98,9 +98,9 @@ class TestParser(TestCase):
         source_dir = os.path.realpath(os.path.join(TEST_DIRNAME,
                                                    '../resources/tf_parsing_comparison/modifications_diff'))
         config_parser = Parser()
-        res = config_parser.parse_hcl_module(source_dir, 'AWS')
+        _, _, _, tf_definitions = config_parser.parse_hcl_module(source_dir, 'AWS')
         expected = ['https://www.googleapis.com/auth/devstorage.read_only', 'https://www.googleapis.com/auth/logging.write',
                     'https://www.googleapis.com/auth/monitoring.write', 'https://www.googleapis.com/auth/service.management.readonly',
                     'https://www.googleapis.com/auth/servicecontrol', 'https://www.googleapis.com/auth/trace.append']
-        result_resource = res[2][source_dir + '/main.tf']['resource'][0]['google_compute_instance']['tfer--test3']['service_account'][0]['scopes'][0]
+        result_resource = tf_definitions[source_dir + '/main.tf']['resource'][0]['google_compute_instance']['tfer--test3']['service_account'][0]['scopes'][0]
         self.assertListEqual(result_resource, expected)

--- a/tests/terraform/module_loading/loaders/test_local_path_loader.py
+++ b/tests/terraform/module_loading/loaders/test_local_path_loader.py
@@ -7,15 +7,15 @@ from checkov.terraform.module_loading.loaders.local_path_loader import loader
 class TestLocalPathLoader(unittest.TestCase):
     def test_child_dir(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
-        with loader.load(current_dir, "./resources", None, '') as content:
+        with loader.load(current_dir, "./resources", None, '', '') as content:
             assert content.loaded()
             assert content.path() == os.path.join(current_dir, "resources")
 
     def test_unhandled_source(self):
-        with loader.load("current_dir", "hashicorp/consul/aws", None, '') as content:
+        with loader.load("current_dir", "hashicorp/consul/aws", None, '', '') as content:
             assert not content.loaded()
 
     def test_bad_source(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         with self.assertRaises(FileNotFoundError):
-            loader.load(current_dir, "./path_that_doesnt_exist", None, '')
+            loader.load(current_dir, "./path_that_doesnt_exist", None, '', '')

--- a/tests/terraform/module_loading/test_registry.py
+++ b/tests/terraform/module_loading/test_registry.py
@@ -324,3 +324,285 @@ def test_load_local_path(git_getter, source, expected_content_path, expected_exc
         assert content.path() == str(current_dir / expected_content_path)
 
         git_getter.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "source, source_version, expected_content_path, expected_git_url, expected_dest_dir, expected_module_source, expected_inner_module",
+    [
+        (
+            "terraform-aws-modules/security-group/aws",
+            "4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "",
+        ),
+        (
+            "terraform-aws-modules/security-group/aws//modules/http-80",
+            "4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0/modules/http-80",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "modules/http-80",
+        ),
+    ],
+    ids=["module_with_version", "inner_module_with_version"],
+)
+@mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
+def test_load_terraform_registry(
+    git_getter,
+    source,
+    source_version,
+    expected_content_path,
+    expected_git_url,
+    expected_dest_dir,
+    expected_module_source,
+    expected_inner_module,
+):
+    # given
+    current_dir = Path(__file__).parent / "tmp"
+    registry = ModuleLoaderRegistry(download_external_modules=True)
+
+    # when
+    content = registry.load(current_dir=str(current_dir), source=source, source_version=source_version)
+
+    # then
+    assert content.loaded()
+    assert content.path() == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_content_path)
+
+    git_getter.assert_called_once_with(expected_git_url, mock.ANY)
+
+    git_loader = next(loader for loader in registry.loaders if isinstance(loader, GenericGitLoader))
+    assert git_loader.dest_dir == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_dest_dir)
+    assert git_loader.module_source == expected_module_source
+    assert git_loader.inner_module == expected_inner_module
+
+
+@pytest.mark.parametrize(
+    "source, expected_content_path, expected_git_url, expected_dest_dir, expected_module_source, expected_inner_module",
+    [
+        (
+            "git::https://example.com/network.git",
+            "example.com/network/HEAD",
+            "https://example.com/network.git",
+            "example.com/network/HEAD",
+            "git::https://example.com/network.git",
+            "",
+        ),
+        (
+            "git::https://example.com/network.git?ref=v1.2.0",
+            "example.com/network/v1.2.0",
+            "https://example.com/network.git?ref=v1.2.0",
+            "example.com/network/v1.2.0",
+            "git::https://example.com/network.git?ref=v1.2.0",
+            "",
+        ),
+        (
+            "git::https://example.com/network.git//modules/vpc",
+            "example.com/network/HEAD/modules/vpc",
+            "https://example.com/network",
+            "example.com/network/HEAD",
+            "git::https://example.com/network",
+            "modules/vpc",
+        ),
+        (
+            "git::https://example.com/network.git//modules/vpc?ref=v1.2.0",
+            "example.com/network/v1.2.0/modules/vpc",
+            "https://example.com/network?ref=v1.2.0",
+            "example.com/network/v1.2.0",
+            "git::https://example.com/network?ref=v1.2.0",
+            "modules/vpc",
+        ),
+    ],
+    ids=["module", "module_with_version", "inner_module", "inner_module_with_version"],
+)
+@mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
+def test_load_generic_git(
+    git_getter,
+    source,
+    expected_content_path,
+    expected_git_url,
+    expected_dest_dir,
+    expected_module_source,
+    expected_inner_module,
+):
+    # given
+    current_dir = Path(__file__).parent / "tmp"
+    registry = ModuleLoaderRegistry(download_external_modules=True)
+
+    # when
+    content = registry.load(current_dir=str(current_dir), source=source, source_version="latest")
+
+    # then
+    assert content.loaded()
+    assert content.path() == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_content_path)
+
+    git_getter.assert_called_once_with(expected_git_url, mock.ANY)
+
+    git_loader = next(loader for loader in registry.loaders if isinstance(loader, GenericGitLoader))
+    assert git_loader.dest_dir == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_dest_dir)
+    assert git_loader.module_source == expected_module_source
+    assert git_loader.inner_module == expected_inner_module
+
+
+@pytest.mark.parametrize(
+    "source, expected_content_path, expected_git_url, expected_dest_dir, expected_module_source, expected_inner_module",
+    [
+        (
+            "github.com/terraform-aws-modules/terraform-aws-security-group",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/HEAD",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/HEAD",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group",
+            "",
+        ),
+        (
+            "github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "",
+        ),
+        (
+            "github.com/terraform-aws-modules/terraform-aws-security-group//modules/http-80",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/HEAD/modules/http-80",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/HEAD",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group",
+            "modules/http-80",
+        ),
+        (
+            "github.com/terraform-aws-modules/terraform-aws-security-group//modules/http-80?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0/modules/http-80",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "modules/http-80",
+        ),
+    ],
+    ids=["module", "module_with_version", "inner_module", "inner_module_with_version"],
+)
+@mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
+def test_load_github(
+    git_getter,
+    source,
+    expected_content_path,
+    expected_git_url,
+    expected_dest_dir,
+    expected_module_source,
+    expected_inner_module,
+):
+    # given
+    current_dir = Path(__file__).parent / "tmp"
+    registry = ModuleLoaderRegistry(download_external_modules=True)
+
+    # when
+    content = registry.load(current_dir=str(current_dir), source=source, source_version="latest")
+
+    # then
+    assert content.loaded()
+    assert content.path() == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_content_path)
+
+    git_getter.assert_called_once_with(expected_git_url, mock.ANY)
+
+    git_loader = next(loader for loader in registry.loaders if isinstance(loader, GithubLoader))
+    assert git_loader.dest_dir == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_dest_dir)
+    assert git_loader.module_source == expected_module_source
+    assert git_loader.inner_module == expected_inner_module
+
+
+# TODO: create a dummy repo in bitbucket for more consitent tests
+@pytest.mark.parametrize(
+    "source, expected_content_path, expected_git_url, expected_dest_dir, expected_module_source, expected_inner_module",
+    [
+        (
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/HEAD",
+            "https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/HEAD",
+            "git::https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha",
+            "",
+        ),
+        (
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha?ref=v0.1.0",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/v0.1.0",
+            "https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha?ref=v0.1.0",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/v0.1.0",
+            "git::https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha?ref=v0.1.0",
+            "",
+        ),
+        (
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha//rancher2-ha",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/HEAD/rancher2-ha",
+            "https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/HEAD",
+            "git::https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha",
+            "rancher2-ha",
+        ),
+        (
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha//rancher2-ha?ref=v0.1.0",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/v0.1.0/rancher2-ha",
+            "https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha?ref=v0.1.0",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/v0.1.0",
+            "git::https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha?ref=v0.1.0",
+            "rancher2-ha",
+        ),
+    ],
+    ids=["module", "module_with_version", "inner_module", "inner_module_with_version"],
+)
+@mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
+def test_load_bitbucket(
+    git_getter,
+    source,
+    expected_content_path,
+    expected_git_url,
+    expected_dest_dir,
+    expected_module_source,
+    expected_inner_module,
+):
+    # given
+    current_dir = Path(__file__).parent / "tmp"
+    registry = ModuleLoaderRegistry(download_external_modules=True)
+
+    # when
+    content = registry.load(current_dir=str(current_dir), source=source, source_version="latest")
+
+    # then
+    assert content.loaded()
+    assert content.path() == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_content_path)
+
+    git_getter.assert_called_once_with(expected_git_url, mock.ANY)
+
+    git_loader = next(loader for loader in registry.loaders if isinstance(loader, BitbucketLoader))
+    assert git_loader.dest_dir == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_dest_dir)
+    assert git_loader.module_source == expected_module_source
+    assert git_loader.inner_module == expected_inner_module
+
+
+@pytest.mark.parametrize(
+    "source, expected_content_path, expected_exception",
+    [
+        ("./loaders/resources", "loaders/resources", does_not_raise()),
+        ("../module_loading/loaders/resources", "loaders/resources", does_not_raise()),
+        ("./does_not_exist", "", pytest.raises(FileNotFoundError)),
+    ],
+    ids=["current_dir", "parent_dir", "not_exists"],
+)
+@mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
+def test_load_local_path(git_getter, source, expected_content_path, expected_exception):
+    # given
+    current_dir = Path(__file__).parent
+    registry = ModuleLoaderRegistry()
+
+    # when
+    with expected_exception:
+        content = registry.load(current_dir=str(current_dir), source=source, source_version="latest")
+
+        # then
+        assert content.loaded()
+        assert content.path() == str(current_dir / expected_content_path)
+
+        git_getter.assert_not_called()

--- a/tests/terraform/module_loading/test_registry.py
+++ b/tests/terraform/module_loading/test_registry.py
@@ -1,14 +1,22 @@
 import os
 import shutil
 import unittest
+from contextlib import ExitStack as does_not_raise
+from pathlib import Path
+from unittest import mock
+
+import pytest
 
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
+from checkov.terraform.module_loading.loaders.bitbucket_loader import BitbucketLoader
+from checkov.terraform.module_loading.loaders.git_loader import GenericGitLoader
+from checkov.terraform.module_loading.loaders.github_loader import GithubLoader
 from checkov.terraform.module_loading.registry import ModuleLoaderRegistry
 
 
 class TestModuleLoaderRegistry(unittest.TestCase):
     def setUp(self) -> None:
-        self.current_dir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "./tmp"))
+        self.current_dir = str(Path(__file__).parent / "tmp")
 
     def tearDown(self) -> None:
         if os.path.exists(self.current_dir):
@@ -19,14 +27,300 @@ class TestModuleLoaderRegistry(unittest.TestCase):
         source = "terraform-aws-modules/security-group/aws"
         with registry.load(current_dir=self.current_dir, source=source, source_version="~> 3.0") as content:
             assert content.loaded()
-            expected_content_path = os.path.join(self.current_dir, DEFAULT_EXTERNAL_MODULES_DIR, source)
-            self.assertEqual(expected_content_path, content.path(), f"expected content.path() to be {content.path()}, got {expected_content_path}")
+            expected_content_path = os.path.join(
+                self.current_dir,
+                DEFAULT_EXTERNAL_MODULES_DIR,
+                "github.com/terraform-aws-modules/terraform-aws-security-group",
+            )
+            self.assertRegexpMatches(content.path(), f"^{expected_content_path}/v3.*")
 
     def test_load_terraform_registry_check_cache(self):
         registry = ModuleLoaderRegistry(download_external_modules=True)
-        source1 = "https://github.com/bridgecrewio/checkov_not_working1.git"
+        source1 = "git::https://github.com/bridgecrewio/checkov_not_working1.git"
         registry.load(current_dir=self.current_dir, source=source1, source_version="latest")
         self.assertIn(source1, registry.failed_urls_cache)
-        source2 = "https://github.com/bridgecrewio/checkov_not_working2.git"
+        source2 = "git::https://github.com/bridgecrewio/checkov_not_working2.git"
         registry.load(current_dir=self.current_dir, source=source2, source_version="latest")
         self.assertIn(source1 in registry.failed_urls_cache and source2, registry.failed_urls_cache)
+
+
+@pytest.mark.parametrize(
+    "source, source_version, expected_content_path, expected_git_url, expected_dest_dir, expected_module_source, expected_inner_module",
+    [
+        (
+            "terraform-aws-modules/security-group/aws",
+            "4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "",
+        ),
+        (
+            "terraform-aws-modules/security-group/aws//modules/http-80",
+            "4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0/modules/http-80",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "modules/http-80",
+        ),
+    ],
+    ids=["module_with_version", "inner_module_with_version"],
+)
+@mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
+def test_load_terraform_registry(
+    git_getter,
+    source,
+    source_version,
+    expected_content_path,
+    expected_git_url,
+    expected_dest_dir,
+    expected_module_source,
+    expected_inner_module,
+):
+    # given
+    current_dir = Path(__file__).parent / "tmp"
+    registry = ModuleLoaderRegistry(download_external_modules=True)
+
+    # when
+    content = registry.load(current_dir=str(current_dir), source=source, source_version=source_version)
+
+    # then
+    assert content.loaded()
+    assert content.path() == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_content_path)
+
+    git_getter.assert_called_once_with(expected_git_url, mock.ANY)
+
+    git_loader = next(loader for loader in registry.loaders if isinstance(loader, GenericGitLoader))
+    assert git_loader.dest_dir == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_dest_dir)
+    assert git_loader.module_source == expected_module_source
+    assert git_loader.inner_module == expected_inner_module
+
+
+@pytest.mark.parametrize(
+    "source, expected_content_path, expected_git_url, expected_dest_dir, expected_module_source, expected_inner_module",
+    [
+        (
+            "git::https://example.com/network.git",
+            "example.com/network/HEAD",
+            "https://example.com/network.git",
+            "example.com/network/HEAD",
+            "git::https://example.com/network.git",
+            "",
+        ),
+        (
+            "git::https://example.com/network.git?ref=v1.2.0",
+            "example.com/network/v1.2.0",
+            "https://example.com/network.git?ref=v1.2.0",
+            "example.com/network/v1.2.0",
+            "git::https://example.com/network.git?ref=v1.2.0",
+            "",
+        ),
+        (
+            "git::https://example.com/network.git//modules/vpc",
+            "example.com/network/HEAD/modules/vpc",
+            "https://example.com/network",
+            "example.com/network/HEAD",
+            "git::https://example.com/network",
+            "modules/vpc",
+        ),
+        (
+            "git::https://example.com/network.git//modules/vpc?ref=v1.2.0",
+            "example.com/network/v1.2.0/modules/vpc",
+            "https://example.com/network?ref=v1.2.0",
+            "example.com/network/v1.2.0",
+            "git::https://example.com/network?ref=v1.2.0",
+            "modules/vpc",
+        ),
+    ],
+    ids=["module", "module_with_version", "inner_module", "inner_module_with_version"],
+)
+@mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
+def test_load_generic_git(
+    git_getter,
+    source,
+    expected_content_path,
+    expected_git_url,
+    expected_dest_dir,
+    expected_module_source,
+    expected_inner_module,
+):
+    # given
+    current_dir = Path(__file__).parent / "tmp"
+    registry = ModuleLoaderRegistry(download_external_modules=True)
+
+    # when
+    content = registry.load(current_dir=str(current_dir), source=source, source_version="latest")
+
+    # then
+    assert content.loaded()
+    assert content.path() == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_content_path)
+
+    git_getter.assert_called_once_with(expected_git_url, mock.ANY)
+
+    git_loader = next(loader for loader in registry.loaders if isinstance(loader, GenericGitLoader))
+    assert git_loader.dest_dir == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_dest_dir)
+    assert git_loader.module_source == expected_module_source
+    assert git_loader.inner_module == expected_inner_module
+
+
+@pytest.mark.parametrize(
+    "source, expected_content_path, expected_git_url, expected_dest_dir, expected_module_source, expected_inner_module",
+    [
+        (
+            "github.com/terraform-aws-modules/terraform-aws-security-group",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/HEAD",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/HEAD",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group",
+            "",
+        ),
+        (
+            "github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "",
+        ),
+        (
+            "github.com/terraform-aws-modules/terraform-aws-security-group//modules/http-80",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/HEAD/modules/http-80",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/HEAD",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group",
+            "modules/http-80",
+        ),
+        (
+            "github.com/terraform-aws-modules/terraform-aws-security-group//modules/http-80?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0/modules/http-80",
+            "https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0",
+            "git::https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v4.0.0",
+            "modules/http-80",
+        ),
+    ],
+    ids=["module", "module_with_version", "inner_module", "inner_module_with_version"],
+)
+@mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
+def test_load_github(
+    git_getter,
+    source,
+    expected_content_path,
+    expected_git_url,
+    expected_dest_dir,
+    expected_module_source,
+    expected_inner_module,
+):
+    # given
+    current_dir = Path(__file__).parent / "tmp"
+    registry = ModuleLoaderRegistry(download_external_modules=True)
+
+    # when
+    content = registry.load(current_dir=str(current_dir), source=source, source_version="latest")
+
+    # then
+    assert content.loaded()
+    assert content.path() == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_content_path)
+
+    git_getter.assert_called_once_with(expected_git_url, mock.ANY)
+
+    git_loader = next(loader for loader in registry.loaders if isinstance(loader, GithubLoader))
+    assert git_loader.dest_dir == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_dest_dir)
+    assert git_loader.module_source == expected_module_source
+    assert git_loader.inner_module == expected_inner_module
+
+
+# TODO: create a dummy repo in bitbucket for more consitent tests
+@pytest.mark.parametrize(
+    "source, expected_content_path, expected_git_url, expected_dest_dir, expected_module_source, expected_inner_module",
+    [
+        (
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/HEAD",
+            "https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/HEAD",
+            "git::https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha",
+            "",
+        ),
+        (
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha?ref=v0.1.0",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/v0.1.0",
+            "https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha?ref=v0.1.0",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/v0.1.0",
+            "git::https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha?ref=v0.1.0",
+            "",
+        ),
+        (
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha//rancher2-ha",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/HEAD/rancher2-ha",
+            "https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/HEAD",
+            "git::https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha",
+            "rancher2-ha",
+        ),
+        (
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha//rancher2-ha?ref=v0.1.0",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/v0.1.0/rancher2-ha",
+            "https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha?ref=v0.1.0",
+            "bitbucket.org/nuarch/terraform-aws-rancher-server-ha/v0.1.0",
+            "git::https://bitbucket.org/nuarch/terraform-aws-rancher-server-ha?ref=v0.1.0",
+            "rancher2-ha",
+        ),
+    ],
+    ids=["module", "module_with_version", "inner_module", "inner_module_with_version"],
+)
+@mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
+def test_load_bitbucket(
+    git_getter,
+    source,
+    expected_content_path,
+    expected_git_url,
+    expected_dest_dir,
+    expected_module_source,
+    expected_inner_module,
+):
+    # given
+    current_dir = Path(__file__).parent / "tmp"
+    registry = ModuleLoaderRegistry(download_external_modules=True)
+
+    # when
+    content = registry.load(current_dir=str(current_dir), source=source, source_version="latest")
+
+    # then
+    assert content.loaded()
+    assert content.path() == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_content_path)
+
+    git_getter.assert_called_once_with(expected_git_url, mock.ANY)
+
+    git_loader = next(loader for loader in registry.loaders if isinstance(loader, BitbucketLoader))
+    assert git_loader.dest_dir == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_dest_dir)
+    assert git_loader.module_source == expected_module_source
+    assert git_loader.inner_module == expected_inner_module
+
+
+@pytest.mark.parametrize(
+    "source, expected_content_path, expected_exception",
+    [
+        ("./loaders/resources", "loaders/resources", does_not_raise()),
+        ("../module_loading/loaders/resources", "loaders/resources", does_not_raise()),
+        ("./does_not_exist", "", pytest.raises(FileNotFoundError)),
+    ],
+    ids=["current_dir", "parent_dir", "not_exists"],
+)
+@mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
+def test_load_local_path(git_getter, source, expected_content_path, expected_exception):
+    # given
+    current_dir = Path(__file__).parent
+    registry = ModuleLoaderRegistry()
+
+    # when
+    with expected_exception:
+        content = registry.load(current_dir=str(current_dir), source=source, source_version="latest")
+
+        # then
+        assert content.loaded()
+        assert content.path() == str(current_dir / expected_content_path)
+
+        git_getter.assert_not_called()

--- a/tests/terraform/parser/resources/registry_security_group/registry_security_group.tf
+++ b/tests/terraform/parser/resources/registry_security_group/registry_security_group.tf
@@ -1,6 +1,6 @@
 module "security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "~> 3.0"
+  version = "3.18.0"
 
   name        = "example"
   description = "Security group for example usage with EC2 instance"

--- a/tests/terraform/parser/resources/registry_security_group_inner_module/main.tf
+++ b/tests/terraform/parser/resources/registry_security_group_inner_module/main.tf
@@ -1,5 +1,6 @@
 module "web_server_sg" {
-  source = "terraform-aws-modules/security-group/aws//modules/http-80"
+  source  = "terraform-aws-modules/security-group/aws//modules/http-80"
+  version = "4.0.0"
 
   name        = "web-server"
   description = "Security group for web-server with HTTP ports open within VPC"

--- a/tests/terraform/parser/test_parser_modules.py
+++ b/tests/terraform/parser/test_parser_modules.py
@@ -27,9 +27,8 @@ class TestParserInternals(unittest.TestCase):
                                download_external_modules=True,
                                external_modules_download_path=DEFAULT_EXTERNAL_MODULES_DIR)
 
-        external_aws_modules_path = os.path.join(self.external_module_path, 'terraform-aws-modules')
+        external_aws_modules_path = os.path.join(self.external_module_path, 'github.com/terraform-aws-modules/terraform-aws-security-group/v3.18.0')
         assert os.path.exists(external_aws_modules_path)
-        assert os.path.exists(os.path.join(external_aws_modules_path, 'security-group'))
 
     def test_load_inner_registry_module(self):
         parser = Parser()
@@ -41,7 +40,7 @@ class TestParserInternals(unittest.TestCase):
                                download_external_modules=True,
                                external_modules_download_path=DEFAULT_EXTERNAL_MODULES_DIR)
         self.assertEqual(11, len(list(out_definitions.keys())))
-        expected_remote_module_path = f'{DEFAULT_EXTERNAL_MODULES_DIR}/terraform-aws-modules/security-group/aws'
+        expected_remote_module_path = f'{DEFAULT_EXTERNAL_MODULES_DIR}/github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0'
         expected_inner_remote_module_path = f'{expected_remote_module_path}/modules/http-80'
         expected_main_file = os.path.join(directory, 'main.tf')
         expected_inner_main_file = os.path.join(directory, expected_inner_remote_module_path, 'main.tf')


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

The biggest change I did was to restructure on where to clone the module repositories. Instead of just using one folder for the best suitable version of module, now each module version, which is used will get its own folder and be checked. The result is something like this:
```shell
github.com/terraform-aws-modules/terraform-aws-security-group/v3.18.0
github.com/terraform-aws-modules/terraform-aws-security-group/v4.0.0
github.com/terraform-aws-modules/terraform-aws-security-group/HEAD
```
the `HEAD` version of a module is the latest commit on the default branch.

Module references with SSH should also work, but I will add some tests to make sure it really works 😄 
