### PR TITLE
Add lambda dlq check

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -12,7 +12,7 @@ jobs:
           python-version: 3.7
       - name: Install cfn-lint
         run: |
-          pip install cfn-lint==0.51.0
+          pip install cfn-lint==0.53.0
       - name: Lint Cloudformation templates
         run: |
           cfn-lint tests/cloudformation/checks/resource/aws/**/* -i W

--- a/checkov/cloudformation/checks/resource/aws/LambdaDLQConfigured.py
+++ b/checkov/cloudformation/checks/resource/aws/LambdaDLQConfigured.py
@@ -1,0 +1,21 @@
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories
+
+
+class LambdaDLQConfigured(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
+        id = "CKV_AWS_116"
+        supported_resources = ["AWS::Lambda::Function"]
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "Properties/DeadLetterConfig/TargetArn"
+
+    def get_expected_value(self) -> str:
+        return ANY_VALUE
+
+
+check = LambdaDLQConfigured()

--- a/checkov/cloudformation/checks/resource/base_resource_check.py
+++ b/checkov/cloudformation/checks/resource/base_resource_check.py
@@ -1,29 +1,32 @@
 from abc import abstractmethod
+from typing import List, Callable, Optional, Dict, Any
 
 from checkov.cloudformation.checks.resource.registry import cfn_registry
 from checkov.common.checks.base_check import BaseCheck
+from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.common.multi_signature import multi_signature
 
 
 class BaseResourceCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_resources):
-        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_resources,
-                         block_type="resource")
+    def __init__(self, name: str, id: str, categories: List[CheckCategories], supported_resources: List[str]) -> None:
+        super().__init__(
+            name=name, id=id, categories=categories, supported_entities=supported_resources, block_type="resource"
+        )
         self.supported_resources = supported_resources
         cfn_registry.register(self)
 
-    def scan_entity_conf(self, conf, entity_type):
+    def scan_entity_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
         return self.scan_resource_conf(conf, entity_type)
 
     @multi_signature()
     @abstractmethod
-    def scan_resource_conf(self, conf, entity_type):
+    def scan_resource_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
         raise NotImplementedError()
 
     @classmethod
     @scan_resource_conf.add_signature(args=["self", "conf"])
-    def _scan_resource_conf_self_conf(cls, wrapped):
-        def wrapper(self, conf, entity_type=None):
+    def _scan_resource_conf_self_conf(cls, wrapped: Callable[..., CheckResult]) -> Callable[..., CheckResult]:
+        def wrapper(self: BaseCheck, conf: Dict[str, Any], entity_type: Optional[str] = None) -> CheckResult:
             # keep default argument for entity_type so old code, that doesn't set it, will work.
             return wrapped(self, conf)
 

--- a/checkov/cloudformation/checks/resource/base_resource_negative_value_check.py
+++ b/checkov/cloudformation/checks/resource/base_resource_negative_value_check.py
@@ -1,9 +1,8 @@
 from abc import abstractmethod
-from typing import List, Any, Optional
+from typing import List, Any, Optional, Dict
 
 from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.cloudformation.context_parser import ContextParser
-from checkov.cloudformation.parser.node import dict_node, str_node
 from checkov.common.models.consts import ANY_VALUE
 from checkov.common.models.enums import CheckResult, CheckCategories
 
