### PR TITLE
Improve cloudsplaining usage

### DIFF
--- a/checkov/common/checks/base_check.py
+++ b/checkov/common/checks/base_check.py
@@ -25,6 +25,7 @@ class BaseCheck(metaclass=MultiSignatureMeta):
         self.supported_entities = supported_entities
         self.logger = logging.getLogger("{}".format(self.__module__))
         self.evaluated_keys: List[str] = []
+        self.entity_path = ""
 
     def run(
         self,
@@ -51,6 +52,7 @@ class BaseCheck(metaclass=MultiSignatureMeta):
         else:
             try:
                 self.evaluated_keys = []
+                self.entity_path = f"{scanned_file}:{entity_type}:{entity_name}"
                 check_result["result"] = self.scan_entity_conf(entity_configuration, entity_type)
                 check_result["evaluated_keys"] = self.get_evaluated_keys()
                 message = 'File {}, {}  "{}.{}" check "{}" Result: {} '.format(

--- a/checkov/terraform/checks/data/BaseCloudsplainingIAMCheck.py
+++ b/checkov/terraform/checks/data/BaseCloudsplainingIAMCheck.py
@@ -7,27 +7,35 @@ from cloudsplaining.scan.policy_document import PolicyDocument
 
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.data.base_check import BaseDataCheck
-from checkov.terraform.checks.utils.iam_terraform_document_to_policy_converter import \
-    convert_terraform_conf_to_iam_policy
+from checkov.terraform.checks.utils.iam_terraform_document_to_policy_converter import (
+    convert_terraform_conf_to_iam_policy,
+)
 
 
 class BaseCloudsplainingIAMCheck(BaseDataCheck):
+    # creating a PolicyDocument is computational expensive,
+    # therefore a cache is defined at class level
+    policy_document_cache: Dict[str, PolicyDocument] = {}
+
     def __init__(self, name: str, id: str) -> None:
-        super().__init__(name=name, id=id, categories=[CheckCategories.IAM], supported_data=['aws_iam_policy_document'])
+        super().__init__(name=name, id=id, categories=[CheckCategories.IAM], supported_data=["aws_iam_policy_document"])
 
     def scan_data_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
-        key = 'statement'
-        if key in conf.keys():
+        if "statement" in conf.keys():
             try:
-                converted_conf = convert_terraform_conf_to_iam_policy(conf)
-                policy = PolicyDocument(converted_conf)
-                violations = self.cloudsplaining_analysis(policy)
-            except Exception as e:
+                if self.entity_path not in BaseCloudsplainingIAMCheck.policy_document_cache.keys():
+                    converted_conf = convert_terraform_conf_to_iam_policy(conf)
+                    policy = PolicyDocument(converted_conf)
+                    BaseCloudsplainingIAMCheck.policy_document_cache[self.entity_path] = policy
+                violations = self.cloudsplaining_analysis(
+                    BaseCloudsplainingIAMCheck.policy_document_cache[self.entity_path]
+                )
+            except Exception:
                 # this might occur with templated iam policies where ARN is not in place or similar
-                logging.debug("could not run cloudsplaining analysis on policy {}", conf)
+                logging.debug(f"could not run cloudsplaining analysis on policy {conf}")
                 return CheckResult.UNKNOWN
             if violations:
-                logging.debug("detailed cloudsplainging finding: {}", json.dumps(violations))
+                logging.debug(f"detailed cloudsplainging finding: {json.dumps(violations, indent=2, default=str)}")
                 return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/tests/terraform/checks/data/aws/example_AdminPolicyDocument/main.tf
+++ b/tests/terraform/checks/data/aws/example_AdminPolicyDocument/main.tf
@@ -1,0 +1,71 @@
+# pass
+
+data "aws_iam_policy_document" "pass" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:Describe*",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "list" {
+  version = "2012-10-17"
+
+  statement = [{
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "${aws_s3_bucket.default.arn}/*"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }]
+
+  # Support replication ARNs
+  statement = ["${flatten(data.aws_iam_policy_document.replication.*.statement)}"]
+
+  # Support deployment ARNs
+  statement = ["${flatten(data.aws_iam_policy_document.deployment.*.statement)}"]
+}
+
+# fail
+
+data "aws_iam_policy_document" "fail" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "*"
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "no_effect" {
+  version = "2012-10-17"
+
+  statement {
+    actions = [
+      "*"
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# unknown
+

--- a/tests/terraform/checks/data/aws/example_CloudSplainingCredentialsExposure/main.tf
+++ b/tests/terraform/checks/data/aws/example_CloudSplainingCredentialsExposure/main.tf
@@ -1,0 +1,76 @@
+# pass
+
+data "aws_iam_policy_document" "allowed_action" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+        "ecr:GetAuthorizationToken",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "deny" {
+  version = "2012-10-17"
+
+  statement {
+   sid       = "DenyOutsideCallers"
+   effect    = "Deny"
+   actions   = ["*"]
+   resources = ["*"]
+
+   condition {
+     test     = "NotIpAddress"
+     variable = "aws:SourceIp"
+     values = [
+       "1.2.3.4/16"
+     ]
+   }
+
+   condition {
+     test     = "Bool"
+     variable = "aws:ViaAWSService"
+     values   = ["false"]
+   }
+ }
+}
+
+data "aws_iam_policy_document" "pass" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+        "lambda:CreateFunction",
+        "lambda:CreateEventSourceMapping",
+        "dynamodb:CreateTable",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# fail
+
+data "aws_iam_policy_document" "fail" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "iam:CreateAccessKey"
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# unknown
+

--- a/tests/terraform/checks/data/aws/example_CloudSplainingDataExfiltration/main.tf
+++ b/tests/terraform/checks/data/aws/example_CloudSplainingDataExfiltration/main.tf
@@ -1,0 +1,44 @@
+# pass
+
+data "aws_iam_policy_document" "pass" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "lambda:CreateFunction",
+      "lambda:CreateEventSourceMapping",
+      "dynamodb:CreateTable",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# fail
+
+data "aws_iam_policy_document" "fail" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:PassRole",
+      "ssm:GetParameter",
+      "s3:GetObject",
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath",
+      "secretsmanager:GetSecretValue",
+      "s3:PutObject",
+      "ec2:CreateTags"
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# unknown
+

--- a/tests/terraform/checks/data/aws/example_CloudSplainingPrivilegeEscalation/main.tf
+++ b/tests/terraform/checks/data/aws/example_CloudSplainingPrivilegeEscalation/main.tf
@@ -1,0 +1,40 @@
+# pass
+
+data "aws_iam_policy_document" "pass" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "lambda:CreateFunction",
+      "lambda:CreateEventSourceMapping",
+      "dynamodb:CreateTable",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# fail
+
+data "aws_iam_policy_document" "fail" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:PassRole",
+      "lambda:CreateFunction",
+      "lambda:CreateEventSourceMapping",
+      "dynamodb:CreateTable",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# unknown
+

--- a/tests/terraform/checks/data/aws/example_CloudsplainingPermissionsManagement/main.tf
+++ b/tests/terraform/checks/data/aws/example_CloudsplainingPermissionsManagement/main.tf
@@ -1,0 +1,34 @@
+# pass
+
+data "aws_iam_policy_document" "pass" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "arn:aws:s3:::example",
+    ]
+  }
+}
+
+# fail
+
+data "aws_iam_policy_document" "fail" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:*"
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# unknown
+

--- a/tests/terraform/checks/data/aws/example_StarActionPolicyDocument/main.tf
+++ b/tests/terraform/checks/data/aws/example_StarActionPolicyDocument/main.tf
@@ -1,0 +1,77 @@
+# pass
+
+data "aws_iam_policy_document" "flatten" {
+  version = "2012-10-17"
+
+  statement = flatten(var.policy_json, [])
+}
+
+data "aws_iam_policy_document" "pass" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      "arn:aws:s3:::my_corporate_bucket/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "unknown" {
+  version = "2012-10-17"
+
+  statement = [{
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "${aws_s3_bucket.default.arn}/*"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }]
+
+  # Support replication ARNs
+  statement = ["${flatten(data.aws_iam_policy_document.replication.*.statement)}"]
+
+  # Support deployment ARNs
+  statement = ["${flatten(data.aws_iam_policy_document.deployment.*.statement)}"]
+}
+
+# fail
+
+data "aws_iam_policy_document" "fail" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "*"
+    ]
+    resources = [
+      "arn:aws:s3:::my_corporate_bucket/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "no_effect" {
+  version = "2012-10-17"
+
+  statement {
+    actions = [
+      "*"
+    ]
+    resources = [
+      "arn:aws:s3:::my_corporate_bucket/*",
+    ]
+  }
+}
+
+# unknown
+

