### PR TITLE
Fix start and end line numbers of CFN definitions.

### DIFF
--- a/checkov/cloudformation/cfn_utils.py
+++ b/checkov/cloudformation/cfn_utils.py
@@ -128,7 +128,14 @@ def build_definitions_context(definitions, definitions_raw, root_folder):
                         start_line = attr_value.start_mark.line
                         end_line = attr_value.end_mark.line
                         # fix lines number for yaml and json files
-                        if file_path.endswith(".yaml") or file_path.endswith(".yml"):
+                        first_line_index = 0
+                        while not str.strip(definitions_raw[file_path][first_line_index][1]):
+                            first_line_index += 1
+                        # check if the file is a json file
+                        if str.strip(definitions_raw[file_path][first_line_index][1])[0] is "{":
+                            start_line += 1
+                            end_line += 1
+                        else:
                             current_line = str.strip(definitions_raw[file_path][start_line - 1][1])
                             while not current_line or current_line[0] is YAML_COMMENT_MARK:
                                 start_line -= 1
@@ -137,9 +144,7 @@ def build_definitions_context(definitions, definitions_raw, root_folder):
                             while not current_line or current_line[0] is YAML_COMMENT_MARK:
                                 end_line -= 1
                                 current_line = str.strip(definitions_raw[file_path][end_line - 1][1])
