### PR TITLE
Route53 check was missing aws_instance

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/Route53ARecordAttachedResource.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/Route53ARecordAttachedResource.yaml
@@ -32,6 +32,7 @@ definition:
            resource_types:
               - aws_route53_record
            connected_resource_types:
+              - aws_instance
               - aws_eip
               - aws_elb
               - aws_lb

--- a/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/expected.yaml
+++ b/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/expected.yaml
@@ -3,6 +3,7 @@ pass:
   - "aws_route53_record.pass2"
   - 'aws_route53_record.pass3'
   - 'aws_route53_record.pass4'
+  - "aws_route53_record.legacy-tf"
 fail:
   - "aws_route53_record.fail"
 ignore:

--- a/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
+++ b/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
@@ -67,3 +67,15 @@ resource "aws_route53_record" "pass4" {
     evaluate_target_health = true
   }
 }
+
+resource "aws_route53_record" "legacy-tf" {
+  count = var.instance_count
+  zone_id = data.aws_route53_zone.dns_zone.zone_id
+  name = "brochureworker-${count.index + 1}.${data.aws_route53_zone.dns_zone.name}"
+  type = "A"
+  records = ["${aws_instance.brochureworker.*.private_ip[count.index]}"]
+  ttl = "300"
+}
+
+resource "aws_instance" "brochureworker" {
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Some brave folks still putting instances directly public.