--- a/tests/terraform/checks/data/aws/test_AdminPolicyDocument.py
+++ b/tests/terraform/checks/data/aws/test_AdminPolicyDocument.py
@@ -1,53 +1,38 @@
 import unittest
+from pathlib import Path
 
-import hcl2
-
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.data.aws.AdminPolicyDocument import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestAdminPolicyDocument(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_AdminPolicyDocument"
 
-    def test_success(self):
-        resource_conf = {'version': ['2012-10-17'], 'statement': [{'actions': [['s3:Describe*']], 'resources': [['*']], 'effect': ['Allow']}]}
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-    def test_failure(self):
-        resource_conf = {'version': ['2012-10-17'], 'statement': [{'actions': [['*']], 'resources': [['*']], 'effect': ['Allow']}]}
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passing_resources = {
+            "aws_iam_policy_document.list",
+            "aws_iam_policy_document.pass",
+        }
+        failing_resources = {
+            "aws_iam_policy_document.fail",
+            "aws_iam_policy_document.no_effect",
+        }
 
-    def test_failure_no_effect(self):
-        resource_conf = {'version': ['2012-10-17'], 'statement': [{'actions': [['*']], 'resources': [['*']]}]}
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
 
-    def test_passed_list_statement(self):
-        hcl_res = hcl2.loads("""
-            data "aws_iam_policy_document" "default" {
-              statement = [{
-                actions = ["s3:GetObject"]
-            
-                resources = ["${aws_s3_bucket.default.arn}/*"]
-            
-                principals {
-                  type        = "AWS"
-                  identifiers = ["*"]
-                }
-              }]
-            
-              # Support replication ARNs
-              statement = ["${flatten(data.aws_iam_policy_document.replication.*.statement)}"]
-            
-              # Support deployment ARNs
-              statement = ["${flatten(data.aws_iam_policy_document.deployment.*.statement)}"]
-            }
-        """)
-        resource_conf = hcl_res['data'][0]['aws_iam_policy_document']['default']
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/data/aws/test_CloudSplainingDataExfiltration.py
+++ b/tests/terraform/checks/data/aws/test_CloudSplainingDataExfiltration.py
@@ -1,64 +1,42 @@
 import unittest
+from pathlib import Path
 
-import hcl2
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.data.aws.IAMDataExfiltration import check
-
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestcloudsplainingDataExfiltration(unittest.TestCase):
+    def setUp(self):
+        from checkov.terraform.checks.data.BaseCloudsplainingIAMCheck import BaseCloudsplainingIAMCheck
 
-    def test_failure(self):
-        hcl_res = hcl2.loads("""
-            data "aws_iam_policy_document" "example" {
-              statement {
-                sid = "1"
-                effect = "Allow"
+        # needs to be reset, because the cache belongs to the class not instance
+        BaseCloudsplainingIAMCheck.policy_document_cache = {}
 
-                actions = [
-                        "iam:PassRole",
-                        "ssm:GetParameter",
-                        "s3:GetObject",
-                        "ssm:GetParameter",
-                        "ssm:GetParameters",
-                        "ssm:GetParametersByPath",
-                        "secretsmanager:GetSecretValue",
-                        "s3:PutObject",
-                        "ec2:CreateTags"
-                ]
-            
-                resources = [
-                  "*",
-                ]
-              }
-            }
-        """)
-        resource_conf = hcl_res['data'][0]['aws_iam_policy_document']['example']
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_CloudSplainingDataExfiltration"
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-            data "aws_iam_policy_document" "example" {
-              statement {
-                sid = "1"
-                effect = "Allow"
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-                actions = [
-                    "lambda:CreateFunction",
-                    "lambda:CreateEventSourceMapping",
-                    "dynamodb:CreateTable",
-                ]
-            
-                resources = [
-                  "*",
-                ]
-              }
-            }
-        """)
-        resource_conf = hcl_res['data'][0]['aws_iam_policy_document']['example']
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passing_resources = {
+            "aws_iam_policy_document.pass",
+        }
+        failing_resources = {
+            "aws_iam_policy_document.fail",
+        }
 
-if __name__ == '__main__':
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/data/aws/test_CloudSplainingPrivilegeEscalation.py
+++ b/tests/terraform/checks/data/aws/test_CloudSplainingPrivilegeEscalation.py
@@ -1,60 +1,46 @@
 import unittest
+from pathlib import Path
 
 import hcl2
+
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.data.aws.IAMPrivilegeEscalation import check
 
 from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestcloudsplainingPrivilegeEscalation(unittest.TestCase):
+    def setUp(self):
+        from checkov.terraform.checks.data.BaseCloudsplainingIAMCheck import BaseCloudsplainingIAMCheck
 
-    def test_failure(self):
-        hcl_res = hcl2.loads("""
-            data "aws_iam_policy_document" "example" {
-              statement {
-                sid = "1"
-                effect = "Allow"
+        # needs to be reset, because the cache belongs to the class not instance
+        BaseCloudsplainingIAMCheck.policy_document_cache = {}
 
-                actions = [
-                    "iam:PassRole",
-                    "lambda:CreateFunction",
-                    "lambda:CreateEventSourceMapping",
-                    "dynamodb:CreateTable",
-                    "dynamodb:PutItem",
-                ]
-            
-                resources = [
-                  "*",
-                ]
-              }
-            }
-        """)
-        resource_conf = hcl_res['data'][0]['aws_iam_policy_document']['example']
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_CloudSplainingPrivilegeEscalation"
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-            data "aws_iam_policy_document" "example" {
-              statement {
-                sid = "1"
-                effect = "Allow"
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-                actions = [
-                    "lambda:CreateFunction",
-                    "lambda:CreateEventSourceMapping",
-                    "dynamodb:CreateTable",
-                ]
-            
-                resources = [
-                  "*",
-                ]
-              }
-            }
-        """)
-        resource_conf = hcl_res['data'][0]['aws_iam_policy_document']['example']
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passing_resources = {
+            "aws_iam_policy_document.pass",
+        }
+        failing_resources = {
+            "aws_iam_policy_document.fail",
+        }
 