-                        elif file_path.endswith(".json"):
-                            start_line += 1
-                            end_line += 1
+
                         code_lines = definitions_raw[file_path][start_line - 1: end_line]
                         file_abs_path = create_file_abs_path(root_folder, file_path)
                         dpath.new(definitions_context,

--- a/checkov/cloudformation/cfn_utils.py
+++ b/checkov/cloudformation/cfn_utils.py
@@ -126,6 +126,19 @@ def build_definitions_context(definitions, definitions_raw, root_folder):
                     if isinstance(attr_value, dict_node):
                         start_line = attr_value.start_mark.line
                         end_line = attr_value.end_mark.line
+                        # fix lines number for yaml and json files
+                        if file_path.endswith(".yaml") or file_path.endswith(".yml"):
+                            current_line = str.strip(definitions_raw[file_path][start_line - 1][1])
+                            while not current_line or current_line[0] is "#":
+                                start_line -= 1
+                                current_line = str.strip(definitions_raw[file_path][start_line - 1][1])
+                            current_line = str.strip(definitions_raw[file_path][end_line - 1][1])
+                            while not current_line or current_line[0] is "#":
+                                end_line -= 1
+                                current_line = str.strip(definitions_raw[file_path][end_line - 1][1])
+                        elif file_path.endswith(".json"):
+                            start_line += 1
+                            end_line += 1
                         code_lines = definitions_raw[file_path][start_line - 1: end_line]
                         file_abs_path = create_file_abs_path(root_folder, file_path)
                         dpath.new(definitions_context,

--- a/checkov/cloudformation/cfn_utils.py
+++ b/checkov/cloudformation/cfn_utils.py
@@ -11,6 +11,7 @@ from checkov.cloudformation.parser import parse
 from checkov.cloudformation.parser.node import dict_node, list_node, str_node
 from checkov.common.runners.base_runner import filter_ignored_paths
 from checkov.runner_filter import RunnerFilter
+from checkov.common.models.consts import YAML_COMMENT_MARK
 
 CF_POSSIBLE_ENDINGS = frozenset([".yml", ".yaml", ".json", ".template"])
 
@@ -129,11 +130,11 @@ def build_definitions_context(definitions, definitions_raw, root_folder):
                         # fix lines number for yaml and json files
                         if file_path.endswith(".yaml") or file_path.endswith(".yml"):
                             current_line = str.strip(definitions_raw[file_path][start_line - 1][1])
-                            while not current_line or current_line[0] is "#":
+                            while not current_line or current_line[0] is YAML_COMMENT_MARK:
                                 start_line -= 1
                                 current_line = str.strip(definitions_raw[file_path][start_line - 1][1])
                             current_line = str.strip(definitions_raw[file_path][end_line - 1][1])
-                            while not current_line or current_line[0] is "#":
+                            while not current_line or current_line[0] is YAML_COMMENT_MARK:
                                 end_line -= 1
                                 current_line = str.strip(definitions_raw[file_path][end_line - 1][1])
                         elif file_path.endswith(".json"):

--- a/checkov/common/models/consts.py
+++ b/checkov/common/models/consts.py
@@ -4,3 +4,4 @@ DOCKER_IMAGE_REGEX = r'(?:[^\s\/]+/)?([^\s:]+):?([^\s]*)'
 access_key_pattern = "(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])" # nosec
 secret_key_pattern = "(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])" # nosec
 linode_token_pattern ="(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{64}(?![A-Za-z0-9/+=])" # nosec
+YAML_COMMENT_MARK = '#'

--- a/tests/cloudformation/utils/file_formats/test2.yaml
+++ b/tests/cloudformation/utils/file_formats/test2.yaml
@@ -1,0 +1,206 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: AWS CloudFormation Template to deploy insecure infrastructure
+Parameters:
+  LatestAmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+#test
+Resources:
+  ####################
+  ###  EC2 in VPC  ###
+  ####################
+  WebHostStorage:
+    # Unencrypted Volume
+    Type: AWS::EC2::Volume
+    Properties:
+      AvailabilityZone: !Select
+        - 0
+        - Fn::GetAZs: ""
+      #Encrypted: False
+      Size: 1
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::AccountId}-${CompanyName}-${Environment}-ebs"
+
+  #############
+  ###  KMS  ###
+  #############
+
+  LogsKey:
+    # Key does not have rotation enabled
+    Type: AWS::KMS::Key
+    Properties:
+      Description: !Sub "${AWS::AccountId}-${CompanyName}-${Environment}-logs bucket key"
+      PendingWindowInDays: 7
+      KeyPolicy:
+        Version: '2012-10-17'
+        Id: key-default-1
+        Statement:
+        - Sid: Enable IAM User Permissions
+          Effect: Allow
+          Principal:
+            AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+          Action: kms:*
+          Resource: '*'
+
+  LogsKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${AWS::AccountId}-${CompanyName}-${Environment}-logs-bucket-key"
+      TargetKeyId: !Ref LogsKey
+
+  DBAppInstance:
+    # EC2 have plain text secrets in user data
+    Type: AWS::EC2::Instance
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - 0
+        - Fn::GetAZs: ""
+      ImageId: !Ref LatestAmiId
+      InstanceType: t2.nano
+      IamInstanceProfile: !Ref EC2Profile
+      SecurityGroupIds:
+        - !Ref WebNodeSG
+      SubnetId: !Ref WebSubnet
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::AccountId}-${CompanyName}-${Environment}-dbapp"
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          ### Config from https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Tutorials.WebServerDB.CreateWebServer.html
+          sudo yum -y update
+          sudo yum -y install httpd php php-mysqlnd
+          sudo systemctl enable httpd
+          sudo systemctl start httpd
+          sudo mkdir /var/www/inc
+          cat << EnD > /tmp/dbinfo.inc
+          <?php
+          define('DB_SERVER', '${DefaultDB.Endpoint.Address}:${DefaultDB.Endpoint.Port}');
+          define('DB_USERNAME', 'admin');
+          define('DB_PASSWORD', '${Password}');
+          define('DB_DATABASE', '${DefaultDB}');
+          ?>
+          EnD
+          sudo mv /tmp/dbinfo.inc /var/www/inc
+          sudo chown root:root /var/www/inc/dbinfo.inc
+          cat << EnD > /tmp/index.php
+          <?php include "../inc/dbinfo.inc"; ?>
+          <html>
+          <body>
+          <h1>Sample page</h1>
+          <?php
+            /* Connect to MySQL and select the database. */
+            $connection = mysqli_connect(DB_SERVER, DB_USERNAME, DB_PASSWORD);
+            if (mysqli_connect_errno()) echo "Failed to connect to MySQL: " . mysqli_connect_error();
+            $database = mysqli_select_db($connection, DB_DATABASE);
+            /* Ensure that the EMPLOYEES table exists. */
+            VerifyEmployeesTable($connection, DB_DATABASE);
+            /* If input fields are populated, add a row to the EMPLOYEES table. */
+            $employee_name = htmlentities($_POST['NAME']);
+            $employee_address = htmlentities($_POST['ADDRESS']);
+            if (strlen($employee_name) || strlen($employee_address)) {
+              AddEmployee($connection, $employee_name, $employee_address);
+            }
+          ?>
+          <!-- Input form -->
+          <form action="<?PHP echo $_SERVER['SCRIPT_NAME'] ?>" method="POST">
+            <table border="0">
+              <tr>
+                <td>NAME</td>
+                <td>ADDRESS</td>
+              </tr>
+              <tr>
+                <td>
+                  <input type="text" name="NAME" maxlength="45" size="30" />
+                </td>
+                <td>
+                  <input type="text" name="ADDRESS" maxlength="90" size="60" />
+                </td>
+                <td>
+                  <input type="submit" value="Add Data" />
+                </td>
+              </tr>
+            </table>
+          </form>
+          <!-- Display table data. -->
+          <table border="1" cellpadding="2" cellspacing="2">
+            <tr>
+              <td>ID</td>
+              <td>NAME</td>
+              <td>ADDRESS</td>
+            </tr>
+          <?php
+          $result = mysqli_query($connection, "SELECT * FROM EMPLOYEES");
+          while($query_data = mysqli_fetch_row($result)) {
+            echo "<tr>";
+            echo "<td>",$query_data[0], "</td>",
+                 "<td>",$query_data[1], "</td>",
+                 "<td>",$query_data[2], "</td>";
+            echo "</tr>";
+          }
+          ?>
+          </table>
+          <!-- Clean up. -->
+          <?php
+            mysqli_free_result($result);
+            mysqli_close($connection);
+          ?>
+          </body>
+          </html>
+          <?php
+          /* Add an employee to the table. */
+          function AddEmployee($connection, $name, $address) {
+             $n = mysqli_real_escape_string($connection, $name);
+             $a = mysqli_real_escape_string($connection, $address);
+             $query = "INSERT INTO EMPLOYEES (NAME, ADDRESS) VALUES ('$n', '$a');";
+             if(!mysqli_query($connection, $query)) echo("<p>Error adding employee data.</p>");
+          }
+          /* Check whether the table exists and, if not, create it. */
+          function VerifyEmployeesTable($connection, $dbName) {
+            if(!TableExists("EMPLOYEES", $connection, $dbName))
+            {
+               $query = "CREATE TABLE EMPLOYEES (
+                   ID int(11) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                   NAME VARCHAR(45),
+                   ADDRESS VARCHAR(90)
+                 )";
+               if(!mysqli_query($connection, $query)) echo("<p>Error creating table.</p>");
+            }
+          }
+          /* Check for the existence of a table. */
+          function TableExists($tableName, $connection, $dbName) {
+            $t = mysqli_real_escape_string($connection, $tableName);
+            $d = mysqli_real_escape_string($connection, $dbName);
+            $checktable = mysqli_query($connection,
+                "SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_NAME = '$t' AND TABLE_SCHEMA = '$d'");
+            if(mysqli_num_rows($checktable) > 0) return true;
+            return false;
+          }
+          ?>
+          EnD
+          sudo mv /tmp/index.php /var/www/html
+          sudo chown root:root /var/www/html/index.php
+
+Outputs:
+  EC2PublicDNS:
+    # test comment
+    # test comment2
+    Description: Web Host Public DNS Name
+    Value: !GetAtt [EC2Instance, PublicDnsName]
+  VpcId:
+    Description: The ID of the VPC
+    # test comment
+    Value: !Ref WebVPC
+  PublicSubnet:
+    Description: The ID of the Public Subnet
+    Value: !Ref WebSubnet
+    # test comment
+  PublicSubnet2:
+    Description: The ID of the Public Subnet
+    Value: !Ref WebSubnet2
+
+  UserName:
+    Description: The Name of the IAM User
+    Value: !Ref User

