### PR TITLE
Resource counting all resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,20 +104,19 @@ jobs:
             echo "# $i resource scans (auto generated)" >> "$scansdoc"
             echo "" >> "$scansdoc"
             pipenv run python checkov/main.py --list --framework "$i" >> "$scansdoc"
-            git commit --reuse-message=HEAD@{1} "$scansdoc" || echo "No changes to commit"
-
+            git add $scansdoc
           done
 
           #add cloudformation scans to serverless
           export scansdoc="docs/5.Policy Index/serverless.md"
           pipenv run python checkov/main.py --list --framework cloudformation >> "$scansdoc"
-          git commit --reuse-message=HEAD@{1} "$scansdoc" || echo "No changes to commit"
+          git add $scansdoc
+          git commit --reuse-message=HEAD@{1} || echo "No changes to commit"
 
           ## update python version
           echo "version = '$new_tag'" > 'checkov/version.py'
           echo "checkov==$new_tag" > 'kubernetes/requirements.txt'
 
-          # git commit --reuse-message=HEAD@{1} checkov/version.py kubernetes/requirements.txt coverage.svg || echo "No changes to commit"
           git commit --reuse-message=HEAD@{1} checkov/version.py kubernetes/requirements.txt coverage.svg || echo "No changes to commit"
           git push origin
           git tag $new_tag

--- a/checkov/arm/runner.py
+++ b/checkov/arm/runner.py
@@ -87,6 +87,7 @@ class Runner(BaseRunner):
 
                     for resource in definitions[arm_file]['resources']:
                         resource_id = arm_context_parser.extract_arm_resource_id(resource)
+                        report.add_resource(f'{arm_file}:{resource_id}')
                         resource_name = arm_context_parser.extract_arm_resource_name(resource)
                         entity_lines_range, entity_code_lines = arm_context_parser.extract_arm_resource_code_lines(resource)
                         if entity_lines_range and entity_code_lines:

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -7,6 +7,7 @@ from checkov.cloudformation import cfn_utils
 from checkov.cloudformation.cfn_utils import create_definitions, build_definitions_context
 from checkov.cloudformation.checks.resource.registry import cfn_registry
 from checkov.cloudformation.context_parser import ContextParser
+from checkov.cloudformation.graph_builder.graph_components.block_types import BlockType
 from checkov.cloudformation.parser.cfn_keywords import TemplateSections
 from checkov.cloudformation.graph_builder.graph_to_definitions import convert_graph_vertices_to_definitions
 from checkov.cloudformation.graph_builder.local_graph import CloudformationLocalGraph
@@ -62,6 +63,9 @@ class Runner(BaseRunner):
 
             logging.info("creating cloudformation graph")
             local_graph = self.graph_manager.build_graph_from_definitions(self.definitions)
+            for vertex in local_graph.vertices:
+                if vertex.block_type == BlockType.RESOURCE:
+                    report.add_resource(f'{vertex.path}:{vertex.id}')
             self.graph_manager.save_graph(local_graph)
             self.definitions, self.breadcrumbs = convert_graph_vertices_to_definitions(local_graph.vertices, root_folder)
 

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -329,12 +329,6 @@ class Report:
     def print_json(self) -> None:
         print(self.get_json())
 
-    def _count_resources(self) -> int:
-        unique_resources = set()
-        for record in self.passed_checks + self.failed_checks:
-            unique_resources.add(record.file_path + "." + record.resource)
-        return len(unique_resources)
-
     @staticmethod
     def enrich_plan_report(
         report: "Report", enriched_resources: Dict[str, Dict[str, Any]]

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -1,6 +1,6 @@
 import json
 from collections import defaultdict
-from typing import List, Dict, Union, Any, Optional
+from typing import List, Dict, Union, Any, Optional, Set
 from colorama import init
 from junit_xml import TestCase, TestSuite, to_xml_report_string
 from tabulate import tabulate
@@ -21,6 +21,7 @@ class Report:
         self.failed_checks: List[Record] = []
         self.skipped_checks: List[Record] = []
         self.parsing_errors: List[str] = []
+        self.resources: Set[str] = set()
 
     def add_parsing_errors(self, errors: List[str]) -> None:
         for file in errors:
@@ -29,6 +30,9 @@ class Report:
     def add_parsing_error(self, file: str) -> None:
         if file:
             self.parsing_errors.append(file)
+
+    def add_resource(self, resource: str) -> None:
+        self.resources.add(resource)
 
     def add_record(self, record: Record) -> None:
         if record.check_result["result"] == CheckResult.PASSED:
@@ -44,7 +48,8 @@ class Report:
             "failed": len(self.failed_checks),
             "skipped": len(self.skipped_checks),
             "parsing_errors": len(self.parsing_errors),
-            "resource_count": self._count_resources(),
+            "resource_count": len(self.resources),
+            "resources": list(self.resources),
             "checkov_version": version,
         }
 

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -49,7 +49,6 @@ class Report:
             "skipped": len(self.skipped_checks),
             "parsing_errors": len(self.parsing_errors),
             "resource_count": len(self.resources),
