### PR TITLE
use a singleton registry per check type

### DIFF
--- a/checkov/common/checks_infra/registry.py
+++ b/checkov/common/checks_infra/registry.py
@@ -56,6 +56,11 @@ class Registry(BaseRegistry):
         return resources_types.get(provider)
 
 
+_registry_instances = {}
+
+
 def get_graph_checks_registry(check_type):
-    return Registry(parser=NXGraphCheckParser(),
-                    checks_dir=f"{Path(__file__).parent.parent.parent}/{check_type}/checks/graph_checks")
+    if not _registry_instances.get(check_type):
+        _registry_instances[check_type] = Registry(parser=NXGraphCheckParser(),
+                             checks_dir=f"{Path(__file__).parent.parent.parent}/{check_type}/checks/graph_checks")
+    return _registry_instances[check_type]

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -24,7 +24,6 @@ class TestRunnerValid(unittest.TestCase):
         checks_allowlist = ['CKV_AWS_41', 'CKV_AZURE_1']
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
                             runner_filter=RunnerFilter(framework='all', checks=checks_allowlist))
-
         report_json = report.get_json()
         self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -24,6 +24,7 @@ class TestRunnerValid(unittest.TestCase):
         checks_allowlist = ['CKV_AWS_41', 'CKV_AZURE_1']
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
                             runner_filter=RunnerFilter(framework='all', checks=checks_allowlist))
+
         report_json = report.get_json()
         self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
@@ -116,6 +117,8 @@ class TestRunnerValid(unittest.TestCase):
 
         self.assertEqual(1, passing_custom)
         self.assertEqual(2, failed_custom)
+        # Remove external checks from registry.
+        runner.graph_registry.checks[:] = [check for check in runner.graph_registry.checks if "CUSTOM" not in check.id]
 
     def test_runner_extra_yaml_check(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -144,6 +147,8 @@ class TestRunnerValid(unittest.TestCase):
 
         self.assertEqual(passing_custom, 0)
         self.assertEqual(failed_custom, 3)
+        # Remove external checks from registry.
+        runner.graph_registry.checks[:] = [check for check in runner.graph_registry.checks if "CUSTOM" not in check.id]
 
     def test_runner_specific_file(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -714,6 +719,8 @@ class TestRunnerValid(unittest.TestCase):
             found += 1
         self.assertEqual(found, len(scanner.supported_resources))
         self.assertEqual(len(list(filter(lambda c: c.id == CUSTOM_GRAPH_CHECK_ID, runner.graph_registry.checks))), 1)
+        # Remove external checks from registry.
+        runner.graph_registry.checks[:] = [check for check in runner.graph_registry.checks if "CUSTOM" not in check.id]
 
     def test_wrong_check_imports(self):
         wrong_imports = ["arm", "cloudformation", "dockerfile", "helm", "kubernetes", "serverless"]


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes an issue that prevented platform custom policies from being saved in the registry, which prevented them from running.