### PR TITLE
Fix contains attribute solver

### DIFF
--- a/checkov/arm/checks/resource/NSGRulePortAccessRestricted.py
+++ b/checkov/arm/checks/resource/NSGRulePortAccessRestricted.py
@@ -25,7 +25,7 @@ class NSGRulePortAccessRestricted(BaseResourceCheck):
         self.port = port
 
     def is_port_in_range(self, portRange):
-        if re.match(PORT_RANGE, portRange):
+        if re.match(PORT_RANGE, str(portRange)):
             start, end = int(portRange.split('-')[0]), int(portRange.split('-')[1])
             if start <= self.port <= end:
                 return True

--- a/checkov/common/checks_infra/solvers/attribute_solvers/contains_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/contains_attribute_solver.py
@@ -22,5 +22,5 @@ class ContainsAttributeSolver(BaseAttributeSolver):
             except ValueError:
                 pass
         if isinstance(att, dict):
-            return self.value in att or any(self.value in val for val in att.values())
+            return self.value in att or any(self.value in val for val in att.values() if type(val) in [str, list, set, dict])
         return self.value in att


### PR DESCRIPTION
When running YAML checks, we might use the `contains` operator. 
If the attribute value being searched is not iterable, i.e not in `[str, list, set, dict]`, we won't be able to run the `in` operator on it.
This added condition protects us from attempting to run on different types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
