### PR TITLE
CFN Graph creation crashes due to DependsOn resource missing

### DIFF
--- a/checkov/cloudformation/graph_builder/graph_components/block_types.py
+++ b/checkov/cloudformation/graph_builder/graph_components/block_types.py
@@ -13,14 +13,3 @@ class BlockType(CommonBlockType):
     CONDITION = "conditions"
     TRANSFORM = "transform"
     OUTPUT = "outputs"
-
-
-class CloudformationTemplateSections(str, Enum):
-    RESOURCES = "Resources"
-    METADATA = "Metadata"
-    PARAMETERS = "Parameters"
-    RULES = "Rules"
-    MAPPINGS = "Mappings"
-    CONDITIONS = "Conditions"
-    TRANSFORM = "Transform"
-    OUTPUTS = "Outputs"

--- a/checkov/cloudformation/graph_builder/local_graph.py
+++ b/checkov/cloudformation/graph_builder/local_graph.py
@@ -101,8 +101,9 @@ class CloudformationLocalGraph(LocalGraph):
                 if isinstance(target_ids, list):
                     for target_id in target_ids:
                         if isinstance(target_id, str):
-                            dest_vertex_index = self._vertices_indexes[vertex_path][target_id]
-                            self._create_edge(origin_node_index, dest_vertex_index, label=attribute)
+                            dest_vertex_index = self._vertices_indexes.get(vertex_path, {}).get(target_id, None)
+                            if dest_vertex_index:
+                                self._create_edge(origin_node_index, dest_vertex_index, label=attribute)
                         else:
                             logging.info(f"[CloudformationLocalGraph] didnt create edge for target_id {target_id}"
                                          f"and vertex_path {vertex_path} as target_id is not a string")

--- a/checkov/cloudformation/graph_builder/local_graph.py
+++ b/checkov/cloudformation/graph_builder/local_graph.py
@@ -102,7 +102,7 @@ class CloudformationLocalGraph(LocalGraph):
                     for target_id in target_ids:
                         if isinstance(target_id, str):
                             dest_vertex_index = self._vertices_indexes.get(vertex_path, {}).get(target_id, None)
-                            if dest_vertex_index:
+                            if dest_vertex_index is not None:
                                 self._create_edge(origin_node_index, dest_vertex_index, label=attribute)
                         else:
                             logging.info(f"[CloudformationLocalGraph] didnt create edge for target_id {target_id}"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. When the resource in the `DependsOn` attribute is missing, CFN crashed, so I changed it to safe extraction
2. Removed unused ENUM (created a duplication in the new file `cfn_keyword` in PR #1498)