### PR TITLE
docs: Add missing operators

### DIFF
--- a/docs/3.Custom Policies/YAML Custom Policies.md
+++ b/docs/3.Custom Policies/YAML Custom Policies.md
@@ -76,14 +76,22 @@ definition:
 | ----- | ----- |
 | Equals | `equals` |
 | Not Equals | `not_equals` |
+| Regex Match | `regex_match` |
+| Not Regex Match | `not_regex_match` |
 | Exists | `exists` |
 | Not Exists | `not_exists` |
+| Any | `any` |
 | Contains | `contains` |
 | Not Contains | `not_contains` |
+| Within | `within` |
 | Starts With | `starting_with` |
-| Not Starts with | `not_starting_with` |
+| Not Starts With | `not_starting_with` |
 | Ends With | `ending_with` |
 | Not Ends With | `not_ending_with` |
+| Greater Than | `greater_than` |
+| Greater Than Or Equal | `greater_than_or_equal` |
+| Less Than | `less_than` |
+| Less Than Or Equal | `less_than_or_equal` |
 
 ### Attribute Condition: Keys and Values
 
@@ -92,7 +100,7 @@ definition:
 | `cond_type` | string | Must be `attribute` |
 | `resource_type` | collection of strings | Use either `all` or `[resource types from list]` |
 | `attribute` | string | Attribute of defined resource types. For example, `automated_snapshot_retention_period` |
-| `operator` | string | - `equals`, `not_equals`, `exists`, `not exists`, `contains`, `not_contains`, `starting_with`, `not_starting_with`, `ending_with`, `not_ending_with` |
+| `operator` | string | - `equals`, `not_equals`, `regex_match`, `not_regex_match`, `exists`, `not exists`, `any`, `contains`, `not_contains`, `within`, `starting_with`, `not_starting_with`, `ending_with`, `not_ending_with`, `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal` |
 | `value` (not relevant for operator: `exists`/`not_exists`) | string | User input. |
 
 


### PR DESCRIPTION
This adds newer operators to the docs, or ones that weren't originally there on checkov 2.0's release but were missed in the docs. 

- Regex was added in #1604 
- gt, gte, lt, lte was added in #1618 
- Any and Within was added in #1023

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
