### PR TITLE
Skip check wildcard not honored for secrets

### DIFF
--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -180,7 +180,7 @@ class Runner(BaseRunner):
         secret: PotentialSecret,
         runner_filter: RunnerFilter
     ) -> Optional[_CheckResult]:
-        if (check_id in runner_filter.skip_checks or bc_check_id in runner_filter.skip_checks or not runner_filter.should_run_check(check_id, bc_check_id)) and check_id in CHECK_ID_TO_SECRET_TYPE.keys():
+        if not runner_filter.should_run_check(check_id, bc_check_id) and check_id in CHECK_ID_TO_SECRET_TYPE.keys():
             return {
                 "result": CheckResult.SKIPPED,
                 "suppress_comment": f"Secret scan {check_id} is skipped"

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -154,7 +154,7 @@ class Runner(BaseRunner):
                     check_id=check_id,
                     bc_check_id=bc_check_id,
                     secret=secret,
-                    skipped_checks=runner_filter.skip_checks,
+                    runner_filter=runner_filter,
                 ) or result
                 report.add_resource(f'{secret.filename}:{secret.secret_hash}')
                 report.add_record(Record(
@@ -178,9 +178,9 @@ class Runner(BaseRunner):
         check_id: str,
         bc_check_id: str,
         secret: PotentialSecret,
-        skipped_checks: List[str]
+        runner_filter: RunnerFilter
     ) -> Optional[_CheckResult]:
-        if (check_id in skipped_checks or bc_check_id in skipped_checks) and check_id in CHECK_ID_TO_SECRET_TYPE.keys():
+        if (check_id in runner_filter.skip_checks or bc_check_id in runner_filter.skip_checks or not runner_filter.should_run_check(check_id, bc_check_id)) and check_id in CHECK_ID_TO_SECRET_TYPE.keys():
             return {
                 "result": CheckResult.SKIPPED,
                 "suppress_comment": f"Secret scan {check_id} is skipped"

--- a/tests/secrets/test_runner.py
+++ b/tests/secrets/test_runner.py
@@ -72,6 +72,16 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.parsing_errors, [])
         self.assertEqual(report.passed_checks, [])
 
+    def test_runner_skip_check_wildcard(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/resources/cfn"
+        runner = Runner()
+        report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework='secrets', skip_checks=['CKV_SECRET*']))
+        self.assertEqual(len(report.skipped_checks), 2)
+        self.assertEqual(report.parsing_errors, [])
+        self.assertEqual(report.passed_checks, [])
+
     def test_runner_multiple_files(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         valid_dir_path = current_dir + "/resources"


### PR DESCRIPTION
Fixes https://github.com/bridgecrewio/checkov/issues/1641

This PR removes the secrets-only filtering / suppression logic that was in place, replacing it with a call to the common `RunnerFilter.should_run_check` determination logic.

On `master`:
```
checkov --directory jvgiac --framework secrets --skip-check 'CKV_SECRET_*'                                                              Py checkov-bBv59Y8z

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By bridgecrew.io | version: 2.0.438

secrets scan results:

Passed checks: 0, Failed checks: 1, Skipped checks: 0

Check: CKV_SECRET_2: "AWS Access Key"
        FAILED for resource: 25910f981e85ca04baf359199dd0bd4a3ae738b6
        File: /CKV_SECRET_2.json:6-7
        Guide: https://docs.bridgecrew.io/docs/git_secrets_2

                6 |         "Any": "AKIAIOSFODNN7EXAMPLE"
```

On this branch:

```
checkov --directory jvgiac --framework secrets --skip-check 'CKV_SECRET_*'                                           Py checkov-bBv59Y8z

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By bridgecrew.io | version: 2.0.438

secrets scan results:

Passed checks: 0, Failed checks: 0, Skipped checks: 1

Check: CKV_SECRET_2: "AWS Access Key"
        SKIPPED for resource: 25910f981e85ca04baf359199dd0bd4a3ae738b6
        Suppress comment: Secret scan CKV_SECRET_2 is skipped
        File: /CKV_SECRET_2.json:6-7
        Guide: https://docs.bridgecrew.io/docs/git_secrets_2
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
