### PR TITLE
Support wildcarding in --soft-fail-on list

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -1,3 +1,4 @@
+import fnmatch
 import json
 from collections import defaultdict
 from typing import List, Dict, Union, Any, Optional, Set
@@ -95,7 +96,8 @@ class Report:
         if soft_fail_on:
             soft_fail_on = convert_csv_string_arg_to_list(soft_fail_on)
             if all(
-                (check_id in soft_fail_on or bc_check_id in soft_fail_on)
+                any((fnmatch.fnmatch(check_id, pattern) or (bc_check_id and fnmatch.fnmatch(bc_check_id, pattern)))
+                    for pattern in soft_fail_on)
                 for (check_id, bc_check_id) in (
                     (failed_check.check_id, failed_check.bc_check_id)
                     for failed_check in self.failed_checks

--- a/tests/common/output/test_get_exit_code.py
+++ b/tests/common/output/test_get_exit_code.py
@@ -73,6 +73,12 @@ class TestGetExitCode(unittest.TestCase):
         negative_test_soft_fail_on_code = r.get_exit_code(None, soft_fail_on=['CKV_AWS_157'], hard_fail_on=None)
         negative_test_soft_fail_on_code_bc_id = r.get_exit_code(None, soft_fail_on=['BC_AWS_157'], hard_fail_on=None)
 
+        positive_test_soft_fail_on_wildcard_code = r.get_exit_code(None, soft_fail_on=['CKV_AWS*'])
+        positive_test_soft_fail_on_wildcard_code_bc_id = r.get_exit_code(None, soft_fail_on=['BC_AWS*'])
+
+        negative_test_soft_fail_on_wildcard_code = r.get_exit_code(None, soft_fail_on=['CKV_OTHER*'])
+        negative_test_soft_fail_on_wildcard_code_bc_id = r.get_exit_code(None, soft_fail_on=['BC_OTHER*'])
+
         # When hard_fail_on=['check1', 'check2'], exit code should be 1 if any checks in the hard_fail_on list fail
         positive_test_hard_fail_on_code = r.get_exit_code(None, soft_fail_on=None, hard_fail_on=['CKV_AWS_157'])
         positive_test_hard_fail_on_code_bc_id = r.get_exit_code(None, soft_fail_on=None, hard_fail_on=['BC_AWS_157'])
@@ -87,6 +93,12 @@ class TestGetExitCode(unittest.TestCase):
         self.assertEqual(positive_test_soft_fail_on_code_bc_id, 0)
         self.assertEqual(negative_test_soft_fail_on_code, 1)
         self.assertEqual(negative_test_soft_fail_on_code_bc_id, 1)
+
+        self.assertEqual(positive_test_soft_fail_on_wildcard_code, 0)
+        self.assertEqual(positive_test_soft_fail_on_wildcard_code_bc_id, 0)
+        self.assertEqual(negative_test_soft_fail_on_wildcard_code, 1)
+        self.assertEqual(negative_test_soft_fail_on_wildcard_code_bc_id, 1)
+
         self.assertEqual(positive_test_hard_fail_on_code, 1)
         self.assertEqual(positive_test_hard_fail_on_code_bc_id, 1)
         self.assertEqual(negative_test_hard_fail_on_code, 0)


### PR DESCRIPTION
This PR adds support for wildcarding in the `--soft-fail-on` flag.  

On master:

```
checkov --directory jvgiac --check 'CKV_AWS_3' --soft-fail-on 'CKV_AWS*'

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By bridgecrew.io | version: 2.0.438

cloudformation scan results:

Passed checks: 0, Failed checks: 1, Skipped checks: 0

Check: CKV_AWS_3: "Ensure all data stored in the EBS is securely encrypted"
        FAILED for resource: AWS::EC2::Volume.Ebs1
        File: /PASS.json:3-7
        Guide: https://docs.bridgecrew.io/docs/general_3-encrypt-eps-volume

                3 |     "Ebs1": {
                4 |       "Type": "AWS::EC2::Volume",
                5 |       "Properties": {
                6 |       }
                7 |     }


❯ echo $?                                                                                               3s Py checkov-bBv59Y8z
1
```

On this branch:
```
checkov --directory jvgiac --check 'CKV_AWS_3' --soft-fail-on 'CKV_AWS*'

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By bridgecrew.io | version: 2.0.438

cloudformation scan results:

Passed checks: 0, Failed checks: 1, Skipped checks: 0

Check: CKV_AWS_3: "Ensure all data stored in the EBS is securely encrypted"
        FAILED for resource: AWS::EC2::Volume.Ebs1
        File: /PASS.json:3-7
        Guide: https://docs.bridgecrew.io/docs/general_3-encrypt-eps-volume

                3 |     "Ebs1": {
                4 |       "Type": "AWS::EC2::Volume",
                5 |       "Properties": {
                6 |       }
                7 |     }


❯ echo $?                                                                                3s Py checkov-bBv59Y8z
0
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
