### PR TITLE
Fix missing BC IDs in graph checks

### DIFF
--- a/checkov/common/output/graph_record.py
+++ b/checkov/common/output/graph_record.py
@@ -8,6 +8,6 @@ class GraphRecord(Record):
         super().__init__(record.check_id, record.check_name, record.check_result, record.code_block, record.file_path,
                          record.file_line_range, record.resource, record.evaluations, record.check_class,
                          record.file_abs_path, record.entity_tags, record.caller_file_path,
-                         record.caller_file_line_range)
+                         record.caller_file_line_range, bc_check_id=record.bc_check_id)
         self.fixed_definition = record.fixed_definition
         self.breadcrumbs = breadcrumbs


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes a missing param in GraphRecord that caused some bc_id values to not get passed into records