### PR TITLE
aws lambda terraform - checks encryption settings for env vars

### DIFF
--- a/checkov/terraform/checks/resource/aws/LambdaEnvironmentEncryptionSettings.py
+++ b/checkov/terraform/checks/resource/aws/LambdaEnvironmentEncryptionSettings.py
@@ -1,0 +1,38 @@
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckResult,CheckCategories
+
+
+class LambdaEnvironmentEncryptionSettings(BaseResourceCheck):
+
+    def __init__(self):
+        name = "Check encryption settings for Lambda environmental variable"
+        id = "CKV_AWS_173"
+        supported_resources = ['aws_lambda_function']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        self.evaluated_keys = 'environment/[0]/variables'
+
+        # check that if I have env vars I have a KMS key
+        if len(conf.get('environment', [])) > 0:
+           if 'kms_key_arn' in conf:
+               if  len(conf["kms_key_arn"]) == 0:
+                   return CheckResult.FAILED
+               else:
+                   return CheckResult.PASSED
+           else:
+                return CheckResult.FAILED
+        else: 
+            #no env vars so should be no key as that causes state mismatch
+            if 'kms_key_arn' in conf:  
+               if  len(conf["kms_key_arn"]) == 0:
+                   return CheckResult.PASSED
+               else:
+                   return CheckResult.FAILED
+        # neither env vars nor kms key
+        return CheckResult.UNKNOWN
+		
+
+
+check = LambdaEnvironmentEncryptionSettings()

--- a/tests/terraform/checks/resource/aws/example_LambdaEnvironmentEncryptionSettings/main.tf
+++ b/tests/terraform/checks/resource/aws/example_LambdaEnvironmentEncryptionSettings/main.tf
@@ -1,0 +1,59 @@
+resource "aws_lambda_function" "fail" {
+   function_name                  = var.function_name
+   role                           = aws_iam_role.lambda-messageprocessor.arn
+   runtime                        = "python3.6"
+   handler                        = "handler.lambda_handler"
+   filename                       = data.archive_file.notify.output_path
+   source_code_hash               = data.archive_file.notify.output_base64sha256
+   reserved_concurrent_executions = var.concurrency
+   tracing_config {
+       mode = "PassThrough"
+    }
+    environment {
+        test="true"
+    }
+}
+
+resource "aws_lambda_function" "failkmsnovars" {
+   function_name                  = var.function_name
+   role                           = aws_iam_role.lambda-messageprocessor.arn
+   runtime                        = "python3.6"
+   handler                        = "handler.lambda_handler"
+   filename                       = data.archive_file.notify.output_path
+   source_code_hash               = data.archive_file.notify.output_base64sha256
+   reserved_concurrent_executions = var.concurrency
+   tracing_config {
+       mode = "PassThrough"
+    }
+   kms_key_arn = aws_kms_key.anyoldguff.arn
+}
+
+resource "aws_lambda_function" "ignore" {
+   function_name                  = var.function_name
+   role                           = aws_iam_role.lambda-messageprocessor.arn
+   runtime                        = "python3.6"
+   handler                        = "handler.lambda_handler"
+   filename                       = data.archive_file.notify.output_path
+   source_code_hash               = data.archive_file.notify.output_base64sha256
+   reserved_concurrent_executions = var.concurrency
+   tracing_config {
+       mode = "PassThrough"
+    }
+}
+
+resource "aws_lambda_function" "pass" {
+   function_name                  = var.function_name
+   role                           = aws_iam_role.lambda-messageprocessor.arn
+   runtime                        = "python3.6"
+   handler                        = "handler.lambda_handler"
+   filename                       = data.archive_file.notify.output_path
+   source_code_hash               = data.archive_file.notify.output_base64sha256
+   reserved_concurrent_executions = var.concurrency
+   tracing_config {
+       mode = "PassThrough"
+    }
+    environment {
+        test="true"
+    }
+   kms_key_arn = aws_kms_key.anyoldguff.arn
+}

--- a/tests/terraform/checks/resource/aws/test_LambdaEnvironmentEncryptionSettings.py
+++ b/tests/terraform/checks/resource/aws/test_LambdaEnvironmentEncryptionSettings.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.LambdaEnvironmentEncryptionSettings import check
+from checkov.terraform.runner import Runner
+
+class TestLambdaEnvironmentEncryptionSettings(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_LambdaEnvironmentEncryptionSettings"
+        report = runner.run(
+            root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
+        )
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_lambda_function.pass", 
+        }
+        failing_resources = {
+            "aws_lambda_function.fail",
+            "aws_lambda_function.failkmsnovars"
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Environmental variables for lambdas are supposed to be encrypted, this checks for that. 
Also if there no env vars theyre shouldn't be a key set, this also checks for that.