@@ -20,7 +19,7 @@ class BaseResourceNegativeValueCheck(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
         self.missing_block_result = missing_block_result
 
-    def scan_resource_conf(self, conf: dict_node, entity_type: str_node) -> CheckResult:
+    def scan_resource_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
         excluded_key = self.get_excluded_key()
         if excluded_key is not None:
             path_elements = excluded_key.split("/")

--- a/checkov/common/checks/base_check.py
+++ b/checkov/common/checks/base_check.py
@@ -69,13 +69,13 @@ class BaseCheck(metaclass=MultiSignatureMeta):
 
     @multi_signature()
     @abstractmethod
-    def scan_entity_conf(self, conf: Dict[str, List[Any]], entity_type: str) -> CheckResult:
+    def scan_entity_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
         raise NotImplementedError()
 
     @classmethod
     @scan_entity_conf.add_signature(args=["self", "conf"])
-    def _scan_entity_conf_self_conf(cls, wrapped: Callable) -> Callable:
-        def wrapper(self: "BaseCheck", conf: Dict[str, List[Any]], entity_type: Optional[str] = None) -> CheckResult:
+    def _scan_entity_conf_self_conf(cls, wrapped: Callable[..., CheckResult]) -> Callable[..., CheckResult]:
+        def wrapper(self: "BaseCheck", conf: Dict[str, Any], entity_type: Optional[str] = None) -> CheckResult:
             # keep default argument for entity_type so old code, that doesn't set it, will work.
             return wrapped(self, conf)
 

--- a/tests/cloudformation/checks/resource/aws/example_LambdaDLQConfigured/FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_LambdaDLQConfigured/FAIL.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Default:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: arn:aws:iam::123456789012:role/lambda-role
+      Code:
+        S3Bucket: my-bucket
+        S3Key: function.zip
+      Runtime: python3.9

--- a/tests/cloudformation/checks/resource/aws/example_LambdaDLQConfigured/FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_LambdaDLQConfigured/FAIL.yaml
@@ -8,4 +8,4 @@ Resources:
       Code:
         S3Bucket: my-bucket
         S3Key: function.zip
-      Runtime: python3.9
+      Runtime: python3.8

--- a/tests/cloudformation/checks/resource/aws/example_LambdaDLQConfigured/PASS.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_LambdaDLQConfigured/PASS.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Enabled:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: arn:aws:iam::123456789012:role/lambda-role
+      Code:
+        S3Bucket: my-bucket
+        S3Key: function.zip
+      Runtime: python3.9
+      DeadLetterConfig:
+        TargetArn: arn:aws:sqs:eu-central-1:123456789012:dlq

--- a/tests/cloudformation/checks/resource/aws/example_LambdaDLQConfigured/PASS.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_LambdaDLQConfigured/PASS.yaml
@@ -8,6 +8,6 @@ Resources:
       Code:
         S3Bucket: my-bucket
         S3Key: function.zip
-      Runtime: python3.9
+      Runtime: python3.8
       DeadLetterConfig:
         TargetArn: arn:aws:sqs:eu-central-1:123456789012:dlq

--- a/tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentCredentials/FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentCredentials/FAIL.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Secret:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: nodejs12.x
+      Role: arn:aws:iam::123456789012:role/lambda-role
+      Handler: index.handler
+      Environment:
+        Variables:
+          key1: AKIAAAAAAAAAAAAAAAAA
+          key2: Val2
+      Code:
+        ZipFile: |
+          print('hi')
+      Description: Invoke a function during stack creation.
+      TracingConfig:
+        Mode: Active

--- a/tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentCredentials/PASS.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentCredentials/PASS.yaml
@@ -1,22 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  l1:
-    Type: AWS::Lambda::Function
-    Properties:
-      Runtime: nodejs12.x
-      Role: arn:aws:iam::123456789012:role/lambda-role
-      Handler: index.handler
-      Environment:
-        Variables:
-          key1: AKIAAAAAAAAAAAAAAAAA
-          key2: Val2
-      Code:
-        ZipFile: |
-          print('hi')
-      Description: Invoke a function during stack creation.
-      TracingConfig:
-        Mode: Active
-  l2:
+  NoSecret:
     Type: AWS::Lambda::Function
     Properties:
       Runtime: nodejs12.x
@@ -32,7 +16,7 @@ Resources:
       Description: Invoke a function during stack creation.
       TracingConfig:
         Mode: Active
-  l3:
+  NoEnv:
     Type: AWS::Lambda::Function
     Properties:
       Runtime: nodejs12.x
@@ -44,4 +28,3 @@ Resources:
       Description: Invoke a function during stack creation.
       TracingConfig:
         Mode: Active
-

--- a/tests/cloudformation/checks/resource/aws/test_LambdaDLQConfigured.py
+++ b/tests/cloudformation/checks/resource/aws/test_LambdaDLQConfigured.py
@@ -1,30 +1,29 @@
 import unittest
 from pathlib import Path
 
-from checkov.cloudformation.checks.resource.aws.LambdaEnvironmentCredentials import check
+from checkov.cloudformation.checks.resource.aws.LambdaDLQConfigured import check
 from checkov.cloudformation.runner import Runner
 from checkov.runner_filter import RunnerFilter
 
 
 class TestLambdaEnvironmentCredentials(unittest.TestCase):
     def test_summary(self):
-        test_files_dir = Path(__file__).parent / "example_LambdaEnvironmentCredentials"
+        test_files_dir = Path(__file__).parent / "example_LambdaDLQConfigured"
 
         report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
         passing_resources = {
-            "AWS::Lambda::Function.NoEnv",
-            "AWS::Lambda::Function.NoSecret",
+            "AWS::Lambda::Function.Enabled",
         }
         failing_resources = {
-            "AWS::Lambda::Function.Secret",
+            "AWS::Lambda::Function.Default",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["passed"], 1)
         self.assertEqual(summary["failed"], 1)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This check already existed for Terraform and I also cleaned up the tests for the check `LambdaEnvironmentCredentials` to reflect the newer way of testing.

Other than that I also adjusted the type hints for the BaseCheck classes and I probably will rework them later again, because the `@multi_signature` decorator is still a mystery for me to type hint it correctly 😵 