### PR TITLE
Python 3 test improvements. Better asserts and subTest

### DIFF
--- a/checkov/terraform/graph_builder/graph_components/blocks.py
+++ b/checkov/terraform/graph_builder/graph_components/blocks.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from copy import deepcopy
 from typing import Union, Dict, Any

--- a/tests/arm/runner/test_runner.py
+++ b/tests/arm/runner/test_runner.py
@@ -27,7 +27,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='arm', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -50,7 +50,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='arm', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -72,7 +72,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='arm', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
@@ -94,7 +94,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='arm', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')

--- a/tests/arm/runner/test_runner.py
+++ b/tests/arm/runner/test_runner.py
@@ -27,7 +27,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='arm', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -50,7 +50,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='arm', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -72,7 +72,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='arm', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
@@ -94,7 +94,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='arm', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')

--- a/tests/cloudformation/runner/test_runner.py
+++ b/tests/cloudformation/runner/test_runner.py
@@ -29,7 +29,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='cloudformation', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -52,7 +52,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='cloudformation', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -74,7 +74,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='cloudformation', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
@@ -96,7 +96,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='cloudformation', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')

--- a/tests/cloudformation/runner/test_runner.py
+++ b/tests/cloudformation/runner/test_runner.py
@@ -29,7 +29,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='cloudformation', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -52,7 +52,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='cloudformation', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -74,7 +74,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='cloudformation', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
@@ -96,7 +96,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='cloudformation', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')

--- a/tests/common/goget/test_goget_base.py
+++ b/tests/common/goget/test_goget_base.py
@@ -12,7 +12,7 @@ class TestBaseGetter(unittest.TestCase):
         result_dir = getter.get()
         print(current_dir)
         print(result_dir)
-        self.assertTrue(current_dir in result_dir)
+        self.assertIn(current_dir, result_dir)
 
         # Cleanup
         os.rmdir(getter.temp_dir)

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -28,14 +28,15 @@ class TestBCApiUrl(unittest.TestCase):
         instance = BcPlatformIntegration()
         instance.setup_http_manager()
         instance.get_id_mapping()
-        self.assertEqual(None,instance.ckv_to_bc_id_mapping)
+        self.assertIsNone(instance.ckv_to_bc_id_mapping)
 
     @mock.patch.dict(os.environ, {'BC_SKIP_MAPPING': 'FALSE'})
     def test_skip_mapping_false(self):
         instance = BcPlatformIntegration()
         instance.setup_http_manager()
         instance.get_id_mapping()
-        self.assertNotEqual(None,instance.ckv_to_bc_id_mapping)
+        self.assertIsNotNone(instance.ckv_to_bc_id_mapping)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/graph/terraform/checks/test_yaml_policies.py
+++ b/tests/graph/terraform/checks/test_yaml_policies.py
@@ -206,7 +206,9 @@ class TestYamlPolicies(unittest.TestCase):
         assert found
 
     def assert_entities(self, expected_entities: List[str], results: List[CheckResult], assertion: bool):
-        self.assertEqual(len(expected_entities), len(results), f"mismatch in number of results in {'passed' if assertion else 'failed'}, expected: {len(expected_entities)}, got: {len(results)}")
+        self.assertEqual(len(expected_entities), len(results),
+                         f"mismatch in number of results in {'passed' if assertion else 'failed'}, "
+                         f"expected: {len(expected_entities)}, got: {len(results)}")
         for expected_entity in expected_entities:
             found = False
             for check_result in results:
@@ -214,7 +216,7 @@ class TestYamlPolicies(unittest.TestCase):
                 if entity_id == expected_entity:
                     found = True
                     break
-            self.assertIn(found, f"expected to find entity {expected_entity}, {'passed' if assertion else 'failed'}")
+            self.assertTrue(found, f"expected to find entity {expected_entity}, {'passed' if assertion else 'failed'}")
 
 
 def get_policy_results(root_folder, policy):

--- a/tests/graph/terraform/checks/test_yaml_policies.py
+++ b/tests/graph/terraform/checks/test_yaml_policies.py
@@ -214,7 +214,7 @@ class TestYamlPolicies(unittest.TestCase):
                 if entity_id == expected_entity:
                     found = True
                     break
