### PR TITLE
fixed n2n enc check to support old hcl

### DIFF
--- a/checkov/terraform/checks/resource/aws/ElasticsearchNodeToNodeEncryption.py
+++ b/checkov/terraform/checks/resource/aws/ElasticsearchNodeToNodeEncryption.py
@@ -24,17 +24,21 @@ class ElasticsearchNodeToNodeEncryption(BaseResourceCheck):
                 if "instance_count" not in cluster_config:
                     return CheckResult.PASSED
                 self.evaluated_keys = ['cluster_config/[0]/instance_count']
-                instance_count_list = cluster_config["instance_count"];
-                if len(instance_count_list) != 1:
-                    return CheckResult.UNKNOWN
-                instance_count = force_int(instance_count_list[0])
+                instance_count = cluster_config["instance_count"]
+                if isinstance(instance_count, list):
+                    instance_count = instance_count[0]
+                    if not isinstance(instance_count, int):
+                        return CheckResult.UNKNOWN
                 if instance_count:
                     if instance_count > 1:
                         self.evaluated_keys.append('node_to_node_encryption/[0]/enabled')
                         if "node_to_node_encryption" in conf.keys() and "enabled" in conf["node_to_node_encryption"][0]:
-                            if len(conf["node_to_node_encryption"][0]["enabled"]) != 1:
+                            n2n_enc_enabled = conf["node_to_node_encryption"][0]["enabled"]
+                            if isinstance(n2n_enc_enabled, list):
+                                n2n_enc_enabled = conf["node_to_node_encryption"][0]["enabled"][0]
+                            if not isinstance(n2n_enc_enabled, bool):
                                 return CheckResult.UNKNOWN
-                            if conf["node_to_node_encryption"][0]["enabled"][0]:
+                            if n2n_enc_enabled:
                                 return CheckResult.PASSED
                             else:
                                 return CheckResult.FAILED

--- a/tests/terraform/checks/resource/aws/example_ElasticsearchNodeToNodeEncryption/main.tf
+++ b/tests/terraform/checks/resource/aws/example_ElasticsearchNodeToNodeEncryption/main.tf
@@ -29,6 +29,18 @@ resource "aws_elasticsearch_domain" "node_to_node_encryption_enabled" {
   }
 }
 
+resource "aws_elasticsearch_domain" "old_hcl" {
+  domain_name           = "old_hcl"
+
+  cluster_config = {
+    instance_count = 2
+  }
+
+  node_to_node_encryption = {
+    enabled = true
+  }
+}
+
 # fail
 resource "aws_elasticsearch_domain" "node_to_node_encryption_disabled" {
   domain_name           = "node_to_node_encryption_disabled"

--- a/tests/terraform/checks/resource/aws/test_ElasticsearchNodeToNodeEncryption.py
+++ b/tests/terraform/checks/resource/aws/test_ElasticsearchNodeToNodeEncryption.py
@@ -19,7 +19,8 @@ class TestElasticsearchNodeToNodeEncryption(unittest.TestCase):
             "aws_elasticsearch_domain.without_cluster_config",
             "aws_elasticsearch_domain.without_instance_count",
             "aws_elasticsearch_domain.instance_count_not_bigger_than_1",
-            "aws_elasticsearch_domain.node_to_node_encryption_enabled"
+            "aws_elasticsearch_domain.node_to_node_encryption_enabled",
+            "aws_elasticsearch_domain.old_hcl"
         }
         failing_resources = {
             "aws_elasticsearch_domain.node_to_node_encryption_disabled",
@@ -29,7 +30,7 @@ class TestElasticsearchNodeToNodeEncryption(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 4)
+        self.assertEqual(summary["passed"], 5)
         self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixed the check to support old HCL syntax.
The check didn't support 
`something = { ... }`
but did support
`something { ... }`