### PR TITLE
Continue scanning if sls enrichment fails

### DIFF
--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -149,7 +149,10 @@ class Runner(BaseRunner):
                             # "Enriching" copies things like "environment" and "stackTags" down into the
                             # function data from the provider block since logically that's what serverless
                             # does. This allows checks to see what the complete data would be.
-                            sls_context_parser.enrich_function_with_provider(item_name)
+                            try:
+                                sls_context_parser.enrich_function_with_provider(item_name)
+                            except Exception as e:
+                                logging.debug(f'{e} \nContinuing without enrichment for {item_name}.', exc_info=True)
                         entity = EntityDetails(sls_context_parser.provider_type, item_content)
                         results = registry.scan(sls_file, entity, skipped_checks, runner_filter)
                         tags = cfn_utils.get_resource_tags(entity, registry)

--- a/tests/serverless/runner/resources/serverless.test.yml
+++ b/tests/serverless/runner/resources/serverless.test.yml
@@ -5,9 +5,8 @@ service:
 provider:
   name: aws
   runtime: nodejs12.x
-  environment:
-    SOME_PROVIDER_VAR: spv_value
-  stackTags:
+  environment: ${self:custom.environment}
+    stackTags:
     MY_TAG: tag_value
 
 plugins:
@@ -20,6 +19,7 @@ package:
 custom:
   my_custom_var: ${self:custom.another_custom_var}
   another_custom_var: sourced-in-value
+  environment: production
 
 layers:
   hello:

--- a/tests/serverless/runner/resources/serverless.yml
+++ b/tests/serverless/runner/resources/serverless.yml
@@ -5,8 +5,7 @@ service:
 provider:
   name: aws
   runtime: nodejs12.x
-  environment:
-    SOME_PROVIDER_VAR: spv_value
+  environment: ${self:custom.environment}
   stackTags:
     MY_TAG: tag_value
 
@@ -20,6 +19,7 @@ package:
 custom:
   my_custom_var: ${self:custom.another_custom_var}
   another_custom_var: sourced-in-value
+  environment: prod
 
 layers:
   hello:
@@ -29,6 +29,8 @@ layers:
 functions:
   myFunction:
     handler: myfunction.invoke
+    environment:
+      VARIABLE: ${self:custom.my_custom_var}
 
 resources:
   Resources:

--- a/tests/serverless/runner/test_runner.py
+++ b/tests/serverless/runner/test_runner.py
@@ -118,7 +118,7 @@ class TestRunnerValid(unittest.TestCase):
 
     def test_context_enrichment_exception_handling(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
-        scan_file_path = os.path.join(current_dir, "resources", "serverless.yml")
+        scan_file_path = os.path.join(current_dir, "resources", "serverless.test.yml")
         runner = Runner()
         try:
             runner.run(root_folder=None, external_checks_dir=None, files=[scan_file_path],

--- a/tests/serverless/runner/test_runner.py
+++ b/tests/serverless/runner/test_runner.py
@@ -116,6 +116,16 @@ class TestRunnerValid(unittest.TestCase):
 
         assert len(check_imports) == 0, f"Wrong imports were added: {check_imports}"
 
+    def test_context_enrichment_exception_handling(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        scan_file_path = os.path.join(current_dir, "resources", "serverless.yml")
+        runner = Runner()
+        try:
+            runner.run(root_folder=None, external_checks_dir=None, files=[scan_file_path],
+                       runner_filter=RunnerFilter(framework='serverless'))
+        except ValueError as e:
+            self.fail(f"Serverless context enrichment failed with exception:\n{e}")
+
     def tearDown(self):
         pass
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR handles the exception in the cases where checkov fails during attribute enrichment for the serverless framework. 