### PR TITLE
Support PC tokens in checkov

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ GitPython = "*"
 bandit = "*"
 urllib3-mock = "*"
 jsonschema = "*"
+
 [packages]
 #
 # REMINDER: Update "install_requires" deps on setup.py when changing
@@ -43,6 +44,7 @@ detect_secrets = "*"
 policyuniverse = "*"
 typing-extensions = "*"
 importlib-metadata = ">=0.12"
+cachetools = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7a388cabc3f278f4f8f33ef3b69e1fc2c1f7e3ee04834937f16d39826c135ff2"
+            "sha256": "373ac65bf8fa48c93bf6c90a7abb63e4992ef6ba50894ce19ca9704eba1ad6be"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,11 +26,11 @@
         },
         "beautifulsoup4": {
             "hashes": [
-                "sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35",
-                "sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25",
-                "sha256:fff47e031e34ec82bf17e00da8f592fe7de69aeea38be00523c04623c04fb666"
+                "sha256:9a315ce70049920ea4572a4055bc4bd700c940521d36fc858205ad4fcde149bf",
+                "sha256:c23ad23c521d818955a4151a67d81580319d4bf548d3d49f4223ae041ff98891"
             ],
-            "version": "==4.9.3"
+            "markers": "python_version >= '3.1'",
+            "version": "==4.10.0"
         },
         "boto3": {
             "hashes": [
@@ -54,6 +54,14 @@
                 "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"
             ],
             "version": "==1.5.2"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001",
+                "sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff"
+            ],
+            "index": "pypi",
+            "version": "==4.2.2"
         },
         "certifi": {
             "hashes": [
@@ -136,11 +144,11 @@
         },
         "docker": {
             "hashes": [
-                "sha256:3e8bc47534e0ca9331d72c32f2881bb13b93ded0bcdeab3c833fb7cf61c0a9a5",
-                "sha256:fc961d622160e8021c10d1bcabc388c57d55fb1f917175afbe24af442e6879bd"
+                "sha256:21ec4998e90dff7a7aaaa098ca8d839c7de412b89e6f6c30908372d58fecf663",
+                "sha256:9b17f0723d83c1f3418d2aa17bf90b24dbe97deda06208dd4262fa30a6ee87eb"
             ],
             "index": "pypi",
-            "version": "==5.0.0"
+            "version": "==5.0.2"
         },
         "dockerfile-parse": {
             "hashes": [
@@ -288,11 +296,11 @@
         },
         "networkx": {
             "hashes": [
-                "sha256:2306f1950ce772c5a59a57f5486d59bb9cab98497c45fc49cbc45ac0dec119bb",
-                "sha256:5fcb7004be69e8fbdf07dcb502efa5c77cadcaad6982164134eeb9721f826c2e"
+                "sha256:80b6b89c77d1dfb64a4c7854981b60aeea6360ac02c6d4e4913319e0a313abef",
+                "sha256:c0946ed31d71f1b732b5aaa6da5a0388a345019af232ce2f49c766e2d6795c51"
             ],
             "index": "pypi",
-            "version": "==2.6.2"
+            "version": "==2.6.3"
         },
         "packaging": {
             "hashes": [
@@ -312,11 +320,11 @@
         },
         "policyuniverse": {
             "hashes": [
-                "sha256:1d5136329b4c4d33b114f8c781ebb2e306ff9dc6969d106ece2567e312b2dd15",
-                "sha256:a95adcecd8c5b6aafedbf0094217f9251589a5a350b3db54aa55b6cabc26a7ff"
+                "sha256:184f854fc716754ff07cd9f601923d1ce30a6826617e7c2b252abebe76746b6d",
+                "sha256:44145447d473c37ff2776667b5e1018a00c0a493c16a0a489399521b3786a8be"
             ],
             "index": "pypi",
-            "version": "==1.4.0.20210816"
+            "version": "==1.4.0.20210819"
         },
         "pyparsing": {
             "hashes": [
@@ -420,7 +428,7 @@
                 "sha256:052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc",
                 "sha256:c2c1c2d44f158cdbddab7824a9af8c4f83c76b1e23e049479aa432feb6c4c23b"
             ],
-            "markers": "python_version >= '3'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.2.1"
         },
         "tabulate": {

--- a/checkov/common/bridgecrew/image_scanning/docker_image_scanning_integration.py
+++ b/checkov/common/bridgecrew/image_scanning/docker_image_scanning_integration.py
@@ -6,16 +6,15 @@ import requests
 from datetime import datetime, timedelta
 
 from checkov.common.bridgecrew.platform_integration import bc_integration
-from checkov.common.bridgecrew.integration_features.base_integration_feature import BC_API_URL
 from checkov.common.util.data_structures_utils import merge_dicts
-from checkov.common.util.http_utils import get_auth_header, get_default_get_headers, get_default_post_headers
+from checkov.common.util.http_utils import get_default_get_headers, get_default_post_headers
 
 
 class DockerImageScanningIntegration:
-    docker_image_scanning_base_url = f"{BC_API_URL}/vulnerabilities/docker-images"
+    docker_image_scanning_base_url = f"{bc_integration.api_url}/api/v1/vulnerabilities/docker-images"
 
     def get_bc_api_key(self):
-        return bc_integration.bc_api_key
+        return bc_integration.get_auth_token()
 
     def get_proxy_address(self):
         return f"{self.docker_image_scanning_base_url}/twistcli/proxy"
@@ -24,7 +23,7 @@ class DockerImageScanningIntegration:
         os_type = platform.system().lower()
         headers = merge_dicts(
             get_default_get_headers(bc_integration.bc_source, bc_integration.bc_source_version),
-            get_auth_header(bc_integration.bc_api_key)
+            {'Authorization': self.get_bc_api_key}
         )
         response = requests.request('GET', f"{self.docker_image_scanning_base_url}/twistcli/download?os={os_type}", headers=headers)
         open(cli_file_name, 'wb').write(response.content)
@@ -35,7 +34,7 @@ class DockerImageScanningIntegration:
     def report_results(self, docker_image_name, dockerfile_path, dockerfile_content, twistcli_scan_result):
         headers = merge_dicts(
             get_default_post_headers(bc_integration.bc_source, bc_integration.bc_source_version),
-            get_auth_header(bc_integration.bc_api_key)
+            {'Authorization': self.get_bc_api_key}
         )
         vulnerabilities = list(map(lambda x: {
             'cveId': x['id'],
@@ -61,5 +60,6 @@ class DockerImageScanningIntegration:
         }
         response = requests.request('POST', f"{self.docker_image_scanning_base_url}/report", headers=headers, json=payload)
         response.raise_for_status()
+
 
 docker_image_scanning_integration = DockerImageScanningIntegration()

--- a/checkov/common/bridgecrew/integration_features/base_integration_feature.py
+++ b/checkov/common/bridgecrew/integration_features/base_integration_feature.py
@@ -2,19 +2,10 @@ import os
 from abc import ABC, abstractmethod
 
 from checkov.common.bridgecrew.integration_features.integration_feature_registry import integration_feature_registry
-
-BC_API_URL = os.getenv('BC_API_URL', "https://www.bridgecrew.cloud/api/v1")
+from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
 
 class BaseIntegrationFeature(ABC):
-    integrations_api_url = f"{BC_API_URL}/integrations/types/checkov"
-    guidelines_api_url = f"{BC_API_URL}/guidelines"
-    onboarding_url = f"{BC_API_URL}/signup/checkov"
-    api_token_url = f"{BC_API_URL}/integrations/apiToken"
-    suppressions_url = f"{BC_API_URL}/suppressions"
-    policies_url = f"{BC_API_URL}/policies/table/data"
-    fixes_url = f"{BC_API_URL}/fixes/checkov"
-
-    def __init__(self, bc_integration, order):
+    def __init__(self, bc_integration: BcPlatformIntegration, order):
         self.bc_integration = bc_integration
         bc_integration.setup_http_manager()
         self.order = order

--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -15,6 +15,7 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
         super().__init__(bc_integration, order=0)
         self.policies = {}
         self.platform_policy_parser = NXGraphCheckParser()
+        self.policies_url = f"{self.bc_integration.api_url}/api/v1/policies/table/data"
 
     def is_valid(self):
         return self.bc_integration.is_integration_configured() and not self.bc_integration.skip_policy_download \

--- a/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
@@ -8,8 +8,7 @@ import requests
 from checkov.common.bridgecrew.integration_features.base_integration_feature import BaseIntegrationFeature
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.util.data_structures_utils import merge_dicts
-from checkov.common.util.http_utils import get_auth_header, extract_error_message, \
-    get_default_post_headers
+from checkov.common.util.http_utils import extract_error_message, get_default_post_headers
 
 SUPPORTED_FIX_FRAMEWORKS = ['terraform', 'cloudformation']
 
@@ -18,6 +17,7 @@ class FixesIntegration(BaseIntegrationFeature):
 
     def __init__(self, bc_integration):
         super().__init__(bc_integration, order=10)
+        self.fixes_url = f"{self.bc_integration.api_url}/api/v1/fixes/checkov"
 
     def is_valid(self):
         return self.bc_integration.is_integration_configured() and not self.bc_integration.skip_fixes \
@@ -80,7 +80,7 @@ class FixesIntegration(BaseIntegrationFeature):
 
         headers = merge_dicts(
             get_default_post_headers(self.bc_integration.bc_source, self.bc_integration.bc_source_version),
-            get_auth_header(self.bc_integration.bc_api_key)
+            {"Authorization": self.bc_integration.get_auth_token()}
         )
 
         response = requests.request('POST', self.fixes_url, headers=headers, json=payload)

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -17,6 +17,7 @@ class SuppressionsIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration):
         super().__init__(bc_integration, order=0)
         self.suppressions = {}
+        self.suppressions_url = f"{self.bc_integration.api_url}/api/v1/suppressions"
 
         # bcorgname_provider_timestamp (ex: companyxyz_aws_1234567891011)
         # the provider may be lower or upper depending on where the policy was created

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os.path
 import re
-import time
 import webbrowser
 from concurrent import futures
 from json import JSONDecodeError
@@ -30,6 +29,7 @@ from checkov.common.runners.base_runner import filter_ignored_paths
 from checkov.version import version as checkov_version
 
 EMAIL_PATTERN = r"[^@]+@[^@]+\.[^@]+"
+UUID_V4_PATTERN = r"^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$"
 
 ACCOUNT_CREATION_TIME = 180  # in seconds
 
@@ -60,15 +60,18 @@ class BcPlatformIntegration(object):
         self.skip_policy_download = False
         self.timestamp = None
         self.scan_reports = []
-        self.bc_api_url = os.getenv('BC_API_URL', "https://www.bridgecrew.cloud/api/v1")
+        self.api_url = os.getenv('BC_API_URL', "https://www.bridgecrew.cloud")
+        self.prisma_url = os.getenv("PRISMA_API_URL")
+        if self.prisma_url:
+            self.api_url = self.prisma_url + '/bridgecrew'
         self.bc_source = None
         self.bc_source_version = None
-        self.integrations_api_url = f"{self.bc_api_url}/integrations/types/checkov"
-        self.guidelines_api_url = f"{self.bc_api_url}/guidelines"
-        self.onboarding_url = f"{self.bc_api_url}/signup/checkov"
-        self.api_token_url = f"{self.bc_api_url}/integrations/apiToken"
-        self.suppressions_url = f"{self.bc_api_url}/suppressions"
-        self.fixes_url = f"{self.bc_api_url}/fixes/checkov"
+        self.integrations_api_url = f"{self.api_url}/api/v1/integrations/types/checkov"
+        self.guidelines_api_url = f"{self.api_url}/api/v1/guidelines"
+        self.onboarding_url = f"{self.api_url}/api/v1/signup/checkov"
+        self.api_token_url = f"{self.api_url}/api/v1/integrations/apiToken"
+        self.suppressions_url = f"{self.api_url}/api/v1/suppressions"
+        self.fixes_url = f"{self.api_url}/api/v1/fixes/checkov"
         self.guidelines = None
         self.bc_id_mapping = None
         self.ckv_to_bc_id_mapping = None
@@ -76,6 +79,23 @@ class BcPlatformIntegration(object):
         self.platform_integration_configured = False
         self.http = None
         self.excluded_paths = []
+
+    @staticmethod
+    def is_bc_token(token: str) -> bool:
+        return re.match(UUID_V4_PATTERN, token) is not None
+
+    def get_auth_token(self) -> str:
+        if self.is_bc_token(self.bc_api_key):
+            return self.bc_api_key
+        # This is a Prisma Cloud token
+        if not self.prisma_url:
+            raise ValueError("Got a prisma token, but the env variable PRISMA_API_URL is not set")
+        [username, password] = self.bc_api_key.split['::']
+        request = self.http.request("POST", f"{self.prisma_url}/login",
+                                    body=json.dumps({"username": username, "password": password}),
+                                    headers={"Content-Type": "application/json"})
+        token = json.loads(request.data.decode("utf8"))['token']
+        return token
 
     def setup_http_manager(self, ca_certificate=os.getenv('BC_CA_BUNDLE', None)):
         """
@@ -96,16 +116,14 @@ class BcPlatformIntegration(object):
             except KeyError:
                 self.http = urllib3.PoolManager()
 
-    def setup_bridgecrew_credentials(self, bc_api_key, repo_id, skip_fixes=False, skip_suppressions=False,
+    def setup_bridgecrew_credentials(self, repo_id, skip_fixes=False, skip_suppressions=False,
                                      skip_policy_download=False, source=None, source_version=None, repo_branch=None):
         """
         Setup credentials against Bridgecrew's platform.
         :param source:
         :param skip_fixes: whether to skip querying fixes from Bridgecrew
         :param repo_id: Identity string of the scanned repository, of the form <repo_owner>/<repo_name>
-        :param bc_api_key: Bridgecrew issued API key
         """
-        self.bc_api_key = bc_api_key
         self.repo_id = repo_id
         self.repo_branch = repo_branch
         self.skip_fixes = skip_fixes
@@ -117,7 +135,7 @@ class BcPlatformIntegration(object):
         if self.bc_source.upload_results:
             try:
                 self.skip_fixes = True  # no need to run fixes on CI integration
-                repo_full_path, response = self.get_s3_role(bc_api_key, repo_id)
+                repo_full_path, response = self.get_s3_role(repo_id)
                 self.bucket, self.repo_path = repo_full_path.split("/", 1)
                 self.timestamp = self.repo_path.split("/")[-1]
                 self.credentials = response["creds"]
@@ -144,9 +162,10 @@ class BcPlatformIntegration(object):
 
         self.platform_integration_configured = True
 
-    def get_s3_role(self, bc_api_key, repo_id):
+    def get_s3_role(self, repo_id):
+        token = self.get_auth_token()
         request = self.http.request("POST", self.integrations_api_url, body=json.dumps({"repoId": repo_id}),
-                                    headers={"Authorization": bc_api_key, "Content-Type": "application/json"})
+                                    headers={"Authorization": token, "Content-Type": "application/json"})
         response = json.loads(request.data.decode("utf8"))
         while ('Message' in response or 'message' in response):
             if 'Message' in response and response['Message'] == UNAUTHORIZED_MESSAGE:
@@ -154,7 +173,7 @@ class BcPlatformIntegration(object):
             if 'message' in response and "cannot be found" in response['message']:
                 self.loading_output("creating role")
                 request = self.http.request("POST", self.integrations_api_url, body=json.dumps({"repoId": repo_id}),
-                                            headers={"Authorization": bc_api_key, "Content-Type": "application/json"})
+                                            headers={"Authorization": token, "Content-Type": "application/json"})
                 response = json.loads(request.data.decode("utf8"))
 
         repo_full_path = response["path"]
@@ -201,7 +220,8 @@ class BcPlatformIntegration(object):
         logging.info(f"Persisting {len(files_to_persist)} files")
         with futures.ThreadPoolExecutor() as executor:
             futures.wait(
-                [executor.submit(self._persist_file, full_file_path, relative_file_path) for full_file_path, relative_file_path in files_to_persist],
+                [executor.submit(self._persist_file, full_file_path, relative_file_path) for
+                 full_file_path, relative_file_path in files_to_persist],
                 return_when=futures.FIRST_EXCEPTION,
             )
         logging.info(f"Done persisting {len(files_to_persist)} files")
@@ -243,7 +263,7 @@ class BcPlatformIntegration(object):
                                                  "author": BC_AUTHOR_NAME, "author_url": BC_AUTHOR_URL,
                                                  "run_id": BC_RUN_ID, "run_url": BC_RUN_URL,
                                                  "repository_url": BC_REPOSITORY_URL}),
-                                            headers={"Authorization": self.bc_api_key,
+                                            headers={"Authorization": self.get_auth_token(),
                                                      "Content-Type": "application/json",
                                                      'x-api-client': self.bc_source.name,
                                                      'x-api-checkov-version': checkov_version
@@ -391,7 +411,7 @@ class BcPlatformIntegration(object):
 
             if args.directory:
                 repo_id = self.get_repository(args)
-                self.setup_bridgecrew_credentials(bc_api_key=self.bc_api_key, repo_id=repo_id)
+                self.setup_bridgecrew_credentials(repo_id=repo_id)
             if self.is_integration_configured():
                 self._upload_run(args, scan_reports)
 
@@ -518,10 +538,11 @@ class BcPlatformIntegration(object):
                 sleep(1)
 
     def get_excluded_paths(self):
-        repo_settings_api_url = f'{self.bc_api_url}/vcs/settings/scheme'
+        repo_settings_api_url = f'{self.api_url}/api/v1/vcs/settings/scheme'
         try:
             request = self.http.request("GET", repo_settings_api_url,
-                                        headers={"Authorization": self.bc_api_key, "Content-Type": "application/json"})
+                                        headers={"Authorization": self.get_auth_token(),
+                                                 "Content-Type": "application/json"})
             response = json.loads(request.data.decode("utf8"))
             if 'scannedFiles' in response:
                 for section in response.get('scannedFiles').get('sections'):

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -10,10 +10,12 @@ from time import sleep
 from typing import Optional
 
 import boto3
+import cachetools as cachetools
 import dpath.util
 import requests
 import urllib3
 from botocore.exceptions import ClientError
+from cachetools import TTLCache
 from colorama import Style
 from termcolor import colored
 from tqdm import trange
@@ -83,6 +85,7 @@ class BcPlatformIntegration(object):
     def is_bc_token(token: str) -> bool:
         return re.match(UUID_V4_PATTERN, token) is not None
 
+    @cachetools.cached(TTLCache(maxsize=1, ttl=540))
     def get_auth_token(self) -> str:
         if self.is_bc_token(self.bc_api_key):
             return self.bc_api_key

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -71,7 +71,6 @@ class BcPlatformIntegration(object):
         self.onboarding_url = f"{self.api_url}/api/v1/signup/checkov"
         self.api_token_url = f"{self.api_url}/api/v1/integrations/apiToken"
         self.suppressions_url = f"{self.api_url}/api/v1/suppressions"
-        self.fixes_url = f"{self.api_url}/api/v1/fixes/checkov"
         self.guidelines = None
         self.bc_id_mapping = None
         self.ckv_to_bc_id_mapping = None

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -10,12 +10,11 @@ from time import sleep
 from typing import Optional
 
 import boto3
-import cachetools as cachetools
 import dpath.util
 import requests
 import urllib3
 from botocore.exceptions import ClientError
-from cachetools import TTLCache
+from cachetools import cached, TTLCache
 from colorama import Style
 from termcolor import colored
 from tqdm import trange
@@ -85,7 +84,7 @@ class BcPlatformIntegration(object):
     def is_bc_token(token: str) -> bool:
         return re.match(UUID_V4_PATTERN, token) is not None
 
-    @cachetools.cached(TTLCache(maxsize=1, ttl=540))
+    @cached(TTLCache(maxsize=1, ttl=540))
     def get_auth_token(self) -> str:
         if self.is_bc_token(self.bc_api_key):
             return self.bc_api_key

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -64,7 +64,7 @@ class BcPlatformIntegration(object):
         self.api_url = os.getenv('BC_API_URL', "https://www.bridgecrew.cloud")
         self.prisma_url = os.getenv("PRISMA_API_URL")
         if self.prisma_url:
-            self.api_url = self.prisma_url + '/bridgecrew'
+            self.api_url = f"{self.prisma_url}/bridgecrew"
         self.bc_source = None
         self.bc_source_version = None
         self.integrations_api_url = f"{self.api_url}/api/v1/integrations/types/checkov"
@@ -91,7 +91,7 @@ class BcPlatformIntegration(object):
         # This is a Prisma Cloud token
         if not self.prisma_url:
             raise ValueError("Got a prisma token, but the env variable PRISMA_API_URL is not set")
-        [username, password] = self.bc_api_key.split['::']
+        username, password = self.bc_api_key.split('::')
         request = self.http.request("POST", f"{self.prisma_url}/login",
                                     body=json.dumps({"username": username, "password": password}),
                                     headers={"Content-Type": "application/json"})

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -123,7 +123,8 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
             source = SourceTypes[BCSourceType.DISABLED]
 
         try:
-            bc_integration.setup_bridgecrew_credentials(bc_api_key=config.bc_api_key, repo_id=config.repo_id,
+            bc_integration.bc_api_key = config.bc_api_key
+            bc_integration.setup_bridgecrew_credentials(repo_id=config.repo_id,
                                                         skip_fixes=config.skip_fixes,
                                                         skip_suppressions=config.skip_suppressions,
                                                         skip_policy_download=config.skip_policy_download,

--- a/docs/2.Basics/Visualizing Checkov Output.md
+++ b/docs/2.Basics/Visualizing Checkov Output.md
@@ -62,6 +62,8 @@ To enrich Bridgecrew's context with CI/CD systems data, we strongly recommend th
 | BC_RUN_URL | Link to the run in the CI system | https://github.com/bridgecrewio/checkov/actions/runs/525220526 |
 | BC_REPOSITORY_URL | Link to the GitHub repository | https://github.com/bridgecrewio/checkov/ |
 | BC_SOURCE | Name of CI system being integrated | githubActions |
+| BC_API_URL | URL of BC app for platform integration | https://www.bridgecrew.cloud |
+| PRISMA_API_URL | URL of Prisma app for platform integration | https://app3.prismacloud.io |
 
 ## Bridgecrew platform view
 

--- a/docs/2.Basics/Visualizing Checkov Output.md
+++ b/docs/2.Basics/Visualizing Checkov Output.md
@@ -40,7 +40,7 @@ The table below details the arguments used when executing the API token:
 
 | Argument | Description |
 | -------- | ----------- |
-| `<key>` | Bridgecrew issued API key |
+| `<key>` | Bridgecrew issued API key or Prisma cloud API key in the following format `ACCESS_KEY::SECRET_KEY` |
 | `<repo_id>` | Identifying string of the scanned repository, following the standard Git repository naming scheme: `<owner>/<name>` |
 | `<branch>` | Branch name to be persisted on platform. Defaults to the master branch. **NOTE:** Ensure the scanned directory (supplied in the `-d` flag) is currently checked out from the given branch name. |
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "detect-secrets",
         "policyuniverse",
         "typing-extensions",
+        "cachetools"
     ],
     license="Apache License 2.0",
     name="checkov",

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -11,7 +11,17 @@ class TestBCApiUrl(unittest.TestCase):
     @mock.patch.dict(os.environ, {'BC_API_URL': 'foo'})
     def test_overriding_bc_api_url(self):
         instance = BcPlatformIntegration()
-        self.assertEqual(instance.bc_api_url, "foo")
+        self.assertEqual(instance.api_url, "foo")
+
+    @mock.patch.dict(os.environ, {'PRISMA_API_URL': 'prisma'})
+    def test_overriding_pc_api_url(self):
+        instance = BcPlatformIntegration()
+        self.assertEqual(instance.api_url, "prisma/bridgecrew")
+        self.assertEqual(instance.prisma_url, "prisma")
+
+    def test_no_overriding_api_url(self):
+        instance = BcPlatformIntegration()
+        self.assertEqual(instance.api_url, "https://www.bridgecrew.cloud")
 
     @mock.patch.dict(os.environ, {'BC_SKIP_MAPPING': 'TRUE'})
     def test_skip_mapping(self):


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR adds support for PC customers. It leverages the access key and secret key (inputted as `ACCESS_KEY::SECRET_KEY`, authenticates with prisma and leverages the temp token for the next calls.