### PR TITLE
Align graphs blocks paths

### DIFF
--- a/checkov/cloudformation/cfn_utils.py
+++ b/checkov/cloudformation/cfn_utils.py
@@ -117,6 +117,9 @@ def get_folder_definitions(
         except TypeError:
             logging.info(f"CloudFormation skipping {file} as it is not a valid CF template")
 
+    definitions = {create_file_abs_path(root_folder, file_path): v for (file_path, v) in definitions.items()}
+    definitions_raw = {create_file_abs_path(root_folder, file_path): v for (file_path, v) in definitions_raw.items()}
+
     return definitions, definitions_raw
 
 
@@ -204,9 +207,6 @@ def create_definitions(
         if v and isinstance(v, dict_node) and v.__contains__("Resources") and isinstance(v["Resources"], dict_node)
     }
     definitions_raw = {k: v for k, v in definitions_raw.items() if k in definitions.keys()}
-
-    definitions = {create_file_abs_path(root_folder, file_path): v for (file_path, v) in definitions.items()}
-    definitions_raw = {create_file_abs_path(root_folder, file_path): v for (file_path, v) in definitions_raw.items()}
 
     for cf_file in definitions.keys():
         cf_context_parser = ContextParser(cf_file, definitions[cf_file], definitions_raw[cf_file])

--- a/checkov/cloudformation/cfn_utils.py
+++ b/checkov/cloudformation/cfn_utils.py
@@ -157,17 +157,16 @@ def build_definitions_context(
                                 current_line = str.strip(definitions_raw[file_path][end_line - 1][1])
 
                         code_lines = definitions_raw[file_path][start_line - 1 : end_line]
-                        file_abs_path = create_file_abs_path(root_folder, file_path)
                         dpath.new(
                             definitions_context,
-                            [file_abs_path, str(file_path_definition), str(attribute)],
+                            [file_path, str(file_path_definition), str(attribute)],
                             {"start_line": start_line, "end_line": end_line, "code_lines": code_lines},
                         )
                         if file_path_definition.upper() == CloudformationTemplateSections.RESOURCES.value.upper():
                             skipped_checks = ContextParser.collect_skip_comments(code_lines)
                             dpath.new(
                                 definitions_context,
-                                [file_abs_path, str(file_path_definition), str(attribute), "skipped_checks"],
+                                [file_path, str(file_path_definition), str(attribute), "skipped_checks"],
                                 skipped_checks,
                             )
     return definitions_context
@@ -205,6 +204,9 @@ def create_definitions(
         if v and isinstance(v, dict_node) and v.__contains__("Resources") and isinstance(v["Resources"], dict_node)
     }
     definitions_raw = {k: v for k, v in definitions_raw.items() if k in definitions.keys()}
+
+    definitions = {create_file_abs_path(root_folder, file_path): v for (file_path, v) in definitions.items()}
+    definitions_raw = {create_file_abs_path(root_folder, file_path): v for (file_path, v) in definitions_raw.items()}
 
     for cf_file in definitions.keys():
         cf_context_parser = ContextParser(cf_file, definitions[cf_file], definitions_raw[cf_file])

--- a/tests/cloudformation/graph/graph_builder/test_local_graph.py
+++ b/tests/cloudformation/graph/graph_builder/test_local_graph.py
@@ -48,17 +48,17 @@ class TestLocalGraph(TestCase):
         definitions, _ = create_definitions(root_folder=resources_dir, files=None, runner_filter=RunnerFilter())
         local_graph = CloudformationLocalGraph(definitions)
         local_graph.build_graph(render_variables=False)
-        tf_definitions, breadcrumbs = convert_graph_vertices_to_definitions(local_graph.vertices, resources_dir)
+        definitions, breadcrumbs = convert_graph_vertices_to_definitions(local_graph.vertices, resources_dir)
 
-        self.assertIsNotNone(tf_definitions)
-        self.assertEqual(len(tf_definitions.items()), 2)
+        self.assertIsNotNone(definitions)
+        self.assertEqual(len(definitions.items()), 2)
 
-        test_yaml_definitions = tf_definitions['/test.yaml'][CloudformationTemplateSections.RESOURCES]
+        test_yaml_definitions = definitions[os.path.join(resources_dir, 'test.yaml')][CloudformationTemplateSections.RESOURCES]
         self.assertEqual(len(test_yaml_definitions.keys()), 2)
         self.assertIn('MyDB', test_yaml_definitions.keys())
         self.assertIn('MySourceQueue', test_yaml_definitions.keys())
 
-        test_json_definitions = tf_definitions['/test.json'][CloudformationTemplateSections.RESOURCES]
+        test_json_definitions = definitions[os.path.join(resources_dir, 'test.json')][CloudformationTemplateSections.RESOURCES]
         self.assertEqual(len(test_json_definitions.keys()), 2)
         self.assertIn('MyDB', test_json_definitions.keys())
         self.assertIn('MySourceQueue', test_json_definitions.keys())

--- a/tests/cloudformation/runner/test_runner.py
+++ b/tests/cloudformation/runner/test_runner.py
@@ -188,7 +188,7 @@ class TestRunnerValid(unittest.TestCase):
         dir_abs_path = os.path.dirname(os.path.realpath(__file__))
 
         definitions = {
-            '/s3.yaml': {
+            f'{dir_abs_path}/s3.yaml': {
                 'Resources': {
                     'MySourceQueue': {
                         'Type': 'AWS::SQS::Queue',

--- a/tests/cloudformation/test_graph_manager.py
+++ b/tests/cloudformation/test_graph_manager.py
@@ -16,15 +16,15 @@ class TestCloudformationGraphManager(TestCase):
         local_graph, definitions = graph_manager.build_graph_from_source_directory(root_dir, render_variables=False)
 
         expected_resources_by_file = {
-            "/tags.yaml": [
+            os.path.join(root_dir, "tags.yaml"): [
                 "AWS::S3::Bucket.DataBucket",
                 "AWS::S3::Bucket.NoTags",
                 "AWS::EKS::Nodegroup.EKSClusterNodegroup",
                 "AWS::AutoScaling::AutoScalingGroup.TerraformServerAutoScalingGroup"],
-            "/cfn_newline_at_end.yaml": [
+            os.path.join(root_dir, "cfn_newline_at_end.yaml"): [
                 "AWS::RDS::DBInstance.MyDB",
                 "AWS::S3::Bucket.MyBucket"],
-            "/success.json": [
+            os.path.join(root_dir, "success.json"): [
                 "AWS::S3::Bucket.acmeCWSBucket",
                 "AWS::S3::Bucket.acmeCWSBucket2",
                 "AWS::S3::BucketPolicy.acmeCWSBucketPolicy",

--- a/tests/cloudformation/utils/test_cfn_utils.py
+++ b/tests/cloudformation/utils/test_cfn_utils.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from checkov.cloudformation.cfn_utils import get_folder_definitions, build_definitions_context
+from checkov.cloudformation.cfn_utils import create_definitions, build_definitions_context
 from checkov.cloudformation.parser.node import dict_node
 from checkov.cloudformation.graph_builder.graph_components.block_types import CloudformationTemplateSections
 
@@ -14,7 +14,7 @@ class TestCfnUtils(unittest.TestCase):
     def setUp(self):
         self.test_root_dir = os.path.realpath(os.path.join(TEST_DIRNAME, RELATIVE_PATH))
 
-        definitions, definitions_raw = get_folder_definitions(self.test_root_dir, None)
+        definitions, definitions_raw = create_definitions(self.test_root_dir, None)
         self.definitions_context = build_definitions_context(definitions, definitions_raw, self.test_root_dir)
 
     def validate_definition_lines(self, definition: dict_node, start_line, end_line, code_lines):
@@ -24,20 +24,20 @@ class TestCfnUtils(unittest.TestCase):
 
     def test_parameters_value(self):
         # Asserting test.yaml file
-        yaml_parameters = self.definitions_context[self.test_root_dir + '/test.yaml'][
+        yaml_parameters = self.definitions_context[os.path.join(self.test_root_dir, 'test.yaml')][
                 CloudformationTemplateSections.PARAMETERS.value]
         self.assertIsNotNone(yaml_parameters)
         self.assertEqual(len(yaml_parameters), 2)
         self.validate_definition_lines(yaml_parameters['KmsMasterKeyId'], 4, 7, 4)
         self.validate_definition_lines(yaml_parameters['DBName'], 8, 11, 4)
         # Asserting test2.yaml file
-        yaml2_parameters = self.definitions_context[self.test_root_dir + '/test2.yaml'][
+        yaml2_parameters = self.definitions_context[os.path.join(self.test_root_dir, 'test2.yaml')][
             CloudformationTemplateSections.PARAMETERS.value]
         self.assertIsNotNone(yaml2_parameters)
         self.assertEqual(len(yaml2_parameters), 1)
         self.validate_definition_lines(yaml2_parameters['LatestAmiId'], 4, 6, 3)
         # Asserting json file
-        json_parameters = self.definitions_context[self.test_root_dir + '/test.json'][
+        json_parameters = self.definitions_context[os.path.join(self.test_root_dir, 'test.json')][
                 CloudformationTemplateSections.PARAMETERS.value]
         self.assertIsNotNone(json_parameters)
         self.assertEqual(len(json_parameters), 2)
@@ -46,14 +46,14 @@ class TestCfnUtils(unittest.TestCase):
 
     def test_resources_value(self):
         # Asserting test.yaml file
-        yaml_resources = self.definitions_context[self.test_root_dir + '/test.yaml'][
+        yaml_resources = self.definitions_context[os.path.join(self.test_root_dir, 'test.yaml')][
                 CloudformationTemplateSections.RESOURCES.value]
         self.assertIsNotNone(yaml_resources)
         self.assertEqual(len(yaml_resources), 2)
         self.validate_definition_lines(yaml_resources['MySourceQueue'], 13, 16, 4)
         self.validate_definition_lines(yaml_resources['MyDB'], 17, 26, 10)
         # Asserting test2.yaml file
-        yaml2_resources = self.definitions_context[self.test_root_dir + '/test2.yaml'][
+        yaml2_resources = self.definitions_context[os.path.join(self.test_root_dir, 'test2.yaml')][
             CloudformationTemplateSections.RESOURCES.value]
         self.assertIsNotNone(yaml2_resources)
         self.assertEqual(len(yaml2_resources), 4)
@@ -62,7 +62,7 @@ class TestCfnUtils(unittest.TestCase):
         self.validate_definition_lines(yaml2_resources['LogsKeyAlias'], 46, 50, 5)
         self.validate_definition_lines(yaml2_resources['DBAppInstance'], 52, 184, 133)
         # Asserting json file
-        json_resources = self.definitions_context[self.test_root_dir + '/test.json'][
+        json_resources = self.definitions_context[os.path.join(self.test_root_dir, 'test.json')][
                 CloudformationTemplateSections.RESOURCES.value]
         self.assertIsNotNone(json_resources)
         self.assertEqual(len(json_resources), 2)
@@ -71,13 +71,13 @@ class TestCfnUtils(unittest.TestCase):
 
     def test_outputs_value(self):
         # Asserting test.yaml file
-        yaml_outputs = self.definitions_context[self.test_root_dir + '/test.yaml'][
+        yaml_outputs = self.definitions_context[os.path.join(self.test_root_dir, 'test.yaml')][
                 CloudformationTemplateSections.OUTPUTS.value]
         self.assertIsNotNone(yaml_outputs)
         self.assertEqual(len(yaml_outputs), 1)
         self.validate_definition_lines(yaml_outputs['DBAppPublicDNS'], 28, 30, 3)
         # Asserting test2.yaml file
-        yaml2_outputs = self.definitions_context[self.test_root_dir + '/test2.yaml'][
+        yaml2_outputs = self.definitions_context[os.path.join(self.test_root_dir, 'test2.yaml')][
             CloudformationTemplateSections.OUTPUTS.value]
         self.assertIsNotNone(yaml2_outputs)
         self.assertEqual(len(yaml2_outputs), 5)
@@ -87,14 +87,14 @@ class TestCfnUtils(unittest.TestCase):
         self.validate_definition_lines(yaml2_outputs['PublicSubnet2'], 200, 202, 3)
         self.validate_definition_lines(yaml2_outputs['UserName'], 204, 206, 3)
         # Asserting json file
-        json_outputs = self.definitions_context[self.test_root_dir + '/test.json'][
+        json_outputs = self.definitions_context[os.path.join(self.test_root_dir, 'test.json')][
                 CloudformationTemplateSections.OUTPUTS.value]
         self.assertIsNotNone(json_outputs)
         self.assertEqual(len(json_outputs), 1)
         self.validate_definition_lines(json_outputs['DBAppPublicDNS'], 35, 38, 4)
 
     def test_skipped_check_exists(self):
-        skipped_checks = self.definitions_context[self.test_root_dir + '/test.yaml'][
+        skipped_checks = self.definitions_context[os.path.join(self.test_root_dir, 'test.yaml')][
                 CloudformationTemplateSections.RESOURCES.value]['MyDB']['skipped_checks']
         self.assertEqual(len(skipped_checks), 1)
         self.assertEqual(skipped_checks[0]['id'], 'CKV_AWS_16')

--- a/tests/cloudformation/utils/test_cfn_utils.py
+++ b/tests/cloudformation/utils/test_cfn_utils.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from checkov.cloudformation.cfn_utils import create_definitions, build_definitions_context
+from checkov.cloudformation.cfn_utils import get_folder_definitions, build_definitions_context
 from checkov.cloudformation.parser.node import dict_node
 from checkov.cloudformation.graph_builder.graph_components.block_types import CloudformationTemplateSections
 
@@ -14,7 +14,7 @@ class TestCfnUtils(unittest.TestCase):
     def setUp(self):
         self.test_root_dir = os.path.realpath(os.path.join(TEST_DIRNAME, RELATIVE_PATH))
 
-        definitions, definitions_raw = create_definitions(self.test_root_dir, None)
+        definitions, definitions_raw = get_folder_definitions(self.test_root_dir, None)
         self.definitions_context = build_definitions_context(definitions, definitions_raw, self.test_root_dir)
 
     def validate_definition_lines(self, definition: dict_node, start_line, end_line, code_lines):


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

The purpose of this PR is to align the CFN graph block file path with TF graph block file path, because as it works right now, the TF block holds the absolute path and the CFN block holds the shorter path 