### PR TITLE
Filter out appropriate check_ids from report based on config.checks

### DIFF
--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -136,6 +136,8 @@ class Runner(BaseRunner):
                 check_id = SECRET_TYPE_TO_ID.get(secret.type)
                 if not check_id:
                     continue
+                if runner_filter.checks and check_id not in runner_filter.checks:
+                    continue
                 result = {'result': CheckResult.FAILED}
                 line_text = linecache.getline(os.path.join(root_folder, secret.filename),
                                               secret.line_number) if root_folder else linecache.getline(secret.filename,

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -139,9 +139,7 @@ class Runner(BaseRunner):
                 if runner_filter.checks and check_id not in runner_filter.checks:
                     continue
                 result = {'result': CheckResult.FAILED}
-                line_text = linecache.getline(os.path.join(root_folder, secret.filename),
-                                              secret.line_number) if root_folder else linecache.getline(secret.filename,
-                                                                                                        secret.line_number)
+                line_text = linecache.getline(secret.filename,secret.line_number)
                 if line_text != "" and line_text.split()[0] == 'git_commit':
                     continue
                 result = self.search_for_suppression(check_id, root_folder, secret, runner_filter.skip_checks,
@@ -171,8 +169,7 @@ class Runner(BaseRunner):
                             'suppress_comment': f"Secret scan {skipped_check} is skipped"}
         # Check for suppression comment in the line before, the line of, and the line after the secret
         for line_number in [secret.line_number, secret.line_number - 1, secret.line_number + 1]:
-            lt = linecache.getline(os.path.join(root_folder, secret.filename),
-                                   line_number) if root_folder else linecache.getline(secret.filename, line_number)
+            lt = linecache.getline(secret.filename, line_number)
             skip_search = re.search(COMMENT_REGEX, lt)
             if skip_search:
                 return {'result': CheckResult.SKIPPED, 'suppress_comment': skip_search[1]}

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -142,7 +142,7 @@ class Runner(BaseRunner):
                 line_text = linecache.getline(secret.filename,secret.line_number)
                 if line_text != "" and line_text.split()[0] == 'git_commit':
                     continue
-                result = self.search_for_suppression(check_id, root_folder, secret, runner_filter.skip_checks,
+                result = self.search_for_suppression(check_id, secret, runner_filter.skip_checks,
                                                      CHECK_ID_TO_SECRET_TYPE) or result
                 report.add_record(Record(
                     check_id=check_id,

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -160,7 +160,7 @@ class Runner(BaseRunner):
             return report
 
     @staticmethod
-    def search_for_suppression(check_id: str, root_folder: str, secret: PotentialSecret, skipped_checks: list,
+    def search_for_suppression(check_id: str, secret: PotentialSecret, skipped_checks: list,
                                CHECK_ID_TO_SECRET_TYPE: dict) -> Optional[dict]:
         if skipped_checks:
             for skipped_check in skipped_checks:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR addresses a bug where running checkov like so `checkov -d path/to/iac -c <any-check>` also displays secret scanning related checks. 

This was also reported in #1363 

This also addresses issues with printing code blocks correctly for secret scanning.

Before this change code blocks for secret scanning were blank.

```
Check: CKV_SECRET_19: "Hex High Entropy String"
	FAILED for resource: fc24931058dd40abe8e4719cc5d9be508c7e2585
	File: /terraform/azure/sql.tf:15-16
	Guide: https://docs.bridgecrew.io/docs/git_secrets_19

		15 |
```

After this change:

```
Check: CKV_SECRET_19: "Hex High Entropy String"
	FAILED for resource: fc24931058dd40abe8e4719cc5d9be508c7e2585
	File: /terraform/azure/sql.tf:15-16
	Guide: https://docs.bridgecrew.io/docs/git_secrets_19

		15 |   administrator_login_password = "Aa12345678"
```