### PR TITLE
Fail gracefully on BC integration feature errors

### DIFF
--- a/checkov/common/bridgecrew/integration_features/base_integration_feature.py
+++ b/checkov/common/bridgecrew/integration_features/base_integration_feature.py
@@ -19,6 +19,7 @@ class BaseIntegrationFeature(ABC):
         bc_integration.setup_http_manager()
         self.order = order
         integration_feature_registry.register(self)
+        self.integration_feature_failures = False
 
     @abstractmethod
     def is_valid(self):

--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -31,7 +31,7 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
             logging.debug(f'Found {len(self.policies)} custom policies from the platform.')
         except Exception as e:
             self.integration_feature_failures = True
-            logging.error(f'{e} \n Scanning without applying custom policies from the platform.')
+            logging.debug(f'{e} \nScanning without applying custom policies from the platform.')
 
     @staticmethod
     def _convert_raw_check(policy):

--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -17,16 +17,21 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
         self.platform_policy_parser = NXGraphCheckParser()
 
     def is_valid(self):
-        return self.bc_integration.is_integration_configured() and not self.bc_integration.skip_policy_download
+        return self.bc_integration.is_integration_configured() and not self.bc_integration.skip_policy_download \
+               and not self.integration_feature_failures
 
     def pre_scan(self):
-        self.policies = self._get_policies_from_platform()
-        for policy in self.policies:
-            converted_check = self._convert_raw_check(policy)
-            resource_types = Registry._get_resource_types(converted_check['metadata'])
-            check = self.platform_policy_parser.parse_raw_check(converted_check, resources_types=resource_types)
-            get_graph_checks_registry("terraform").checks.append(check)
-        logging.debug(f'Found {len(self.policies)} custom policies from the platform.')
+        try:
+            self.policies = self._get_policies_from_platform()
+            for policy in self.policies:
+                converted_check = self._convert_raw_check(policy)
+                resource_types = Registry._get_resource_types(converted_check['metadata'])
+                check = self.platform_policy_parser.parse_raw_check(converted_check, resources_types=resource_types)
+                get_graph_checks_registry("terraform").checks.append(check)
+            logging.debug(f'Found {len(self.policies)} custom policies from the platform.')
+        except Exception as e:
+            self.integration_feature_failures = True
+            logging.error(f'{e} \n Scanning without applying custom policies from the platform.')
 
     @staticmethod
     def _convert_raw_check(policy):

--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -31,7 +31,7 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
             logging.debug(f'Found {len(self.policies)} custom policies from the platform.')
         except Exception as e:
             self.integration_feature_failures = True
-            logging.debug(f'{e} \nScanning without applying custom policies from the platform.')
+            logging.debug(f'{e} \nScanning without applying custom policies from the platform.', exc_info=True)
 
     @staticmethod
     def _convert_raw_check(policy):

--- a/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
@@ -30,7 +30,7 @@ class FixesIntegration(BaseIntegrationFeature):
             self._get_platform_fixes(scan_report)
         except Exception as e:
             self.integration_feature_failures = True
-            logging.error(f'{e} \n Custom fixes will not be applied.')
+            logging.debug(f'{e} \nFixes will not be applied.')
 
     def _get_platform_fixes(self, scan_report):
 

--- a/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
@@ -30,7 +30,7 @@ class FixesIntegration(BaseIntegrationFeature):
             self._get_platform_fixes(scan_report)
         except Exception as e:
             self.integration_feature_failures = True
-            logging.debug(f'{e} \nFixes will not be applied.')
+            logging.debug(f'{e} \nFixes will not be applied.', exc_info=True)
 
     def _get_platform_fixes(self, scan_report):
 

--- a/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
@@ -20,12 +20,17 @@ class FixesIntegration(BaseIntegrationFeature):
         super().__init__(bc_integration, order=10)
 
     def is_valid(self):
-        return self.bc_integration.is_integration_configured() and not self.bc_integration.skip_fixes
+        return self.bc_integration.is_integration_configured() and not self.bc_integration.skip_fixes \
+               and not self.integration_feature_failures
 
     def post_runner(self, scan_report):
-        if scan_report.check_type not in SUPPORTED_FIX_FRAMEWORKS:
-            return
-        self._get_platform_fixes(scan_report)
+        try:
+            if scan_report.check_type not in SUPPORTED_FIX_FRAMEWORKS:
+                return
+            self._get_platform_fixes(scan_report)
+        except Exception as e:
+            self.integration_feature_failures = True
+            logging.error(f'{e} \n Custom fixes will not be applied.')
 
     def _get_platform_fixes(self, scan_report):
 

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -34,7 +34,7 @@ class SuppressionsIntegration(BaseIntegrationFeature):
             logging.debug(f'Found {len(self.suppressions)} valid suppressions from the platform.')
         except Exception as e:
             self.integration_feature_failures = True
