### PR TITLE
Remove ContextParser instance from CFN runner

### DIFF
--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -70,7 +70,7 @@ class Runner(BaseRunner):
             file_abs_path = create_file_abs_path(root_folder, cf_file)
 
             if isinstance(definition, dict) and CloudformationTemplateSections.RESOURCES in definition.keys():
-                cf_context_parser = ContextParser(cf_file, definition, self.definitions_raw[cf_file])
+                cf_context_parser = ContextParser(cf_file, definition)
                 for resource_name, resource in definition[CloudformationTemplateSections.RESOURCES].items():
                     resource_id = cf_context_parser.extract_cf_resource_id(resource, resource_name)
                     # check that the resource can be parsed as a CF resource

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -1,6 +1,5 @@
 import logging
-import os
-from typing import Optional, List, Dict, Tuple
+from typing import Optional, List
 
 from checkov.cloudformation import cfn_utils
 from checkov.cloudformation.cfn_utils import create_file_abs_path, create_definitions, build_definitions_context
@@ -65,6 +64,15 @@ class Runner(BaseRunner):
             self.definitions, self.breadcrumbs = convert_graph_vertices_to_definitions(local_graph.vertices, root_folder)
 
         # run checks
+        self.check_definitions(root_folder, runner_filter, report)
+
+        # run graph checks
+        graph_report = self.get_graph_checks_report(root_folder, runner_filter)
+        merge_reports(report, graph_report)
+
+        return report
+
+    def check_definitions(self, root_folder, runner_filter, report):
         for cf_file, definition in self.definitions.items():
 
             file_abs_path = create_file_abs_path(root_folder, cf_file)
@@ -101,12 +109,6 @@ class Runner(BaseRunner):
                                     entity_tags=tags,
                                 )
                                 report.add_record(record=record)
-
-        # run graph checks
-        graph_report = self.get_graph_checks_report(root_folder, runner_filter)
-        merge_reports(report, graph_report)
-
-        return report
 
     def get_graph_checks_report(self, root_folder: str, runner_filter: RunnerFilter) -> Report:
         report = Report(self.check_type)

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -70,9 +70,8 @@ class Runner(BaseRunner):
             file_abs_path = create_file_abs_path(root_folder, cf_file)
 
             if isinstance(definition, dict) and CloudformationTemplateSections.RESOURCES in definition.keys():
-                cf_context_parser = ContextParser(cf_file, definition)
                 for resource_name, resource in definition[CloudformationTemplateSections.RESOURCES].items():
-                    resource_id = cf_context_parser.extract_cf_resource_id(resource, resource_name)
+                    resource_id = ContextParser.extract_cf_resource_id(resource, resource_name)
                     # check that the resource can be parsed as a CF resource
                     if resource_id:
                         resource_context = self.context[file_abs_path][


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

There are 2 reasons for this change:

1. The CFN runner used the ContextParser instance because it needed the non static method `extract_cf_resource_code_lines` of this class but it doesn't use it anymore (after a recent refactor), it uses only static methods
2. When invoking the `run` method of the CFN runner with external `context`, `breadcrumbs` and `definitions`, the `definitions_raw` is not calculated, and then checkov crashes for `self.definitions_raw[cf_file]` of `                cf_context_parser = ContextParser(cf_file, definition, self.definitions_raw[cf_file])
`