### PR TITLE
Add cfn redshift logging check

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/RedshiftClusterLogging.py
+++ b/checkov/cloudformation/checks/resource/aws/RedshiftClusterLogging.py
@@ -1,0 +1,21 @@
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories
+
+
+class RedshiftClusterLogging(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure Redshift Cluster logging is enabled"
+        id = "CKV_AWS_71"
+        supported_resources = ["AWS::Redshift::Cluster"]
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "Properties/LoggingProperties/BucketName"
+
+    def get_expected_value(self) -> str:
+        return ANY_VALUE
+
+
+check = RedshiftClusterLogging()

--- a/checkov/cloudformation/checks/resource/aws/RedshiftClusterPubliclyAccessible.py
+++ b/checkov/cloudformation/checks/resource/aws/RedshiftClusterPubliclyAccessible.py
@@ -1,0 +1,22 @@
+from typing import List
+
+from checkov.cloudformation.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class RedshiftClusterPubliclyAccessible(BaseResourceNegativeValueCheck):
+    def __init__(self) -> None:
+        name = "Redshift cluster should not be publicly accessible"
+        id = "CKV_AWS_87"
+        supported_resources = ["AWS::Redshift::Cluster"]
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "Properties/PubliclyAccessible"
+
+    def get_forbidden_values(self) -> List[bool]:
+        return [True]
+
+
+check = RedshiftClusterPubliclyAccessible()

--- a/checkov/cloudformation/checks/resource/aws/RedshiftInEc2ClassicMode.py
+++ b/checkov/cloudformation/checks/resource/aws/RedshiftInEc2ClassicMode.py
@@ -1,20 +1,20 @@
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.models.consts import ANY_VALUE
 from checkov.common.models.enums import CheckCategories
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
 class RedshiftInEc2ClassicMode(BaseResourceValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure Redshift is not deployed outside of a VPC"
         id = "CKV_AWS_154"
-        supported_resources = ['aws_redshift_cluster']
+        supported_resources = ["AWS::Redshift::Cluster"]
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return "cluster_subnet_group_name"
+    def get_inspected_key(self) -> str:
+        return "Properties/ClusterSubnetGroupName"
 
-    def get_expected_value(self):
+    def get_expected_value(self) -> str:
         return ANY_VALUE
 
 

--- a/tests/cloudformation/checks/resource/aws/example_RedshiftClusterLogging/RedshiftClusterLogging-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RedshiftClusterLogging/RedshiftClusterLogging-FAILED.yaml
@@ -1,0 +1,9 @@
+Resources:
+  RedshiftClusterDefault:
+    Type: "AWS::Redshift::Cluster"
+    Properties:
+      DBName: "mydb"
+      MasterUsername: "master"
+      MasterUserPassword: "MasterUserPassword"
+      NodeType: "ds2.xlarge"
+      ClusterType: "single-node"

--- a/tests/cloudformation/checks/resource/aws/example_RedshiftClusterLogging/RedshiftClusterLogging-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RedshiftClusterLogging/RedshiftClusterLogging-PASSED.yaml
@@ -1,0 +1,11 @@
+Resources:
+  RedshiftClusterEnabled:
+    Type: "AWS::Redshift::Cluster"
+    Properties:
+      DBName: "mydb"
+      MasterUsername: "master"
+      MasterUserPassword: "MasterUserPassword"
+      NodeType: "ds2.xlarge"
+      ClusterType: "single-node"
+      LoggingProperties:
+        BucketName: "bucket"

--- a/tests/cloudformation/checks/resource/aws/example_RedshiftClusterPubliclyAccessible/RedshiftClusterPubliclyAccessible-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RedshiftClusterPubliclyAccessible/RedshiftClusterPubliclyAccessible-FAILED.yaml
@@ -1,0 +1,10 @@
+Resources:
+  RedshiftClusterDisabled:
+    Type: "AWS::Redshift::Cluster"
+    Properties:
+      DBName: "mydb"
+      MasterUsername: "master"
+      MasterUserPassword: "MasterUserPassword"
+      NodeType: "ds2.xlarge"
+      ClusterType: "single-node"
+      PubliclyAccessible: true

--- a/tests/cloudformation/checks/resource/aws/example_RedshiftClusterPubliclyAccessible/RedshiftClusterPubliclyAccessible-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RedshiftClusterPubliclyAccessible/RedshiftClusterPubliclyAccessible-PASSED.yaml
@@ -1,0 +1,18 @@
+Resources:
+  RedshiftClusterDefault:
+    Type: "AWS::Redshift::Cluster"
+    Properties:
+      DBName: "mydb"
+      MasterUsername: "master"
+      MasterUserPassword: "MasterUserPassword"
+      NodeType: "ds2.xlarge"
+      ClusterType: "single-node"
+  RedshiftClusterEnabled:
+    Type: "AWS::Redshift::Cluster"
+    Properties:
+      DBName: "mydb"
+      MasterUsername: "master"
+      MasterUserPassword: "MasterUserPassword"
+      NodeType: "ds2.xlarge"
+      ClusterType: "single-node"
+      PubliclyAccessible: false

--- a/tests/cloudformation/checks/resource/aws/example_RedshiftInEc2ClassicMode/RedshiftInEc2ClassicMode-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RedshiftInEc2ClassicMode/RedshiftInEc2ClassicMode-FAILED.yaml
@@ -1,0 +1,9 @@
+Resources:
+  RedshiftClusterDefault:
+    Type: "AWS::Redshift::Cluster"
+    Properties:
+      DBName: "mydb"
+      MasterUsername: "master"
+      MasterUserPassword: "MasterUserPassword"
+      NodeType: "ds2.xlarge"
+      ClusterType: "single-node"

--- a/tests/cloudformation/checks/resource/aws/example_RedshiftInEc2ClassicMode/RedshiftInEc2ClassicMode-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RedshiftInEc2ClassicMode/RedshiftInEc2ClassicMode-PASSED.yaml
@@ -1,0 +1,10 @@
+Resources:
+  RedshiftClusterEnabled:
+    Type: "AWS::Redshift::Cluster"
+    Properties:
+      DBName: "mydb"
+      MasterUsername: "master"
+      MasterUserPassword: "MasterUserPassword"
+      NodeType: "ds2.xlarge"
+      ClusterType: "single-node"
+      ClusterSubnetGroupName: "subnet-ebd9cead"

--- a/tests/cloudformation/checks/resource/aws/test_RedshiftClusterLogging.py
+++ b/tests/cloudformation/checks/resource/aws/test_RedshiftClusterLogging.py
@@ -1,0 +1,35 @@
+import unittest
+from pathlib import Path
+
+from checkov.cloudformation.checks.resource.aws.RedshiftClusterLogging import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestRedshiftClusterLogging(unittest.TestCase):
+    def test_summary(self):
+        test_files_dir = Path(__file__).parent / "example_RedshiftClusterLogging"
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::Redshift::Cluster.RedshiftClusterEnabled",
+        }
+        failing_resources = {
+            "AWS::Redshift::Cluster.RedshiftClusterDefault",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_RedshiftClusterPubliclyAccessible.py
+++ b/tests/cloudformation/checks/resource/aws/test_RedshiftClusterPubliclyAccessible.py
@@ -1,0 +1,36 @@
+import unittest
+from pathlib import Path
+
+from checkov.cloudformation.checks.resource.aws.RedshiftClusterPubliclyAccessible import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestRedshiftClusterPubliclyAccessible(unittest.TestCase):
+    def test_summary(self):
+        test_files_dir = Path(__file__).parent / "example_RedshiftClusterPubliclyAccessible"
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::Redshift::Cluster.RedshiftClusterDefault",
+            "AWS::Redshift::Cluster.RedshiftClusterEnabled",
+        }
+        failing_resources = {
+            "AWS::Redshift::Cluster.RedshiftClusterDisabled",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_RedshiftInEc2ClassicMode.py
+++ b/tests/cloudformation/checks/resource/aws/test_RedshiftInEc2ClassicMode.py
@@ -1,0 +1,35 @@
+import unittest
+from pathlib import Path
+
+from checkov.cloudformation.checks.resource.aws.RedshiftInEc2ClassicMode import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestRedshiftInEc2ClassicMode(unittest.TestCase):
+    def test_summary(self):
+        test_files_dir = Path(__file__).parent / "example_RedshiftInEc2ClassicMode"
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::Redshift::Cluster.RedshiftClusterEnabled",
+        }
+        failing_resources = {
+            "AWS::Redshift::Cluster.RedshiftClusterDefault",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

AWS recently added the possibility to set logging for Redshift cluster via CloudFormation, the Terraform check existed already. I also added some other missing Redshift checks to CloudFormation.