### PR TITLE
Fixes Github upload sarif results failure

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -193,6 +193,7 @@ class Report:
         runs = []
         rules = []
         results = []
+        ruleset = set()
         for idx, record in enumerate(self.failed_checks):
             rule = {
                 "id": record.check_id,
@@ -204,6 +205,11 @@ class Report:
                 },
                 "defaultConfiguration": {"level": "error"},
             }
+            if rule not in ruleset:
+                ruleset.add(rule)
+                rules.append(rule)
+            else:
+                idx = rules.index(rule)
             if record.file_line_range[0] == 0:
                 record.file_line_range[0] = 1
             if record.file_line_range[1] == 0:
@@ -225,7 +231,6 @@ class Report:
                     }
                 ],
             }
-            rules.append(rule)
             results.append(result)
 
         runs.append({

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -205,8 +205,8 @@ class Report:
                 },
                 "defaultConfiguration": {"level": "error"},
             }
-            if rule not in ruleset:
-                ruleset.add(rule)
+            if record.check_id not in ruleset:
+                ruleset.add(record.check_id)
                 rules.append(rule)
             else:
                 idx = rules.index(rule)

--- a/tests/common/output/test_sarif_report.py
+++ b/tests/common/output/test_sarif_report.py
@@ -50,6 +50,60 @@ class TestSarifReport(unittest.TestCase):
             jsonschema.validate(instance=json_structure, schema=get_sarif_schema()),
         )
 
+    def test_multiples_of_same_rule_do_not_break_schema(self):
+        record1 = Record(
+            check_id="CKV_AWS_21",
+            check_name="Some Check",
+            check_result={"result": CheckResult.FAILED},
+            code_block=None,
+            file_path="./s3.tf",
+            file_line_range=[1, 3],
+            resource="aws_s3_bucket.operations",
+            evaluations=None,
+            check_class=None,
+            file_abs_path=",.",
+            entity_tags={"tag1": "value1"},
+        )
+
+        record2 = Record(
+            check_id="CKV_AWS_3",
+            check_name="Ensure all data stored in the EBS is securely encrypted",
+            check_result={"result": CheckResult.FAILED},
+            code_block=None,
+            file_path="./ec2.tf",
+            file_line_range=[1, 3],
+            resource="aws_ebs_volume.web_host_storage",
+            evaluations=None,
+            check_class=None,
+            file_abs_path=",.",
+            entity_tags={"tag1": "value1"},
+        )
+
+        record3 = Record(
+            check_id="CKV_AWS_3",
+            check_name="Ensure all data stored in the EBS is securely encrypted",
+            check_result={"result": CheckResult.FAILED},
+            code_block=None,
+            file_path="./ec2.tf",
+            file_line_range=[7, 10],
+            resource="aws_ebs_volume.web_host_storage",
+            evaluations=None,
+            check_class=None,
+            file_abs_path=",.",
+            entity_tags={"tag1": "value1"},
+        )
+
+        r = Report("terraform")
+        r.add_record(record=record1)
+        r.add_record(record=record2)
+        r.add_record(record=record3)
+        json_structure = r.get_sarif_json()
+        print(json.dumps(json_structure))
+        self.assertEqual(
+            None,
+            jsonschema.validate(instance=json_structure, schema=get_sarif_schema()),
+        )
+
 
 def get_sarif_schema():
     file_name, headers = urllib.request.urlretrieve(


### PR DESCRIPTION
Closes #1521.

This PR adds some logic to ensure the rules in the rules array are unique, which is required by the SARIF schema. It also adds a unit test to validate the change. The test checks to see that a case where two records have the same rule is handled properly. If you add the test to the current master branch it fails; with the logic changes to report.py in this PR it passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
