### PR TITLE
fix case when left side of within is null

### DIFF
--- a/checkov/common/checks_infra/solvers/filter_solvers/within_filter_solver.py
+++ b/checkov/common/checks_infra/solvers/filter_solvers/within_filter_solver.py
@@ -14,4 +14,7 @@ class WithinFilterSolver(BaseFilterSolver):
         return self._get_operation()(*args)
 
     def _get_operation(self, *args: Any, **kwargs: Any) -> Callable[..., bool]:
-        return lambda check: check.get(self.attribute) in self.value
+        def op(check):
+            val = check.get(self.attribute)
+            return val and (val in self.value)
+        return op

--- a/checkov/common/graph/checks_infra/registry.py
+++ b/checkov/common/graph/checks_infra/registry.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Dict, Any
 
 from networkx import DiGraph
@@ -23,6 +24,7 @@ class BaseRegistry:
         for check in self.checks:
             if not runner_filter.should_run_check(check.id, check.bc_id):
                 continue
+            logging.debug(f'Running graph check: {check.id}')
             passed, failed = check.run(graph_connector)
             check_result = self._process_check_result(passed, [], CheckResult.PASSED)
             check_result = self._process_check_result(failed, check_result, CheckResult.FAILED)

--- a/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/expected.yaml
+++ b/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/expected.yaml
@@ -10,3 +10,4 @@ fail:
   - "aws_route53_record.fail"
 ignore:
   - "aws_route53_record.ignore"
+  - "aws_route53_record.ignore2"

--- a/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
+++ b/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
@@ -45,6 +45,15 @@ resource "aws_route53_record" "ignore" {
   records = [module.controller.loadbalancer_dns_name]
 }
 
+resource "aws_route53_record" "ignore2" {
+  # it is possible to have a plan with a route53 record that has no type. I am not sure how, but this is a test
+  # of that case.
+  zone_id = data.aws_route53_zone.primary.zone_id
+  name    = "dns.freebeer.site"
+  ttl     = "300"
+  records = ["1.1.1.1"]
+}
+
 resource "aws_route53_record" "pass3" {
   zone_id = var.zone_id
   name = "test.example.com"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes a case when `get(attribute)` returns `None` and when does an `in <string>` op, which crashes.

Also adds a debug log prior to each graph check to make it easier to see which graph check crashes a run.