### PR TITLE
Fix/Improvement to CKV2_AWS_28

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/ALBProtectedByWAF.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/ALBProtectedByWAF.yaml
@@ -15,6 +15,12 @@ definition:
         resource_types:
         - aws_lb
         connected_resource_types:
+        - aws_wafv2_web_acl_association
+      - cond_type: connection
+        operator: exists
+        resource_types:
+        - aws_lb
+        connected_resource_types:
         - aws_wafregional_web_acl_association
       - cond_type: attribute
         value: true

--- a/tests/terraform/graph/checks/resources/ALBProtectedByWAF/expected.yaml
+++ b/tests/terraform/graph/checks/resources/ALBProtectedByWAF/expected.yaml
@@ -1,5 +1,6 @@
 pass:
   - "aws_lb.lb_good_1"
+  - "aws_lb.lb_good_2"
   - "aws_lb.ignore"
 
 fail:

--- a/tests/terraform/graph/checks/resources/ALBProtectedByWAF/main.tf
+++ b/tests/terraform/graph/checks/resources/ALBProtectedByWAF/main.tf
@@ -2,10 +2,18 @@ resource "aws_lb" "lb_good_1" {
   internal= false
 }
 
+resource "aws_lb" "lb_good_2" {
+  internal= false
+}
 
 resource "aws_wafregional_web_acl_association" "foo" {
   resource_arn = aws_lb.lb_good_1.arn
   web_acl_id = aws_wafregional_web_acl.foo.id
+}
+
+resource "aws_wafv2_web_acl_association" "bar" {
+  resource_arn = aws_lb.lb_good_2.arn
+  web_acl_arn = aws_wafv2_web_acl.bar.arn
 }
 
 //public no WAF


### PR DESCRIPTION
Fix/Improvement of _Check public alb has waf_  #1434. Added support for checking if ALB is associated to a _aws_wafv2_web_acl_association_ which is the latest version of AWS WAF. 

1. Added support for aws_wafv2_web_acl_association to CKV2_AWS_28 / Terraform
2. Updated tests
3. Updated expected results

cc @JamesWoolfenden @rotemavni 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
