### PR TITLE
Adding 3 new checks for * principals in Glacier Vaults, SNS Topic Policies, and SQS Queue Policies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -40,6 +40,7 @@ dockerfile-parse ="*"
 docker = "*"
 configargparse = "*"
 detect_secrets = "*"
+policyuniverse = "*"
 
 [requires]
 python_version = "3.7"

--- a/checkov/terraform/checks/resource/aws/GlacierVaultAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/GlacierVaultAnyPrincipal.py
@@ -1,0 +1,28 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.util.type_forcers import force_list
+
+from policyuniverse.policy import Policy
+
+import json
+
+
+class GlacierVaultAnyPrincipal(BaseResourceCheck):
+
+    def __init__(self):
+        name = "Ensure Glacier Vault access policy is not public by only allowing specific services or principals to access it"
+        id = "CKV_AWS_167"
+        supported_resources = ['aws_glacier_vault']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'access_policy' in conf:
+            policy = Policy(conf['access_policy'][0])
+            if policy.is_internet_accessible():
+                 return CheckResult.FAILED
+        return CheckResult.PASSED
+
+check = GlacierVaultAnyPrincipal()
+
+

--- a/checkov/terraform/checks/resource/aws/SNSTopicPolicyAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/SNSTopicPolicyAnyPrincipal.py
@@ -1,0 +1,28 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.util.type_forcers import force_list
+
+from policyuniverse.policy import Policy
+
+import json
+
+
+class SNSTopicPolicyAnyPrincipal(BaseResourceCheck):
+
+    def __init__(self):
+        name = "Ensure SNS topic policy is not public by only allowing specific services or principals to access it"
+        id = "CKV_AWS_169"
+        supported_resources = ['aws_sns_topic_policy']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'policy' in conf:
+            policy = Policy(conf['policy'][0])
+            if policy.is_internet_accessible():
+                 return CheckResult.FAILED
+        return CheckResult.PASSED
+
+check = SNSTopicPolicyAnyPrincipal()
+
+

--- a/checkov/terraform/checks/resource/aws/SQSQueuePolicyAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/SQSQueuePolicyAnyPrincipal.py
@@ -1,0 +1,28 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.util.type_forcers import force_list
+
+from policyuniverse.policy import Policy
+
+import json
+
+
+class SQSQueuePolicyAnyPrincipal(BaseResourceCheck):
+
+    def __init__(self):
+        name = "Ensure SQS queue policy is not public by only allowing specific services or principals to access it"
+        id = "CKV_AWS_168"
+        supported_resources = ['aws_sqs_queue_policy']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'policy' in conf:
+            policy = Policy(conf['policy'][0])
+            if policy.is_internet_accessible():
+                 return CheckResult.FAILED
+        return CheckResult.PASSED
+
+check = SQSQueuePolicyAnyPrincipal()
+
+

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
         "dockerfile-parse",
         "docker",
         "configargparse",
-        "detect-secrets"
+        "detect-secrets",
+        "policyuniverse"
     ],
     license="Apache License 2.0",
     name="checkov",

--- a/tests/terraform/checks/resource/aws/example_GlacierVaultAnyPrincipal/main.tf
+++ b/tests/terraform/checks/resource/aws/example_GlacierVaultAnyPrincipal/main.tf
@@ -1,0 +1,146 @@
+# pass
+resource "aws_glacier_vault" "my_archive1" {
+  name = "MyArchive"
+
+  access_policy = <<EOF
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Sid": "add-read-only-perm",
+          "Principal": "*",
+          "Effect": "Deny",
+          "Action": [
+             "glacier:InitiateJob",
+             "glacier:GetJobOutput"
+          ],
+          "Resource": "arn:aws:glacier:eu-west-1:432981146916:vaults/MyArchive"
+       }
+    ]
+}
+EOF
+}
+
+# fail
+resource "aws_glacier_vault" "my_archive2" {
+  name = "MyArchive"
+
+  access_policy = <<EOF
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Sid": "add-read-only-perm",
+           "Principal": { 
+            "AWS": [
+                "arn:aws:iam::123456789101:role/vault-reader", 
+                "*"
+            ]
+          },
+          "Effect": "Allow",
+          "Action": [
+             "glacier:InitiateJob",
+             "glacier:GetJobOutput"
+          ],
+          "Resource": "arn:aws:glacier:eu-west-1:432981146916:vaults/MyArchive"
+       }
+    ]
+}
+EOF
+}
+
+# fail
+resource "aws_glacier_vault" "my_archive3" {
+  name = "MyArchive"
+
+  access_policy = <<EOF
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Sid": "add-read-only-perm",
+          "Principal": { 
+            "AWS": "arn:aws:iam::*:role/vault-reader"
+          },
+          "Effect": "Allow",
+          "Action": [
+             "glacier:InitiateJob",
+             "glacier:GetJobOutput"
+          ],
+          "Resource": "arn:aws:glacier:eu-west-1:432981146916:vaults/MyArchive"
+       }
+    ]
+}
+EOF
+}
+
+# fail
+resource "aws_glacier_vault" "my_archive4" {
+  name = "MyArchive"
+
+  access_policy = <<EOF
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Sid": "add-read-only-perm",
+           "Principal": { 
+            "AWS": "*"
+          },
+          "Effect": "Allow",
+          "Action": [
+             "glacier:InitiateJob",
+             "glacier:GetJobOutput"
+          ],
+          "Resource": "arn:aws:glacier:eu-west-1:432981146916:vaults/MyArchive"
+       }
+    ]
+}
+EOF
+}
+
+# fail
+resource "aws_glacier_vault" "my_archive5" {
+  name = "MyArchive"
+
+  access_policy = <<EOF
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Sid": "add-read-only-perm",
+          "Principal": "*",
+          "Effect": "Allow",
+          "Action": [
+             "glacier:InitiateJob",
+             "glacier:GetJobOutput"
+          ],
+          "Resource": "arn:aws:glacier:eu-west-1:432981146916:vaults/MyArchive"
+       }
+    ]
+}
+EOF
+}
+
+# pass
+resource "aws_glacier_vault" "my_archive6" {
+  name = "MyArchive"
+
+  access_policy = <<EOF
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Sid": "add-read-only-perm",
+          "Principal": "arn:aws:iam::123456789101:role/vault-reader",
+          "Effect": "Allow",
+          "Action": [
+             "glacier:InitiateJob",
+             "glacier:GetJobOutput"
+          ],
+          "Resource": "arn:aws:glacier:eu-west-1:432981146916:vaults/MyArchive"
+       }
+    ]
+}
+EOF
+}

