### PR TITLE
Update Dockerfile to run as a non-root user 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,12 @@ RUN apk update && apk add --no-cache git util-linux bash openssl
 RUN pip install --no-cache-dir -U checkov
 RUN wget -q -O get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3; chmod 700 get_helm.sh; VERIFY_CHECKSUM=true ./get_helm.sh; rm ./get_helm.sh
 
-COPY ./github_action_resources/entrypoint.sh /entrypoint.sh
-COPY ./github_action_resources/checkov-problem-matcher.json /usr/local/lib/checkov-problem-matcher.json
-COPY ./github_action_resources/checkov-problem-matcher-softfail.json /usr/local/lib/checkov-problem-matcher-softfail.json
-
 RUN addgroup -S -g ${GID} ${USERNAME} && \
-    adduser -S -D -u ${UID} -G ${USERNAME} ${USERNAME} && \
-    chown -R ${USERNAME}:0 /entrypoint.sh && \
-    chown -R ${USERNAME}:0 /usr/local/lib/ && \
-    chmod -R g=u /entrypoint.sh && \
-    chmod -R g=u /usr/local/lib/
+    adduser -S -D -u ${UID} -G ${USERNAME} ${USERNAME} 
+
+COPY --chown=${USERNAME}:0 ./github_action_resources/entrypoint.sh /entrypoint.sh
+COPY --chown=${USERNAME}:0 ./github_action_resources/checkov-problem-matcher.json /usr/local/lib/checkov-problem-matcher.json
+COPY  --chown=${USERNAME}:0 ./github_action_resources/checkov-problem-matcher-softfail.json /usr/local/lib/checkov-problem-matcher-softfail.json
 
 USER ${UID}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.7-alpine
 
+ARG UID=1000
+ARG GID=1000
+ARG USERNAME=checkov
+
 RUN apk update && apk add --no-cache git util-linux bash openssl
 
 RUN pip install --no-cache-dir -U checkov
@@ -8,6 +12,15 @@ RUN wget -q -O get_helm.sh https://raw.githubusercontent.com/helm/helm/master/sc
 COPY ./github_action_resources/entrypoint.sh /entrypoint.sh
 COPY ./github_action_resources/checkov-problem-matcher.json /usr/local/lib/checkov-problem-matcher.json
 COPY ./github_action_resources/checkov-problem-matcher-softfail.json /usr/local/lib/checkov-problem-matcher-softfail.json
+
+RUN addgroup -S -g ${GID} ${USERNAME} && \
+    adduser -S -D -u ${UID} -G ${USERNAME} ${USERNAME} && \
+    chown -R ${USERNAME}:0 /entrypoint.sh && \
+    chown -R ${USERNAME}:0 /usr/local/lib/ && \
+    chmod -R g=u /entrypoint.sh && \
+    chmod -R g=u /usr/local/lib/
+
+USER ${UID}
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The Checkov Dockerfile is currently running with default root privileges. It is good practice to user a non-root adds an extra layer of security. 
 > [docker docs](https://docs.docker.com/engine/security/#linux-kernel-capabilities) & [bitnami blog](https://engineering.bitnami.com/articles/why-non-root-containers-are-important-for-security.html) on dockerfile security
```console
$ docker run -it --entrypoint sh bridgecrew/checkov:2.0.348 
/ # id
uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)
```
This is the container after my changes have been applied 
```console
$ docker run -it --entrypoint sh pandoraholladay/git-checkov
/ $ id
uid=1000(checkov) gid=1000(checkov) groups=1000(checkov)
/ $ ls -la
total 84
/ $ ls -la
total 84
drwxr-xr-x    1 root     root          4096 Aug 16 12:39 .
drwxr-xr-x    1 root     root          4096 Aug 16 12:39 ..
-rwxr-xr-x    1 root     root             0 Aug 16 12:39 .dockerenv
drwxr-xr-x    1 root     root          4096 Aug 16 12:05 bin
drwxr-xr-x    5 root     root           360 Aug 16 12:39 dev
-rwxr-xr-x    1 checkov  root          2700 Aug 16 12:01 entrypoint.sh
drwxr-xr-x    1 root     root          4096 Aug 16 12:39 etc
drwxr-xr-x    1 root     root          4096 Aug 16 12:37 home
drwxr-xr-x    1 root     root          4096 Aug 16 12:05 lib
drwxr-xr-x    5 root     root          4096 Aug  5 12:25 media
drwxr-xr-x    2 root     root          4096 Aug  5 12:25 mnt
drwxr-xr-x    2 root     root          4096 Aug  5 12:25 opt
dr-xr-xr-x  204 root     root             0 Aug 16 12:39 proc
drwx------    1 root     root          4096 Aug 16 12:06 root
drwxr-xr-x    2 root     root          4096 Aug  5 12:25 run
drwxr-xr-x    1 root     root          4096 Aug 16 12:05 sbin
drwxr-xr-x    2 root     root          4096 Aug  5 12:25 srv
dr-xr-xr-x   13 root     root             0 Aug 16 12:39 sys
drwxrwxrwt    1 root     root          4096 Aug 16 12:06 tmp
drwxr-xr-x    1 root     root          4096 Aug 16 12:05 usr
drwxr-xr-x    1 root     root          4096 Aug 16 12:05 var
/ $ ls -la usr/local/lib/
total 3192
drwxr-xr-x    1 root     root          4096 Aug 16 12:37 .
drwxr-xr-x    1 root     root          4096 Aug  6 21:46 ..
-rw-r--r--    1 checkov  root           385 Aug 16 12:01 checkov-problem-matcher-softfail.json
-rw-r--r--    1 checkov  root           356 Aug 16 12:01 checkov-problem-matcher.json
lrwxrwxrwx    1 root     root            20 Aug  6 21:46 libpython3.7m.so -> libpython3.7m.so.1.0
-r-xr-xr-x    1 root     root       3215832 Aug  6 21:46 libpython3.7m.so.1.0
-r-xr-xr-x    1 root     root         13696 Aug  6 21:46 libpython3.so
drwxr-xr-x    2 root     root          4096 Aug  6 21:46 pkgconfig
drwxr-xr-x    1 root     root          4096 Aug  6 21:46 python3.7
/ $ id
uid=1000(checkov) gid=1000(checkov) groups=1000(checkov)
/ $ ./entrypoint.sh 

       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By bridgecrew.io | version: 2.0.350 
...
...
```
By specifying USER by UID we ensure that this Dockefile is compliant with Openshifts SCC that specifies "mustRunAsNonRoot".

```
....
USER ${UID}

ENTRYPOINT ["/entrypoint.sh"]
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
