### PR TITLE
Fix wrong evaluation of CKV2_AZURE_8 if azurerm_monitor_activity_log_alert.enabled=true

### DIFF
--- a/checkov/terraform/checks/graph_checks/azure/StorageContainerActivityLogsNotPublic.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/StorageContainerActivityLogsNotPublic.yaml
@@ -31,7 +31,7 @@ definition:
             - azurerm_monitor_activity_log_alert
           attribute: enabled
           operator: equals
-          value: 'true'
+          value: true
     - cond_type: connection
       resource_types:
         - azurerm_storage_container

--- a/tests/terraform/graph/checks/resources/StorageContainerActivityLogsNotPublic/expected.yaml
+++ b/tests/terraform/graph/checks/resources/StorageContainerActivityLogsNotPublic/expected.yaml
@@ -1,4 +1,5 @@
 pass:
-  - "azurerm_storage_account.ok_account"
+  - "azurerm_storage_account.ok_account_1"
+  - "azurerm_storage_account.ok_account_2"
 fail:
   - "azurerm_storage_account.not_ok_account"

--- a/tests/terraform/graph/checks/resources/StorageContainerActivityLogsNotPublic/main.tf
+++ b/tests/terraform/graph/checks/resources/StorageContainerActivityLogsNotPublic/main.tf
@@ -1,6 +1,12 @@
-resource "azurerm_storage_container" "ok_container" {
+resource "azurerm_storage_container" "ok_container_1" {
   name                  = "vhds"
-  storage_account_name  = azurerm_storage_account.ok_account.name
+  storage_account_name  = azurerm_storage_account.ok_account_1.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "ok_container_2" {
+  name                  = "vhds"
+  storage_account_name  = azurerm_storage_account.ok_account_2.name
   container_access_type = "private"
 }
 
@@ -10,7 +16,15 @@ resource "azurerm_storage_container" "not_ok_container" {
   container_access_type = "private"
 }
 
-resource "azurerm_storage_account" "ok_account" {
+resource "azurerm_storage_account" "ok_account_1" {
+  name                     = "examplesa"
+  resource_group_name      = azurerm_resource_group.main.name
+  location                 = azurerm_resource_group.main.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_storage_account" "ok_account_2" {
   name                     = "examplesa"
   resource_group_name      = azurerm_resource_group.main.name
   location                 = azurerm_resource_group.main.location
@@ -26,14 +40,37 @@ resource "azurerm_storage_account" "not_ok_account" {
   account_replication_type = "GRS"
 }
 
-resource "azurerm_monitor_activity_log_alert" "ok_monitor_activity_log_alert" {
+resource "azurerm_monitor_activity_log_alert" "ok_monitor_activity_log_alert_1" {
   name                = "example-activitylogalert"
   resource_group_name = azurerm_resource_group.main.name
   scopes              = [azurerm_resource_group.main.id]
   description         = "This alert will monitor a specific storage account updates."
 
   criteria {
-    resource_id    = azurerm_storage_account.ok_account.id
+    resource_id    = azurerm_storage_account.ok_account_1.id
+    operation_name = "Microsoft.Storage/storageAccounts/write"
+    category       = "Recommendation"
+  }
+
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main.id
+
+    webhook_properties = {
+      from = "terraform"
+    }
+  }
+}
+
+resource "azurerm_monitor_activity_log_alert" "ok_monitor_activity_log_alert_2" {
+  name                = "example-activitylogalert"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [azurerm_resource_group.main.id]
+  description         = "This alert will monitor a specific storage account updates."
+  enabled             = true
+
+  criteria {
+    resource_id    = azurerm_storage_account.ok_account_2.id
     operation_name = "Microsoft.Storage/storageAccounts/write"
     category       = "Recommendation"
   }


### PR DESCRIPTION
CKV2_AZURE_8 fails if "azurerm_monitor_activity_log_alert.enabled=true" is explicitly set.
This PR fixes the check and adds an additional unit test for the specific use case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
