### PR TITLE
Improve performance

### DIFF
--- a/checkov/common/graph/checks_infra/solvers/base_solver.py
+++ b/checkov/common/graph/checks_infra/solvers/base_solver.py
@@ -26,4 +26,4 @@ class BaseSolver:
 
     @staticmethod
     def resource_type_pred(v: Dict[str, Any], resource_types: List[str]) -> bool:
-        return len(resource_types) == 0 or v.get("resource_type") in resource_types
+        return not resource_types or ("resource_type" in v and v["resource_type"] in resource_types)

--- a/checkov/terraform/checks/resource/azure/AppServiceUsedAzureFiles.py
+++ b/checkov/terraform/checks/resource/azure/AppServiceUsedAzureFiles.py
@@ -11,7 +11,7 @@ class AppServiceUsedAzureFiles(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):
-        return "storage_account/type"
+        return "storage_account/[0]/type"
 
     def get_expected_value(self):
         return 'AzureFiles'

--- a/checkov/terraform/checks/resource/azure/MySQLTreatDetectionEnabled.py
+++ b/checkov/terraform/checks/resource/azure/MySQLTreatDetectionEnabled.py
@@ -12,7 +12,7 @@ class MySQLTreatDetectionEnabled(BaseResourceValueCheck):
 
 
     def get_inspected_key(self):
-        return "threat_detection_policy/enabled"
+        return "threat_detection_policy/[0]/enabled"
 
 
 check = MySQLTreatDetectionEnabled()

--- a/checkov/terraform/checks/resource/azure/PostgresSQLTreatDetectionEnabled.py
+++ b/checkov/terraform/checks/resource/azure/PostgresSQLTreatDetectionEnabled.py
@@ -12,7 +12,7 @@ class PostgresSQLTreatDetectionEnabled(BaseResourceValueCheck):
 
 
     def get_inspected_key(self):
-        return "threat_detection_policy/enabled"
+        return "threat_detection_policy/[0]/enabled"
 
 
 check = PostgresSQLTreatDetectionEnabled()

--- a/checkov/terraform/checks/resource/gcp/GoogleComupteBlockProjectSSH.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComupteBlockProjectSSH.py
@@ -11,7 +11,7 @@ class GoogleComputeBlockProjectSSH(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):
-        return 'metadata/block-project-ssh-keys'
+        return 'metadata/[0]/block-project-ssh-keys'
 
 
 check = GoogleComputeBlockProjectSSH()

--- a/checkov/terraform/graph_builder/graph_components/module.py
+++ b/checkov/terraform/graph_builder/graph_components/module.py
@@ -40,8 +40,9 @@ class Module:
             dependencies = [[]]
         else:
             module_dependency_num = self.dep_index_mapping.get(block.path, "")
-        for dep_trail in dependencies:
-            block = deepcopy(block)
+        for i, dep_trail in enumerate(dependencies):
+            if i > 0:
+                block = deepcopy(block)
             block.module_dependency = unify_dependency_path(dep_trail)
             block.module_dependency_num = module_dependency_num
             self.blocks.append(block)

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -270,7 +270,7 @@ class TerraformLocalGraph(LocalGraph):
             dest_module_path = Path(curr_module_dir) / dest_module_source
         else:
             try:
