### PR TITLE
CF - Check - TransferServerIsPublic

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/TransferServerIsPublic.py
+++ b/checkov/cloudformation/checks/resource/aws/TransferServerIsPublic.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class TransferServerIsPublic(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Transfer Server is not exposed publicly."
+        id = "CKV_AWS_164"
+        supported_resources = ['AWS::Transfer::Server']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'Properties/EndpointType'
+
+    def get_expected_values(self):
+        return ["VPC", "VPC_ENDPOINT"]
+
+
+check = TransferServerIsPublic()

--- a/tests/cloudformation/checks/resource/aws/example_TransferServerIsPublic/FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_TransferServerIsPublic/FAIL.yaml
@@ -4,7 +4,5 @@ Resources:
     Type: AWS::Transfer::Server
     Properties: 
       EndpointType: "PUBLIC"
-  VPCENDPOINT:
+  NONE:
     Type: AWS::Transfer::Server
-    Properties: 
-      EndpointType: "VPC_ENDPOINT"

--- a/tests/cloudformation/checks/resource/aws/example_TransferServerIsPublic/FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_TransferServerIsPublic/FAIL.yaml
@@ -4,7 +4,7 @@ Resources:
     Type: AWS::Transfer::Server
     Properties: 
       EndpointType: "PUBLIC"
-  VPC_ENDPOINT:
+  VPCENDPOINT:
     Type: AWS::Transfer::Server
     Properties: 
       EndpointType: "VPC_ENDPOINT"

--- a/tests/cloudformation/checks/resource/aws/example_TransferServerIsPublic/FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_TransferServerIsPublic/FAIL.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources: 
+  PUBLIC:
+    Type: AWS::Transfer::Server
+    Properties: 
+      EndpointType: "PUBLIC"
+  VPC_ENDPOINT:
+    Type: AWS::Transfer::Server
+    Properties: 
+      EndpointType: "VPC_ENDPOINT"

--- a/tests/cloudformation/checks/resource/aws/example_TransferServerIsPublic/PASS.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_TransferServerIsPublic/PASS.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources: 
+  VPC:
+    Type: AWS::Transfer::Server
+    Properties: 
+      EndpointType: "VPC"
+  NONE:
+    Type: AWS::Transfer::Server

--- a/tests/cloudformation/checks/resource/aws/example_TransferServerIsPublic/PASS.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_TransferServerIsPublic/PASS.yaml
@@ -4,5 +4,7 @@ Resources:
     Type: AWS::Transfer::Server
     Properties: 
       EndpointType: "VPC"
-  NONE:
+  VPCENDPOINT:
     Type: AWS::Transfer::Server
+    Properties: 
+      EndpointType: "VPC_ENDPOINT"

--- a/tests/cloudformation/checks/resource/aws/test_TransferServerIsPublic.py
+++ b/tests/cloudformation/checks/resource/aws/test_TransferServerIsPublic.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.TransferServerIsPublic import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestTransferServerIsPublic(unittest.TestCase):
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_TransferServerIsPublic"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::Transfer::Server.VPC",
+            "AWS::Transfer::Server.VPC_ENDPOINT",
+        }
+        failing_resources = {
+            "AWS::Transfer::Server.PUBLIC",
+            "AWS::Transfer::Server.NONE",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cloudformation/checks/resource/aws/test_TransferServerIsPublic.py
+++ b/tests/cloudformation/checks/resource/aws/test_TransferServerIsPublic.py
@@ -27,8 +27,8 @@ class TestTransferServerIsPublic(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/cloudformation/checks/resource/aws/test_TransferServerIsPublic.py
+++ b/tests/cloudformation/checks/resource/aws/test_TransferServerIsPublic.py
@@ -17,7 +17,7 @@ class TestTransferServerIsPublic(unittest.TestCase):
 
         passing_resources = {
             "AWS::Transfer::Server.VPC",
-            "AWS::Transfer::Server.VPC_ENDPOINT",
+            "AWS::Transfer::Server.VPCENDPOINT",
         }
         failing_resources = {
             "AWS::Transfer::Server.PUBLIC",


### PR DESCRIPTION
Hello,

CF check for this as already done for TF.

TF Check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/TransferServerIsPublic.py
CF Doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-transfer-server.html

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
