### PR TITLE
Relax argument requirements when using --list

### DIFF
--- a/checkov/common/bridgecrew/bc_source.py
+++ b/checkov/common/bridgecrew/bc_source.py
@@ -1,14 +1,30 @@
-from typing import Optional
-
-# Helper methods for determining behavior based on different BC_SOURCE values. Python enums are limiting here, and
-# using a class is overkill
+from dataclasses import dataclass
 
 
-def should_upload_results(source: Optional[str]) -> bool:
-    """Whether scan results should be uploaded to the platform. Default for unknown sources is False."""
-    if source == 'vscode':
-        return False
-    elif source == 'cli':
-        return True
+class SourceType:
+    def __init__(self, name: str, upload_results: bool):
+        self.name = name
+        self.upload_results = upload_results
+
+
+@dataclass
+class BCSourceType:
+    VSCODE = 'vscode'
+    CLI = 'cli'
+    DISABLED = 'disabled'  # use this to indicate that #TODO
+
+
+SourceTypes = {
+    BCSourceType.VSCODE: SourceType(BCSourceType.VSCODE, False),
+    BCSourceType.CLI: SourceType(BCSourceType.CLI, True),
+    BCSourceType.DISABLED: SourceType(BCSourceType.VSCODE, False)
+}
+
+
+def get_source_type(source: str):
+    # helper method to get the source type with a default - using dict.get is ugly; you have to do:
+    # SourceTypes.get(xyz, SourceTypes[BCSourceType.Disabled])
+    if source in SourceTypes:
+        return SourceTypes[source]
     else:
-        return False
+        return SourceTypes[BCSourceType.DISABLED]

--- a/checkov/common/bridgecrew/bc_source.py
+++ b/checkov/common/bridgecrew/bc_source.py
@@ -1,0 +1,14 @@
+
+
+# Helper methods for determining behavior based on different BC_SOURCE values. Python enums are limiting here, and
+# using a class is overkill
+
+
+def should_upload_results(source: str) -> bool:
+    """Whether scan results should be uploaded to the platform. Default for unknown sources is False."""
+    if source == 'vscode':
+        return False
+    elif source == 'cli':
+        return True
+    else:
+        return False

--- a/checkov/common/bridgecrew/bc_source.py
+++ b/checkov/common/bridgecrew/bc_source.py
@@ -11,7 +11,7 @@ class SourceType:
 class BCSourceType:
     VSCODE = 'vscode'
     CLI = 'cli'
-    DISABLED = 'disabled'  # use this to indicate that #TODO
+    DISABLED = 'disabled'  # use this as a placeholder for generic no-upload logic
 
 
 SourceTypes = {

--- a/checkov/common/bridgecrew/bc_source.py
+++ b/checkov/common/bridgecrew/bc_source.py
@@ -1,10 +1,10 @@
-
+from typing import Optional
 
 # Helper methods for determining behavior based on different BC_SOURCE values. Python enums are limiting here, and
 # using a class is overkill
 
 
-def should_upload_results(source: str) -> bool:
+def should_upload_results(source: Optional[str]) -> bool:
     """Whether scan results should be uploaded to the platform. Default for unknown sources is False."""
     if source == 'vscode':
         return False

--- a/checkov/common/bridgecrew/image_scanning/docker_image_scanning_integration.py
+++ b/checkov/common/bridgecrew/image_scanning/docker_image_scanning_integration.py
@@ -56,7 +56,7 @@ class DockerImageScanningIntegration:
             'dockerImageName': docker_image_name,
             'dockerFilePath': dockerfile_path,
             'dockerFileContent': dockerfile_content,
-            'sourceType': bc_integration.bc_source,
+            'sourceType': bc_integration.bc_source.name,
             'vulnerabilities': vulnerabilities
         }
         response = requests.request('POST', f"{self.docker_image_scanning_base_url}/report", headers=headers, json=payload)

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -18,6 +18,7 @@ from termcolor import colored
 from tqdm import trange
 from urllib3.exceptions import HTTPError
 
+from checkov.common.bridgecrew.bc_source import should_upload_results
 from checkov.common.bridgecrew.ci_variables import *
 from checkov.common.bridgecrew.platform_errors import BridgecrewAuthError
 from checkov.common.bridgecrew.platform_key import read_key, persist_key, bridgecrew_file
@@ -113,7 +114,7 @@ class BcPlatformIntegration(object):
         if source_version:
             self.bc_source_version = source_version
 
