### PR TITLE
add check CKV_AWS_170 for QLDB permissions mode

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/QLDBLedgerPermissionsMode.py
+++ b/checkov/cloudformation/checks/resource/aws/QLDBLedgerPermissionsMode.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class QLDBLedgerPermissionsMode(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure QLDB ledger permissions mode is set to STANDARD"
+        id = "CKV_AWS_170"
+        supported_resources = ["AWS::QLDB::Ledger"]
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "Properties/PermissionsMode"
+
+    def get_expected_value(self) -> str:
+        return "STANDARD"
+
+
+check = QLDBLedgerPermissionsMode()

--- a/checkov/terraform/checks/resource/aws/QLDBLedgerPermissionsMode.py
+++ b/checkov/terraform/checks/resource/aws/QLDBLedgerPermissionsMode.py
@@ -1,0 +1,20 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class QLDBLedgerPermissionsMode(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure QLDB ledger permissions mode is set to STANDARD"
+        id = "CKV_AWS_170"
+        supported_resources = ["aws_qldb_ledger"]
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "permissions_mode"
+
+    def get_expected_value(self) -> str:
+        return "STANDARD"
+
+
+check = QLDBLedgerPermissionsMode()

--- a/tests/cloudformation/checks/resource/aws/example_QLDBLedgerPermissionsMode/FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_QLDBLedgerPermissionsMode/FAIL.yaml
@@ -1,0 +1,7 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AllowAll:
+    Type: "AWS::QLDB::Ledger"
+    Properties:
+      Name: "ledger"
+      PermissionsMode: "ALLOW_ALL"

--- a/tests/cloudformation/checks/resource/aws/example_QLDBLedgerPermissionsMode/PASS.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_QLDBLedgerPermissionsMode/PASS.yaml
@@ -1,0 +1,7 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Standard:
+    Type: "AWS::QLDB::Ledger"
+    Properties:
+      Name: "ledger"
+      PermissionsMode: "STANDARD"

--- a/tests/cloudformation/checks/resource/aws/test_QLDBLedgerPermissionsMode.py
+++ b/tests/cloudformation/checks/resource/aws/test_QLDBLedgerPermissionsMode.py
@@ -1,0 +1,36 @@
+import unittest
+from pathlib import Path
+
+from checkov.cloudformation.checks.resource.aws.QLDBLedgerPermissionsMode import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestQLDBLedgerPermissionsMode(unittest.TestCase):
+    def test_summary(self):
+        test_files_dir = Path(__file__).parent / "example_QLDBLedgerPermissionsMode"
+
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::QLDB::Ledger.Standard",
+        }
+        failing_resources = {
+            "AWS::QLDB::Ledger.AllowAll",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/example_QLDBLedgerPermissionsMode/main.tf
+++ b/tests/terraform/checks/resource/aws/example_QLDBLedgerPermissionsMode/main.tf
@@ -1,0 +1,13 @@
+# pass
+
+resource "aws_qldb_ledger" "standard" {
+  name             = "ledger"
+  permissions_mode = "STANDARD"
+}
+
+# failure
+
+resource "aws_qldb_ledger" "allow_all" {
+  name             = "ledger"
+  permissions_mode = "ALLOW_ALL"
+}

--- a/tests/terraform/checks/resource/aws/test_QLDBLedgerPermissionsMode.py
+++ b/tests/terraform/checks/resource/aws/test_QLDBLedgerPermissionsMode.py
@@ -1,0 +1,36 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.QLDBLedgerPermissionsMode import check
+from checkov.terraform.runner import Runner
+
+
+class TestQLDBLedgerPermissionsMode(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_QLDBLedgerPermissionsMode"
+
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_qldb_ledger.standard",
+        }
+        failing_resources = {
+            "aws_qldb_ledger.allow_all",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

A bit background can be found here https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started-standard-mode.html.

The possibility to change the permissions mode via Terraform was released today, which I included a few days ago, my first Terraform Provider PR 😄 
