### PR TITLE
Kerberos check was giving all EMR cluster a passed check

### DIFF
--- a/checkov/terraform/checks/resource/aws/EMRClusterKerberosAttributes.py
+++ b/checkov/terraform/checks/resource/aws/EMRClusterKerberosAttributes.py
@@ -4,7 +4,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 
 class EMRClusterKerberosAttributes(BaseResourceCheck):
     def __init__(self):
-        name = "Ensure that EMR clusters have Kerberos Enabled"
+        name = "Ensure that EMR clusters with Kerberos have Kerberos Realm set"
         id = "CKV_AWS_114"
         supported_resources = ['aws_emr_cluster']
         categories = [CheckCategories.GENERAL_SECURITY]
@@ -17,7 +17,7 @@ class EMRClusterKerberosAttributes(BaseResourceCheck):
                 return CheckResult.PASSED
             else:
                 return CheckResult.FAILED
-        return CheckResult.PASSED
+        return CheckResult.SKIPPED
 
 
 check = EMRClusterKerberosAttributes()

--- a/tests/terraform/checks/resource/aws/test_EMRClusterKerberosAttributes.py
+++ b/tests/terraform/checks/resource/aws/test_EMRClusterKerberosAttributes.py
@@ -7,7 +7,7 @@ import hcl2
 
 class TestEMRClusterKerberosAttributes(unittest.TestCase):
 
-    def test_success_no_kerberos(self):
+    def test_skipped_no_kerberos(self):
         hcl_res = hcl2.loads("""
 resource "aws_emr_cluster" "test" {
   name          = "emr-test-arn"
@@ -27,7 +27,7 @@ resource "aws_emr_cluster" "test" {
         """)
         resource_conf = hcl_res['resource'][0]['aws_emr_cluster']['test']
         scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(CheckResult.SKIPPED, scan_result)
 
     def test_success(self):
         hcl_res = hcl2.loads("""


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I've modified the check to give a skip for all EMR clusters rather than a pass. And changed the name of the check to reflect what it is actual is about. Should it check that all required parameters are checked not just realm? 

Will need to change docs if you pass this change.