### PR TITLE
Bugfix/value error on retrieval of rule index

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -209,7 +209,9 @@ class Report:
                 ruleset.add(record.check_id)
                 rules.append(rule)
             else:
-                idx = rules.index(rule)
+                for r in rules:
+                    if r['id'] == rule['id']:
+                        idx = rules.index(r)
             if record.file_line_range[0] == 0:
                 record.file_line_range[0] = 1
             if record.file_line_range[1] == 0:

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -212,6 +212,7 @@ class Report:
                 for r in rules:
                     if r['id'] == rule['id']:
                         idx = rules.index(r)
+                        break
             if record.file_line_range[0] == 0:
                 record.file_line_range[0] = 1
             if record.file_line_range[1] == 0:


### PR DESCRIPTION
Fixes #1586.

This PR fixes I bug I introduced in PR #1572. In the current state, when multiple findings reference the same Checkov rule, get_sarif_json() will fail with a ValueError.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
