### PR TITLE
Cloudformation graph bugfixes

### DIFF
--- a/checkov/cloudformation/graph_builder/graph_to_definitions.py
+++ b/checkov/cloudformation/graph_builder/graph_to_definitions.py
@@ -14,7 +14,7 @@ def convert_graph_vertices_to_definitions(
     for vertex in vertices:
         block_path = vertex.path
         block_type = CloudformationTemplateSections.RESOURCES.value if vertex.block_type == 'resource' else vertex.block_type
-        block_name = vertex.name.split('.')[1]  # vertex.name is "type.name" so type.name -> [type, name]
+        block_name = vertex.name.split('.')[-1]  # vertex.name is "type.name" so type.name -> [type, name]
 
         definition = {
             'Type': vertex.attributes['resource_type'],

--- a/checkov/cloudformation/graph_builder/local_graph.py
+++ b/checkov/cloudformation/graph_builder/local_graph.py
@@ -38,7 +38,7 @@ class CloudformationLocalGraph(LocalGraph):
             attributes.end_mark = attributes.end_mark
             block = CloudformationBlock(
                 name=f"{resource_type}.{resource_name}",
-                config=resource.get("Properties"),
+                config=resource.get("Properties", {}),
                 path=file_path,
                 block_type=BlockType.RESOURCE,
                 attributes=attributes,


### PR DESCRIPTION
* Use empty dictionary when "Properties" doesn't exist in resource
* Get the correct resource name when the vertex block name contains more than one dot

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
