### PR TITLE
include external checks in --check flag

### DIFF
--- a/checkov/main.py
+++ b/checkov/main.py
@@ -72,7 +72,8 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
                                  download_external_modules=convert_str_to_bool(config.download_external_modules),
                                  external_modules_download_path=config.external_modules_download_path,
                                  evaluate_variables=convert_str_to_bool(config.evaluate_variables),
-                                 runners=checkov_runners, excluded_paths=excluded_paths)
+                                 runners=checkov_runners, excluded_paths=excluded_paths,
+                                 all_external=config.run_all_external_checks)
     if outer_registry:
         runner_registry = outer_registry
         runner_registry.runner_filter = runner_filter
@@ -250,6 +251,10 @@ def add_parser_args(parser):
     parser.add('--skip-check',
                help='filter scan to run on all check but a specific check identifier(denylist), You can '
                     'specify multiple checks separated by comma delimiter', action='append', default=None)
+    parser.add('--run-all-external-checks', action='store_true',
+               help='Run all external checks (loaded via --external-checks options) even if the checks are not present '
+                    'in the --check list. This allows you to always ensure that new checks present in the external '
+                    'source are used. If an external check is included in --skip-check, it will still be skipped.')
     parser.add('--bc-api-key', help='Bridgecrew API key', env_var='BC_API_KEY')
     parser.add('--docker-image', help='Scan docker images by name or ID. Only works with --bc-api-key flag')
     parser.add('--dockerfile-path', help='Path to the Dockerfile of the scanned docker image')

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -23,7 +23,7 @@ class RunnerFilter(object):
         runners: Optional[List[str]] = None,
         skip_framework: Optional[str] = None,
         excluded_paths: Optional[List[str]] = None,
-        all_external = False
+        all_external: bool = False
     ) -> None:
 
         self.checks = convert_csv_string_arg_to_list(checks)

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -22,7 +22,8 @@ class RunnerFilter(object):
         evaluate_variables: bool = True,
         runners: Optional[List[str]] = None,
         skip_framework: Optional[str] = None,
-        excluded_paths: Optional[List[str]] = None
+        excluded_paths: Optional[List[str]] = None,
+        all_external = False
     ) -> None:
 
         self.checks = convert_csv_string_arg_to_list(checks)
@@ -47,9 +48,10 @@ class RunnerFilter(object):
         self.external_modules_download_path = external_modules_download_path
         self.evaluate_variables = evaluate_variables
         self.excluded_paths = excluded_paths
+        self.all_external = all_external
 
     def should_run_check(self, check_id: str) -> bool:
-        if RunnerFilter.is_external_check(check_id):
+        if RunnerFilter.is_external_check(check_id) and self.all_external:
             pass  # enabled unless skipped
         elif self.checks:
             if check_id in self.checks:

--- a/tests/common/test_runner_filter.py
+++ b/tests/common/test_runner_filter.py
@@ -45,15 +45,25 @@ class TestRunnerFilter(unittest.TestCase):
     def test_should_run_external2(self):
         instance = RunnerFilter(checks=["CHECK_1"], skip_checks=["CHECK_2"])
         instance.notify_external_check("EXT_CHECK_999")
-        self.assertTrue(instance.should_run_check("EXT_CHECK_999"))
+        self.assertFalse(instance.should_run_check("EXT_CHECK_999"))
 
     def test_should_run_external3(self):
         instance = RunnerFilter(checks=["EXT_CHECK_999"])
         instance.notify_external_check("EXT_CHECK_999")
         self.assertTrue(instance.should_run_check("EXT_CHECK_999"))
 
+    def test_should_run_external4(self):
+        instance = RunnerFilter(checks=["CHECK_1"], skip_checks=["CHECK_2"], all_external=True)
+        instance.notify_external_check("EXT_CHECK_999")
+        self.assertTrue(instance.should_run_check("EXT_CHECK_999"))
+
     def test_should_run_external_disabled(self):
         instance = RunnerFilter(skip_checks=["CHECK_1", "EXT_CHECK_999"])
+        instance.notify_external_check("EXT_CHECK_999")
+        self.assertFalse(instance.should_run_check("EXT_CHECK_999"))
+
+    def test_should_run_external_disabled2(self):
+        instance = RunnerFilter(skip_checks=["CHECK_1", "EXT_CHECK_999"], all_external=True)
         instance.notify_external_check("EXT_CHECK_999")
         self.assertFalse(instance.should_run_check("EXT_CHECK_999"))
 

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -617,7 +617,7 @@ class TestRunnerValid(unittest.TestCase):
                               external_checks_dir=None,
                               runner_filter=RunnerFilter(checks="CKV_AWS_19"))  # bucket encryption
 
-        self.assertEqual(len(report.failed_checks), 4)
+        self.assertEqual(len(report.failed_checks), 2)
         self.assertEqual(len(report.passed_checks), 0)
 
         found_inside = False


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Treats externally loaded checks like all other checks in the `--check` flag. This changes the previous default behavior, in which all external checks would always run (unless skipped with `--skip-check`), even if they were not included in `--check`.

As discussed in [this issue](https://github.com/bridgecrewio/checkov/issues/466), some users rely on this old default behavior to ensure that any external checks added to a repo always get run, without modifying the `--check` list. To preserve this behavior, this change also introduces a new flag: `--run-all-external-checks`

