### PR TITLE
Fix Terraform Sql Server Vulnerability Assessment (VA) Checks

### DIFF
--- a/checkov/terraform/checks/graph_checks/azure/VAconfiguredToSendReports.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/VAconfiguredToSendReports.yaml
@@ -1,5 +1,5 @@
 metadata:
-  name: "Ensure that VA setting Periodic Recurring Scans is enabled on a SQL server"
+  name: "Ensure Azure SQL server ADS VA Send scan reports to is configured"
   id: "CKV2_AZURE_4"
   category: "GENERAL_SECURITY"
 definition:

--- a/checkov/terraform/checks/graph_checks/azure/VAconfiguredToSendReports.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/VAconfiguredToSendReports.yaml
@@ -44,7 +44,7 @@ definition:
         - cond_type: filter
           attribute: resource_type
           value:
-            - azurerm_mssql_server_security_alert_policy
+            - azurerm_mssql_server_vulnerability_assessment
           operator: within
         
        

--- a/checkov/terraform/checks/graph_checks/azure/VAconfiguredToSendReports.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/VAconfiguredToSendReports.yaml
@@ -4,12 +4,19 @@ metadata:
   category: "GENERAL_SECURITY"
 definition:
       and:
-        - resource_types:
-          - azurerm_sql_server
-          connected_resource_types:
-          - azurerm_mssql_server_security_alert_policy
-          operator:  exists
-          cond_type: connection
+        - or:
+          - resource_types:
+            - azurerm_sql_server
+            connected_resource_types:
+            - azurerm_mssql_server_security_alert_policy
+            operator:  exists
+            cond_type: connection
+          - resource_types:
+            - azurerm_mssql_server
+            connected_resource_types:
+            - azurerm_mssql_server_security_alert_policy
+            operator:  exists
+            cond_type: connection
         - cond_type: attribute
           resource_types:
             - "azurerm_mssql_server_security_alert_policy"

--- a/checkov/terraform/checks/graph_checks/azure/VAconfiguredToSendReportsToAdmins.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/VAconfiguredToSendReportsToAdmins.yaml
@@ -43,7 +43,7 @@ definition:
         - cond_type: filter
           attribute: resource_type
           value:
-            - azurerm_mssql_server_security_alert_policy
+            - azurerm_mssql_server_vulnerability_assessment
           operator: within
         
        

--- a/checkov/terraform/checks/graph_checks/azure/VAconfiguredToSendReportsToAdmins.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/VAconfiguredToSendReportsToAdmins.yaml
@@ -4,12 +4,19 @@ metadata:
   category: "GENERAL_SECURITY"
 definition:
       and:
-        - resource_types:
-          - azurerm_sql_server
-          connected_resource_types:
-          - azurerm_mssql_server_security_alert_policy
-          operator:  exists
-          cond_type: connection
+        - or:
+          - resource_types:
+            - azurerm_sql_server
+            connected_resource_types:
+            - azurerm_mssql_server_security_alert_policy
+            operator:  exists
+            cond_type: connection
+          - resource_types:
+            - azurerm_mssql_server
+            connected_resource_types:
+            - azurerm_mssql_server_security_alert_policy
+            operator:  exists
+            cond_type: connection
         - cond_type: attribute
           resource_types:
             - "azurerm_mssql_server_security_alert_policy"

--- a/checkov/terraform/checks/graph_checks/azure/VAsetPeriodicScansOnSQL.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/VAsetPeriodicScansOnSQL.yaml
@@ -38,6 +38,6 @@ definition:
         - cond_type: filter
           attribute: resource_type
           value:
-            - azurerm_mssql_server_security_alert_policy
+            - azurerm_mssql_server_vulnerability_assessment
           operator: within
 

--- a/checkov/terraform/checks/graph_checks/azure/VAsetPeriodicScansOnSQL.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/VAsetPeriodicScansOnSQL.yaml
@@ -4,12 +4,19 @@ metadata:
   category: "GENERAL_SECURITY"
 definition:
     and:
