### PR TITLE
Improve terraform graph building runtime

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -286,8 +286,10 @@ class TerraformLocalGraph(LocalGraph):
             dest_module_path = Path(curr_module_dir) / dest_module_source
         else:
             try:
+                if not self.relative_paths_cache.get(dest_module_source):
+                    self.relative_paths_cache[dest_module_source] = list(Path(self.module.source_dir).rglob(dest_module_source))
                 dest_module_path = next(
-                    (path for path in Path(self.module.source_dir).rglob(dest_module_source)), dest_module_path
+                    (path for path in self.relative_paths_cache.get(dest_module_source)), dest_module_path
                 )
             except NotImplementedError as e:
                 if 'Non-relative patterns are unsupported' in str(e):

--- a/checkov/terraform/graph_builder/utils.py
+++ b/checkov/terraform/graph_builder/utils.py
@@ -1,7 +1,6 @@
-from typing import Tuple, List
+from typing import Tuple
 import os
 import re
-from copy import deepcopy
 from typing import Union, List, Any, Dict, Optional, Callable, overload
 
 from checkov.terraform.graph_builder.graph_components.attribute_names import CustomAttributes
@@ -296,9 +295,7 @@ def attribute_has_nested_attributes(attribute_key: str, attributes: Dict[str, An
     Example 1: if attributes.keys == [key1, key.key2], type(attributes[key1]) is dict and return True for key1
     Example 2: if attributes.keys == [key1, key1.0], type(attributes[key1]) is list and return True for key1
     """
-    copy_of_attributes = deepcopy(attributes)
-    copy_of_attributes.pop(attribute_key)
-    prefixes_with_attribute_key = [a for a in copy_of_attributes.keys() if a.startswith(attribute_key)]
+    prefixes_with_attribute_key = [a for a in attributes.keys() if a.startswith(attribute_key) and a != attribute_key]
     if not any(re.findall(r"\.\d+", a) for a in prefixes_with_attribute_key):
         # if there aro no numeric parts in the key such as key1.0.key2
         return isinstance(attributes[attribute_key], dict)


### PR DESCRIPTION
Two improvements that impact building edges for large graphs:
1. Removed deepcopy from attribute_has_nested_attributes
2. Use cache for modules paths

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