-            "resources": list(self.resources),
             "checkov_version": version,
         }
 

--- a/checkov/dockerfile/runner.py
+++ b/checkov/dockerfile/runner.py
@@ -58,6 +58,7 @@ class Runner(BaseRunner):
                 path_to_convert = (os.path.join(root_folder, docker_file_path)) if root_folder else docker_file_path
 
             file_abs_path = os.path.abspath(path_to_convert)
+            report.add_resource(file_abs_path)
             skipped_checks = collect_skipped_checks(definitions[docker_file_path])
             instructions = definitions[docker_file_path]
 

--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -189,6 +189,7 @@ class Runner(BaseRunner):
                     report.passed_checks += chart_results.passed_checks
                     report.parsing_errors += chart_results.parsing_errors
                     report.skipped_checks += chart_results.skipped_checks
+                    report.resources.update(chart_results.resources)
 
                 except:
                     with tempfile.TemporaryDirectory() as save_error_dir:

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -187,10 +187,12 @@ class Runner(BaseRunner):
                     variable_evaluations = {}
 
                     for check, check_result in results.items():
+                        resource_id = check.get_resource_id(entity_conf)
+                        report.add_resource(f'{k8_file}:{resource_id}')
                         record = Record(check_id=check.id, bc_check_id=check.bc_id, check_name=check.name, check_result=check_result,
                                         code_block=entity_code_lines, file_path=k8_file,
                                         file_line_range=entity_lines_range,
-                                        resource=check.get_resource_id(entity_conf), evaluations=variable_evaluations,
+                                        resource=resource_id, evaluations=variable_evaluations,
                                         check_class=check.__class__.__module__, file_abs_path=file_abs_path)
                         report.add_record(record=record)
 

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -156,6 +156,7 @@ class Runner(BaseRunner):
                     secret=secret,
                     skipped_checks=runner_filter.skip_checks,
                 ) or result
+                report.add_resource(f'{secret.filename}:{secret.secret_hash}')
                 report.add_record(Record(
                     check_id=check_id,
                     bc_check_id=bc_check_id,

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -113,6 +113,7 @@ class Runner(BaseRunner):
                     if not cf_resource_id:
                         # Not Type attribute for resource
                         continue
+                    report.add_resource(f'{file_abs_path}:{cf_resource_id}')
                     entity_lines_range, entity_code_lines = cf_context_parser.extract_cf_resource_code_lines(
                         resource)
                     if entity_lines_range and entity_code_lines:

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -90,7 +90,6 @@ class Runner(BaseRunner):
                             parsing_errors.update(file_parsing_errors)
                             continue
                 local_graph = self.graph_manager.build_graph_from_definitions(self.definitions)
-                print(1)
             else:
                 raise Exception("Root directory was not specified, files were not specified")
 

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -23,6 +23,7 @@ from checkov.terraform.checks.resource.registry import resource_registry
 from checkov.terraform.context_parsers.registry import parser_registry
 from checkov.terraform.evaluation.base_variable_evaluation import BaseVariableEvaluation
 from checkov.terraform.graph_builder.graph_components.attribute_names import CustomAttributes
+from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 from checkov.terraform.graph_builder.graph_to_tf_definitions import convert_graph_vertices_to_tf_definitions
 from checkov.terraform.graph_builder.local_graph import TerraformLocalGraph
 from checkov.terraform.graph_manager import TerraformGraphManager
@@ -89,9 +90,13 @@ class Runner(BaseRunner):
                             parsing_errors.update(file_parsing_errors)
                             continue
                 local_graph = self.graph_manager.build_graph_from_definitions(self.definitions)
+                print(1)
             else:
                 raise Exception("Root directory was not specified, files were not specified")
 
+            for vertex in local_graph.vertices:
+                if vertex.block_type == BlockType.RESOURCE:
+                    report.add_resource(f'{vertex.path}:{vertex.id}')
             self.graph_manager.save_graph(local_graph)
             self.definitions, self.breadcrumbs = convert_graph_vertices_to_tf_definitions(local_graph.vertices, root_folder)
         else:

--- a/tests/common/runner_registry/test_runner_registry.py
+++ b/tests/common/runner_registry/test_runner_registry.py
@@ -33,7 +33,7 @@ class TestRunnerRegistry(unittest.TestCase):
         reports = runner_registry.run(root_folder=test_files_dir)
 
         # The number of resources that will get scan results. Note that this may change if we add policies covering new resource types.
-        counts_by_type = {"kubernetes": 13, "terraform": 3, "cloudformation": 3}
+        counts_by_type = {"kubernetes": 13, "terraform": 3, "cloudformation": 4}
 
         for report in reports:
             self.assertEqual(


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Updates the resource counting logic to be supplied by the runners. This ensures that graph runners (TF, CFN) count all resources. Other runners will count resources the same way (i.e., resources that are scanned by a policy).