### PR TITLE
Prevent checkov crash when rendering Fn::Sub

### DIFF
--- a/checkov/cloudformation/graph_builder/local_graph.py
+++ b/checkov/cloudformation/graph_builder/local_graph.py
@@ -122,10 +122,10 @@ class CloudformationLocalGraph(LocalGraph):
                             if dest_vertex_index is not None:
                                 self._create_edge(origin_node_index, dest_vertex_index, label=attribute)
                         else:
-                            logging.info(f"[CloudformationLocalGraph] didnt create edge for target_id {target_id}"
+                            logging.debug(f"[CloudformationLocalGraph] didnt create edge for target_id {target_id}"
                                          f"and vertex_path {vertex_path} as target_id is not a string")
                 else:
-                    logging.info(f"[CloudformationLocalGraph] didnt create edge for target_ids {target_ids}"
+                    logging.debug(f"[CloudformationLocalGraph] didnt create edge for target_ids {target_ids}"
                                  f"and vertex_path {vertex_path} as target_ids is not a list")
 
     def _extract_source_value_attrs(self, matching_path):

--- a/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
@@ -109,6 +109,9 @@ class CloudformationVariableRenderer(VariableRenderer):
         return None
 
     def _evaluate_sub_connection(self, value: str, dest_vertex_attributes: Dict[str, Any]) -> Optional[str]:
+        if isinstance(value, list):
+            # TODO: Render values of list type
+            return None
         evaluated_value = None
 
         # value = '..${ref/getatt}..${ref/getatt}..${ref/getatt}..'


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. checkov crashes while rendering Fn::Sub value which is a list and not a string. For now, skip values of list type
2. changed `logging.info` to `debug` level in some places