### PR TITLE
Python empty init

### DIFF
--- a/checkov/arm/base_registry.py
+++ b/checkov/arm/base_registry.py
@@ -3,9 +3,6 @@ from checkov.common.checks.base_check_registry import BaseCheckRegistry
 
 class Registry(BaseCheckRegistry):
 
-    def __init__(self):
-        super().__init__()
-
     def extract_entity_details(self, entity):
         resource_name, resource = next(iter(entity.items()))
         resource_type = str(resource['type'])    # entity['type'] ??

--- a/checkov/cloudformation/checks/resource/base_registry.py
+++ b/checkov/cloudformation/checks/resource/base_registry.py
@@ -3,9 +3,6 @@ from checkov.common.checks.base_check_registry import BaseCheckRegistry
 
 class Registry(BaseCheckRegistry):
 
-    def __init__(self):
-        super().__init__()
-
     def extract_entity_details(self, entity):
         resource_name, resource = next(iter(entity.items()))
         resource_type = resource['Type']

--- a/checkov/dockerfile/base_registry.py
+++ b/checkov/dockerfile/base_registry.py
@@ -3,10 +3,6 @@ from checkov.common.models.enums import CheckResult
 
 
 class Registry(BaseCheckRegistry):
-    def __init__(self):
-        super().__init__()
-
-
     def scan(self, scanned_file, entity, skipped_checks, runner_filter):
 
         results = {}

--- a/checkov/helm/base_registry.py
+++ b/checkov/helm/base_registry.py
@@ -4,9 +4,6 @@ from checkov.runner_filter import RunnerFilter
 
 class Registry(BaseCheckRegistry):
 
-    def __init__(self):
-        super().__init__()
-
     def extract_entity_details(self, entity):
         kind = entity["kind"]
         conf = entity

--- a/checkov/terraform/checks/data/base_registry.py
+++ b/checkov/terraform/checks/data/base_registry.py
@@ -4,9 +4,6 @@ from checkov.common.checks.base_check_registry import BaseCheckRegistry
 
 
 class Registry(BaseCheckRegistry):
-    def __init__(self) -> None:
-        super().__init__()
-
     def extract_entity_details(
         self, entity: Dict[str, Dict[str, Dict[str, List[Dict[str, Any]]]]]
     ) -> Tuple[str, str, Dict[str, List[Dict[str, Any]]]]:

--- a/checkov/terraform/checks/resource/base_registry.py
+++ b/checkov/terraform/checks/resource/base_registry.py
@@ -4,9 +4,6 @@ from checkov.common.checks.base_check_registry import BaseCheckRegistry
 
 
 class Registry(BaseCheckRegistry):
-    def __init__(self) -> None:
-        super().__init__()
-
     def extract_entity_details(self, entity: Dict[str, Any]) -> Tuple[str, str, Dict[str, Any]]:
         resource_type = list(entity.keys())[0]
         resource_name = list(list(entity.values())[0].keys())[0]

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -1,11 +1,11 @@
-FROM python
+FROM python:3.9
 
 COPY kubernetes/requirements.txt /requirements.txt
 
 # Install checkov
 RUN pip install -r /requirements.txt
-RUN apt-get update
-RUN apt install -y git
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
+  rm -rf /var/lib/apt/lists/*;
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
     && chmod +x kubectl && mv kubectl /usr/local/bin


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I found a couple more, compared to #1342. 

https://github.com/hadolint/hadolint checks for the missing `rm -rf /var/lib/apt/lists/*` instruction. `checkov` doesn't do that. The Dockerfile also misses a tag, instead of the implied `latest`.