-            logging.debug(f'{e} \nScanning without applying suppressions configured in the platform.')
+            logging.debug(f'{e} \nScanning without applying suppressions configured in the platform.', exc_info=True)
 
     def post_runner(self, scan_report):
         self._apply_suppressions_to_report(scan_report)

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -34,7 +34,7 @@ class SuppressionsIntegration(BaseIntegrationFeature):
             logging.debug(f'Found {len(self.suppressions)} valid suppressions from the platform.')
         except Exception as e:
             self.integration_feature_failures = True
-            logging.error(f'{e} \n Scanning without applying suppressions.')
+            logging.debug(f'{e} \nScanning without applying suppressions configured in the platform.')
 
     def post_runner(self, scan_report):
         self._apply_suppressions_to_report(scan_report)

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -23,13 +23,18 @@ class SuppressionsIntegration(BaseIntegrationFeature):
         self.custom_policy_id_regex = re.compile(r'^[a-zA-Z0-9]+_[a-zA-Z]+_\d{13}$')
 
     def is_valid(self):
-        return self.bc_integration.is_integration_configured() and not self.bc_integration.skip_suppressions
+        return self.bc_integration.is_integration_configured() and not self.bc_integration.skip_suppressions \
+               and not self.integration_feature_failures
 
     def pre_scan(self):
-        suppressions = sorted(self._get_suppressions_from_platform(), key=lambda s: s['checkovPolicyId'])
-        # group and map by policy ID
-        self.suppressions = {policy_id: list(sup) for policy_id, sup in groupby(suppressions, key=lambda s: s['checkovPolicyId'])}
-        logging.debug(f'Found {len(self.suppressions)} valid suppressions from the platform.')
+        try:
+            suppressions = sorted(self._get_suppressions_from_platform(), key=lambda s: s['checkovPolicyId'])
+            # group and map by policy ID
+            self.suppressions = {policy_id: list(sup) for policy_id, sup in groupby(suppressions, key=lambda s: s['checkovPolicyId'])}
+            logging.debug(f'Found {len(self.suppressions)} valid suppressions from the platform.')
+        except Exception as e:
+            self.integration_feature_failures = True
+            logging.error(f'{e} \n Scanning without applying suppressions.')
 
     def post_runner(self, scan_report):
         self._apply_suppressions_to_report(scan_report)

--- a/tests/common/integration_features/test_custom_policies_integration.py
+++ b/tests/common/integration_features/test_custom_policies_integration.py
@@ -30,6 +30,9 @@ class TestCustomPoliciesIntegration(unittest.TestCase):
         instance.skip_policy_download = False
         self.assertFalse(custom_policies_integration.is_valid())
 
+        custom_policies_integration.integration_feature_failures = True
+        self.assertFalse(custom_policies_integration.is_valid())
+
     def test_policy_load(self):
         # response from API
         policies = [

--- a/tests/common/integration_features/test_fixes_integration.py
+++ b/tests/common/integration_features/test_fixes_integration.py
@@ -25,6 +25,9 @@ class TestFixesIntegration(unittest.TestCase):
         instance.skip_fixes = False
         self.assertFalse(fixes_integration.is_valid())
 
+        fixes_integration.integration_feature_failures = True
+        self.assertFalse(fixes_integration.is_valid())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/common/integration_features/test_suppressions_integration.py
+++ b/tests/common/integration_features/test_suppressions_integration.py
@@ -27,6 +27,9 @@ class TestSuppressionsIntegration(unittest.TestCase):
         instance.skip_suppressions = False
         self.assertFalse(suppressions_integration.is_valid())
 
+        suppressions_integration.integration_feature_failures = True
+        self.assertFalse(suppressions_integration.is_valid())
+
 
     def test_policy_id_regex(self):
         suppressions_integration = SuppressionsIntegration(BcPlatformIntegration())

--- a/tests/common/integration_features/test_suppressions_integration.py
+++ b/tests/common/integration_features/test_suppressions_integration.py
@@ -27,6 +27,7 @@ class TestSuppressionsIntegration(unittest.TestCase):
         instance.skip_suppressions = False
         self.assertFalse(suppressions_integration.is_valid())
 
+
     def test_policy_id_regex(self):
         suppressions_integration = SuppressionsIntegration(BcPlatformIntegration())
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR handles errors caused when the integration feature registry is run. An example of this would be, if an API token gets an error response while fetching custom policies from the platform, checkov will still complete the scan without erroring out. 