### PR TITLE
Check that EMR security config uses KMS for S3EncryptionConfiguration #1424

### DIFF
--- a/checkov/terraform/checks/resource/aws/EMRClusterIsEncryptedKMS.py
+++ b/checkov/terraform/checks/resource/aws/EMRClusterIsEncryptedKMS.py
@@ -1,0 +1,23 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class EMRClusterIsEncryptedKMS(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure Cluster security configuration encryption is using SSE-KMS"
+        id = "CKV_AWS_170"
+        supported_resources = ['aws_emr_security_configuration']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'configuration' in conf:
+            configuration = conf['configuration'][0]
+            if "SSE-KMS" in configuration:
+                return CheckResult.PASSED
+            else:
+                return CheckResult.FAILED
+        return CheckResult.SKIPPED
+
+
+check = EMRClusterIsEncryptedKMS()

--- a/tests/terraform/checks/resource/aws/example_EMRClusterIsEncryptedKMS/main.tf
+++ b/tests/terraform/checks/resource/aws/example_EMRClusterIsEncryptedKMS/main.tf
@@ -1,0 +1,44 @@
+resource "aws_emr_security_configuration" "fail" {
+  name = "fail"
+
+  configuration = <<EOF
+{
+  "EncryptionConfiguration": {
+    "EnableAtRestEncryption": true,
+    "AtRestEncryptionConfiguration": {
+      "S3EncryptionConfiguration": {
+        "EncryptionMode": "SSE-S3"
+      },
+      "LocalDiskEncryptionConfiguration": {
+        "EncryptionKeyProviderType": "AwsS3"
+      }
+    }
+  }
+}
+EOF
+}
+
+
+resource "aws_emr_security_configuration" "pass" {
+  name = "pass"
+
+  configuration = <<EOF
+{
+  "EncryptionConfiguration": {
+    "EnableAtRestEncryption": true,
+    "AtRestEncryptionConfiguration": {
+      "S3EncryptionConfiguration": {
+        "EncryptionMode": "SSE-KMS",
+        "AwsKmsKey": "${module.encryption_module.kms_key_alias}"
+      },
+      "LocalDiskEncryptionConfiguration": {
+        "EncryptionKeyProviderType": "AwsKms",
+        "AwsKmsKey": "${module.encryption_module.kms_key_alias}"
+      }
+    },
+    "EnableInTransitEncryption": true
+  }
+}
+EOF
+}
+

--- a/tests/terraform/checks/resource/aws/test_EMRClusterIsEncryptedKMS.py
+++ b/tests/terraform/checks/resource/aws/test_EMRClusterIsEncryptedKMS.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.EMRClusterIsEncryptedKMS import check
+from checkov.terraform.runner import Runner
+
+
+class TestEMRClusterIsEncryptedKMS(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_EMRClusterIsEncryptedKMS"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_emr_security_configuration.pass",
+        }
+        failing_resources = {
+            "aws_emr_security_configuration.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This check emr data for S3 is encrypted with a KMS key of type SSE-KMS.

Partially addresses #1424
