### PR TITLE
feat: skip rules when defined in a module

### DIFF
--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -264,6 +264,9 @@ class Runner(BaseRunner):
                 entity_code_lines = None
                 skipped_checks = None
 
+            if block_type == "module" and skipped_checks is not None:
+                self.push_skipped_checks_down(self, definition_context, full_file_path, skipped_checks)
+            
             if full_file_path in self.evaluations_context:
                 variables_evaluations = {}
                 for var_name, context_info in self.evaluations_context.get(full_file_path, {}).items():
@@ -288,6 +291,35 @@ class Runner(BaseRunner):
                 if breadcrumb:
                     record = GraphRecord(record, breadcrumb)
                 report.add_record(record=record)
+
+    @staticmethod
+    def push_skipped_checks_down(self, definition_context, module_path, skipped_checks):
+        # this method pushes the skipped_checks down the 1 level to all resource types.
+
+        # iterate over definitions to find those that reference the module path
+        # definition is in the format <file>[<referrer>#<index>]
+        # where referrer could be a path, or path1->path2, etc
+
+        for definition in definition_context:
+            _, mod_ref = self._strip_module_referrer(definition)
+            if mod_ref is None:
+                continue
+
+            if module_path not in mod_ref:
+                continue
+
+            for next_type in definition_context[definition]:
+                # skip if type is not a terraform resource
+                if next_type not in CHECK_BLOCK_TYPES:
+                    continue
+
+                # there may be multiple resource types - aws_bucket, etc
+                for resource_type in definition_context[definition][next_type]:
+                    # there may be multiple names for each resource type
+                    for resource_name in definition_context[definition][next_type][resource_type]:
+                        # append the skipped checks from the module to the other resources.
+                        # this could also be from a module to another module.
+                        self.context[definition][next_type][resource_type][resource_name]["skipped_checks"] += skipped_checks
 
     @staticmethod
     def _strip_module_referrer(file_path: str) -> Tuple[str, Optional[str]]:

--- a/tests/terraform/runner/resources/module_skip/another/module/module-3/module.tf
+++ b/tests/terraform/runner/resources/module_skip/another/module/module-3/module.tf
@@ -1,0 +1,4 @@
+# Bucket that will fail (no encryption) defined INSIDE a module
+resource "aws_s3_bucket" "nested-inside" {
+  bucket = "nested-inside-bucket"
+}

--- a/tests/terraform/runner/resources/module_skip/another/module/module.tf
+++ b/tests/terraform/runner/resources/module_skip/another/module/module.tf
@@ -1,0 +1,9 @@
+# Bucket that will fail (no encryption) defined INSIDE a module
+resource "aws_s3_bucket" "nested-inside" {
+  bucket = "nested-inside-bucket"
+}
+
+# this module is used to test 3 layers deep
+module "module-3" {
+  source = "./module-3"
+}

--- a/tests/terraform/runner/resources/module_skip/main.tf
+++ b/tests/terraform/runner/resources/module_skip/main.tf
@@ -1,0 +1,16 @@
+#
+# WARNING: Line numbers mater in this test!
+#          Update test_module_skip if a change is made!
+#
+
+module "test_module" {
+  source = "./module"
+
+  #checkov:skip=CKV_AWS_19:Skip encryption
+}
+
+resource "aws_s3_bucket" "outside" {
+  bucket = "outside-bucket"
+
+  #checkov:skip=CKV_AWS_19:Skip encryption
+}

--- a/tests/terraform/runner/resources/module_skip/module/module.tf
+++ b/tests/terraform/runner/resources/module_skip/module/module.tf
@@ -1,0 +1,17 @@
+#
+# WARNING: Line numbers mater in this test!
+#          Update test_module_skip if a change is made!
+#
+
+# Bucket that will fail (no encryption) defined INSIDE a module
+resource "aws_s3_bucket" "inside" {
+  bucket = "inside-bucket"
+}
+
+resource "aws_s3_bucket" "inside2" {
+  bucket = "inside-bucket-2"
+}
+
+module "another_module" {
+  source = "../another/module"
+}

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -632,6 +632,43 @@ class TestRunnerValid(unittest.TestCase):
         runner.run(root_folder=None, external_checks_dir=None, files=[passing_tf_file_path])
         # If we get here all is well. :-)  Failure would throw an exception.
 
+    def test_module_skip(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        report = Runner().run(root_folder=f"{current_dir}/resources/module_skip",
+                              external_checks_dir=None,
+                              runner_filter=RunnerFilter(checks="CKV_AWS_19"))  # bucket encryption
+
+        self.assertEqual(len(report.skipped_checks), 5)
+        self.assertEqual(len(report.failed_checks), 0)
+        self.assertEqual(len(report.passed_checks), 0)
+
+        found_inside = False
+        found_outside = False
+
+        for record in report.failed_checks:
+            if "inside" in record.resource:
+                found_inside = True
+                print(record)
+                self.assertEqual(record.resource, "module.test_module.aws_s3_bucket.inside")
+                assert record.file_path == "/module/module.tf"
+                self.assertEqual(record.file_line_range, [7, 9])
+                assert record.caller_file_path == "/main.tf"
+                # ATTENTION!! If this breaks, see the "HACK ALERT" comment in runner.run_block.
+                #             A bug might have been fixed.
+                self.assertEqual(record.caller_file_line_range, [6, 8])
+
+            if "outside" in record.resource:
+                found_outside = True
+                self.assertEqual(record.resource, "aws_s3_bucket.outside")
+                assert record.file_path == "/main.tf"
+                self.assertEqual(record.file_line_range, [12, 16])
+                self.assertIsNone(record.caller_file_path)
+                self.assertIsNone(record.caller_file_line_range)
+
+        self.assertFalse(found_inside)
+        self.assertFalse(found_outside)
+
     def test_module_failure_reporting_772(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -667,6 +704,7 @@ class TestRunnerValid(unittest.TestCase):
 
         self.assertTrue(found_inside)
         self.assertTrue(found_outside)
+
 
     def test_loading_external_checks_yaml(self):
         runner = Runner()


### PR DESCRIPTION
Hi,

This is a potential solution #777.

I found that the `skipped_checks` property is already set on all entity types, i.e. modules, resources, etc.
So, I did not need to change the parse algorithm specifically for modules.

From here, I considered 2 potential solutions:
1. Push the skipped checks from one layer down to the next
2. When processing a resource, look up the graph to find other skip checks.

I implemented option 1 as it seemed simple and logical.
Note: This implementation will push skipped checks from a module to all entity types - modules, data, resources and provider.

Looking forward to your feedback.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