-        - resource_types:
-          - azurerm_sql_server
-          connected_resource_types:
-          - azurerm_mssql_server_security_alert_policy
-          operator:  exists
-          cond_type: connection
+        - or:
+          - resource_types:
+            - azurerm_sql_server
+            connected_resource_types:
+            - azurerm_mssql_server_security_alert_policy
+            operator:  exists
+            cond_type: connection
+          - resource_types:
+            - azurerm_mssql_server
+            connected_resource_types:
+            - azurerm_mssql_server_security_alert_policy
+            operator:  exists
+            cond_type: connection
         - cond_type: attribute
           resource_types:
             - "azurerm_mssql_server_security_alert_policy"

--- a/tests/terraform/graph/checks/resources/VAconfiguredToSendReports/expected.yaml
+++ b/tests/terraform/graph/checks/resources/VAconfiguredToSendReports/expected.yaml
@@ -1,5 +1,6 @@
 pass:
   - "azurerm_mssql_server_security_alert_policy.okExample"
+  - "azurerm_mssql_server_security_alert_policy.okLegacyExample"
 fail:
   - "azurerm_mssql_server_security_alert_policy.badExampleNotEnabled"
 

--- a/tests/terraform/graph/checks/resources/VAconfiguredToSendReports/expected.yaml
+++ b/tests/terraform/graph/checks/resources/VAconfiguredToSendReports/expected.yaml
@@ -1,6 +1,6 @@
 pass:
-  - "azurerm_mssql_server_security_alert_policy.okExample"
-  - "azurerm_mssql_server_security_alert_policy.okLegacyExample"
+  - "azurerm_mssql_server_vulnerability_assessment.okExample"
+  - "azurerm_mssql_server_vulnerability_assessment.okLegacyExample"
 fail:
-  - "azurerm_mssql_server_security_alert_policy.badExampleNotEnabled"
+  - "azurerm_mssql_server_vulnerability_assessment.badExampleNotEnabled"
 