-        if self.bc_source != 'vscode':
+        if should_upload_results(source):
             try:
                 self.skip_fixes = True  # no need to run fixes on CI integration
                 repo_full_path, response = self.get_s3_role(bc_api_key, repo_id)

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -18,7 +18,6 @@ from termcolor import colored
 from tqdm import trange
 from urllib3.exceptions import HTTPError
 
-from checkov.common.bridgecrew.bc_source import should_upload_results
 from checkov.common.bridgecrew.ci_variables import *
 from checkov.common.bridgecrew.platform_errors import BridgecrewAuthError
 from checkov.common.bridgecrew.platform_key import read_key, persist_key, bridgecrew_file
@@ -59,7 +58,7 @@ class BcPlatformIntegration(object):
         self.timestamp = None
         self.scan_reports = []
         self.bc_api_url = os.getenv('BC_API_URL', "https://www.bridgecrew.cloud/api/v1")
-        self.bc_source = os.getenv('BC_SOURCE', 'cli')
+        self.bc_source = None
         self.bc_source_version = None
         self.integrations_api_url = f"{self.bc_api_url}/integrations/types/checkov"
         self.guidelines_api_url = f"{self.bc_api_url}/guidelines"
@@ -109,12 +108,10 @@ class BcPlatformIntegration(object):
         self.skip_fixes = skip_fixes
         self.skip_suppressions = skip_suppressions
         self.skip_policy_download = skip_policy_download
-        if source:
-            self.bc_source = source
-        if source_version:
-            self.bc_source_version = source_version
+        self.bc_source = source
+        self.bc_source_version = source_version
 
-        if should_upload_results(source):
+        if self.bc_source.upload_results:
             try:
                 self.skip_fixes = True  # no need to run fixes on CI integration
                 repo_full_path, response = self.get_s3_role(bc_api_key, repo_id)
@@ -222,7 +219,7 @@ class BcPlatformIntegration(object):
         request = None
         try:
 
-            request = self.http.request("PUT", f"{self.integrations_api_url}?source={self.bc_source}",
+            request = self.http.request("PUT", f"{self.integrations_api_url}?source={self.bc_source.name}",
                                    body=json.dumps({"path": self.repo_path, "branch": branch, "to_branch": BC_TO_BRANCH,
                                                     "pr_id": BC_PR_ID, "pr_url": BC_PR_URL,
                                                     "commit_hash": BC_COMMIT_HASH, "commit_url": BC_COMMIT_URL,
@@ -230,7 +227,7 @@ class BcPlatformIntegration(object):
                                                     "run_id": BC_RUN_ID, "run_url": BC_RUN_URL,
                                                     "repository_url": BC_REPOSITORY_URL}),
                                    headers={"Authorization": self.bc_api_key, "Content-Type": "application/json",
-                                            'x-api-client': self.bc_source, 'x-api-checkov-version': checkov_version
+                                            'x-api-client': self.bc_source.name, 'x-api-checkov-version': checkov_version
                                             })
             response = json.loads(request.data.decode("utf8"))
             url = response.get("url", None)

--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -2,6 +2,7 @@ import json
 import requests
 import logging
 
+from checkov.common.bridgecrew.bc_source import SourceType
 from checkov.common.util.consts import DEV_API_GET_HEADERS, DEV_API_POST_HEADERS
 from checkov.common.util.data_structures_utils import merge_dicts
 from checkov.version import version as checkov_version
@@ -35,9 +36,9 @@ def get_version_headers(client, client_version):
     }
 
 
-def get_default_get_headers(client, client_version):
-    return merge_dicts(DEV_API_GET_HEADERS, get_version_headers(client, client_version))
+def get_default_get_headers(client: SourceType, client_version: str):
+    return merge_dicts(DEV_API_GET_HEADERS, get_version_headers(client.name, client_version))
 
 
-def get_default_post_headers(client, client_version):
-    return merge_dicts(DEV_API_POST_HEADERS, get_version_headers(client, client_version))
+def get_default_post_headers(client: SourceType, client_version: str):
+    return merge_dicts(DEV_API_POST_HEADERS, get_version_headers(client.name, client_version))

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -11,6 +11,7 @@ import configargparse
 
 from checkov.arm.runner import Runner as arm_runner
 from checkov.cloudformation.runner import Runner as cfn_runner
