### PR TITLE
Handle double slashes from hcl2 gracefully

### DIFF
--- a/checkov/terraform/graph_builder/graph_components/module.py
+++ b/checkov/terraform/graph_builder/graph_components/module.py
@@ -1,3 +1,4 @@
+import json
 import os
 from copy import deepcopy
 from typing import List, Dict, Any, Set, Callable
@@ -123,7 +124,7 @@ class Module:
             for resource_type, resources in resource_dict.items():
                 self.resources_types.add(resource_type)
                 for name, resource_conf in resources.items():
-                    attributes = deepcopy(resource_conf)
+                    attributes = self.clean_bad_characters(resource_conf)
                     provisioner = attributes.get("provisioner")
                     if provisioner:
                         self._handle_provisioner(provisioner, attributes)
@@ -131,13 +132,17 @@ class Module:
                     resource_block = TerraformBlock(
                         block_type=BlockType.RESOURCE,
                         name=f"{resource_type}.{name}",
-                        config=resource_dict,
+                        config=self.clean_bad_characters(resource_dict),
                         path=path,
                         attributes=attributes,
                         id=f"{resource_type}.{name}",
                         source=self.source
                     )
                     self._add_to_blocks(resource_block)
+
+    @staticmethod
+    def clean_bad_characters(resource_conf):
+        return json.loads(json.dumps(resource_conf).replace("\\\\", "\\"))
 
     def _add_data(self, blocks: List[Dict[str, Dict[str, Any]]], path: str) -> None:
         for data_dict in blocks:

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -112,21 +112,6 @@ class TerraformLocalGraph(LocalGraph):
                             )
         return undetermined_values
 
-    def process_undetermined_values(self, undetermined_values: List[Undetermined]) -> None:
-        for undetermined in undetermined_values:
-            module_vertex = self.vertices[undetermined["module_vertex_id"]]
-            value = module_vertex.attributes.get(undetermined["attribute_name"])
-            if not get_referenced_vertices_in_value(
-                value=value, aliases={}, resources_types=self.get_resources_types_in_graph()
-            ):
-                self.update_vertex_attribute(
-                    undetermined["variable_vertex_id"],
-                    "default",
-                    value,
-                    undetermined["module_vertex_id"],
-                    undetermined["attribute_name"],
-                )
-
     def _get_aliases(self) -> Dict[str, Dict[str, BlockType]]:
         """
         :return aliases: map between alias names that are found inside the blocks and the block type their aliased to.

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -626,9 +626,9 @@ Load JSON or HCL, depending on filename.
                 return json.load(f)
             else:
                 raw_data = hcl2.load(f)
-                non_malformed_definitions = _validate_malformed_definitions(raw_data)
+                non_malformed_definitions = validate_malformed_definitions(raw_data)
                 if clean_definitions:
-                    return _clean_bad_definitions(non_malformed_definitions)
+                    return clean_bad_definitions(non_malformed_definitions)
                 else:
                     return non_malformed_definitions
     except Exception as e:
@@ -646,7 +646,7 @@ def _is_valid_block(block):
     return False
 
 
-def _validate_malformed_definitions(raw_data):
+def validate_malformed_definitions(raw_data):
     raw_data_cleaned = copy.deepcopy(raw_data)
     for block_type, blocks in raw_data.items():
         raw_data_cleaned[block_type] = [block for block in blocks if _is_valid_block(block)]
@@ -654,7 +654,7 @@ def _validate_malformed_definitions(raw_data):
     return raw_data_cleaned
 
 
-def _clean_bad_definitions(tf_definition_list):
+def clean_bad_definitions(tf_definition_list):
     return {
         block_type: list(filter(lambda definition_list: block_type == 'locals' or
                                                         not isinstance(definition_list, dict)

--- a/tests/terraform/parser/resources/double_slash.tf
+++ b/tests/terraform/parser/resources/double_slash.tf
@@ -1,0 +1,10 @@
+resource "helm_release" "test" {
+  name       = "influxdb"
+  repository = "https://helm.influxdata.com"
+  chart      = "influxdb"
+  namespace  = "influxdb"
+  set {
+    name  = "ingress.annotations.kubernetes\\.io/ingress\\.class"
+    value = var.influxdb_ingress_annotations_kubernetes_ingress_class
+  }
+}

--- a/tests/terraform/parser/test_module.py
+++ b/tests/terraform/parser/test_module.py
@@ -1,0 +1,20 @@
+import os
+import unittest
+
+import hcl2
+
+from checkov.terraform.parser import validate_malformed_definitions, clean_bad_definitions, Parser
+
+
+class ModuleTest(unittest.TestCase):
+    def test_module_double_slash_cleanup(self):
+        with open(os.path.join(os.path.dirname(__file__), 'resources', 'double_slash.tf')) as f:
+            tf = hcl2.load(f)
+        non_malformed_definitions = validate_malformed_definitions(tf)
+        definitions = {
+            '/mock/path/to.tf': clean_bad_definitions(non_malformed_definitions)
+        }
+        module, _, _ = Parser().parse_hcl_module_from_tf_definitions(definitions, '', 'terraform')
+        print(module)
+        self.assertEqual(1, len(module.blocks))
+        self.assertEqual('ingress.annotations.kubernetes\\.io/ingress\\.class', module.blocks[0].attributes['set.name'])


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


Apparently, hcl2 lib loads **from file** strings with `\\` as `\\\\`, while it does not do that for strings. This handles it