### PR TITLE
make the path used for suppressions a unix path always

### DIFF
--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -40,7 +40,7 @@ class Record:
         self.code_block = code_block
         self.file_path = file_path
         self.file_abs_path = file_abs_path
-        self.repo_file_path = f'/{os.path.relpath(file_abs_path)}' # matches file paths given in the BC platform.
+        self.repo_file_path = f'/{os.path.relpath(file_abs_path)}'.replace('\\', '/')  # matches file paths given in the BC platform and should always be a unix path
         self.file_line_range = file_line_range
         self.resource = resource
         self.evaluations = evaluations

--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -5,6 +5,7 @@ from colorama import init, Fore, Style
 from termcolor import colored
 
 from checkov.common.models.enums import CheckResult
+from checkov.common.util.file_utils import convert_to_unix_path
 
 init(autoreset=True)
 
@@ -40,7 +41,7 @@ class Record:
         self.code_block = code_block
         self.file_path = file_path
         self.file_abs_path = file_abs_path
-        self.repo_file_path = f'/{os.path.relpath(file_abs_path)}'.replace('\\', '/')  # matches file paths given in the BC platform and should always be a unix path
+        self.repo_file_path = convert_to_unix_path(f'/{os.path.relpath(file_abs_path)}')  # matches file paths given in the BC platform and should always be a unix path
         self.file_line_range = file_line_range
         self.resource = resource
         self.evaluations = evaluations

--- a/checkov/common/util/file_utils.py
+++ b/checkov/common/util/file_utils.py
@@ -1,0 +1,3 @@
+
+def convert_to_unix_path(path: str) -> str:
+    return path.replace('\\', '/')


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes the value for `repo_file_path` on Windows to always be a unix path. This value is never used for actual filesystem operations; it's only used to match suppressions with the platform.
