### PR TITLE
Remove duplicate records for the same resource

### DIFF
--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -131,3 +131,6 @@ class Record:
 
     def get_output_id(self, use_bc_ids: bool) -> str:
         return self.bc_check_id if self.bc_check_id and use_bc_ids else self.check_id
+
+    def get_unique_string(self):
+        return f"{self.check_id}.{self.check_result}.{self.file_abs_path}.{self.file_line_range}.{self.resource}"

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from collections import defaultdict
 from typing import List, Dict, Union, Any, Optional
 

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from collections import defaultdict
 from typing import List, Dict, Union, Any, Optional
 
@@ -228,3 +229,19 @@ def merge_reports(base_report, report_to_merge):
     base_report.failed_checks.extend(report_to_merge.failed_checks)
     base_report.skipped_checks.extend(report_to_merge.skipped_checks)
     base_report.parsing_errors.extend(report_to_merge.parsing_errors)
+
+
+def remove_duplicate_results(report):
+    def dedupe_records(origin_records):
+        record_cache = []
+        new_records = []
+        for record in origin_records:
+            record_hash = record.get_unique_string()
+            if record_hash not in record_cache:
+                new_records.append(record)
+                record_cache.append(record_hash)
+        return new_records
+
+    report.passed_checks = dedupe_records(report.passed_checks)
+    report.failed_checks = dedupe_records(report.failed_checks)
+    return report

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -11,7 +11,7 @@ from checkov.common.graph.db_connectors.networkx.networkx_db_connector import Ne
 from checkov.common.models.enums import CheckResult
 from checkov.common.output.graph_record import GraphRecord
 from checkov.common.output.record import Record
-from checkov.common.output.report import Report, merge_reports
+from checkov.common.output.report import Report, merge_reports, remove_duplicate_results
 from checkov.common.runners.base_runner import BaseRunner
 from checkov.common.util import data_structures_utils
 from checkov.common.variables.context import EvaluationContext
@@ -102,6 +102,7 @@ class Runner(BaseRunner):
 
         graph_report = self.get_graph_checks_report(root_folder, runner_filter)
         merge_reports(report, graph_report)
+        report = remove_duplicate_results(report)
 
         return report
 

--- a/tests/terraform/runner/resources/duplicate_violations/modules/main.tf
+++ b/tests/terraform/runner/resources/duplicate_violations/modules/main.tf
@@ -1,0 +1,17 @@
+
+data "aws_iam_policy_document" "restrictions" {
+
+  # do not allow the account to leave the org except for the exempt
+  statement {
+    effect  = "Deny"
+    resources = [
+      "*",
+    ]
+  }
+
+}
+
+resource "aws_organizations_policy" "restrictions" {
+  name    = "${var.account_name}-restrictions"
+  content = data.aws_iam_policy_document.restrictions.json
+}

--- a/tests/terraform/runner/resources/duplicate_violations/src/main1.tf
+++ b/tests/terraform/runner/resources/duplicate_violations/src/main1.tf
@@ -1,0 +1,4 @@
+module "module1" {
+  source = "../modules/"
+
+}

--- a/tests/terraform/runner/resources/duplicate_violations/src/main2.tf
+++ b/tests/terraform/runner/resources/duplicate_violations/src/main2.tf
@@ -1,0 +1,4 @@
+module "module2" {
+  source = "../modules/"
+
+}

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -817,6 +817,20 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(len(report.passed_checks), 3)
         self.assertEqual(len(report.failed_checks), 3)
 
+    def test_no_duplicate_results(self):
+        resources_path = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "resources", "duplicate_violations")
+        runner = Runner()
+        report = runner.run(root_folder=resources_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework='terraform'))
+
+        unique_checks = []
+        for record in report.passed_checks:
+            check_unique = f"{record.check_id}.{record.resource}"
+            if check_unique in unique_checks:
+                self.fail(f"found duplicate results in report: {record.to_string()}")
+            unique_checks.append(check_unique)
+
     def tearDown(self):
         parser_registry.context = {}
 


### PR DESCRIPTION
When having multiple modules calling the same module we create a vertex for each module. 
This can lead to having duplicate records for the same resource in the scan report.

Added a dedup function that verifies we don't have more than one record with the same:
* check id
* resource
* file path
* lines

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
