### PR TITLE
Refactor windows folder names for saving external modules

### DIFF
--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -1,4 +1,5 @@
 import os
+import hashlib
 
 from checkov.common.goget.github.get_git import GitGetter
 from checkov.terraform.module_loading.content import ModuleContent
@@ -14,9 +15,6 @@ class GenericGitLoader(ModuleLoader):
     def _load_module(self) -> ModuleContent:
         try:
             module_source = self.module_source.replace('git::', '')
-            if os.name == 'nt':
-                self.logger.info(f'Operating System: {os.name}')
-                self._create_valid_windows_dest_dir()
             git_getter = GitGetter(module_source, create_clone_and_result_dirs=False)
             git_getter.temp_dir = self.dest_dir
             git_getter.do_get()
@@ -27,13 +25,6 @@ class GenericGitLoader(ModuleLoader):
         except Exception as e:
             self.logger.error(f'failed to get {self.module_source} because of {e}')
             return ModuleContent(dir=None, failed_url=self.module_source)
-
-    def _create_valid_windows_dest_dir(self):
-        # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
-        reserved_windows_chars = ['<', '>', ':', '"', '|', '?', '*']
-        self.logger.info(f'External module will be cloned to: {self.dest_dir}')
-        for char in reserved_windows_chars:
-            self.dest_dir = self.dest_dir.replace(char, '')
 
 
 loader = GenericGitLoader()

--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -1,5 +1,4 @@
 import os
-import hashlib
 
 from checkov.common.goget.github.get_git import GitGetter
 from checkov.terraform.module_loading.content import ModuleContent

--- a/checkov/terraform/module_loading/registry.py
+++ b/checkov/terraform/module_loading/registry.py
@@ -24,7 +24,7 @@ information, see `loader.ModuleLoader.load`.
         if os.name == 'nt':
             # For windows, due to limitations in the allowed characters for path names, the hash of the source is used.
             # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
-            source_hash = hashlib.md5(source.encode())
+            source_hash = hashlib.md5(source.encode())  # nosec
             local_dir = os.path.join(current_dir, self.external_modules_folder_name, source_hash.hexdigest())
         else:
             local_dir = os.path.join(current_dir, self.external_modules_folder_name, source)

--- a/checkov/terraform/module_loading/registry.py
+++ b/checkov/terraform/module_loading/registry.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import hashlib
 from typing import Optional, List
 
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
@@ -20,7 +21,13 @@ class ModuleLoaderRegistry:
 Search all registered loaders for the first one which is able to load the module source type. For more
 information, see `loader.ModuleLoader.load`.
         """
-        local_dir = os.path.join(current_dir, self.external_modules_folder_name, source)
+        if os.name == 'nt':
+            # For windows, due to limitations in the allowed characters for path names, the hash of the source is used.
+            # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+            source_hash = hashlib.md5(source.encode())
+            local_dir = os.path.join(current_dir, self.external_modules_folder_name, source_hash.hexdigest())
+        else:
+            local_dir = os.path.join(current_dir, self.external_modules_folder_name, source)
         inner_module = ''
         next_url = source
         last_exception = None


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR refactors the name of the directory in which external module sources are cloned on Windows. In the case of windows, instead of using the raw source string for building the destination path, a hash of the source is used instead for avoiding issues with reserved characters. 