### PR TITLE
strips leading slash from record filepath

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -227,7 +227,7 @@ class Report:
                 "locations": [
                     {
                         "physicalLocation": {
-                            "artifactLocation": {"uri": record.file_path},
+                            "artifactLocation": {"uri": record.file_path.lstrip("/")},
                             "region": {
                                 "startLine": int(record.file_line_range[0]),
                                 "endLine": int(record.file_line_range[1]),


### PR DESCRIPTION
Fixes #1599.

This PR removes the prepended '/' from the record filepath in the SARIF results. By doing so, I hope to avoid a double slash in the filepath, which I believe may be causing file previews not to display in Github's code scanning results.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
