### PR TITLE
CFN Runner crashes for non dict template file and file paths that are missing in the definitions object

### DIFF
--- a/checkov/cloudformation/graph_manager.py
+++ b/checkov/cloudformation/graph_manager.py
@@ -31,11 +31,14 @@ class CloudformationGraphManager(GraphManager):
 
         # TODO: replace with real graph rendering
         for cf_file in rendered_definitions.keys():
-            cf_context_parser = ContextParser(cf_file, rendered_definitions[cf_file], definitions_raw[cf_file])
-            logging.debug(
-                "Template Dump for {}: {}".format(cf_file, json.dumps(rendered_definitions[cf_file], indent=2, default=str))
-            )
-            cf_context_parser.evaluate_default_refs()
+            file_definition = rendered_definitions.get(cf_file, None)
+            file_definition_raw = definitions_raw.get(cf_file, None)
+            if file_definition is not None and file_definition_raw is not None:
+                cf_context_parser = ContextParser(cf_file, file_definition, file_definition_raw)
+                logging.debug(
+                    "Template Dump for {}: {}".format(cf_file, json.dumps(file_definition, indent=2, default=str))
+                )
+                cf_context_parser.evaluate_default_refs()
         return local_graph, rendered_definitions
 
     def build_graph_from_definitions(

--- a/checkov/cloudformation/parser/__init__.py
+++ b/checkov/cloudformation/parser/__init__.py
@@ -44,7 +44,7 @@ def parse(filename: str) -> Union[Tuple[dict_node, List[Tuple[int, str]]], Tuple
     except YAMLError as err:
         pass
 
-    if template:
+    if isinstance(template, dict):
         resources = template.get(TemplateSections.RESOURCES.value, None)
         if resources:
             if '__startline__' in resources:

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -67,11 +67,14 @@ class Runner(BaseRunner):
 
         # TODO: replace with real graph rendering
         for cf_file in self.definitions.keys():
-            cf_context_parser = ContextParser(cf_file, self.definitions[cf_file], self.definitions_raw[cf_file])
-            logging.debug(
-                "Template Dump for {}: {}".format(cf_file, json.dumps(self.definitions[cf_file], indent=2, default=str))
-            )
-            cf_context_parser.evaluate_default_refs()
+            file_definition = self.definitions.get(cf_file, None)
+            file_definition_raw = self.definitions_raw.get(cf_file, None)
+            if file_definition is not None and file_definition_raw is not None:
+                cf_context_parser = ContextParser(cf_file, file_definition, file_definition_raw)
+                logging.debug(
+                    "Template Dump for {}: {}".format(cf_file, json.dumps(file_definition, indent=2, default=str))
+                )
+                cf_context_parser.evaluate_default_refs()
 
         # run checks
         self.check_definitions(root_folder, runner_filter, report)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. In some cases the template is not a dict so it crashes for template.get
2. In some cases the file path does not exist in the definitions object