### PR TITLE
GitLab ci example allow_failure can not be a var

### DIFF
--- a/docs/4.Integrations/GitLab CLI.md
+++ b/docs/4.Integrations/GitLab CLI.md
@@ -95,6 +95,11 @@ checkov:
     # Use `script` to emulate `tty` for colored output.
     - script -q -c 'checkov -d . ; echo $? > CKVEXIT'
     - exit $(cat CKVEXIT)
+  artifacts:
+    reports:
+      junit: "checkov.test.xml"
+    paths:
+      - "checkov.test.xml"
 ```
 
 See the [GitLab CI documentation](https://docs.gitlab.com/ee/ci/) for additional information.

--- a/docs/4.Integrations/GitLab CLI.md
+++ b/docs/4.Integrations/GitLab CLI.md
@@ -17,12 +17,10 @@ Here is a basic example:
 ```yaml
 stages:
     - test
-variables: 
-  ALLOWFAILURE: true #True for AutoDevOps compatibility
-
+    
 checkov:
   stage: test
-  allow_failure: $ALLOWFAILURE
+  allow_failure: true #True for AutoDevOps compatibility
   image:
     name: bridgecrew/checkov:latest
     entrypoint:
@@ -72,12 +70,10 @@ Note that in the examples above, the output of the test results does not display
 ```yaml
 stages:
     - test
-variables: 
-  ALLOWFAILURE: true #True for AutoDevOps compatibility
 
 checkov:
   stage: test
-  allow_failure: $ALLOWFAILURE
+  allow_failure: true #True for AutoDevOps compatibility
   image:
     name: bridgecrew/checkov:latest
     entrypoint:
@@ -99,11 +95,6 @@ checkov:
     # Use `script` to emulate `tty` for colored output.
     - script -q -c 'checkov -d . ; echo $? > CKVEXIT'
     - exit $(cat CKVEXIT)
-  artifacts:
-    reports:
-      junit: "checkov.test.xml"
-    paths:
-      - "checkov.test.xml"
 ```
 
 See the [GitLab CI documentation](https://docs.gitlab.com/ee/ci/) for additional information.


### PR DESCRIPTION
In the hosted gitlab.com having a variable for allow_failure fails the CI Lint. Also remove the junit file when the output mode is text.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


![image](https://user-images.githubusercontent.com/8085744/127401277-369de1ea-b8ab-4c78-ab40-67b33b03b813.png)
