### PR TITLE
Allow wildcard for checks

### DIFF
--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -56,7 +56,7 @@ class RunnerFilter(object):
         if RunnerFilter.is_external_check(check_id) and self.all_external:
             pass  # enabled unless skipped
         elif self.checks:
-            if check_id in self.checks or bc_check_id in self.checks:
+            if self.checks and any((fnmatch.fnmatch(check_id, pattern) or (bc_check_id and fnmatch.fnmatch(bc_check_id, pattern))) for pattern in self.checks):
                 return True
             else:
                 return False

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -144,7 +144,7 @@ class Runner(BaseRunner):
                 bc_check_id = bc_integration.ckv_to_bc_id_mapping.get(check_id) if bc_integration.ckv_to_bc_id_mapping else None
                 if not check_id:
                     continue
-                if runner_filter.checks and (check_id not in runner_filter.checks and bc_check_id not in runner_filter.checks):
+                if runner_filter.checks and not runner_filter.should_run_check(check_id, bc_check_id):
                     continue
                 result: _CheckResult = {'result': CheckResult.FAILED}
                 line_text = linecache.getline(secret.filename, secret.line_number)

--- a/tests/common/test_runner_filter.py
+++ b/tests/common/test_runner_filter.py
@@ -29,6 +29,14 @@ class TestRunnerFilter(unittest.TestCase):
         instance = RunnerFilter(checks=["BC_CHECK_1"])
         self.assertTrue(instance.should_run_check("CHECK_1", "BC_CHECK_1"))
 
+    def test_should_run_wildcard_enable(self):
+        instance = RunnerFilter(checks=["CHECK_*"])
+        self.assertTrue(instance.should_run_check("CHECK_1"))
+
+    def test_should_run_wildcard_enable_bc(self):
+        instance = RunnerFilter(checks=["BC_CHECK_*"])
+        self.assertTrue(instance.should_run_check("CHECK_1", "BC_CHECK_1"))
+
     def test_should_run_omitted_specific_enable(self):
         instance = RunnerFilter(checks=["CHECK_1"])
         self.assertFalse(instance.should_run_check("CHECK_999"))

--- a/tests/secrets/test_runner.py
+++ b/tests/secrets/test_runner.py
@@ -62,6 +62,28 @@ class TestRunnerValid(unittest.TestCase):
 
         report.print_console()
 
+    def test_runner_specific_check(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/resources/cfn"
+        runner = Runner()
+        report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework='secrets', checks=['CKV_SECRET_2']))
+        self.assertEqual(len(report.skipped_checks), 0)
+        self.assertEqual(len(report.failed_checks), 1)
+        self.assertEqual(report.parsing_errors, [])
+        self.assertEqual(report.passed_checks, [])
+
+    def test_runner_wildcard_check(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/resources/cfn"
+        runner = Runner()
+        report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework='secrets', checks=['CKV_SECRET*']))
+        self.assertEqual(len(report.skipped_checks), 0)
+        self.assertEqual(len(report.failed_checks), 2)
+        self.assertEqual(report.parsing_errors, [])
+        self.assertEqual(report.passed_checks, [])
+
     def test_runner_skip_check(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         valid_dir_path = current_dir + "/resources/cfn"


### PR DESCRIPTION
This PR adds support for wildcarding in the `--check` configuration option.  This is very similar in implementation to: https://github.com/bridgecrewio/checkov/pull/1649 and the original `--skip-check` wildcarding implementation in https://github.com/bridgecrewio/checkov/pull/750.  

There appears to be some code divergence between secrets and other frameworks.  After discovering that when fixing https://github.com/bridgecrewio/checkov/pull/1649 I have addressed both in this PR for `--check` support.

On master (not running any checks because the wildcard does not match anything explicitly):

```
/checkov --directory jvgiac --check 'CKV_AWS*'                                   Py checkov-bBv59Y8z

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By bridgecrew.io | version: 2.0.438
```

On this branch:

```
checkov --directory jvgiac --check 'CKV_AWS*'                Py checkov-bBv59Y8z

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By bridgecrew.io | version: 2.0.438

cloudformation scan results:

Passed checks: 0, Failed checks: 1, Skipped checks: 0

Check: CKV_AWS_3: "Ensure all data stored in the EBS is securely encrypted"
        FAILED for resource: AWS::EC2::Volume.Ebs1
        File: /PASS.json:3-7
        Guide: https://docs.bridgecrew.io/docs/general_3-encrypt-eps-volume

                3 |     "Ebs1": {
                4 |       "Type": "AWS::EC2::Volume",
                5 |       "Properties": {
                6 |       }
                7 |     }

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