--- a/tests/terraform/graph/checks/resources/VAconfiguredToSendReports/main.tf
+++ b/tests/terraform/graph/checks/resources/VAconfiguredToSendReports/main.tf
@@ -1,9 +1,58 @@
+resource "azurerm_resource_group" "okLegacyExample" {
+  name     = "okLegacyExample-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_sql_server" "okLegacyExample" {
+  name                         = "mysqlserver"
+  resource_group_name          = azurerm_resource_group.okLegacyExample.name
+  location                     = azurerm_resource_group.okLegacyExample.location
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}
+
+resource "azurerm_storage_account" "okLegacyExample" {
+  name                     = "accteststorageaccount"
+  resource_group_name      = azurerm_resource_group.okLegacyExample.name
+  location                 = azurerm_resource_group.okLegacyExample.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_storage_container" "okLegacyExample" {
+  name                  = "accteststoragecontainer"
+  storage_account_name  = azurerm_storage_account.okLegacyExample.name
+  container_access_type = "private"
+}
+
+resource "azurerm_mssql_server_security_alert_policy" "okLegacyExample" {
+  resource_group_name = azurerm_resource_group.okLegacyExample.name
+  server_name         = azurerm_sql_server.okLegacyExample.name
+  state               = "Enabled"
+}
+
+resource "azurerm_mssql_server_vulnerability_assessment" "okLegacyExample" {
+  server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.okLegacyExample.id
+  storage_container_path          = "${azurerm_storage_account.okLegacyExample.primary_blob_endpoint}${azurerm_storage_container.okLegacyExample.name}/"
+  storage_account_access_key      = azurerm_storage_account.okLegacyExample.primary_access_key
+
+  recurring_scans {
+    enabled                   = true
+    email_subscription_admins = true
+    emails = [
+      "email@example1.com",
+      "email@example2.com"
+    ]
+  }
+}
+
 resource "azurerm_resource_group" "okExample" {
   name     = "okExample-resources"
   location = "West Europe"
 }
 
-resource "azurerm_sql_server" "okExample" {
+resource "azurerm_mssql_server" "okExample" {
   name                         = "mysqlserver"
   resource_group_name          = azurerm_resource_group.okExample.name
   location                     = azurerm_resource_group.okExample.location
@@ -28,7 +77,7 @@ resource "azurerm_storage_container" "okExample" {
 
 resource "azurerm_mssql_server_security_alert_policy" "okExample" {
   resource_group_name = azurerm_resource_group.okExample.name
-  server_name         = azurerm_sql_server.okExample.name
+  server_name         = azurerm_mssql_server.okExample.name
   state               = "Enabled"
 }
 

--- a/tests/terraform/graph/checks/resources/VAconfiguredToSendReportsToAdmins/expected.yaml
+++ b/tests/terraform/graph/checks/resources/VAconfiguredToSendReportsToAdmins/expected.yaml
@@ -1,5 +1,6 @@
 pass:
   - "azurerm_mssql_server_security_alert_policy.okExample"
+  - "azurerm_mssql_server_security_alert_policy.okLegacyExample"
 fail:
   - "azurerm_mssql_server_security_alert_policy.badExampleNotEnabled"
 

--- a/tests/terraform/graph/checks/resources/VAconfiguredToSendReportsToAdmins/expected.yaml
+++ b/tests/terraform/graph/checks/resources/VAconfiguredToSendReportsToAdmins/expected.yaml
@@ -1,6 +1,6 @@
 pass:
-  - "azurerm_mssql_server_security_alert_policy.okExample"
-  - "azurerm_mssql_server_security_alert_policy.okLegacyExample"
+  - "azurerm_mssql_server_vulnerability_assessment.okExample"
+  - "azurerm_mssql_server_vulnerability_assessment.okLegacyExample"
 fail:
-  - "azurerm_mssql_server_security_alert_policy.badExampleNotEnabled"
+  - "azurerm_mssql_server_vulnerability_assessment.badExampleNotEnabled"
 

--- a/tests/terraform/graph/checks/resources/VAconfiguredToSendReportsToAdmins/main.tf
+++ b/tests/terraform/graph/checks/resources/VAconfiguredToSendReportsToAdmins/main.tf
@@ -1,9 +1,58 @@
+resource "azurerm_resource_group" "okLegacyExample" {
+  name     = "okLegacyExample-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_sql_server" "okLegacyExample" {
+  name                         = "mysqlserver"
+  resource_group_name          = azurerm_resource_group.okLegacyExample.name
+  location                     = azurerm_resource_group.okLegacyExample.location
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}
+
+resource "azurerm_storage_account" "okLegacyExample" {
+  name                     = "accteststorageaccount"
+  resource_group_name      = azurerm_resource_group.okLegacyExample.name
+  location                 = azurerm_resource_group.okLegacyExample.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_storage_container" "okLegacyExample" {
+  name                  = "accteststoragecontainer"
+  storage_account_name  = azurerm_storage_account.okLegacyExample.name
+  container_access_type = "private"
+}
+
+resource "azurerm_mssql_server_security_alert_policy" "okLegacyExample" {
+  resource_group_name = azurerm_resource_group.okLegacyExample.name
+  server_name         = azurerm_sql_server.okLegacyExample.name
+  state               = "Enabled"
+}
+
+resource "azurerm_mssql_server_vulnerability_assessment" "okLegacyExample" {
+  server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.okLegacyExample.id
+  storage_container_path          = "${azurerm_storage_account.okLegacyExample.primary_blob_endpoint}${azurerm_storage_container.okLegacyExample.name}/"
+  storage_account_access_key      = azurerm_storage_account.okLegacyExample.primary_access_key
+
+  recurring_scans {
+    enabled                   = true
+    email_subscription_admins = true
+    emails = [
+      "email@example1.com",
+      "email@example2.com"
+    ]
+  }
+}
+
 resource "azurerm_resource_group" "okExample" {
   name     = "okExample-resources"
   location = "West Europe"
 }
 
-resource "azurerm_sql_server" "okExample" {
+resource "azurerm_mssql_server" "okExample" {
   name                         = "mysqlserver"
   resource_group_name          = azurerm_resource_group.okExample.name
   location                     = azurerm_resource_group.okExample.location
@@ -28,7 +77,7 @@ resource "azurerm_storage_container" "okExample" {
 
 resource "azurerm_mssql_server_security_alert_policy" "okExample" {
   resource_group_name = azurerm_resource_group.okExample.name
-  server_name         = azurerm_sql_server.okExample.name
+  server_name         = azurerm_mssql_server.okExample.name
   state               = "Enabled"
 }
 

--- a/tests/terraform/graph/checks/resources/VAsetPeriodicScansOnSQL/expected.yaml
+++ b/tests/terraform/graph/checks/resources/VAsetPeriodicScansOnSQL/expected.yaml
@@ -1,5 +1,5 @@
 pass:
-  - "azurerm_mssql_server_security_alert_policy.okExample"
-  - "azurerm_mssql_server_security_alert_policy.okLegacyExample"
+  - "azurerm_mssql_server_vulnerability_assessment.okExample"
+  - "azurerm_mssql_server_vulnerability_assessment.okLegacyExample"
 fail:
-  - "azurerm_mssql_server_security_alert_policy.badExampleNotEnabled"
+  - "azurerm_mssql_server_vulnerability_assessment.badExampleNotEnabled"

--- a/tests/terraform/graph/checks/resources/VAsetPeriodicScansOnSQL/expected.yaml
+++ b/tests/terraform/graph/checks/resources/VAsetPeriodicScansOnSQL/expected.yaml
@@ -1,4 +1,5 @@
 pass:
   - "azurerm_mssql_server_security_alert_policy.okExample"
+  - "azurerm_mssql_server_security_alert_policy.okLegacyExample"
 fail:
   - "azurerm_mssql_server_security_alert_policy.badExampleNotEnabled"

--- a/tests/terraform/graph/checks/resources/VAsetPeriodicScansOnSQL/main.tf
+++ b/tests/terraform/graph/checks/resources/VAsetPeriodicScansOnSQL/main.tf
@@ -1,9 +1,58 @@
+resource "azurerm_resource_group" "okLegacyExample" {
+  name     = "okLegacyExample-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_sql_server" "okLegacyExample" {
+  name                         = "mysqlserver"
+  resource_group_name          = azurerm_resource_group.okLegacyExample.name
+  location                     = azurerm_resource_group.okLegacyExample.location
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}
+
+resource "azurerm_storage_account" "okLegacyExample" {
+  name                     = "accteststorageaccount"
+  resource_group_name      = azurerm_resource_group.okLegacyExample.name
+  location                 = azurerm_resource_group.okLegacyExample.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_storage_container" "okLegacyExample" {
+  name                  = "accteststoragecontainer"
+  storage_account_name  = azurerm_storage_account.okLegacyExample.name
+  container_access_type = "private"
+}
+
+resource "azurerm_mssql_server_security_alert_policy" "okLegacyExample" {
+  resource_group_name = azurerm_resource_group.okLegacyExample.name
+  server_name         = azurerm_sql_server.okLegacyExample.name
+  state               = "Enabled"
+}
+
+resource "azurerm_mssql_server_vulnerability_assessment" "okLegacyExample" {
+  server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.okLegacyExample.id
+  storage_container_path          = "${azurerm_storage_account.okLegacyExample.primary_blob_endpoint}${azurerm_storage_container.okLegacyExample.name}/"
+  storage_account_access_key      = azurerm_storage_account.okLegacyExample.primary_access_key
+
+  recurring_scans {
+    enabled                   = true
+    email_subscription_admins = true
+    emails = [
+      "email@example1.com",
+      "email@example2.com"
+    ]
+  }
+}
+
 resource "azurerm_resource_group" "okExample" {
   name     = "okExample-resources"
   location = "West Europe"
 }
 
-resource "azurerm_sql_server" "okExample" {
+resource "azurerm_mssql_server" "okExample" {
   name                         = "mysqlserver"
   resource_group_name          = azurerm_resource_group.okExample.name
   location                     = azurerm_resource_group.okExample.location
@@ -28,7 +77,7 @@ resource "azurerm_storage_container" "okExample" {
 
 resource "azurerm_mssql_server_security_alert_policy" "okExample" {
   resource_group_name = azurerm_resource_group.okExample.name
-  server_name         = azurerm_sql_server.okExample.name
+  server_name         = azurerm_mssql_server.okExample.name
   state               = "Enabled"
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Several improvements for the checks: CKV2_AZURE_3, CKV2_AZURE_4 and CKV2_AZURE_5.

- The checks didn't consider the Terraform resource `azurerm_mssql_server`. Therefore the checks failed for anyone configuring a vulnerability assessment using the (modern) `azurerm_mssql_server`-resource.
- The checks reported an error on the `azurerm_mssql_server_security_alert_policy`-resource, instead of the `azurerm_mssql_server_vulnerability_assessment `-resource (#1446  #1447 )
- The check CKV2_AZURE_4 error message didn't match the actual check (#1561 )

