### PR TITLE
Bugfix - Handle interpolation syntax when using policyuniverse

### DIFF
--- a/checkov/terraform/checks/resource/aws/GlacierVaultAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/GlacierVaultAnyPrincipal.py
@@ -18,10 +18,11 @@ class GlacierVaultAnyPrincipal(BaseResourceCheck):
 
     def scan_resource_conf(self, conf):
         if 'access_policy' in conf:
-            policy_string = conf['access_policy'][0]
-            if re.match(DATA_TO_JSON_PATTERN, policy_string):
-                return CheckResult.UNKNOWN
-            policy = Policy(policy_string)
+            policy_obj = conf['access_policy'][0]
+            if isinstance(policy_obj, str):
+                if re.match(DATA_TO_JSON_PATTERN, policy_obj):
+                    return CheckResult.UNKNOWN
+            policy = Policy(policy_obj)
             if policy.is_internet_accessible():
                 return CheckResult.FAILED
         return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/aws/GlacierVaultAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/GlacierVaultAnyPrincipal.py
@@ -1,10 +1,10 @@
+import re
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
-from checkov.common.util.type_forcers import force_list
-
 from policyuniverse.policy import Policy
 
-import json
+from checkov.terraform.checks.utils.utils import DATA_TO_JSON_PATTERN
 
 
 class GlacierVaultAnyPrincipal(BaseResourceCheck):
@@ -18,11 +18,13 @@ class GlacierVaultAnyPrincipal(BaseResourceCheck):
 
     def scan_resource_conf(self, conf):
         if 'access_policy' in conf:
-            policy = Policy(conf['access_policy'][0])
+            policy_string = conf['access_policy'][0]
+            if re.match(DATA_TO_JSON_PATTERN, policy_string):
+                return CheckResult.UNKNOWN
+            policy = Policy(policy_string)
             if policy.is_internet_accessible():
-                 return CheckResult.FAILED
+                return CheckResult.FAILED
         return CheckResult.PASSED
 
+
 check = GlacierVaultAnyPrincipal()
-
-

--- a/checkov/terraform/checks/utils/utils.py
+++ b/checkov/terraform/checks/utils/utils.py
@@ -15,6 +15,7 @@ BLOCK_TYPES_STRINGS = ["var", "local", "module", "data"]
 FUNC_CALL_PREFIX_PATTERN = r"([.a-zA-Z]+)\("
 INTERPOLATION_PATTERN = "[${}]"
 INTERPOLATION_EXPR = r"\$\{([^\}]*)\}"
+DATA_TO_JSON_PATTERN = r"\$?\{?(.+?)(?=.json).json\}?"
 BRACKETS_PATTERN = r"[\[\]\)\(\{\}]+"
 INDEX_PATTERN = r"\[([0-9]+)\]"
 IDENTIFIER_PATTERN = r"^[^\d\W]\w*\Z"


### PR DESCRIPTION
@ac-square I expanded the check to support a case where the policy document attribute value is a runtime-rendered json file which terraform load

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
