### PR TITLE
Add breadcrumbs to Cloudformation report

### DIFF
--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -121,6 +121,9 @@ class Runner(BaseRunner):
                                     file_abs_path=file_abs_path,
                                     entity_tags=tags,
                                 )
+                                breadcrumb = self.breadcrumbs.get(record.file_path, {}).get(record.resource)
+                                if breadcrumb:
+                                    record = GraphRecord(record, breadcrumb)
                                 report.add_record(record=record)
 
     def get_graph_checks_report(self, root_folder: str, runner_filter: RunnerFilter) -> Report:

--- a/tests/cloudformation/graph/graph_builder/resources/variable_rendering/render_params/yaml/test.yaml
+++ b/tests/cloudformation/graph/graph_builder/resources/variable_rendering/render_params/yaml/test.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  BucketName:
+    Type: String
+    Description: 'The name of the S3 Bucket to create, make this unique'
+  Status:
+    Type: String
+    Description: 'VersioningConfiguration status'
+    Default: Disabled
+Resources:
+  VersioningS3Bucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Ref BucketName
+      VersioningConfiguration:
+        Status: !Ref Status

--- a/tests/cloudformation/runner/test_runner.py
+++ b/tests/cloudformation/runner/test_runner.py
@@ -238,7 +238,6 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(1, len(report.failed_checks))
         self.assertIsNotNone(report.failed_checks[0].breadcrumbs)
         self.assertIsNotNone(report.failed_checks[0].breadcrumbs.get("VersioningConfiguration.Status"))
-        print(report)
 
     def tearDown(self):
         pass

--- a/tests/cloudformation/runner/test_runner.py
+++ b/tests/cloudformation/runner/test_runner.py
@@ -225,6 +225,21 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(len(report.failed_checks), 3)
         pass
 
+    def test_breadcrumbs_report(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        scan_dir_path = os.path.join(current_dir, "../graph/graph_builder/resources/variable_rendering/render_params")
+
+        dir_abs_path = os.path.abspath(scan_dir_path)
+
+        runner = Runner()
+        report = runner.run(root_folder=dir_abs_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework='cloudformation', download_external_modules=False, checks=["CKV_AWS_21"]))
+
+        self.assertEqual(1, len(report.failed_checks))
+        self.assertIsNotNone(report.failed_checks[0].breadcrumbs)
+        self.assertIsNotNone(report.failed_checks[0].breadcrumbs.get("VersioningConfiguration.Status"))
+        print(report)
+
     def tearDown(self):
         pass
 


### PR DESCRIPTION
If breadcrumbs exist for a resource, convert the record to be `GraphRecord` and add the relevant breadcrumbs to it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
