### PR TITLE
Fix response of get_checkov_mapping_metadata()

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -295,6 +295,7 @@ class BcPlatformIntegration(object):
         if BC_SKIP_MAPPING.upper() == "TRUE":
             logging.debug(f"Skipped mapping API call")
             self.ckv_to_bc_id_mapping = {}
+            return
         try:
             request = self.http.request("GET", self.guidelines_api_url)
             response = json.loads(request.data.decode("utf8"))
@@ -305,6 +306,7 @@ class BcPlatformIntegration(object):
         except Exception as e:
             logging.debug(f"Failed to get the guidelines from {self.guidelines_api_url}, error:\n{e}")
             self.ckv_to_bc_id_mapping = {}
+            return
 
     def onboarding(self):
         if not self.bc_api_key:

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -294,7 +294,7 @@ class BcPlatformIntegration(object):
         BC_SKIP_MAPPING = os.getenv("BC_SKIP_MAPPING","FALSE")
         if BC_SKIP_MAPPING.upper() == "TRUE":
             logging.debug(f"Skipped mapping API call")
-            return {}
+            self.ckv_to_bc_id_mapping = {}
         try:
             request = self.http.request("GET", self.guidelines_api_url)
             response = json.loads(request.data.decode("utf8"))
@@ -304,7 +304,7 @@ class BcPlatformIntegration(object):
             logging.debug(f"Got checkov mappings from Bridgecrew BE")
         except Exception as e:
             logging.debug(f"Failed to get the guidelines from {self.guidelines_api_url}, error:\n{e}")
-            return {}
+            self.ckv_to_bc_id_mapping = {}
 
     def onboarding(self):
         if not self.bc_api_key:

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -18,7 +18,7 @@ class TestBCApiUrl(unittest.TestCase):
         instance = BcPlatformIntegration()
         instance.setup_http_manager()
         instance.get_id_mapping()
-        self.assertIsNone(instance.ckv_to_bc_id_mapping)
+        self.assertDictEqual({}, instance.ckv_to_bc_id_mapping)
 
     @mock.patch.dict(os.environ, {'BC_SKIP_MAPPING': 'FALSE'})
     def test_skip_mapping_false(self):


### PR DESCRIPTION
When `get_checkov_mapping_metadata`  works properly it sets the value of `self.ckv_to_bc_id_mapping` to be the mapping.
When the method cannot be executed it needs to set self.ckv_to_bc_id_mapping = {} rather than return `{}` because that return value is not used.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