-            self.assertTrue(found, f"expected to find entity {expected_entity} in {'passed' if assertion else 'failed'}")
+            self.assertIn(found, f"expected to find entity {expected_entity}, {'passed' if assertion else 'failed'}")
 
 
 def get_policy_results(root_folder, policy):

--- a/tests/graph/terraform/graph_builder/graph_components/test_blocks.py
+++ b/tests/graph/terraform/graph_builder/graph_components/test_blocks.py
@@ -133,7 +133,7 @@ class TestBlocks(TestCase):
 
         err = block.update_inner_attribute(attribute_key="labels.app.kubernetes.io/name", nested_attributes=attributes,
                                            value_to_update="dummy value")
-        self.assertEqual(None, err)
+        self.assertIsNone(err)
 
     def test_update_complex_key2(self):
         config = {}
@@ -148,7 +148,7 @@ class TestBlocks(TestCase):
         value_to_update = "test"
         err = block.update_inner_attribute(attribute_key="var.owning_account.vpc_cidr", nested_attributes=attributes,
                                            value_to_update=value_to_update)
-        self.assertEqual(None, err)
+        self.assertIsNone(err)
         self.assertDictEqual(block.attributes,
                              {'var.owning_account': {'route_to': None, 'route_to_cidr_blocks': '${local.allowed_cidrs}',
                                                      'static_routes': None,

--- a/tests/kubernetes/checks/test_ApiServerAdmissionControlAlwaysAdmit.py
+++ b/tests/kubernetes/checks/test_ApiServerAdmissionControlAlwaysAdmit.py
@@ -22,12 +22,12 @@ class TestApiServerAdmissionControlAlwaysAdmit(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])  
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerAdmissionControlEventRateLimit.py
+++ b/tests/kubernetes/checks/test_ApiServerAdmissionControlEventRateLimit.py
@@ -22,12 +22,12 @@ class TestApiServerAdmissionControlEventRateLimit(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])  
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerAlwaysPullImagesPlugin.py
+++ b/tests/kubernetes/checks/test_ApiServerAlwaysPullImagesPlugin.py
@@ -23,12 +23,12 @@ class TestApiServerAlwaysPullImagesPlugin(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])           
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerAuditLog.py
+++ b/tests/kubernetes/checks/test_ApiServerAuditLog.py
@@ -22,9 +22,9 @@ class TestApiServerProfiling(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerAuditLogMaxAge.py
+++ b/tests/kubernetes/checks/test_ApiServerAuditLogMaxAge.py
@@ -22,9 +22,9 @@ class TestApiServerAuditLogMaxAge(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerAuditLogMaxBackup.py
+++ b/tests/kubernetes/checks/test_ApiServerAuditLogMaxBackup.py
@@ -22,9 +22,9 @@ class TestApiServerProfiling(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerAuditLogMaxSize.py
+++ b/tests/kubernetes/checks/test_ApiServerAuditLogMaxSize.py
@@ -22,9 +22,9 @@ class TestApiServerAuditLogMaxSize(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerAuthorizationModeNode.py
+++ b/tests/kubernetes/checks/test_ApiServerAuthorizationModeNode.py
@@ -22,9 +22,9 @@ class TestApiServerAuthorizationModeNode(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerAuthorizationModeNotAlwaysAllow.py
+++ b/tests/kubernetes/checks/test_ApiServerAuthorizationModeNotAlwaysAllow.py
@@ -22,9 +22,9 @@ class TestApiServerAuthorizationModeNotAlwaysAllow(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerAuthorizationModeRBAC.py
+++ b/tests/kubernetes/checks/test_ApiServerAuthorizationModeRBAC.py
@@ -22,9 +22,9 @@ class TestApiServerAuthorizationModeRBAC(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerEncryptionProviders.py
+++ b/tests/kubernetes/checks/test_ApiServerEncryptionProviders.py
@@ -24,12 +24,12 @@ class TestApiServerEncryptionProviders(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerEtcdCaFile.py
+++ b/tests/kubernetes/checks/test_ApiServerEtcdCaFile.py
@@ -24,12 +24,12 @@ class TestApiServerEtcdCaFile(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerEtcdCertAndKey.py
+++ b/tests/kubernetes/checks/test_ApiServerEtcdCertAndKey.py
@@ -22,9 +22,9 @@ class TestApiServerEtcdCertAndKey(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerKubeletClientCertAndKey.py
+++ b/tests/kubernetes/checks/test_ApiServerKubeletClientCertAndKey.py
@@ -22,9 +22,9 @@ class TestApiServerKubeletClientCertAndKey(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerKubeletHttps.py
+++ b/tests/kubernetes/checks/test_ApiServerKubeletHttps.py
@@ -22,9 +22,9 @@ class ApiServerKubeletHttps(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerNamespaceLifecyclePlugin.py
+++ b/tests/kubernetes/checks/test_ApiServerNamespaceLifecyclePlugin.py
@@ -23,12 +23,12 @@ class TestApiServerNamespaceLifecyclePlugin(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])          
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerNodeRestrictionPlugin.py
+++ b/tests/kubernetes/checks/test_ApiServerNodeRestrictionPlugin.py
@@ -23,12 +23,12 @@ class TestApiServerNodeRestrictionPlugin(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])                   
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerPodSecurityPolicyPlugin.py
+++ b/tests/kubernetes/checks/test_ApiServerPodSecurityPolicyPlugin.py
@@ -23,12 +23,12 @@ class TestApiServerPodSecurityPolicyPlugin(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])        
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerProfiling.py
+++ b/tests/kubernetes/checks/test_ApiServerProfiling.py
@@ -22,9 +22,9 @@ class TestApiServerProfiling(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerRequestTimeout.py
+++ b/tests/kubernetes/checks/test_ApiServerRequestTimeout.py
@@ -23,12 +23,12 @@ class TestApiServerRequestTimeout(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])       
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerSecurePort.py
+++ b/tests/kubernetes/checks/test_ApiServerSecurePort.py
@@ -23,12 +23,12 @@ class TestApiServerSecurePort(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])                   
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerSecurityContextDenyPlugin.py
+++ b/tests/kubernetes/checks/test_ApiServerSecurityContextDenyPlugin.py
@@ -23,12 +23,12 @@ class TestApiServerSecurityContextDenyPlugin(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])            
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerServiceAccountKeyFile.py
+++ b/tests/kubernetes/checks/test_ApiServerServiceAccountKeyFile.py
@@ -23,12 +23,12 @@ class TestApiServerServiceAccountKeyFile(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])             
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerServiceAccountPlugin.py
+++ b/tests/kubernetes/checks/test_ApiServerServiceAccountPlugin.py
@@ -23,12 +23,12 @@ class TestApiServerServiceAccountPlugin(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerStrongCryptographicCiphers.py
+++ b/tests/kubernetes/checks/test_ApiServerStrongCryptographicCiphers.py
@@ -24,12 +24,12 @@ class TestApiServerStrongCryptographicCiphers(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ApiServerTlsCertAndKey.py
+++ b/tests/kubernetes/checks/test_ApiServerTlsCertAndKey.py
@@ -22,9 +22,9 @@ class TestApiServerTlsCertAndKey(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/kubernetes/checks/test_ApiServerkubeletCertificateAuthority.py
+++ b/tests/kubernetes/checks/test_ApiServerkubeletCertificateAuthority.py
@@ -24,12 +24,12 @@ class TestApiServerkubeletCertificateAuthority(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_ControllerManagerBindAddress.py
+++ b/tests/kubernetes/checks/test_ControllerManagerBindAddress.py
@@ -21,14 +21,15 @@ class TestControllerManagerBindAddress(unittest.TestCase):
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
-
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            with self.subTest(record=record):
+                self.assertIn("FAILED", record.file_path)
+                self.assertIn(record.check_id, [check.id])
 
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            with self.subTest(record=record):
+                self.assertIn("PASSED", record.file_path)
+                self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_EtcdAutoTls.py
+++ b/tests/kubernetes/checks/test_EtcdAutoTls.py
@@ -22,9 +22,9 @@ class TestEtcdAutoTls(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_EtcdCertAndKey.py
+++ b/tests/kubernetes/checks/test_EtcdCertAndKey.py
@@ -22,9 +22,9 @@ class TestEtcdCertAndKey(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_EtcdClientCertAuth.py
+++ b/tests/kubernetes/checks/test_EtcdClientCertAuth.py
@@ -22,9 +22,9 @@ class TestEtcdClientCertAuth(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_EtcdPeerFiles.py
+++ b/tests/kubernetes/checks/test_EtcdPeerFiles.py
@@ -24,12 +24,12 @@ class TestEtcdPeerFiles(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeControllerManagerBlockProfiles.py
+++ b/tests/kubernetes/checks/test_KubeControllerManagerBlockProfiles.py
@@ -22,9 +22,9 @@ class TestKubeControllerManagerBlockProfiles(unittest.TestCase):
         self.assertEqual(0, summary['parsing_errors'])
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeControllerManagerRootCAFile.py
+++ b/tests/kubernetes/checks/test_KubeControllerManagerRootCAFile.py
@@ -22,9 +22,9 @@ class TestKubeControllerManagerRootCAFile(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeControllerManagerRotateKubeletServerCertificate.py
+++ b/tests/kubernetes/checks/test_KubeControllerManagerRotateKubeletServerCertificate.py
@@ -24,12 +24,12 @@ class TestKubeControllerManagerRotateKubeletServerCertificate(unittest.TestCase)
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeControllerManagerServiceAccountCredentials.py
+++ b/tests/kubernetes/checks/test_KubeControllerManagerServiceAccountCredentials.py
@@ -22,9 +22,9 @@ class TestKubeControllerManagerServiceAccountCredentials(unittest.TestCase):
         self.assertEqual(0, summary['parsing_errors'])
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeControllerManagerServiceAccountPrivateKeyFile.py
+++ b/tests/kubernetes/checks/test_KubeControllerManagerServiceAccountPrivateKeyFile.py
@@ -22,9 +22,9 @@ class TestKubeControllerManagerServiceAccountPrivateKeyFile(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeControllerManagerTerminatedPods.py
+++ b/tests/kubernetes/checks/test_KubeControllerManagerTerminatedPods.py
@@ -22,9 +22,9 @@ class TestKubeControllerManagerTerminatedPods(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeletAnonymousAuth.py
+++ b/tests/kubernetes/checks/test_KubeletAnonymousAuth.py
@@ -23,12 +23,12 @@ class TestKubeletAnonymousAuth(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeletAuthorizationModeNotAlwaysAllow.py
+++ b/tests/kubernetes/checks/test_KubeletAuthorizationModeNotAlwaysAllow.py
@@ -22,12 +22,12 @@ class TestKubeletAuthorizationModeNotAlwaysAllow(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])            
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeletClientCa.py
+++ b/tests/kubernetes/checks/test_KubeletClientCa.py
@@ -24,12 +24,12 @@ class TestKubeletClientCa(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeletCryptographicCiphers.py
+++ b/tests/kubernetes/checks/test_KubeletCryptographicCiphers.py
@@ -23,12 +23,12 @@ class TestKubeletCryptographicCiphers(unittest.TestCase):
         self.assertEqual(summary['parsing_errors'], 0)
 
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeletHostnameOverride.py
+++ b/tests/kubernetes/checks/test_KubeletHostnameOverride.py
@@ -23,12 +23,12 @@ class TestKubeletHostnameOverride(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeletKeyFilesSetAppropriate.py
+++ b/tests/kubernetes/checks/test_KubeletKeyFilesSetAppropriate.py
@@ -24,12 +24,12 @@ class TestKubeletKeyFilesSetAppropriate(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeletMakeIptablesUtilChains.py
+++ b/tests/kubernetes/checks/test_KubeletMakeIptablesUtilChains.py
@@ -24,12 +24,12 @@ class TestKubeletMakeIptablesUtilChains(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeletProtectKernelDefaults.py
+++ b/tests/kubernetes/checks/test_KubeletProtectKernelDefaults.py
@@ -24,12 +24,12 @@ class TestKubeletProtectKernelDefaults(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeletReadOnlyPort.py
+++ b/tests/kubernetes/checks/test_KubeletReadOnlyPort.py
@@ -24,12 +24,12 @@ class TestKubeletReadOnlyPort(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubeletStreamingConnectionIdleTimeout.py
+++ b/tests/kubernetes/checks/test_KubeletStreamingConnectionIdleTimeout.py
@@ -24,12 +24,12 @@ class TestKubeletStreamingConnectionIdleTimeout(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubletEventCapture.py
+++ b/tests/kubernetes/checks/test_KubletEventCapture.py
@@ -24,12 +24,12 @@ class TestKubletEventCapture(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_KubletRotateCertificates.py
+++ b/tests/kubernetes/checks/test_KubletRotateCertificates.py
@@ -22,17 +22,16 @@ class TestKubletRotateCertificates(unittest.TestCase):
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
         
-        
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            with self.subTest(record=record):
+                self.assertIn("FAILED", record.file_path)
+                self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            with self.subTest(record=record):
+                self.assertIn("PASSED", record.file_path)
+                self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':
     unittest.main()
-        
-    

--- a/tests/kubernetes/checks/test_KubletRotateKubeletServerCertificate.py
+++ b/tests/kubernetes/checks/test_KubletRotateKubeletServerCertificate.py
@@ -24,12 +24,12 @@ class TestKubletRotateKubeletServerCertificate(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_PeerClientCertAuthTrue.py
+++ b/tests/kubernetes/checks/test_PeerClientCertAuthTrue.py
@@ -18,9 +18,9 @@ class TestPeerClientCertAuthTrue(unittest.TestCase):
         self.assertEqual(1, summary['passed'])
         self.assertEqual(2, summary['failed'])
         for failed in report.failed_checks:
-            self.assertTrue("should-fail" in failed.resource)
+            self.assertIn("should-fail", failed.resource)
         for passed in report.passed_checks:
-            self.assertTrue("should-pass" in passed.resource)
+            self.assertIn("should-pass", passed.resource)
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_SchedulerBindAddressy.py
+++ b/tests/kubernetes/checks/test_SchedulerBindAddressy.py
@@ -23,12 +23,12 @@ class TestSchedulerBindAddress(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/checks/test_SchedulerProfiling.py
+++ b/tests/kubernetes/checks/test_SchedulerProfiling.py
@@ -24,12 +24,12 @@ class TestSchedulerProfiling(unittest.TestCase):
         
         
         for record in report.failed_checks:
-            self.assertTrue("FAILED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])
+            self.assertIn("FAILED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
             
         for record in report.passed_checks:
-            self.assertTrue("PASSED" in record.file_path)
-            self.assertTrue(record.check_id in [check.id])              
+            self.assertIn("PASSED", record.file_path)
+            self.assertIn(record.check_id, [check.id])
 
 
 if __name__ == '__main__':

--- a/tests/kubernetes/runner/test_runner.py
+++ b/tests/kubernetes/runner/test_runner.py
@@ -27,7 +27,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='kubernetes', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -50,7 +50,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='kubernetes', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -72,7 +72,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='kubernetes', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
@@ -94,7 +94,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='kubernetes', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')

--- a/tests/kubernetes/runner/test_runner.py
+++ b/tests/kubernetes/runner/test_runner.py
@@ -27,7 +27,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='kubernetes', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -50,7 +50,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='kubernetes', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -72,7 +72,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='kubernetes', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
@@ -94,7 +94,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='kubernetes', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')

--- a/tests/serverless/runner/test_runner.py
+++ b/tests/serverless/runner/test_runner.py
@@ -27,7 +27,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='serverless', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -50,7 +50,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='serverless', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -72,7 +72,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='serverless', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
@@ -94,7 +94,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='serverless', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')

--- a/tests/serverless/runner/test_runner.py
+++ b/tests/serverless/runner/test_runner.py
@@ -27,7 +27,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='serverless', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -50,7 +50,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='serverless', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{dir_rel_path}{record.file_path}')
@@ -72,7 +72,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='serverless', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
@@ -94,7 +94,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='serverless', checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')

--- a/tests/terraform/context_parsers/test_variable_context_parser.py
+++ b/tests/terraform/context_parsers/test_variable_context_parser.py
@@ -25,7 +25,7 @@ class TestVariableContextParser(unittest.TestCase):
                 'assignments'))
 
     def test_assignment_value(self):
-        self.assertEqual(
+        self.assertIs(
             self.definitions_context[os.path.dirname(
                 os.path.realpath(__file__)) + '/../evaluation/resources/default_evaluation/variables.tf'][
                 'variable'].get(

--- a/tests/terraform/context_parsers/test_variable_context_parser2.py
+++ b/tests/terraform/context_parsers/test_variable_context_parser2.py
@@ -26,7 +26,7 @@ class TestVariableContextParser(unittest.TestCase):
                 'assignments'))
 
     def test_assignment_value(self):
-        self.assertEqual(
+        self.assertIs(
             self.definitions_context[os.path.dirname(
                 os.path.realpath(__file__)) + '/../evaluation/resources/default_evaluation/variables.tf'][
                 'variable'].get(

--- a/tests/terraform/module_loading/test_registry.py
+++ b/tests/terraform/module_loading/test_registry.py
@@ -26,10 +26,10 @@ class TestModuleLoaderRegistry(unittest.TestCase):
         registry = ModuleLoaderRegistry(download_external_modules=True)
         source1 = "https://github.com/bridgecrewio/checkov_not_working1.git"
         registry.load(current_dir=self.current_dir, source=source1, source_version="latest")
-        self.assertTrue(source1 in registry.failed_urls_cache)
+        self.assertIn(source1, registry.failed_urls_cache)
         source2 = "https://github.com/bridgecrewio/checkov_not_working2.git"
         registry.load(current_dir=self.current_dir, source=source2, source_version="latest")
-        self.assertTrue(source1 in registry.failed_urls_cache and source2 in registry.failed_urls_cache)
+        self.assertIn(source1 in registry.failed_urls_cache and source2, registry.failed_urls_cache)
 
     def test_load_local_module_absolute_path(self):
         registry = ModuleLoaderRegistry(download_external_modules=True)

--- a/tests/terraform/parser/test_plan_parser.py
+++ b/tests/terraform/parser/test_plan_parser.py
@@ -15,7 +15,7 @@ class TestPlanFileParser(unittest.TestCase):
         resource_tags = resource_attributes['tags'][0]
         for tag_key, tag_value in resource_tags.items():
             if tag_key not in ['start_line', 'end_line']:
-                self.assertTrue(isinstance(tag_value, str))
+                self.assertIsInstance(tag_value, str)
 
 
 if __name__ == '__main__':

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -18,7 +18,7 @@ class TestRunnerValid(unittest.TestCase):
             runner_filter=RunnerFilter(framework="all", checks=checks_allowlist),
         )
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
@@ -40,7 +40,7 @@ class TestRunnerValid(unittest.TestCase):
             runner_filter=RunnerFilter(framework="all"),
         )
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
@@ -60,7 +60,7 @@ class TestRunnerValid(unittest.TestCase):
             runner_filter=RunnerFilter(framework="all"),
         )
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
@@ -91,7 +91,7 @@ class TestRunnerValid(unittest.TestCase):
             runner_filter=RunnerFilter(framework="all"),
         )
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
@@ -136,7 +136,7 @@ class TestRunnerValid(unittest.TestCase):
             runner_filter=RunnerFilter(framework="all"),
         )
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
@@ -164,7 +164,7 @@ class TestRunnerValid(unittest.TestCase):
             root_folder=root_dir, files=None, external_checks_dir=None, runner_filter=RunnerFilter(framework="all")
         )
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
@@ -283,7 +283,7 @@ class TestRunnerValid(unittest.TestCase):
             runner_filter=RunnerFilter(framework="all"),
         )
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(soft_fail=False), 0)
@@ -305,7 +305,7 @@ class TestRunnerValid(unittest.TestCase):
         )
 
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(soft_fail=False), 0)

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -24,7 +24,7 @@ class TestRunnerValid(unittest.TestCase):
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
                             runner_filter=RunnerFilter(framework='all', checks=checks_allowlist))
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         for record in report.failed_checks:
@@ -38,7 +38,7 @@ class TestRunnerValid(unittest.TestCase):
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
                             runner_filter=RunnerFilter(framework='all', skip_checks=checks_denylist))
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
@@ -52,7 +52,7 @@ class TestRunnerValid(unittest.TestCase):
         runner = Runner()
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None)
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
@@ -77,7 +77,7 @@ class TestRunnerValid(unittest.TestCase):
         runner = Runner()
         report = runner.run(root_folder=passing_tf_dir_path, external_checks_dir=None)
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(False), 1)
@@ -100,7 +100,7 @@ class TestRunnerValid(unittest.TestCase):
         for check in resource_registry.checks["aws_s3_bucket"]:
             if check.id == "CUSTOM_AWS_1":
                 resource_registry.checks["aws_s3_bucket"].remove(check)
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
 
@@ -128,7 +128,7 @@ class TestRunnerValid(unittest.TestCase):
         for check in resource_registry.checks["aws_s3_bucket"]:
             if check.id == "CKV2_CUSTOM_1":
                 resource_registry.checks["aws_s3_bucket"].remove(check)
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
 
@@ -152,7 +152,7 @@ class TestRunnerValid(unittest.TestCase):
         runner = Runner()
         report = runner.run(root_folder=None, external_checks_dir=None, files=[passing_tf_file_path])
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         # self.assertEqual(report.get_exit_code(), 0)
@@ -489,7 +489,7 @@ class TestRunnerValid(unittest.TestCase):
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
                             runner_filter=RunnerFilter(framework='terraform', checks=checks_allowlist))
         report_json = report.get_json()
-        self.assertTrue(isinstance(report_json, str))
+        self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suites())
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
@@ -520,7 +520,7 @@ class TestRunnerValid(unittest.TestCase):
 
         all_checks = report.failed_checks + report.passed_checks
 
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
 
         for record in all_checks:
             # no need to join with a '/' because the TF runner adds it to the start of the file path
@@ -544,7 +544,7 @@ class TestRunnerValid(unittest.TestCase):
 
         all_checks = report.failed_checks + report.passed_checks
 
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
 
         for record in all_checks:
             # no need to join with a '/' because the TF runner adds it to the start of the file path
@@ -568,7 +568,7 @@ class TestRunnerValid(unittest.TestCase):
 
         all_checks = report.failed_checks + report.passed_checks
 
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
 
         for record in all_checks:
             # no need to join with a '/' because the TF runner adds it to the start of the file path
@@ -592,7 +592,7 @@ class TestRunnerValid(unittest.TestCase):
 
         all_checks = report.failed_checks + report.passed_checks
 
-        self.assertTrue(len(all_checks) > 0)  # ensure that the assertions below are going to do something
+        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
 
         for record in all_checks:
             # no need to join with a '/' because the TF runner adds it to the start of the file path

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -520,7 +520,7 @@ class TestRunnerValid(unittest.TestCase):
 
         all_checks = report.failed_checks + report.passed_checks
 
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
 
         for record in all_checks:
             # no need to join with a '/' because the TF runner adds it to the start of the file path
@@ -544,7 +544,7 @@ class TestRunnerValid(unittest.TestCase):
 
         all_checks = report.failed_checks + report.passed_checks
 
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
 
         for record in all_checks:
             # no need to join with a '/' because the TF runner adds it to the start of the file path
@@ -568,7 +568,7 @@ class TestRunnerValid(unittest.TestCase):
 
         all_checks = report.failed_checks + report.passed_checks
 
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
 
         for record in all_checks:
             # no need to join with a '/' because the TF runner adds it to the start of the file path
@@ -592,7 +592,7 @@ class TestRunnerValid(unittest.TestCase):
 
         all_checks = report.failed_checks + report.passed_checks
 
-        self.assertGreaterThan(len(all_checks), 0)  # ensure that the assertions below are going to do something
+        self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
 
         for record in all_checks:
             # no need to join with a '/' because the TF runner adds it to the start of the file path


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I used `flake8-assertive` to find these. There are more things that could be adapted to https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests