### PR TITLE
add bc check ID for secrets results

### DIFF
--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -10,6 +10,7 @@ from detect_secrets.core.potential_secret import PotentialSecret
 from detect_secrets.settings import transient_settings
 from typing_extensions import TypedDict
 
+from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.comment.enum import COMMENT_REGEX
 from checkov.common.graph.graph_builder.utils import run_function_multithreaded
 from checkov.common.models.consts import SUPPORTED_FILE_EXTENSIONS
@@ -140,6 +141,7 @@ class Runner(BaseRunner):
 
             for _, secret in iter(secrets):
                 check_id = SECRET_TYPE_TO_ID.get(secret.type)
+                bc_check_id = bc_integration.ckv_to_bc_id_mapping.get(check_id) if bc_integration.ckv_to_bc_id_mapping else None
                 if not check_id:
                     continue
                 if runner_filter.checks and check_id not in runner_filter.checks:
@@ -155,6 +157,7 @@ class Runner(BaseRunner):
                 ) or result
                 report.add_record(Record(
                     check_id=check_id,
+                    bc_check_id=bc_check_id,
                     check_name=secret.type,
                     check_result=result,
                     code_block=[(secret.line_number, line_text)],

--- a/tests/secrets/test_runner.py
+++ b/tests/secrets/test_runner.py
@@ -3,6 +3,7 @@ import unittest
 import os
 from pathlib import Path
 
+from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.secrets.runner import Runner
 from checkov.runner_filter import RunnerFilter
 
@@ -81,6 +82,23 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.parsing_errors, [])
         self.assertEqual(report.passed_checks, [])
         self.assertEqual(len(report.skipped_checks), 1)
+
+    def test_runner_bc_ids(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/resources"
+        runner = Runner()
+        # the other tests will implicitly test this value being None
+        bc_integration.ckv_to_bc_id_mapping = {
+            'CKV_SECRET_2': 'BC_GIT_2'
+        }
+        report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework='secrets'))
+        for fc in report.failed_checks:
+            if fc.check_id == 'CKV_SECRET_2':
+                self.assertEqual(fc.bc_check_id, 'BC_GIT_2')
+            else:
+                self.assertIsNone(fc.bc_check_id)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Updates the secrets runner to get BC check IDs from the platform (which doesn't happen normally due to how secrets checks are loaded)

The runner also needs to be updated to use BC check IDs for suppressions, but that will be a new PR.