### PR TITLE
Fix skip directory upload logic

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -181,6 +181,8 @@ class BcPlatformIntegration(object):
                     self._persist_file(f, os.path.relpath(f, root_dir))
         else:
             for root_path, d_names, f_names in os.walk(root_dir):
+                # self.excluded_paths only contains the config fetched from the platform.
+                # but here we expect the list from runner_registry as well (which includes self.excluded_paths).
                 filter_ignored_paths(root_path, d_names, excluded_paths)
                 filter_ignored_paths(root_path, f_names, excluded_paths)
                 for file_path in f_names:

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -24,6 +24,7 @@ from checkov.common.bridgecrew.platform_key import read_key, persist_key, bridge
 from checkov.common.bridgecrew.wrapper import reduce_scan_reports, persist_checks_results, \
     enrich_and_persist_checks_metadata
 from checkov.common.models.consts import SUPPORTED_FILE_EXTENSIONS
+from checkov.common.runners.base_runner import filter_ignored_paths
 from checkov.version import version as checkov_version
 
 EMAIL_PATTERN = r"[^@]+@[^@]+\.[^@]+"
@@ -162,7 +163,7 @@ class BcPlatformIntegration(object):
         """
         return self.platform_integration_configured
 
-    def persist_repository(self, root_dir, files=None):
+    def persist_repository(self, root_dir, files=None, excluded_paths=[]):
         """
         Persist the repository found on root_dir path to Bridgecrew's platform. If --file flag is used, only files
         that are specified will be persisted.
@@ -180,10 +181,8 @@ class BcPlatformIntegration(object):
                     self._persist_file(f, os.path.relpath(f, root_dir))
         else:
             for root_path, d_names, f_names in os.walk(root_dir):
-                if any(re.findall(re.compile(exp), root_path) for exp in self.excluded_paths):
-                    # no need to persist files from excluded directories
-                    logging.info(f"skipping persisting excluded directory {root_path}")
-                    continue
+                filter_ignored_paths(root_path, d_names, excluded_paths)
+                filter_ignored_paths(root_path, f_names, excluded_paths)
                 for file_path in f_names:
                     _, file_extension = os.path.splitext(file_path)
                     if file_extension in SUPPORTED_FILE_EXTENSIONS:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -148,7 +148,7 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
             if baseline:
                 baseline.compare_and_reduce_reports(scan_reports)
             if bc_integration.is_integration_configured():
-                bc_integration.persist_repository(root_folder)
+                bc_integration.persist_repository(root_folder, excluded_paths=runner_filter.excluded_paths)
                 bc_integration.persist_scan_results(scan_reports)
                 url = bc_integration.commit_repository(config.branch)
 
@@ -179,7 +179,7 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
         if bc_integration.is_integration_configured():
             files = [os.path.abspath(file) for file in config.file]
             root_folder = os.path.split(os.path.commonprefix(files))[0]
-            bc_integration.persist_repository(root_folder, files)
+            bc_integration.persist_repository(root_folder, files, excluded_paths=runner_filter.excluded_paths)
             bc_integration.persist_scan_results(scan_reports)
             url = bc_integration.commit_repository(config.branch)
         return runner_registry.print_reports(scan_reports, config, url=url, created_baseline_path=created_baseline_path,


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes the logic to filter out which directories to upload to use the same logic that filters out directories to scan (this will include the hardcoded defaults like node_modules and .terraform). Ultimately, this ensures that we only upload what we scan.