### PR TITLE
handle unspecified os.scandir order with --var-file

### DIFF
--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -264,6 +264,9 @@ class Parser:
             if data:
                 var_value_and_file_map.update({k: (v, var_file.path) for k, v in data.items()})
                 self.external_variables_data.extend([(k, v, var_file.path) for k, v in data.items()])
+
+        # it's possible that os.scandir returned the var files in a different order than they were specified
+        explicit_var_files.sort(key=lambda f: vars_files.index(f.path))
         for var_file in explicit_var_files:
             data = _load_or_die_quietly(var_file, self.out_parsing_errors)
             if data:

--- a/tests/terraform/graph/variable_rendering/test_render_scenario.py
+++ b/tests/terraform/graph/variable_rendering/test_render_scenario.py
@@ -134,8 +134,8 @@ class TestRendererScenarios(TestCase):
 
         self.go(test_dir, vars_files=['other2.tfvars', 'other3.tfvars'])
 
-        # test that the file order is preserved (we expect the os.scandir to return entries in the same order,
-        # so one of these tests will fail if the tfvars file precedence is not properly applied)
+        # test that the file order is preserved (we expect the os.scandir to return entries in the same order for both
+        # of these tests so one of these tests will fail if the tfvars file precedence is not properly applied)
         main_tf_path = os.path.realpath(os.path.join(TEST_DIRNAME, '../../parser/resources/parser_scenarios', test_dir, 'main.tf'))
         different_expected = {
             main_tf_path: {
@@ -189,7 +189,7 @@ class TestRendererScenarios(TestCase):
         got_tf_definitions, _ = convert_graph_vertices_to_tf_definitions(local_graph.vertices, resources_dir)
         expected = load_expected(replace_expected, dir_name, resources_dir)
 
-        for expected_file, expected_block_type_dict in different_expected.items() if different_expected else expected.items():
+        for expected_file, expected_block_type_dict in (different_expected or expected).items():
             module_removed_path = expected_file
             got_file = got_tf_definitions.get(module_removed_path)
             self.assertIsNotNone(got_file)

--- a/tests/terraform/graph/variable_rendering/test_render_scenario.py
+++ b/tests/terraform/graph/variable_rendering/test_render_scenario.py
@@ -78,13 +78,13 @@ class TestRendererScenarios(TestCase):
     def test_module_matryoshka(self):
         self.go("module_matryoshka")
 
-    def test_list_default_622(self):            # see https://github.com/bridgecrewio/checkov/issues/622
+    def test_list_default_622(self):  # see https://github.com/bridgecrewio/checkov/issues/622
         self.go("list_default_622", {"log_types_enabled": {'default': [['api',
-              'audit',
-              'authenticator',
-              'controllerManager',
-              'scheduler']],
- 'type': ['list(string)']}})
+                                                                        'audit',
+                                                                        'authenticator',
+                                                                        'controllerManager',
+                                                                        'scheduler']],
+                                                           'type': ['list(string)']}})
 
     def test_module_reference(self):
         self.go("module_reference")
@@ -129,7 +129,41 @@ class TestRendererScenarios(TestCase):
         # only_here = "hello" (from var definition default)
         # other_var_1 = "abc" (from var definition default - other1.tfvars is not loaded)
         # other_var_2 = "xyz" (from other2.tfvars - overwrites var default)