--- a/tests/cloudformation/utils/test_cfn_utils.py
+++ b/tests/cloudformation/utils/test_cfn_utils.py
@@ -23,46 +23,75 @@ class TestCfnUtils(unittest.TestCase):
         self.assertEqual(len(definition['code_lines']), code_lines)
 
     def test_parameters_value(self):
-        # Asserting yaml file
+        # Asserting test.yaml file
         yaml_parameters = self.definitions_context[self.test_root_dir + '/test.yaml'][
                 CloudformationTemplateSections.PARAMETERS.value]
         self.assertIsNotNone(yaml_parameters)
         self.assertEqual(len(yaml_parameters), 2)
         self.validate_definition_lines(yaml_parameters['KmsMasterKeyId'], 4, 7, 4)
         self.validate_definition_lines(yaml_parameters['DBName'], 8, 11, 4)
+        # Asserting test2.yaml file
+        yaml2_parameters = self.definitions_context[self.test_root_dir + '/test2.yaml'][
+            CloudformationTemplateSections.PARAMETERS.value]
+        self.assertIsNotNone(yaml2_parameters)
+        self.assertEqual(len(yaml2_parameters), 1)
+        self.validate_definition_lines(yaml2_parameters['LatestAmiId'], 4, 6, 3)
         # Asserting json file
         json_parameters = self.definitions_context[self.test_root_dir + '/test.json'][
                 CloudformationTemplateSections.PARAMETERS.value]
         self.assertIsNotNone(json_parameters)
         self.assertEqual(len(json_parameters), 2)
