### PR TITLE
Fixes to `CKV_GCP_31` and `CKV_AWS_8`

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/LaunchConfigurationEBSEncryption.py
+++ b/checkov/cloudformation/checks/resource/aws/LaunchConfigurationEBSEncryption.py
@@ -20,6 +20,8 @@ class LaunchConfigurationEBSEncryption(BaseResourceCheck):
         ebs_encryption_confs = []
         if 'Properties' in conf.keys() and conf['Properties'].get('BlockDeviceMappings'):
             for block_device_mapping in conf['Properties']['BlockDeviceMappings']:
+                if not isinstance(block_device_mapping, dict):
+                    return CheckResult.UNKNOWN
                 if block_device_mapping.get('Ebs') and not block_device_mapping.get('VirtualName'):
                     ebs_encryption_confs.append(block_device_mapping['Ebs'].get('Encrypted'))
                 else:

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccountFullAccess.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccountFullAccess.py
@@ -27,11 +27,11 @@ class GoogleComputeDefaultServiceAccountFullAccess(BaseResourceCheck):
         if 'service_account' in conf.keys():
             service_account_conf = conf['service_account'][0]
             if isinstance(service_account_conf, dict):
-                if 'email' in conf['service_account'][0]:
-                    if re.match(DEFAULT_SERVICE_ACCOUNT, conf['service_account'][0]['email'][0]):
-                        if FULL_ACCESS_API in conf['service_account'][0]['scopes'][0]:
+                if 'email' in service_account_conf:
+                    if re.match(DEFAULT_SERVICE_ACCOUNT, service_account_conf['email'][0]):
+                        if len(service_account_conf['scopes']) > 0 and FULL_ACCESS_API in service_account_conf['scopes'][0]:
                             return CheckResult.FAILED
-                elif FULL_ACCESS_API in conf['service_account'][0]['scopes'][0]:
+                elif len(service_account_conf['scopes']) > 0 and FULL_ACCESS_API in service_account_conf['scopes'][0]:
                     return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/tests/cloudformation/checks/resource/aws/example_LaunchConfigurationEBSEncryption/LaunchConfigurationEBSEncryption-UNKNOWN.yml
+++ b/tests/cloudformation/checks/resource/aws/example_LaunchConfigurationEBSEncryption/LaunchConfigurationEBSEncryption-UNKNOWN.yml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: ElasticsearchDomain resource
+Resources:
+  AutoScalingConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      ImageId: ami-0ff8a91507f77f867
+      SecurityGroups:
+      - myExistingEC2SecurityGroup
+      InstanceType: m1.small
+      BlockDeviceMappings: !If
+        - Storage
+        - - DeviceName: !FindInMap
+              - "Entry1"
+              - "Entry2"
+              - "Entry3"
+            Ebs:
+              VolumeSize: VolumeSize"
+              DeleteOnTermination: "True"
+          - DeviceName: "/dev/sdk"
+            Ebs:
+              VolumeSize: 50
+              Encrypted: true
+          - DeviceName: "/dev/sdf"
+            Ebs:
+              Encrypted: true

--- a/tests/cloudformation/checks/resource/aws/example_LaunchConfigurationEBSEncryption/LaunchConfigurationEBSEncryption-UNKNOWN.yml
+++ b/tests/cloudformation/checks/resource/aws/example_LaunchConfigurationEBSEncryption/LaunchConfigurationEBSEncryption-UNKNOWN.yml
@@ -1,5 +1,16 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: ElasticsearchDomain resource
+
+Conditions:
+  Storage: !Not [!Equals [0, 0]]
+
+Mappings:
+  Test:
+    Entry1:
+      AMI: ami-0128839b21d19300e
+    Entry2:
+      AMI: ami-0583ca2f3ce809fcb
+
 Resources:
   AutoScalingConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
@@ -11,9 +22,9 @@ Resources:
       BlockDeviceMappings: !If
         - Storage
         - - DeviceName: !FindInMap
+              - Test
               - "Entry1"
               - "Entry2"
-              - "Entry3"
             Ebs:
               VolumeSize: VolumeSize"
               DeleteOnTermination: "True"
@@ -21,6 +32,6 @@ Resources:
             Ebs:
               VolumeSize: 50
               Encrypted: true
-          - DeviceName: "/dev/sdf"
+        - - DeviceName: "/dev/sdf"
             Ebs:
               Encrypted: true


### PR DESCRIPTION
Fixed two checks:
**Cloudformation `CKV_AWS_8`:**
Handled a case where the value of `BlockDeviceMappings` is not a dictionary, for example - an If function.
 
**Terraform `CKV_GCP_31`:**
Handled the case where `scopes` is an empty array.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