-        self.go("tfvars", vars_files=['other2.tfvars'])
+
+        test_dir = 'tfvars'
+
+        self.go(test_dir, vars_files=['other2.tfvars', 'other3.tfvars'])
+
+        # test that the file order is preserved (we expect the os.scandir to return entries in the same order,
+        # so one of these tests will fail if the tfvars file precedence is not properly applied)
+        main_tf_path = os.path.realpath(os.path.join(TEST_DIRNAME, '../../parser/resources/parser_scenarios', test_dir, 'main.tf'))
+        different_expected = {
+            main_tf_path: {
+                "variable": [
+                    {
+                        "foo": {}
+                    },
+                    {
+                        "list_data": {}
+                    },
+                    {
+                        "map_data": {}
+                    }
+                ],
+                "resource": [
+                    {
+                        "aws_s3_bucket": {
+                            "my_bucket": {
+                                "bucket": [
+                                    "hello-nimrodIsCöol-nine-dev-abc-xyz-qwerty"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+        self.go("tfvars", vars_files=['other3.tfvars', 'other2.tfvars'], different_expected=different_expected)
 
     def test_account_dirs_and_modules(self):
         self.go("account_dirs_and_modules")
@@ -150,11 +184,12 @@ class TestRendererScenarios(TestCase):
         if vars_files:
             vars_files = [os.path.join(resources_dir, f) for f in vars_files]
         graph_manager = TerraformGraphManager(dir_name, [dir_name])
-        local_graph, _ = graph_manager.build_graph_from_source_directory(resources_dir, render_variables=True, vars_files=vars_files)
+        local_graph, _ = graph_manager.build_graph_from_source_directory(resources_dir, render_variables=True,
+                                                                         vars_files=vars_files)
         got_tf_definitions, _ = convert_graph_vertices_to_tf_definitions(local_graph.vertices, resources_dir)
         expected = load_expected(replace_expected, dir_name, resources_dir)
 
-        for expected_file, expected_block_type_dict in expected.items():
+        for expected_file, expected_block_type_dict in different_expected.items() if different_expected else expected.items():
             module_removed_path = expected_file
             got_file = got_tf_definitions.get(module_removed_path)
             self.assertIsNotNone(got_file)

--- a/tests/terraform/graph/variable_rendering/test_render_scenario.py
+++ b/tests/terraform/graph/variable_rendering/test_render_scenario.py
@@ -79,12 +79,22 @@ class TestRendererScenarios(TestCase):
         self.go("module_matryoshka")
 
     def test_list_default_622(self):  # see https://github.com/bridgecrewio/checkov/issues/622
-        self.go("list_default_622", {"log_types_enabled": {'default': [['api',
-                                                                        'audit',
-                                                                        'authenticator',
-                                                                        'controllerManager',
-                                                                        'scheduler']],
-                                                           'type': ['list(string)']}})
+        different_expected = {
+            "log_types_enabled": {
+                'default':
+                    [
+                        [
+                            'api',
+                            'audit',
+                            'authenticator',
+                            'controllerManager',
+                            'scheduler'
+                        ]
+                    ],
+                'type': ['list(string)']
+            }
+        }
+        self.go("list_default_622", different_expected)
 
     def test_module_reference(self):
         self.go("module_reference")
@@ -136,8 +146,6 @@ class TestRendererScenarios(TestCase):
 
         # test that the file order is preserved (we expect the os.scandir to return entries in the same order for both
         # of these tests so one of these tests will fail if the tfvars file precedence is not properly applied)
-        main_tf_path = os.path.realpath(
-            os.path.join(TEST_DIRNAME, '../../parser/resources/parser_scenarios', test_dir, 'main.tf'))
         different_expected = {
             "my_bucket": {
                 "bucket": [

--- a/tests/terraform/graph/variable_rendering/test_render_scenario.py
+++ b/tests/terraform/graph/variable_rendering/test_render_scenario.py
@@ -136,30 +136,12 @@ class TestRendererScenarios(TestCase):
 
         # test that the file order is preserved (we expect the os.scandir to return entries in the same order for both
         # of these tests so one of these tests will fail if the tfvars file precedence is not properly applied)
-        main_tf_path = os.path.realpath(os.path.join(TEST_DIRNAME, '../../parser/resources/parser_scenarios', test_dir, 'main.tf'))
+        main_tf_path = os.path.realpath(
+            os.path.join(TEST_DIRNAME, '../../parser/resources/parser_scenarios', test_dir, 'main.tf'))
         different_expected = {
-            main_tf_path: {
-                "variable": [
-                    {
-                        "foo": {}
-                    },
-                    {
-                        "list_data": {}
-                    },
-                    {
-                        "map_data": {}
-                    }
-                ],
-                "resource": [
-                    {
-                        "aws_s3_bucket": {
-                            "my_bucket": {
-                                "bucket": [
-                                    "hello-nimrodIsCöol-nine-dev-abc-xyz-qwerty"
-                                ]
-                            }
-                        }
-                    }
+            "my_bucket": {
+                "bucket": [
+                    "hello-nimrodIsCöol-nine-dev-abc-xyz-qwerty"
                 ]
             }
         }
@@ -189,7 +171,7 @@ class TestRendererScenarios(TestCase):
         got_tf_definitions, _ = convert_graph_vertices_to_tf_definitions(local_graph.vertices, resources_dir)
         expected = load_expected(replace_expected, dir_name, resources_dir)
 
-        for expected_file, expected_block_type_dict in (different_expected or expected).items():
+        for expected_file, expected_block_type_dict in expected.items():
             module_removed_path = expected_file
             got_file = got_tf_definitions.get(module_removed_path)
             self.assertIsNotNone(got_file)

--- a/tests/terraform/parser/resources/parser_scenarios/tfvars/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/tfvars/expected.json
@@ -16,7 +16,7 @@
         "aws_s3_bucket": {
           "my_bucket": {
             "bucket": [
-              "hello-nimrodIsCöol-nine-dev-abc-xyz"
+              "hello-nimrodIsCöoler-nine-dev-abc-xyz-qwerty"
             ]
           }
         }

--- a/tests/terraform/parser/resources/parser_scenarios/tfvars/main.tf
+++ b/tests/terraform/parser/resources/parser_scenarios/tfvars/main.tf
@@ -10,7 +10,10 @@ variable "other_var_1" {
 variable "other_var_2" {
   default = "abc"
 }
+variable "other_var_3" {
+  default = "abc"
+}
 
 resource "aws_s3_bucket" "my_bucket" {
-  bucket = "${var.only_here}-${var.foo}-${var.list_data[0]}-${var.map_data[stage]}-${var.other_var_1}-${var.other_var_2}"
+  bucket = "${var.only_here}-${var.foo}-${var.list_data[0]}-${var.map_data[stage]}-${var.other_var_1}-${var.other_var_2}-${var.other_var_3}"
 }

--- a/tests/terraform/parser/resources/parser_scenarios/tfvars/other3.tfvars
+++ b/tests/terraform/parser/resources/parser_scenarios/tfvars/other3.tfvars
@@ -1,0 +1,2 @@
+other_var_3 = "qwerty"
+foo = "nimrodIsCöoler"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes an issue with the new `--var-file` arg where they might not be processed in the correct order, depending on the order that `os.scandir` returns files.