-                if not self.relative_paths_cache.get(dest_module_source):
+                if dest_module_source not in self.relative_paths_cache:
                     self.relative_paths_cache[dest_module_source] = list(Path(self.module.source_dir).rglob(dest_module_source))
                 dest_module_path = next(
                     (path for path in self.relative_paths_cache.get(dest_module_source)), dest_module_path

--- a/checkov/terraform/graph_builder/variable_rendering/renderer.py
+++ b/checkov/terraform/graph_builder/variable_rendering/renderer.py
@@ -73,8 +73,8 @@ class TerraformVariableRenderer(VariableRenderer):
                 return
 
         modified_vertex_attributes = self.local_graph.vertices[edge.origin].attributes
-        val_to_eval = deepcopy(modified_vertex_attributes.get(edge.label, ""))
-        origin_val = deepcopy(val_to_eval)
+        origin_val = modified_vertex_attributes.get(edge.label, "")
+        val_to_eval = deepcopy(origin_val)
         first_key_path = None
 
         if referenced_vertices:
@@ -127,8 +127,7 @@ class TerraformVariableRenderer(VariableRenderer):
             if value is not None:
                 return value
 
-        reversed_key_path = deepcopy(key_path)
-        reversed_key_path.reverse()
+        reversed_key_path = key_path[::-1]
         for i, _ in enumerate(reversed_key_path):
             key = join_trimmed_strings(char_to_join=".", str_lst=reversed_key_path, num_to_trim=i)
             value = attributes.get(key, None)
@@ -170,16 +169,16 @@ class TerraformVariableRenderer(VariableRenderer):
         for vertex_reference in referenced_vertices:
             block_type = vertex_reference.block_type
             attribute_path = vertex_reference.sub_parts
-            copy_of_attribute_path = deepcopy(attribute_path)
+            copy_of_attribute_path = attribute_path.copy()
             if vertex_attributes[CustomAttributes.BLOCK_TYPE] == block_type:
-                for i in range(len(copy_of_attribute_path)):
+                for i, _ in enumerate(copy_of_attribute_path):
                     copy_of_attribute_path[i] = remove_index_pattern_from_str(copy_of_attribute_path[i])
                     name = ".".join(copy_of_attribute_path[: i + 1])
                     if vertex_attributes[CustomAttributes.BLOCK_NAME] == name:
                         return attribute_path, vertex_reference.origin_value
             elif block_type == BlockType.MODULE:
                 copy_of_attribute_path.reverse()
-                for i in range(len(copy_of_attribute_path)):
+                for i, _ in enumerate(copy_of_attribute_path):
                     copy_of_attribute_path[i] = remove_index_pattern_from_str(copy_of_attribute_path[i])
                     name = ".".join(copy_of_attribute_path[: i + 1])
                     if vertex_attributes[CustomAttributes.BLOCK_NAME] == name:

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -229,12 +229,12 @@ class Runner(BaseRunner):
                     caller_file_path = f"/{os.path.relpath(abs_caller_file, root_folder)}"
 
                     try:
-                        caller_context = dpath.get(definition_context[abs_caller_file],
-                                                   # HACK ALERT: module data is currently double-nested in
-                                                   #             definition context. If fixed, remove the
-                                                   #             addition of "module." at the beginning.
-                                                   "module." + referrer_id,
-                                                   separator=".")
+                        caller_context = definition_context[abs_caller_file]
+                        # HACK ALERT: module data is currently double-nested in
+                        #             definition context. If fixed, remove the
+                        #             addition of "module." at the beginning.
+                        for part in f"module.{referrer_id}".split("."):
+                            caller_context = caller_context[part]
                     except KeyError:
                         logging.debug("Unable to find caller context for: %s", abs_caller_file)
                         caller_context = None


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Relates #1589 

I still didn't figure out, why the scans became so much slower like described in the issue, but I did some profiling on the project, while scanning one of my Terraform projects.

I started with following
<img width="766" alt="initial_time" src="https://user-images.githubusercontent.com/33207684/133867825-c42056a9-1438-4f7d-a53a-a38b33bec971.png">
and finished with this 🙂 (profiling slows the run down dramatically, without it takes ~ 8 sec)
<img width="767" alt="final_time" src="https://user-images.githubusercontent.com/33207684/133867840-850c9c0d-fdba-4268-ba2d-df56a6fb2f8b.png">

Taking a look on the worst methods (top 10), I started with this
<img width="1105" alt="initial_own_time" src="https://user-images.githubusercontent.com/33207684/133868052-d5173585-44a5-4127-9699-15f61e913647.png">
and finished with this 💪 
<img width="1101" alt="final_own_time" src="https://user-images.githubusercontent.com/33207684/133868103-42a7ca75-36e7-4f75-a3f1-e7bb09f3dbcb.png">

For the `<listcomp>` and `fnmatchcase` I will create a separate PR, which will dramatically reduce it usage, it is related to usgae of the `cloudsplaining` lib.

After improving `resource_type_pred` I got following time
<img width="1096" alt="improve_2" src="https://user-images.githubusercontent.com/33207684/133868596-c265e5f2-5264-4eaa-9cf2-b165ef08295b.png">
It looks like `resource_type` is not present so often, so it makes to first check its existence. Also removing the length calculation reduced the time by 500ms.

After improving `_get_dest_module_path` I got following time
<img width="1096" alt="improve_3" src="https://user-images.githubusercontent.com/33207684/133868695-033632c8-e020-4185-9022-b432d6dff217.png">
reason behind is, if a module can't be found an empty list will be assigned to the cache and if this module is referenced several times through the Terraform config, then it will be again checked. So, I changed the condition check to just check the existence of the module name in the cache.

After removing a couple of `deepcopy` and optimizing the usage of it, if it was really needed (`deepmerge` is also using `deepcopy` quite a lot) I got following time
<img width="1096" alt="improve_6" src="https://user-images.githubusercontent.com/33207684/133868826-e08e86d1-04d5-4183-86b4-58e777c46c8c.png">

I also fixed some other minor things, which are not really worth mentioning, like incorrect `inspected_key` definitions.

