### PR TITLE
Enable running graph checks on plan files

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9ce74bdb9a5a9ebec8fcb092ccafb2f3f3e8018a5de3b696b01a4011d920392e"
+            "sha256": "545e001cb2dc3b81d116e09db7ec753318e8a2e15f9e04b445ca9fad77b24906"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,19 +34,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:2c2f70608934b03f9c08f4cd185de223b5abd18245dd4d4800e1fbc2a2523e31",
-                "sha256:fccfa81cda69bb2317ed97e7149d7d84d19e6ec3bfbe3f721139e7ac0c407c73"
+                "sha256:3b35689c215c982fe9f7ef78d748aa9b0cd15c3b2eb04f9b460aaa63fe2fbd03",
+                "sha256:b1cbeb92123799001b97f2ee1cdf470e21f1be08314ae28fc7ea357925186f1c"
             ],
             "index": "pypi",
-            "version": "==1.17.98"
+            "version": "==1.17.105"
         },
         "botocore": {
             "hashes": [
-                "sha256:b2a49de4ee04b690142c8e7240f0f5758e3f7673dd39cf398efe893bf5e11c3f",
-                "sha256:b955b23fe2fbdbbc8e66f37fe2970de6b5d8169f940b200bcf434751709d38f6"
+                "sha256:b0fda4edf8eb105453890700d49011ada576d0cc7326a0699dfabe9e872f552c",
+                "sha256:b5ba72d22212b0355f339c2a98b3296b3b2202a48e6a2b1366e866bc65a64b67"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.98"
+            "version": "==1.20.105"
         },
         "cached-property": {
             "hashes": [
@@ -75,7 +75,7 @@
                 "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
                 "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==8.0.1"
         },
         "click-option-group": {
@@ -83,7 +83,7 @@
                 "sha256:9653a2297357335d7325a1827e71ac1245d91c97d959346a7decabd4a52d5354",
                 "sha256:a6e924f3c46b657feb5b72679f7e930f8e5b224b766ab35c91ae4019b4e0615e"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version < '4' and python_full_version >= '3.6.0'",
             "version": "==0.5.3"
         },
         "cloudsplaining": {
@@ -104,19 +104,19 @@
         },
         "configargparse": {
             "hashes": [
-                "sha256:afbd2823d29ed30cbd53513ea8290938e3dc3136ad9cfffdc684c9225c19adc5",
-                "sha256:dded3590373b7dae6ce6d0afeb4ae3def74761fdd78730952863914d4cb4bdb5"
+                "sha256:371f46577e76ec71a183b88378f36dd09f4b946f60fe60712f411b020f26b812",
+                "sha256:ebef7b5379600fa34c276debf36e72ac8b37e7e42e6f0cfaed49c61e206eb604"
             ],
             "index": "pypi",
-            "version": "==1.5"
+            "version": "==1.5.1"
         },
         "contextlib2": {
             "hashes": [
-                "sha256:01f490098c18b19d2bd5bb5dc445b2054d2fa97f09a4280ba2c5f3c394c8162e",
-                "sha256:3355078a159fbb44ee60ea80abd0d87b80b78c248643b49aa6d94673b413609b"
+                "sha256:3fbdb64466afd23abaf6c977627b75b6139a5a3e8ce38405c5b413aed7a0471f",
+                "sha256:ab1e2bfe1d01d968e1b7e8d9023bc51ef3509bba217bb730cee3827e1ee82869"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.6.0.post1"
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==21.6.0"
         },
         "decorator": {
             "hashes": [
@@ -190,18 +190,18 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00",
-                "sha256:b142cc1dd1342f31ff04bb7d022492b09920cb64fed867cd3ea6f80fe3ebd139"
+                "sha256:079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac",
+                "sha256:9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.5.0"
+            "version": "==4.6.1"
         },
         "jinja2": {
             "hashes": [
                 "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4",
                 "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==3.0.1"
         },
         "jmespath": {
@@ -230,7 +230,7 @@
                 "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49",
                 "sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==3.3.4"
         },
         "markupsafe": {
@@ -270,7 +270,7 @@
                 "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
                 "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==2.0.1"
         },
         "networkx": {
@@ -283,19 +283,27 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
-                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
             ],
             "index": "pypi",
-            "version": "==20.9"
+            "version": "==21.0"
         },
         "policy-sentry": {
             "hashes": [
                 "sha256:15c1aa5e4d887d07df495518445126182d4a551e177c192a46169593ce971fbc",
                 "sha256:2c3e4405a72f8284f7a3c987fbd666b3ae63fd095101e004e9ee6a1fb1ab76ff"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==0.11.10"
+        },
+        "policyuniverse": {
+            "hashes": [
+                "sha256:aa6fb334a6fbfdd5616868eee07f04548950ac293904985a9756b88cb7fe8ff3",
+                "sha256:e3299d870e174b18d42f127d3205b0be70efa5b460f3090dfc17093bb8d598da"
+            ],
+            "index": "pypi",
+            "version": "==1.3.8.20210630"
         },
         "pyparsing": {
             "hashes": [
@@ -444,27 +452,27 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
-                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.5"
+            "version": "==1.26.6"
         },
         "websocket-client": {
             "hashes": [
                 "sha256:b68e4959d704768fa20e35c9d508c8dc2bbc041fd8d267c0d7345cffe2824568",
                 "sha256:e5c333bfa9fa739538b652b6f8c8fc2559f1d364243c8a689d7c0e1d41c2e611"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==1.1.0"
         },
         "zipp": {
             "hashes": [
-                "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
-                "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
+                "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3",
+                "sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.4.1"
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==3.5.0"
         }
     },
     "develop": {
@@ -568,11 +576,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00",
-                "sha256:b142cc1dd1342f31ff04bb7d022492b09920cb64fed867cd3ea6f80fe3ebd139"
+                "sha256:079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac",
+                "sha256:9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.5.0"
+            "version": "==4.6.1"
         },
         "iniconfig": {
             "hashes": [
@@ -583,11 +591,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
-                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
             ],
             "index": "pypi",
-            "version": "==20.9"
+            "version": "==21.0"
         },
         "pbr": {
             "hashes": [
@@ -715,11 +723,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
-                "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
+                "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3",
+                "sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.4.1"
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==3.5.0"
         }
     }
 }

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -1,24 +1,24 @@
-import logging
 import json
 import logging
 import os
 
+from checkov.terraform.graph_builder.graph_components.attribute_names import CustomAttributes
+
 from checkov.common.output.record import Record
 from checkov.common.output.report import Report
-from checkov.common.runners.base_runner import BaseRunner, filter_ignored_paths
+from checkov.common.runners.base_runner import filter_ignored_paths
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.registry import resource_registry
 from checkov.terraform.context_parsers.registry import parser_registry
-# Allow the evaluation of empty variables
 from checkov.terraform.plan_parser import parse_tf_plan
+from checkov.terraform.runner import graph_registry, Runner as TerraformRunner, merge_reports
 
 
-class Runner(BaseRunner):
+class Runner(TerraformRunner):
     check_type = "terraform_plan"
 
     def __init__(self):
-        self.tf_definitions = {}
-        self.definitions_context = {}
+        super().__init__()
         self.template_lines = {}
 
     block_type_registries = {
@@ -33,6 +33,7 @@ class Runner(BaseRunner):
         if external_checks_dir:
             for directory in external_checks_dir:
                 resource_registry.load_external_checks(directory)
+                graph_registry.load_external_checks(directory)
 
         if root_folder:
             files = [] if not files else files
@@ -67,11 +68,20 @@ class Runner(BaseRunner):
 
         report.add_parsing_errors(parsing_errors.keys())
 
+        graph = self.graph_manager.build_graph_from_tf_definitions(self.tf_definitions, render_variables=False)
+        self.graph_manager.save_graph(graph)
+
+        graph_report = self.get_graph_checks_report(root_folder, runner_filter)
+        merge_reports(report, graph_report)
+
         return report
 
-    def check_tf_definition(self, report, runner_filter,
-                            ):
+    def get_entity_context_and_evaluations(self, entity):
+        raw_context = self.get_entity_context(entity[CustomAttributes.BLOCK_NAME].split("."), entity[CustomAttributes.FILE_PATH])
+        raw_context['definition_path'] = entity[CustomAttributes.BLOCK_NAME].split('.')
+        return raw_context, None
 
+    def check_tf_definition(self, report, runner_filter):
         for full_file_path, definition in self.tf_definitions.items():
             scanned_file = f"/{os.path.relpath(full_file_path)}"
             logging.debug(f"Scanning file: {scanned_file}")
@@ -80,12 +90,10 @@ class Runner(BaseRunner):
                     self.run_block(definition[block_type], full_file_path, report, scanned_file,
                                    block_type, runner_filter)
 
-    def run_block(self, entities, full_file_path, report, scanned_file, block_type,
-                  runner_filter=None):
+    def run_block(self, entities, full_file_path, report, scanned_file, block_type, runner_filter=None):
         registry = self.block_type_registries[block_type]
         if registry:
             for entity in entities:
-                entity_evaluations = None
                 context_parser = parser_registry.context_parsers[block_type]
                 definition_path = context_parser.get_entity_context_path(entity)
                 entity_id = ".".join(definition_path)
@@ -98,7 +106,7 @@ class Runner(BaseRunner):
                     record = Record(check_id=check.id, check_name=check.name, check_result=check_result,
                                     code_block=entity_code_lines, file_path=scanned_file,
                                     file_line_range=entity_lines_range,
-                                    resource=entity_id, evaluations=entity_evaluations,
+                                    resource=entity_id, evaluations=None,
                                     check_class=check.__class__.__module__, file_abs_path=full_file_path)
                     report.add_record(record=record)
 
@@ -112,6 +120,7 @@ class Runner(BaseRunner):
                     resource_defintion = resource[resource_type][resource_name]
                     entity_context['start_line'] = resource_defintion['start_line'][0]
                     entity_context['end_line'] = resource_defintion['end_line'][0]
-                    entity_context['code_lines'] = self.template_lines[entity_context['start_line']:entity_context['end_line']]
+                    entity_context['code_lines'] = self.template_lines[
+                                                   entity_context['start_line']:entity_context['end_line']]
                     return entity_context
         return entity_context

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -150,9 +150,10 @@ class Runner(BaseRunner):
                                     evaluations=entity_evaluations,
                                     check_class=check.__class__.__module__,
                                     file_abs_path=os.path.abspath(full_file_path))
-                    breadcrumb = self.breadcrumbs.get(record.file_path, {}).get(record.resource)
-                    if breadcrumb:
-                        record = GraphRecord(record, breadcrumb)
+                    if self.breadcrumbs:
+                        breadcrumb = self.breadcrumbs.get(record.file_path, {}).get(record.resource)
+                        if breadcrumb:
+                            record = GraphRecord(record, breadcrumb)
 
                     report.add_record(record=record)
         return report

--- a/tests/terraform/runner/extra_yaml_checks/test_tag.yaml
+++ b/tests/terraform/runner/extra_yaml_checks/test_tag.yaml
@@ -1,0 +1,12 @@
+metadata:
+  name: "Ensure all resources are tagged with the relevant env"
+  id: "CUSTOM_AWS_1"
+  category: "GENERAL_SECURITY"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "all"
+  attribute: "tags.env"
+  operator: "exists"

--- a/tests/terraform/runner/extra_yaml_checks/test_tag.yaml
+++ b/tests/terraform/runner/extra_yaml_checks/test_tag.yaml
@@ -1,6 +1,6 @@
 metadata:
   name: "Ensure all resources are tagged with the relevant env"
-  id: "CUSTOM_AWS_1"
+  id: "CUSTOM_GRAPH_AWS_1"
   category: "GENERAL_SECURITY"
 scope:
   provider: "AWS"

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -56,7 +56,7 @@ class TestRunnerValid(unittest.TestCase):
         report = runner.run(
             root_folder=None,
             files=[valid_plan_path],
-            external_checks_dir=None,
+            external_checks_dir=[current_dir + "/extra_yaml_checks"],
             runner_filter=RunnerFilter(framework="all"),
         )
         report_json = report.get_json()
@@ -66,7 +66,7 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
         self.assertEqual(report.get_exit_code(soft_fail=True), 0)
 
-        self.assertEqual(report.get_summary()["failed"], 15)
+        self.assertEqual(report.get_summary()["failed"], 18)
         self.assertEqual(report.get_summary()["passed"], 0)
 
         failed_check_ids = set([c.check_id for c in report.failed_checks])
@@ -76,6 +76,7 @@ class TestRunnerValid(unittest.TestCase):
             "CKV_AWS_39",
             "CKV_AWS_58",
             "CKV_AWS_151",
+            "CUSTOM_AWS_1"
         }
 
         assert failed_check_ids == expected_failed_check_ids

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -3,6 +3,7 @@ import unittest
 
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.plan_runner import Runner
+from checkov.terraform.runner import graph_registry
 
 
 class TestRunnerValid(unittest.TestCase):
@@ -53,6 +54,7 @@ class TestRunnerValid(unittest.TestCase):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         valid_plan_path = current_dir + "/resources/plan_nested_child_modules/tfplan.json"
         runner = Runner()
+        graph_registry.checks = []
         report = runner.run(
             root_folder=None,
             files=[valid_plan_path],
@@ -76,7 +78,7 @@ class TestRunnerValid(unittest.TestCase):
             "CKV_AWS_39",
             "CKV_AWS_58",
             "CKV_AWS_151",
-            "CUSTOM_AWS_1"
+            "CUSTOM_GRAPH_AWS_1"
         }
 
         assert failed_check_ids == expected_failed_check_ids
@@ -85,6 +87,7 @@ class TestRunnerValid(unittest.TestCase):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         valid_plan_path = current_dir + "/resources/plan_root_module_resources_no_values/tfplan.json"
         runner = Runner()
+        graph_registry.checks = []
         report = runner.run(
             root_folder=None,
             files=[valid_plan_path],

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -653,10 +653,8 @@ class TestRunnerValid(unittest.TestCase):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         extra_checks_dir_path = current_dir + "/extra_yaml_checks"
         runner.load_external_checks([extra_checks_dir_path])
-        self.assertEqual(len(graph_registry.checks), base_len + 1)
-        self.assertEqual(graph_registry.checks[base_len].id, CUSTOM_GRAPH_CHECK_ID)
-        self.assertEqual(graph_registry.checks[base_len].name, 'Ensure bucket has versioning and owner tag')
-        graph_registry.checks = list(filter(lambda c: c.id != CUSTOM_GRAPH_CHECK_ID, graph_registry.checks))
+        self.assertEqual(len(graph_registry.checks), base_len + 2)
+        graph_registry.checks = graph_registry.checks[:base_len]
 
     def test_loading_external_checks_yaml_multiple_times(self):
         runner = Runner()
@@ -667,7 +665,8 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(len(graph_registry.checks), 2)
         runner.load_external_checks(extra_checks_dir_path)
         self.assertEqual(len(graph_registry.checks), 2)
-        self.assertListEqual(['CUSTOM_GRAPH_AWS_1', 'CKV2_CUSTOM_1'], [x.id for x in graph_registry.checks])
+        self.assertIn('CUSTOM_GRAPH_AWS_1', [x.id for x in graph_registry.checks])
+        self.assertIn('CKV2_CUSTOM_1', [x.id for x in graph_registry.checks])
         graph_registry.checks = []
 
     def test_loading_external_checks_python(self):
@@ -712,9 +711,6 @@ class TestRunnerValid(unittest.TestCase):
             found += 1
         self.assertEqual(found, len(scanner.supported_resources))
         self.assertEqual(len(list(filter(lambda c: c.id == CUSTOM_GRAPH_CHECK_ID, graph_registry.checks))), 1)
-        self.assertEqual(graph_registry.checks[-1].id, CUSTOM_GRAPH_CHECK_ID)
-        self.assertEqual(graph_registry.checks[-1].name, 'Ensure bucket has versioning and owner tag')
-        graph_registry.checks = list(filter(lambda c: c.id != CUSTOM_GRAPH_CHECK_ID, graph_registry.checks))
 
     def test_wrong_check_imports(self):
         wrong_imports = ["arm", "cloudformation", "dockerfile", "helm", "kubernetes", "serverless"]

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -648,6 +648,7 @@ class TestRunnerValid(unittest.TestCase):
 
     def test_loading_external_checks_yaml(self):
         runner = Runner()
+        graph_registry.checks = []
         graph_registry.load_checks()
         base_len = len(graph_registry.checks)
         current_dir = os.path.dirname(os.path.realpath(__file__))

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -660,17 +660,15 @@ class TestRunnerValid(unittest.TestCase):
 
     def test_loading_external_checks_yaml_multiple_times(self):
         runner = Runner()
-        base_len = len(graph_registry.checks)
         current_dir = os.path.dirname(os.path.realpath(__file__))
+        graph_registry.checks = []
         extra_checks_dir_path = [current_dir + "/extra_yaml_checks"]
         runner.load_external_checks(extra_checks_dir_path)
-        self.assertEqual(len(graph_registry.checks), base_len + 1)
-        self.assertEqual(graph_registry.checks[base_len].id, CUSTOM_GRAPH_CHECK_ID)
-        self.assertEqual(graph_registry.checks[base_len].name, 'Ensure bucket has versioning and owner tag')
+        self.assertEqual(len(graph_registry.checks), 2)
         runner.load_external_checks(extra_checks_dir_path)
-        self.assertEqual(len(graph_registry.checks), base_len + 1)
-        self.assertEqual(graph_registry.checks[base_len].id, CUSTOM_GRAPH_CHECK_ID)
-        graph_registry.checks = list(filter(lambda c: c.id != CUSTOM_GRAPH_CHECK_ID, graph_registry.checks))
+        self.assertEqual(len(graph_registry.checks), 2)
+        self.assertListEqual(['CUSTOM_GRAPH_AWS_1', 'CKV2_CUSTOM_1'], [x.id for x in graph_registry.checks])
+        graph_registry.checks = []
 
     def test_loading_external_checks_python(self):
         runner = Runner()

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -83,7 +83,7 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.get_exit_code(False), 1)
         summary = report.get_summary()
         self.assertGreaterEqual(summary['passed'], 1)
-        self.assertEqual(5, summary['failed'])
+        self.assertEqual(7, summary['failed'])
         self.assertEqual(1, summary['skipped'])
         self.assertEqual(0, summary["parsing_errors"])
 
@@ -113,8 +113,8 @@ class TestRunnerValid(unittest.TestCase):
             if record.check_id == "CUSTOM_AWS_1":
                 failed_custom = failed_custom + 1
 
-        self.assertEqual(passing_custom, 1)
-        self.assertEqual(failed_custom, 2)
+        self.assertEqual(1, passing_custom)
+        self.assertEqual(2, failed_custom)
 
     def test_runner_extra_yaml_check(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -158,7 +158,7 @@ class TestRunnerValid(unittest.TestCase):
         # self.assertEqual(report.get_exit_code(), 0)
         summary = report.get_summary()
         self.assertGreaterEqual(summary['passed'], 1)
-        self.assertEqual(3, summary['failed'])
+        self.assertEqual(4, summary['failed'])
         self.assertEqual(0, summary["parsing_errors"])
 
     def test_check_ids_dont_collide(self):


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I'm using the terraform runner for most of the heavylifting, + leveraged the `build_graph_from_tf_definitions` to generate the graph.
Had to override the `get_entity_context_and_evaluations` from the tf runner - and that's basically it.

Resolves #1270 