-        self.validate_definition_lines(json_parameters['KmsMasterKeyId'], 4, 8, 5)
-        self.validate_definition_lines(json_parameters['DBName'], 9, 13, 5)
+        self.validate_definition_lines(json_parameters['KmsMasterKeyId'], 5, 9, 5)
+        self.validate_definition_lines(json_parameters['DBName'], 10, 14, 5)
 
     def test_resources_value(self):
+        # Asserting test.yaml file
         yaml_resources = self.definitions_context[self.test_root_dir + '/test.yaml'][
                 CloudformationTemplateSections.RESOURCES.value]
         self.assertIsNotNone(yaml_resources)
         self.assertEqual(len(yaml_resources), 2)
         self.validate_definition_lines(yaml_resources['MySourceQueue'], 13, 16, 4)
         self.validate_definition_lines(yaml_resources['MyDB'], 17, 26, 10)
+        # Asserting test2.yaml file
+        yaml2_resources = self.definitions_context[self.test_root_dir + '/test2.yaml'][
+            CloudformationTemplateSections.RESOURCES.value]
+        self.assertIsNotNone(yaml2_resources)
+        self.assertEqual(len(yaml2_resources), 4)
+        self.validate_definition_lines(yaml2_resources['WebHostStorage'], 12, 23, 12)
+        self.validate_definition_lines(yaml2_resources['LogsKey'], 29, 44, 16)
+        self.validate_definition_lines(yaml2_resources['LogsKeyAlias'], 46, 50, 5)
+        self.validate_definition_lines(yaml2_resources['DBAppInstance'], 52, 184, 133)
+        # Asserting json file
         json_resources = self.definitions_context[self.test_root_dir + '/test.json'][
                 CloudformationTemplateSections.RESOURCES.value]
         self.assertIsNotNone(json_resources)
         self.assertEqual(len(json_resources), 2)
-        self.validate_definition_lines(json_resources['MySourceQueue'], 16, 21, 6)
-        self.validate_definition_lines(json_resources['MyDB'], 22, 31, 10)
+        self.validate_definition_lines(json_resources['MySourceQueue'], 17, 22, 6)
+        self.validate_definition_lines(json_resources['MyDB'], 23, 32, 10)
 
     def test_outputs_value(self):
+        # Asserting test.yaml file
         yaml_outputs = self.definitions_context[self.test_root_dir + '/test.yaml'][
                 CloudformationTemplateSections.OUTPUTS.value]
         self.assertIsNotNone(yaml_outputs)
         self.assertEqual(len(yaml_outputs), 1)
         self.validate_definition_lines(yaml_outputs['DBAppPublicDNS'], 28, 30, 3)
+        # Asserting test2.yaml file
+        yaml2_outputs = self.definitions_context[self.test_root_dir + '/test2.yaml'][
+            CloudformationTemplateSections.OUTPUTS.value]
+        self.assertIsNotNone(yaml2_outputs)
+        self.assertEqual(len(yaml2_outputs), 5)
+        self.validate_definition_lines(yaml2_outputs['EC2PublicDNS'], 187, 191, 5)
+        self.validate_definition_lines(yaml2_outputs['VpcId'], 192, 195, 4)
+        self.validate_definition_lines(yaml2_outputs['PublicSubnet'], 196, 198, 3)
+        self.validate_definition_lines(yaml2_outputs['PublicSubnet2'], 200, 202, 3)
+        self.validate_definition_lines(yaml2_outputs['UserName'], 204, 206, 3)
+        # Asserting json file
         json_outputs = self.definitions_context[self.test_root_dir + '/test.json'][
                 CloudformationTemplateSections.OUTPUTS.value]
         self.assertIsNotNone(json_outputs)
         self.assertEqual(len(json_outputs), 1)
-        self.validate_definition_lines(json_outputs['DBAppPublicDNS'], 34, 37, 4)
+        self.validate_definition_lines(json_outputs['DBAppPublicDNS'], 35, 38, 4)
 
     def test_skipped_check_exists(self):
         skipped_checks = self.definitions_context[self.test_root_dir + '/test.yaml'][


### PR DESCRIPTION
There was a problem in the calculation of the start and end line of CFN definitions.
in yaml file - the end line was the last line before the next definition (including an empty line or comments).
for resources in yaml file - the start line was the line above the "Type" line, even if it was a comment or empty line.
in json file - the start and end lines were the line above the correct line.

I fixed the line numbers in the build_definitions_context function in cfn_utils file and added or fixed tests to check the correct values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.