### PR TITLE
Add support for ssh git clone. Use valid windows filenames

### DIFF
--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -14,8 +14,9 @@ class GenericGitLoader(ModuleLoader):
     def _load_module(self) -> ModuleContent:
         try:
             module_source = self.module_source.replace('git::', '')
-            if module_source.startswith('ssh:'):
-                return ModuleContent(dir=None, failed_url=self.module_source)
+            if os.name == 'nt':
+                self.logger.info(f'Operating System: {os.uname()}')
+                self._create_valid_windows_dest_dir()
             git_getter = GitGetter(module_source, create_clone_and_result_dirs=False)
             git_getter.temp_dir = self.dest_dir
             git_getter.do_get()
@@ -26,6 +27,13 @@ class GenericGitLoader(ModuleLoader):
         except Exception as e:
             self.logger.error(f'failed to get {self.module_source} because of {e}')
             return ModuleContent(dir=None, failed_url=self.module_source)
+
+    def _create_valid_windows_dest_dir(self):
+        # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+        reserved_windows_chars = ['<', '>', ':', '"', '|', '?', '*']
+        self.logger.info(f'External module will be cloned to: {self.dest_dir}')
+        for char in reserved_windows_chars:
+            self.dest_dir = self.dest_dir.replace(char, '')
 
 
 loader = GenericGitLoader()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

- This PR adds support for cloning external modules which use a "Generic Git Repository" format with `ssh:` 
- https://www.terraform.io/docs/language/modules/sources.html#generic-git-repository
- External module destination path is changed for windows so that it excludes "reserved windows characters"
- https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions