### PR TITLE
serialize set as list for json

### DIFF
--- a/checkov/common/bridgecrew/wrapper.py
+++ b/checkov/common/bridgecrew/wrapper.py
@@ -4,6 +4,7 @@ import json
 import itertools
 import dpath.util
 from checkov.common.models.consts import SUPPORTED_FILE_EXTENSIONS
+from checkov.common.util.json_utils import CustomJSONEncoder
 
 checkov_results_prefix = 'checkov_results'
 check_reduced_keys = (
@@ -19,7 +20,7 @@ def _is_scanned_file(file):
 
 def _put_json_object(s3_client, json_obj, bucket, object_path):
     try:
-        s3_client.put_object(Bucket=bucket, Key=object_path, Body=json.dumps(json_obj))
+        s3_client.put_object(Bucket=bucket, Key=object_path, Body=json.dumps(json_obj, cls=CustomJSONEncoder))
     except Exception as e:
         logging.error(f"failed to persist object {json_obj} into S3 bucket {bucket}\n{e}")
         raise e

--- a/checkov/common/util/json_utils.py
+++ b/checkov/common/util/json_utils.py
@@ -4,6 +4,6 @@ import json
 class CustomJSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, set):
-            return str(list(o))
+            return json.JSONEncoder.default(self, list(o))
         else:
             return json.JSONEncoder.default(self, o)

--- a/checkov/common/util/json_utils.py
+++ b/checkov/common/util/json_utils.py
@@ -4,6 +4,6 @@ import json
 class CustomJSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, set):
-            return json.dumps(list(o))
+            return list(o)
         else:
             return json.JSONEncoder.default(self, o)

--- a/checkov/common/util/json_utils.py
+++ b/checkov/common/util/json_utils.py
@@ -1,0 +1,9 @@
+import json
+
+
+class CustomJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, set):
+            return str(list(o))
+        else:
+            return json.JSONEncoder.default(self, o)

--- a/checkov/common/util/json_utils.py
+++ b/checkov/common/util/json_utils.py
@@ -4,6 +4,6 @@ import json
 class CustomJSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, set):
-            return json.JSONEncoder.default(self, list(o))
+            return json.dumps(list(o))
         else:
             return json.JSONEncoder.default(self, o)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This google module produced a JSON serialization error when running with platform integration and --download-external-modules.

https://github.com/terraform-google-modules/terraform-google-service-accounts

This is because it has sets in the definition, which don't get serialized to JSON.

This PR adds a JSON encoder to convert them to lists first.