-if __name__ == '__main__':
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/data/aws/test_CloudsplainingIAMWrite.py
+++ b/tests/terraform/checks/data/aws/test_CloudsplainingIAMWrite.py
@@ -7,6 +7,12 @@ from checkov.terraform.runner import Runner
 
 
 class TestCloudsplainingIAMWrite(unittest.TestCase):
+    def setUp(self):
+        from checkov.terraform.checks.data.BaseCloudsplainingIAMCheck import BaseCloudsplainingIAMCheck
+
+        # needs to be reset, because the cache belongs to the class not instance
+        BaseCloudsplainingIAMCheck.policy_document_cache = {}
+
     def test(self):
         test_files_dir = Path(__file__).parent / "example_CloudsplainingIAMWrite"
 

--- a/tests/terraform/checks/data/aws/test_CloudsplainingPermissionsManagement.py
+++ b/tests/terraform/checks/data/aws/test_CloudsplainingPermissionsManagement.py
@@ -1,54 +1,42 @@
 import unittest
+from pathlib import Path
 
-import hcl2
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.data.aws.IAMPermissionsManagement import check
-
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestCloudsplainingIAMWrite(unittest.TestCase):
+    def setUp(self):
+        from checkov.terraform.checks.data.BaseCloudsplainingIAMCheck import BaseCloudsplainingIAMCheck
 
