### PR TITLE
understand platform suppressions with bcorg_ prefix

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -138,7 +138,6 @@ class SuppressionsIntegration(BaseIntegrationFeature):
             return False
 
         if suppression['suppressionType'] == 'Accounts':
-
             if not any(self._repo_matches(account) for account in suppression['accountIds']):
                 return False
 

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -145,7 +145,7 @@ class SuppressionsIntegration(BaseIntegrationFeature):
 
     def _repo_matches(self, repo_name):
         # matches xyz_org/repo or org/repo (where xyz is the BC org name and the CLI repo prefix from the platform)
-        return re.search(f'^(\\w+_)?{self.bc_integration.repo_id}$', repo_name) is not None
+        return re.match(f'^(\\w+_)?{self.bc_integration.repo_id}$', repo_name) is not None
 
 
 integration = SuppressionsIntegration(bc_integration)

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -85,10 +85,10 @@ class SuppressionsIntegration(BaseIntegrationFeature):
         elif type == 'Accounts':
             # This should be true, because we validated when we downloaded the policies.
             # But checking here adds some resiliency against bugs if that changes.
-            return self.bc_integration.repo_id in suppression['accountIds']
+            return any(self._repo_matches(account) for account in suppression['accountIds'])
         elif type == 'Resources':
             for resource in suppression['resources']:
-                if resource['accountId'] == self.bc_integration.repo_id and resource['resourceId'] == f'{record.repo_file_path}:{record.resource}':
+                if self._repo_matches(resource['accountId']) and resource['resourceId'] == f'{record.repo_file_path}:{record.resource}':
                     return True
             return False
         elif type == 'Tags':
@@ -138,10 +138,15 @@ class SuppressionsIntegration(BaseIntegrationFeature):
             return False
 
         if suppression['suppressionType'] == 'Accounts':
-            if self.bc_integration.repo_id not in suppression['accountIds']:
+
+            if not any(self._repo_matches(account) for account in suppression['accountIds']):
                 return False
 
         return True
+
+    def _repo_matches(self, repo_name):
+        # matches xyz_org/repo or org/repo (where xyz is the BC org name and the CLI repo prefix from the platform)
+        return re.search(f'^(\\w+_)?{self.bc_integration.repo_id}$', repo_name) is not None
 
 
 integration = SuppressionsIntegration(bc_integration)

--- a/tests/common/integration_features/test_suppressions_integration.py
+++ b/tests/common/integration_features/test_suppressions_integration.py
@@ -74,6 +74,18 @@ class TestSuppressionsIntegration(unittest.TestCase):
         self.assertTrue(suppressions_integration._suppression_valid_for_run(suppression))
 
         suppression = {
+            "suppressionType": "Accounts",
+            "policyId": "BC_AWS_1",
+            "creationDate": 1608816140086,
+            "comment": "No justification comment provided.",
+            "accountIds": [
+                "bcorg_org/repo"
+            ]
+        }
+
+        self.assertTrue(suppressions_integration._suppression_valid_for_run(suppression))
+
+        suppression = {
             "suppressionType": "Resources",
             "policyId": "BC_AWS_1",
             "creationDate": 1608816140086,
@@ -117,6 +129,18 @@ class TestSuppressionsIntegration(unittest.TestCase):
             "comment": "No justification comment provided.",
             "accountIds": [
                 "other/repo"
+            ]
+        }
+
+        self.assertFalse(suppressions_integration._suppression_valid_for_run(suppression))
+
+        suppression = {
+            "suppressionType": "Accounts",
+            "policyId": "BC_AWS_1",
+            "creationDate": 1608816140086,
+            "comment": "No justification comment provided.",
+            "accountIds": [
+                "bcorg_other/repo"
             ]
         }
 
@@ -206,6 +230,32 @@ class TestSuppressionsIntegration(unittest.TestCase):
         self.assertTrue(suppressions_integration._check_suppression(record1, suppression))
         self.assertFalse(suppressions_integration._check_suppression(record2, suppression))
 
