### PR TITLE
Bugfix/incorrect index in rules array

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -194,7 +194,8 @@ class Report:
         rules = []
         results = []
         ruleset = set()
-        for idx, record in enumerate(self.failed_checks):
+        idx = 0
+        for record in self.failed_checks:
             rule = {
                 "id": record.check_id,
                 "name": record.check_name,
@@ -208,6 +209,7 @@ class Report:
             if record.check_id not in ruleset:
                 ruleset.add(record.check_id)
                 rules.append(rule)
+                idx = rules.index(rule)
             else:
                 for r in rules:
                     if r['id'] == rule['id']:

--- a/tests/common/output/test_sarif_report.py
+++ b/tests/common/output/test_sarif_report.py
@@ -1,5 +1,4 @@
 import unittest
-import os
 import json
 import jsonschema
 import urllib.request

--- a/tests/common/output/test_sarif_report.py
+++ b/tests/common/output/test_sarif_report.py
@@ -50,7 +50,7 @@ class TestSarifReport(unittest.TestCase):
             jsonschema.validate(instance=json_structure, schema=get_sarif_schema()),
         )
 
-    def test_multiples_of_same_rule_do_not_break_schema(self):
+    def test_multiple_instances_of_same_rule_do_not_break_schema(self):
         record1 = Record(
             check_id="CKV_AWS_21",
             check_name="Some Check",
@@ -66,8 +66,22 @@ class TestSarifReport(unittest.TestCase):
         )
 
         record2 = Record(
-            check_id="CKV_AWS_3",
-            check_name="Ensure all data stored in the EBS is securely encrypted",
+            check_id="CKV_AWS_111",
+            check_name="Ensure IAM policies does not allow write access without constraints",
+            check_result={"result": CheckResult.FAILED},
+            code_block=None,
+            file_path="./ec2.tf",
+            file_line_range=[22, 25],
+            resource="aws_ebs_volume.web_host_storage",
+            evaluations=None,
+            check_class=None,
+            file_abs_path=",.",
+            entity_tags={"tag1": "value1"},
+        )
+
+        record3 = Record(
+            check_id="CKV2_AWS_3",
+            check_name="Ensure GuardDuty is enabled to specific org/region",
             check_result={"result": CheckResult.FAILED},
             code_block=None,
             file_path="./ec2.tf",
@@ -79,13 +93,83 @@ class TestSarifReport(unittest.TestCase):
             entity_tags={"tag1": "value1"},
         )
 
