### PR TITLE
Adding a rule to detect if an AWS Transfer Server is public

### DIFF
--- a/checkov/terraform/checks/resource/aws/TransferServerIsPublic.py
+++ b/checkov/terraform/checks/resource/aws/TransferServerIsPublic.py
@@ -1,0 +1,19 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class TransferServerIsPublic(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Transfer Server is not exposed publicly."
+        id = "CKV_AWS_164"
+        supported_resources = ['aws_transfer_server']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'endpoint_type'
+
+    def get_expected_values(self):
+        return ["VPC", "VPC_ENDPOINT"]
+
+check = TransferServerIsPublic()

--- a/tests/terraform/checks/resource/aws/example_TransferServerIsPublic/main.tf
+++ b/tests/terraform/checks/resource/aws/example_TransferServerIsPublic/main.tf
@@ -1,0 +1,16 @@
+# fail
+resource "aws_transfer_server" "example_public" {
+    endpoint_type = "PUBLIC"
+    protocols   = ["SFTP"]
+}
+
+# pass
+resource "aws_transfer_server" "example_vpc" {
+    endpoint_type = "VPC"
+    protocols   = ["SFTP"]
+}
+
+# fail
+resource "aws_transfer_server" "example" {
+    protocols   = ["SFTP"]
+}

--- a/tests/terraform/checks/resource/aws/test_TransferServerIsPublic.py
+++ b/tests/terraform/checks/resource/aws/test_TransferServerIsPublic.py
@@ -1,0 +1,36 @@
+import unittest
+
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.aws.TransferServerIsPublic import check
+import hcl2
+
+
+class TestTransferServerIsPublic(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+                resource "aws_transfer_server" "example" {
+                    endpoint_type = "PUBLIC"
+
+                    protocols   = ["SFTP"]
+                }
+            """)
+        resource_conf = hcl_res['resource'][0]['aws_transfer_server']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+                resource "aws_transfer_server" "example" {
+                    endpoint_type = "VPC"
+
+                    protocols   = ["SFTP"]
+                }
+            """)
+        resource_conf = hcl_res['resource'][0]['aws_transfer_server']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

https://aws.amazon.com/premiumsupport/knowledge-center/aws-sftp-endpoint-type/