-    def test_failure(self):
-        hcl_res = hcl2.loads("""
-            data "aws_iam_policy_document" "example" {
-              statement {
-                sid = "1"
-                effect = "Allow"
+        # needs to be reset, because the cache belongs to the class not instance
+        BaseCloudsplainingIAMCheck.policy_document_cache = {}
 
-                actions = [
-                        "iam:*"
-                ]
-            
-                resources = [
-                  "*",
-                ]
-              }
-            }
-        """)
-        resource_conf = hcl_res['data'][0]['aws_iam_policy_document']['example']
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_CloudsplainingPermissionsManagement"
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-            data "aws_iam_policy_document" "example" {
-              statement {
-                sid = "1"
-                effect = "Allow"
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-                actions = [
-                        "s3:*"
-                ]
-            
-                resources = [
-                  "foo",
-                ]
-              }
-            }
-        """)
-        resource_conf = hcl_res['data'][0]['aws_iam_policy_document']['example']
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passing_resources = {
+            "aws_iam_policy_document.pass",
+        }
+        failing_resources = {
+            "aws_iam_policy_document.fail",
+        }
 
-if __name__ == '__main__':
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/data/aws/test_StarActionPolicyDocument.py
+++ b/tests/terraform/checks/data/aws/test_StarActionPolicyDocument.py
@@ -1,61 +1,39 @@
 import unittest
+from pathlib import Path
 
-import hcl2
-
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.data.aws.StarActionPolicyDocument import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestStarActionPolicyDocument(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_StarActionPolicyDocument"
 
-    def test_success(self):
-        resource_conf = {
-            "statement": [{
-                "actions": [["s3:*"]],
-                "resources": [["arn:aws:s3:::my_corporate_bucket/*"]],
-                "effect": ["Allow"]
-            }]
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_iam_policy_document.flatten",
+            "aws_iam_policy_document.pass",
+            "aws_iam_policy_document.unknown",
         }
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
-
-    def test_unknown(self):
-        resource_conf = {'statement': [[{'actions': ['s3:GetObject'], 'principals': {'identifiers': ['*'], 'type': 'AWS'}, 'resources': ['aws_s3_bucket.default.arn/*']}], 'flatten(data.aws_iam_policy_document.deployment.*.statement)', 'flatten(data.aws_iam_policy_document.replication.*.statement)']}
-
-        scan_result = check.scan_data_conf(resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
-
-    def test_failure(self):
-        resource_conf = {
-            "statement": [{
-                "actions": [["*"]],
-                "resources": [["arn:aws:s3:::my_corporate_bucket/*"]],
-                "effect": ["Allow"]
-            }]
+        failing_resources = {
+            "aws_iam_policy_document.fail",
+            "aws_iam_policy_document.no_effect",
         }
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
 
-    def test_failure_no_effect(self):
-        resource_conf = {
-            "statement": [{
-                "actions": [["*"]],
-                "resources": [["arn:aws:s3:::my_corporate_bucket/*"]]
-            }]
-        }
-        scan_result = check.scan_data_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
 
-    def test_flatten_operator(self):
-        conf = hcl2.loads("""
-        data "aws_iam_policy_document" "mock_policy" {
-            statement = flatten(var.policy_json, [])
-        }
-        """)
+        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
 
-        scan_result = check.scan_data_conf(conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Relates #1589 and follow up to #1626

Starting from my previous improvement I could shave of more time 🚀 
<img width="712" alt="cloudsplaining_time" src="https://user-images.githubusercontent.com/33207684/133912703-8a46aed3-902c-4dc7-bff4-b76c2c36f553.png">

And this changed of course the top 10 of the worst methods
<img width="1016" alt="cloudsplaining_own_time" src="https://user-images.githubusercontent.com/33207684/133912712-3de74c52-a66a-41d1-aa26-326989d9e329.png">

The usage of `<listcomp>` and `fnmatchcase` dropped massively and therefore resulted in the performance boost. This improvement will be more impactful in setups with a lot of IAM data resource checks.