-        record3 = Record(
-            check_id="CKV_AWS_3",
-            check_name="Ensure all data stored in the EBS is securely encrypted",
+        record4 = Record(
+            check_id="CKV2_AWS_3",
+            check_name="Ensure GuardDuty is enabled to specific org/region",
+            check_result={"result": CheckResult.FAILED},
+            code_block=None,
+            file_path="./org.tf",
+            file_line_range=[7, 10],
+            resource="aws_ebs_volume.web_host_storage",
+            evaluations=None,
+            check_class=None,
+            file_abs_path=",.",
+            entity_tags={"tag1": "value1"},
+        )
+
+        record5 = Record(
+            check_id="CKV2_AWS_3",
+            check_name="Ensure GuardDuty is enabled to specific org/region",
+            check_result={"result": CheckResult.FAILED},
+            code_block=None,
+            file_path="./org.tf",
+            file_line_range=[15, 20],
+            resource="aws_ebs_volume.web_host_storage",
+            evaluations=None,
+            check_class=None,
+            file_abs_path=",.",
+            entity_tags={"tag1": "value1"},
+        )
+
+        record6 = Record(
+            check_id="CKV2_AWS_3",
+            check_name="Ensure GuardDuty is enabled to specific org/region",
+            check_result={"result": CheckResult.FAILED},
+            code_block=None,
+            file_path="./org.tf",
+            file_line_range=[25, 28],
+            resource="aws_ebs_volume.web_host_storage",
+            evaluations=None,
+            check_class=None,
+            file_abs_path=",.",
+            entity_tags={"tag1": "value1"},
+        )
+
+        record7 = Record(
+            check_id="CKV_AWS_107",
+            check_name="Ensure IAM policies does not allow credentials exposure",
             check_result={"result": CheckResult.FAILED},
             code_block=None,
             file_path="./ec2.tf",
-            file_line_range=[7, 10],
+            file_line_range=[30, 35],
+            resource="aws_ebs_volume.web_host_storage",
+            evaluations=None,
+            check_class=None,
+            file_abs_path=",.",
+            entity_tags={"tag1": "value1"},
+        )
+
+        record8 = Record(
+            check_id="CKV_AWS_110",
+            check_name="Ensure IAM policies does not allow privilege escalation",
+            check_result={"result": CheckResult.FAILED},
+            code_block=None,
+            file_path="./ec2.tf",
+            file_line_range=[30, 35],
+            resource="aws_ebs_volume.web_host_storage",
+            evaluations=None,
+            check_class=None,
+            file_abs_path=",.",
+            entity_tags={"tag1": "value1"},
+        )
+
+        record9 = Record(
+            check_id="CKV_AWS_110",
+            check_name="Ensure IAM policies does not allow privilege escalation",
+            check_result={"result": CheckResult.FAILED},
+            code_block=None,
+            file_path="./ec2.tf",
+            file_line_range=[38, 40],
             resource="aws_ebs_volume.web_host_storage",
             evaluations=None,
             check_class=None,
@@ -97,12 +181,21 @@ class TestSarifReport(unittest.TestCase):
         r.add_record(record=record1)
         r.add_record(record=record2)
         r.add_record(record=record3)
+        r.add_record(record=record4)
+        r.add_record(record=record5)
+        r.add_record(record=record6)
+        r.add_record(record=record7)
+        r.add_record(record=record8)
+        r.add_record(record=record9)
+        r.get_test_suites()
         json_structure = r.get_sarif_json()
         print(json.dumps(json_structure))
         self.assertEqual(
             None,
             jsonschema.validate(instance=json_structure, schema=get_sarif_schema()),
         )
+        self.assertFalse(are_duplicates_in_sarif_rules(json_structure))
+        self.assertTrue(are_rules_indexes_correct_in_results(json_structure))
 
 
 def get_sarif_schema():
@@ -112,6 +205,26 @@ def get_sarif_schema():
     with open(file_name, "r") as file:
         schema = json.load(file)
     return schema
+
+
+def are_duplicates_in_sarif_rules(sarif_json) -> bool:
+    rules = sarif_json["runs"][0]["tool"]["driver"]["rules"]
+    ruleset = set()
+    for rule in rules:
+        ruleset.add(rule["id"])
+
+    return len(rules) != len(ruleset)
+
+
+def are_rules_indexes_correct_in_results(sarif_json) -> bool:
+    rules = sarif_json["runs"][0]["tool"]["driver"]["rules"]
+    results = sarif_json["runs"][0]["results"]
+    for rule in rules:
+        for result in results:
+            if result["ruleId"] == rule["id"]:
+                if result["ruleIndex"] != rules.index(rule) or result["ruleIndex"] > len(rules):
+                    return False
+    return True
 
 
 if __name__ == "__main__":

--- a/tests/common/output/test_sarif_report.py
+++ b/tests/common/output/test_sarif_report.py
@@ -194,7 +194,7 @@ class TestSarifReport(unittest.TestCase):
             jsonschema.validate(instance=json_structure, schema=get_sarif_schema()),
         )
         self.assertFalse(are_duplicates_in_sarif_rules(json_structure))
-        self.assertTrue(are_rules_indexes_correct_in_results(json_structure))
+        self.assertTrue(are_rule_indexes_correct_in_results(json_structure))
 
 
 def get_sarif_schema():
@@ -215,7 +215,7 @@ def are_duplicates_in_sarif_rules(sarif_json) -> bool:
     return len(rules) != len(ruleset)
 
 
-def are_rules_indexes_correct_in_results(sarif_json) -> bool:
+def are_rule_indexes_correct_in_results(sarif_json) -> bool:
     rules = sarif_json["runs"][0]["tool"]["driver"]["rules"]
     results = sarif_json["runs"][0]["results"]
     for rule in rules:


### PR DESCRIPTION
One small problem still exists with the way get_sarif_json() functions: it does not guarantee that the index of a rule is unique and correct within the SARIF results. This PR adds logic to fix this, as well as two test cases to guard against regression.

Relates to #1586 and #1587.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
