### PR TITLE
use / in URL, not OS native path

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -488,7 +488,7 @@ class BcPlatformIntegration(object):
                 sleep(1)
 
     def get_excluded_paths(self):
-        repo_settings_api_url = os.path.join(self.bc_api_url, "vcs/settings/scheme")
+        repo_settings_api_url = f'{self.bc_api_url}/vcs/settings/scheme'
         try:
             request = self.http.request("GET", repo_settings_api_url,
                                         headers={"Authorization": self.bc_api_key, "Content-Type": "application/json"})


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes an issue where os.path.join was used to construct a URL, which broke on windows.