### PR TITLE
Remove unwanted encoding to unicode null value `\u0000`

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -187,4 +187,9 @@ def evaluate(input_str: str) -> Any:
     if "__" in input_str:
         logging.warning(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")
         return input_str
-    return eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
+    evaluated = eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
+    return evaluated if not isinstance(evaluated, str) else remove_unicode_null(evaluated)
+
+
+def remove_unicode_null(input_str: str) -> str:
+    return input_str.replace("\u0000", "\\0")

--- a/tests/terraform/graph/variable_rendering/test_string_evaluation.py
+++ b/tests/terraform/graph/variable_rendering/test_string_evaluation.py
@@ -337,3 +337,9 @@ class TestTerraformEvaluation(TestCase):
 """
         evaluated = evaluate_terraform(input_str)
         self.assertEqual(input_str.replace("\n", ""), evaluated)
+
+    def test_evaluate_(self):
+        input_str = '"10\\.0\\.\\0.\\0/8"'
+        expected = '10\\.0\\.\\0.\\0/8'
+        evaluated = evaluate_terraform(input_str)
+        self.assertEqual(expected, evaluated)


### PR DESCRIPTION
When evaluating strings, the eval method encodes and decodes strings with unicode.
This may cause generating a null value `\u0000`. 

This PR removes this null value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
