### PR TITLE
CF - Check - LambdaEnvironmentEncryptionSettings

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentEncryptionSettings.py
+++ b/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentEncryptionSettings.py
@@ -1,0 +1,36 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class LambdaEnvironmentEncryptionSettings(BaseResourceCheck):
+    def __init__(self):
+        name = "Check encryption settings for Lambda environmental variable"
+        id = "CKV_AWS_173"
+        supported_resources = ['AWS::Lambda::Function']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        env_vars_in_use = False
+        kms_in_use = False
+
+        properties = conf.get('Properties')
+        if properties is not None:
+            env_config = properties.get('Environment')
+            kms_config = properties.get('KmsKeyArn')
+
+            if env_config is not None:
+                env_vars_config = env_config.get('Variables', [])
+                if len(env_vars_config) > 0:
+                    env_vars_in_use = True
+
+            if kms_config is not None:
+                kms_in_use = True
+
+        if env_vars_in_use and not kms_in_use:
+            return CheckResult.FAILED
+            
+        return CheckResult.PASSED
+		
+
+check = LambdaEnvironmentEncryptionSettings()

--- a/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentEncryptionSettings.py
+++ b/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentEncryptionSettings.py
@@ -15,7 +15,7 @@ class LambdaEnvironmentEncryptionSettings(BaseResourceCheck):
         if properties is not None:
             env = properties.get('Environment')
             if env is not None:
-                if env.get('Variables') and not properties.get('KmsKeyArn')
+                if env.get('Variables') and not properties.get('KmsKeyArn'):
                     return CheckResult.FAILED
         return CheckResult.PASSED
 		

--- a/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentEncryptionSettings.py
+++ b/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentEncryptionSettings.py
@@ -11,25 +11,12 @@ class LambdaEnvironmentEncryptionSettings(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        env_vars_in_use = False
-        kms_in_use = False
-
         properties = conf.get('Properties')
         if properties is not None:
-            env_config = properties.get('Environment')
-            kms_config = properties.get('KmsKeyArn')
-
-            if env_config is not None:
-                env_vars_config = env_config.get('Variables', [])
-                if len(env_vars_config) > 0:
-                    env_vars_in_use = True
-
-            if kms_config is not None:
-                kms_in_use = True
-
-        if env_vars_in_use and not kms_in_use:
-            return CheckResult.FAILED
-            
+            env = properties.get('Environment')
+            if env is not None:
+                if env.get('Variables') and not properties.get('KmsKeyArn')
+                    return CheckResult.FAILED
         return CheckResult.PASSED
 		
 

--- a/tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentEncryptionSettings/FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentEncryptionSettings/FAIL.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  EnvAndNoKey:
+    Type: AWS::Lambda::Function
+    Properties:
+      Role: arn:aws:iam::123456789012:role/lambda-role
+      Code:
+        ZipFile: |
+          print('test')
+      Environment:
+        Variables:
+          key: value

--- a/tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentEncryptionSettings/PASS.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentEncryptionSettings/PASS.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  EnvAndKey:
+    Type: AWS::Lambda::Function
+    Properties:
+      Role: arn:aws:iam::123456789012:role/lambda-role
+      Code:
+        ZipFile: |
+          print('test')
+      Environment:
+        Variables:
+          key: value
+      KmsKeyArn: arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+  NoEnvAndNoKey:
+    Type: AWS::Lambda::Function
+    Properties:
+      Role: arn:aws:iam::123456789012:role/lambda-role
+      Code:
+        ZipFile: |
+          print('test')

--- a/tests/cloudformation/checks/resource/aws/test_LambdaEnvironmentEncryptionSettings.py
+++ b/tests/cloudformation/checks/resource/aws/test_LambdaEnvironmentEncryptionSettings.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.LambdaEnvironmentEncryptionSettings import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestLambdaEnvironmentEncryptionSettings(unittest.TestCase):
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_LambdaEnvironmentEncryptionSettings"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        for record in report.failed_checks:
+            self.assertEqual(record.check_id, check.id)
+        
+        for record in report.passed_checks:
+            self.assertEqual(record.check_id, check.id)
+
+        passing_resources = {
+            "AWS::Lambda::Function.EnvAndKey",
+            "AWS::Lambda::Function.NoEnvAndNoKey",
+        }
+
+        failing_resources = {
+            "AWS::Lambda::Function.EnvAndNoKey",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello,

Added CF check as done for TF.

No special case where kms key without env vars causes a problem like with Terraform.

**CF Docs**: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html
**Terraform Check**: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/LambdaEnvironmentEncryptionSettings.py

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
