### PR TITLE
Timeout TF file parsing when stuck

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         python: [3.7, 3.8, 3.9]
     runs-on: [self-hosted, public, linux, x64]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python }}

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -677,7 +677,9 @@ def _hcl2_load(q: Queue, f: io.TextIOWrapper) -> None:
     try:
         raw_data = hcl2.load(f)
         q.put(raw_data)
-    except Exception:
+    except Exception as e:
+        logging.error(f'Failed to parse file {f.name}. Error:')
+        logging.error(e, exc_info=True)
         q.put(None)
 
 def _is_valid_block(block):

--- a/tests/terraform/runner/resources/unbalanced_eval_brackets/main.tf
+++ b/tests/terraform/runner/resources/unbalanced_eval_brackets/main.tf
@@ -1,0 +1,4 @@
+locals {
+  # This is intentionally missing the closing bracket
+  s3_access_logs_prefix = "${replace(var.cdn_logging_prefix, "cdn", "s3")/${var.bucket_name}"
+}

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -885,6 +885,15 @@ class TestRunnerValid(unittest.TestCase):
                 self.fail(f"found duplicate results in report: {record.to_string()}")
             unique_checks.append(check_unique)
 
+    def test_malformed_file_in_parsing_error(self):
+        resources_path = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "resources", "unbalanced_eval_brackets")
+        runner = Runner()
+        report = runner.run(root_folder=resources_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework='terraform'))
+        file_path = os.path.join(resources_path, 'main.tf')
+        self.assertEqual(report.parsing_errors[0], file_path)
+
     def tearDown(self):
         parser_registry.context = {}
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes issue #822 

In some cases when a TF file is malformed, the hcl2 parser hangs "forever" and therefore checkov hangs too. This solution puts the parsing method in a child process under a 60 seconds timeframe.
1. If the parsing succeeds before the time is up, the process is finished and closed automatically (as usual)
2. If the parsing fails before the time is up, the process is finished and closed automatically, the file is added to the "parsing error" dict (as usual)
3. If the parsing isn't finished under the 60 seconds cap, the process will be killed and the file will be added to the "parsing error" dict