+    def test_account_suppression_cli_repo(self):
+        instance = BcPlatformIntegration()
+        instance.repo_id = 'org/repo'
+        suppressions_integration = SuppressionsIntegration(instance)
+        suppression = {
+            "suppressionType": "Accounts",
+            "policyId": "BC_AWS_S3_13",
+            "comment": "testing checkov",
+            "accountIds": ["bcorg_org/repo", "bcorg_not/valid"],
+            "checkovPolicyId": "CKV_AWS_18",
+        }
+
+        record1 = Record(check_id='CKV_AWS_18', check_name=None, check_result=None,
+                         code_block=None, file_path=None,
+                         file_line_range=None,
+                         resource=None, evaluations=None,
+                         check_class=None, file_abs_path='.', entity_tags=None)
+        record2 = Record(check_id='CKV_AWS_1', check_name=None, check_result=None,
+                         code_block=None, file_path=None,
+                         file_line_range=None,
+                         resource=None, evaluations=None,
+                         check_class=None, file_abs_path='.', entity_tags=None)
+
+        self.assertTrue(suppressions_integration._check_suppression(record1, suppression))
+        self.assertFalse(suppressions_integration._check_suppression(record2, suppression))
+
     def test_resource_suppression(self):
         instance = BcPlatformIntegration()
         instance.repo_id = 'org/repo'
@@ -217,6 +267,46 @@ class TestSuppressionsIntegration(unittest.TestCase):
             "resources": [
                 {
                     "accountId": "org/repo",
+                    "resourceId": "/terraform/aws/s3.tf:aws_s3_bucket.operations",
+                }
+            ],
+            "checkovPolicyId": "CKV_AWS_18",
+        }
+
+        record1 = Record(check_id='CKV_AWS_18', check_name=None, check_result=None,
+                         code_block=None, file_path=None,
+                         file_line_range=None,
+                         resource='aws_s3_bucket.operations', evaluations=None,
+                         check_class=None, file_abs_path=',.', entity_tags=None)
+        record1.repo_file_path = '/terraform/aws/s3.tf'
+        record2 = Record(check_id='CKV_AWS_13', check_name=None, check_result=None,
+                         code_block=None, file_path=None,
+                         file_line_range=None,
+                         resource='aws_s3_bucket.no', evaluations=None,
+                         check_class=None, file_abs_path='.', entity_tags=None)
+        record2.repo_file_path = '/terraform/aws/s3.tf'
+        record3 = Record(check_id='CKV_AWS_1', check_name=None, check_result=None,
+                         code_block=None, file_path=None,
+                         file_line_range=None,
+                         resource='aws_s3_bucket.operations', evaluations=None,
+                         check_class=None, file_abs_path='.', entity_tags=None)
+        record3.repo_file_path = '/terraform/aws/s3.tf'
+
+        self.assertTrue(suppressions_integration._check_suppression(record1, suppression))
+        self.assertFalse(suppressions_integration._check_suppression(record2, suppression))
+        self.assertFalse(suppressions_integration._check_suppression(record3, suppression))
+
+    def test_resource_suppression_cli_repo(self):
+        instance = BcPlatformIntegration()
+        instance.repo_id = 'org/repo'
+        suppressions_integration = SuppressionsIntegration(instance)
+        suppression = {
+            "suppressionType": "Resources",
+            "policyId": "BC_AWS_S3_13",
+            "comment": "No justification comment provided.",
+            "resources": [
+                {
+                    "accountId": "bcorg_org/repo",
                     "resourceId": "/terraform/aws/s3.tf:aws_s3_bucket.operations",
                 }
             ],


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Changes the suppression logic to understand suppressions from the platform that are applied to CLI run results (with the `bcorg_` prefix).

So now, suppressing `githuborg/repo` (the real github integration) or `bcorg_githuborg/repo` (a CLI run result) in the platform will apply to checkov runs with `--repo-id githuborg/repo`.