### PR TITLE
Remove traceback on keyboard interrupt

### DIFF
--- a/checkov/main.py
+++ b/checkov/main.py
@@ -5,9 +5,12 @@ import logging
 import os
 import shutil
 import sys
+import signal
 from pathlib import Path
 
 import configargparse
+
+signal.signal(signal.SIGINT, lambda x, y: sys.exit(''))
 
 from checkov.arm.runner import Runner as arm_runner
 from checkov.cloudformation.runner import Runner as cfn_runner


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Removes the stacktrace that is printed when checkov is stopped by a keyboard interrupt.


