### PR TITLE
change os.uname to os.name

### DIFF
--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -15,7 +15,7 @@ class GenericGitLoader(ModuleLoader):
         try:
             module_source = self.module_source.replace('git::', '')
             if os.name == 'nt':
-                self.logger.info(f'Operating System: {os.uname()}')
+                self.logger.info(f'Operating System: {os.name}')
                 self._create_valid_windows_dest_dir()
             git_getter = GitGetter(module_source, create_clone_and_result_dirs=False)
             git_getter.temp_dir = self.dest_dir


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR changes os.uname() to os.name in the git_loader.py class, since that method is not supported on windows. 

https://stackoverflow.com/questions/36250558/error-no-module-named-os-uname-under-python-2-7