+from checkov.common.bridgecrew.bc_source import SourceTypes, BCSourceType, get_source_type
 from checkov.common.bridgecrew.image_scanning.image_scanner import image_scanner
 from checkov.common.bridgecrew.integration_features.integration_feature_registry import integration_feature_registry
 from checkov.common.bridgecrew.platform_integration import bc_integration
@@ -101,14 +102,17 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
             parser.error("--repo-id argument format should be 'organization/repository_name' E.g "
                          "bridgecrewio/checkov")
 
-        source = os.getenv('BC_SOURCE', 'cli')
+        source_env_val = os.getenv('BC_SOURCE', 'cli')
+        source = get_source_type(source_env_val)
+        if source == SourceTypes[BCSourceType.DISABLED]:
+            logger.warning(f'Received unexpected value for BC_SOURCE: {source_env_val}; setting source to DISABLED')
         source_version = os.getenv('BC_SOURCE_VERSION', version)
-        logger.debug(f'BC_SOURCE = {source}, version = {source_version}')
+        logger.debug(f'BC_SOURCE = {source.name}, version = {source_version}')
 
         if config.list:
             # This speeds up execution by not setting up upload credentials (since we won't upload anything anyways)
-            logger.debug('Using --list; setting source to None')
-            source = None
+            logger.debug('Using --list; setting source to DISABLED')
+            source = SourceTypes[BCSourceType.DISABLED]
 
         try:
             bc_integration.setup_bridgecrew_credentials(bc_api_key=config.bc_api_key, repo_id=config.repo_id,

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -2,10 +2,8 @@ import os
 import unittest
 from unittest import mock
 
-from checkov.common.bridgecrew.bc_source import should_upload_results
-from checkov.common.bridgecrew.integration_features.features.suppressions_integration import SuppressionsIntegration
+from checkov.common.bridgecrew.bc_source import get_source_type
 from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
-from checkov.common.output.record import Record
 
 
 class TestBCApiUrl(unittest.TestCase):
@@ -14,15 +12,6 @@ class TestBCApiUrl(unittest.TestCase):
     def test_overriding_bc_api_url(self):
         instance = BcPlatformIntegration()
         self.assertEqual(instance.bc_api_url, "foo")
-
-    @mock.patch.dict(os.environ, {'BC_SOURCE': 'foo'})
-    def test_overriding_bc_source(self):
-        instance = BcPlatformIntegration()
-        self.assertEqual(instance.bc_source, "foo")
-
-    def test_default_bc_source(self):
-        instance = BcPlatformIntegration()
-        self.assertEqual(instance.bc_source, "cli")
 
     @mock.patch.dict(os.environ, {'BC_SKIP_MAPPING': 'TRUE'})
     def test_skip_mapping(self):
@@ -39,10 +28,10 @@ class TestBCApiUrl(unittest.TestCase):
         self.assertIsNotNone(instance.ckv_to_bc_id_mapping)
 
     def test_should_upload(self):
-        self.assertFalse(should_upload_results('vscode'))
-        self.assertTrue(should_upload_results('cli'))
-        self.assertFalse(should_upload_results('xyz'))
-        self.assertFalse(should_upload_results(None))
+        self.assertFalse(get_source_type('vscode').upload_results)
+        self.assertTrue(get_source_type('cli').upload_results)
+        self.assertFalse(get_source_type('xyz').upload_results)
+        self.assertFalse(get_source_type(None).upload_results)
 
 
 if __name__ == '__main__':

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from unittest import mock
 
+from checkov.common.bridgecrew.bc_source import should_upload_results
 from checkov.common.bridgecrew.integration_features.features.suppressions_integration import SuppressionsIntegration
 from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
 from checkov.common.output.record import Record
@@ -36,6 +37,12 @@ class TestBCApiUrl(unittest.TestCase):
         instance.setup_http_manager()
         instance.get_id_mapping()
         self.assertIsNotNone(instance.ckv_to_bc_id_mapping)
+
+    def test_should_upload(self):
+        self.assertFalse(should_upload_results('vscode'))
+        self.assertTrue(should_upload_results('cli'))
+        self.assertFalse(should_upload_results('xyz'))
+        self.assertFalse(should_upload_results(None))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR fixes an annoyance where using `--list` with an API key (which will download custom policies from the platform) still requires a repo-id, even though it will not be used.

It also refactors the logic for how different BC_SOURCE values affect the behavior to make it a little more generic. This refactor was required to make this change work (otherwise, with the platform integration, the repo-id was required to set up S3 credentials, but those creds wouldn't get used).