### PR TITLE
skip non-CF file endings with --file

### DIFF
--- a/checkov/cloudformation/cfn_utils.py
+++ b/checkov/cloudformation/cfn_utils.py
@@ -198,7 +198,9 @@ def create_definitions(
     definitions_raw = {}
     if files:
         for file in files:
-            (definitions[file], definitions_raw[file]) = parse(file, out_parsing_errors)
+            file_ending = os.path.splitext(file)[1]
+            if file_ending in CF_POSSIBLE_ENDINGS:
+                (definitions[file], definitions_raw[file]) = parse(file, out_parsing_errors)
 
     if root_folder:
         definitions, definitions_raw = get_folder_definitions(root_folder, runner_filter.excluded_paths, out_parsing_errors)

--- a/tests/cloudformation/runner/test_runner.py
+++ b/tests/cloudformation/runner/test_runner.py
@@ -9,6 +9,7 @@ from checkov.cloudformation.parser import parse
 from checkov.runner_filter import RunnerFilter
 from checkov.cloudformation.runner import Runner
 from checkov.common.output.report import Report
+from checkov.cloudformation.cfn_utils import create_definitions
 
 
 class TestRunnerValid(unittest.TestCase):
@@ -254,6 +255,11 @@ class TestRunnerValid(unittest.TestCase):
         report = runner.run(root_folder=None, external_checks_dir=None, files=[scan_file_path],
                             runner_filter=RunnerFilter(framework='cloudformation'))
         self.assertEqual(report.parsing_errors, [scan_file_path])
+
+    def test_parse_relevant_files_only(self):
+        definitions, _ = create_definitions(None, ['main.tf'])
+        # just check that we skip the file and return normally
+        self.assertFalse('main.tf' in definitions)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes an issue where certain types of tf files attempt to get parsed by the CFN parser and return a parsing error (they used to be silently skipped until the recent parser error handling updates)