--- a/tests/terraform/checks/resource/aws/example_SNSTopicPolicyAnyPrincipal/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SNSTopicPolicyAnyPrincipal/main.tf
@@ -1,0 +1,182 @@
+# pass
+resource "aws_sns_topic_policy" "sns_tp1" {
+  arn = aws_sns_topic.test.arn
+  
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": "*",
+          "Effect": "Deny",
+          "Action": [
+            "SNS:Subscribe",
+            "SNS:SetTopicAttributes",
+            "SNS:RemovePermission",
+            "SNS:Receive",
+            "SNS:Publish",
+            "SNS:ListSubscriptionsByTopic",
+            "SNS:GetTopicAttributes",
+            "SNS:DeleteTopic",
+            "SNS:AddPermission",
+          ],
+          "Resource": "${aws_sns_topic.test.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sns_topic_policy" "sns_tp2" {
+  arn = aws_sns_topic.test.arn
+
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+           "Principal": { 
+            "AWS": [
+                "arn:aws:iam::123456789101:role/sns", 
+                "*"
+            ]
+          },
+          "Effect": "Allow",
+          "Action": [
+            "SNS:Subscribe",
+            "SNS:SetTopicAttributes",
+            "SNS:RemovePermission",
+            "SNS:Receive",
+            "SNS:Publish",
+            "SNS:ListSubscriptionsByTopic",
+            "SNS:GetTopicAttributes",
+            "SNS:DeleteTopic",
+            "SNS:AddPermission",
+          ],
+          "Resource": "${aws_sns_topic.test.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sns_topic_policy" "sns_tp3" {
+  arn = aws_sns_topic.test.arn
+  
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": { 
+            "AWS": "arn:aws:iam::*:role/sns"
+          },
+          "Effect": "Allow",
+          "Action": [
+            "SNS:Subscribe",
+            "SNS:SetTopicAttributes",
+            "SNS:RemovePermission",
+            "SNS:Receive",
+            "SNS:Publish",
+            "SNS:ListSubscriptionsByTopic",
+            "SNS:GetTopicAttributes",
+            "SNS:DeleteTopic",
+            "SNS:AddPermission",
+          ],
+          "Resource": "${aws_sns_topic.test.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sns_topic_policy" "sns_tp4" {
+  arn = aws_sns_topic.test.arn
+  
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+           "Principal": { 
+            "AWS": "*"
+          },
+          "Effect": "Allow",
+          "Action": [
+            "SNS:Subscribe",
+            "SNS:SetTopicAttributes",
+            "SNS:RemovePermission",
+            "SNS:Receive",
+            "SNS:Publish",
+            "SNS:ListSubscriptionsByTopic",
+            "SNS:GetTopicAttributes",
+            "SNS:DeleteTopic",
+            "SNS:AddPermission",
+          ],
+          "Resource": "${aws_sns_topic.test.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sns_topic_policy" "sns_tp5" {
+  arn = aws_sns_topic.test.arn
+  
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": "*",
+          "Effect": "Allow",
+          "Action": [
+            "SNS:Subscribe",
+            "SNS:SetTopicAttributes",
+            "SNS:RemovePermission",
+            "SNS:Receive",
+            "SNS:Publish",
+            "SNS:ListSubscriptionsByTopic",
+            "SNS:GetTopicAttributes",
+            "SNS:DeleteTopic",
+            "SNS:AddPermission",
+          ],
+          "Resource": "${aws_sns_topic.test.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# pass
+resource "aws_sns_topic_policy" "sns_tp6" {
+  arn = aws_sns_topic.test.arn
+  
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": "arn:aws:iam::123456789101:role/sns",
+          "Effect": "Allow",
+          "Action": [
+            "SNS:Subscribe",
+            "SNS:SetTopicAttributes",
+            "SNS:RemovePermission",
+            "SNS:Receive",
+            "SNS:Publish",
+            "SNS:ListSubscriptionsByTopic",
+            "SNS:GetTopicAttributes",
+            "SNS:DeleteTopic",
+            "SNS:AddPermission",
+          ],
+          "Resource": "${aws_sns_topic.test.arn}"
+       }
+    ]
+}
+POLICY
+}

--- a/tests/terraform/checks/resource/aws/example_SQSQueuePolicyAnyPrincipal/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SQSQueuePolicyAnyPrincipal/main.tf
@@ -1,0 +1,122 @@
+# pass
+resource "aws_sqs_queue_policy" "q1" {
+  queue_url = aws_sqs_queue.q.id
+  
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": "*",
+          "Effect": "Deny",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sqs_queue_policy" "q2" {
+  queue_url = aws_sqs_queue.q.id
+ 
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+           "Principal": { 
+            "AWS": [
+                "arn:aws:iam::123456789101:role/sqs", 
+                "*"
+            ]
+          },
+          "Effect": "Allow",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sqs_queue_policy" "q3" {
+  queue_url = aws_sqs_queue.q.id
+  
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": { 
+            "AWS": "arn:aws:iam::*:role/sqs"
+          },
+          "Effect": "Allow",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sqs_queue_policy" "q4" {
+  queue_url = aws_sqs_queue.q.id
+  
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+           "Principal": { 
+            "AWS": "*"
+          },
+          "Effect": "Allow",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sqs_queue_policy" "q5" {
+  queue_url = aws_sqs_queue.q.id
+  
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": "*",
+          "Effect": "Allow",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# pass
+resource "aws_sqs_queue_policy" "q6" {
+  queue_url = aws_sqs_queue.q.id
+  
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": "arn:aws:iam::123456789101:role/sqs",
+          "Effect": "Allow",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}

--- a/tests/terraform/checks/resource/aws/test_GlacierVaultAnyPrincipal.py
+++ b/tests/terraform/checks/resource/aws/test_GlacierVaultAnyPrincipal.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.GlacierVaultAnyPrincipal import check
+from checkov.terraform.runner import Runner
+
+
+class TestBackupVaultEncrypted(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_GlacierVaultAnyPrincipal"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_glacier_vault.my_archive1",
+            "aws_glacier_vault.my_archive6",
+        }
+        failing_resources = {
+            "aws_glacier_vault.my_archive2",
+            "aws_glacier_vault.my_archive3",
+            "aws_glacier_vault.my_archive4",
+            "aws_glacier_vault.my_archive5",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_SNSTopicPolicyAnyPrincipal.py
+++ b/tests/terraform/checks/resource/aws/test_SNSTopicPolicyAnyPrincipal.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.SNSTopicPolicyAnyPrincipal import check
+from checkov.terraform.runner import Runner
+
+
+class TestBackupVaultEncrypted(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_SNSTopicPolicyAnyPrincipal"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_sns_topic_policy.sns_tp1",
+            "aws_sns_topic_policy.sns_tp6",
+        }
+        failing_resources = {
+            "aws_sns_topic_policy.sns_tp2",
+            "aws_sns_topic_policy.sns_tp3",
+            "aws_sns_topic_policy.sns_tp4",
+            "aws_sns_topic_policy.sns_tp5",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_SQSQueuePolicyAnyPrincipal.py
+++ b/tests/terraform/checks/resource/aws/test_SQSQueuePolicyAnyPrincipal.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.SQSQueuePolicyAnyPrincipal import check
+from checkov.terraform.runner import Runner
+
+
+class TestBackupVaultEncrypted(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_SQSQueuePolicyAnyPrincipal"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_sqs_queue_policy.q1",
+            "aws_sqs_queue_policy.q6",
+        }
+        failing_resources = {
+            "aws_sqs_queue_policy.q2",
+            "aws_sqs_queue_policy.q3",
+            "aws_sqs_queue_policy.q4",
+            "aws_sqs_queue_policy.q5",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces three new checks:

* CKV_AWS_167 - Ensure Glacier Vault access policy is not public by only allowing specific services or principals to access it
* CKV_AWS_168 - Ensure SQS queue policy is not public by only allowing specific services or principals to access it
* CKV_AWS_169 - Ensure SNS topic policy is not public by only allowing specific services or principals to access it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

These checks use Netflix's [policyuniverse](https://github.com/Netflix-Skunkworks/policyuniverse) to parse IAM and resource policies. I recommend using this for all future checks that deal with these policies, as it's as easy as calling `policy.is_internet_accessible()`.


