### PR TITLE
Fix TF check for CKV_AWS_23

### DIFF
--- a/checkov/terraform/checks/resource/aws/SecurityGroupRuleDescription.py
+++ b/checkov/terraform/checks/resource/aws/SecurityGroupRuleDescription.py
@@ -23,18 +23,31 @@ class SecurityGroupRuleDescription(BaseResourceCheck):
         :param conf: aws_security_group configuration
         :return: <CheckResult>
         """
-        if 'description' in conf.keys():
-            if conf['description']:
-                self.evaluated_keys = 'description'
+        group_result = self.check_rule(rule_type='group_or_rule_description', conf=conf)
+        if 'type' not in conf.keys():
+            # 'type' attribute only exists and is required for aws_security_group_rule resources.
+            # Therefore, only if 'type' is not present, ingress and egress blocks must be checked in the resource.
+            egress_result = self.check_rule(rule_type='egress', conf=conf)
+            ingress_result = self.check_rule(rule_type='ingress', conf=conf)
+            if group_result == CheckResult.PASSED and egress_result == CheckResult.PASSED and ingress_result == CheckResult.PASSED:
                 return CheckResult.PASSED
-        egress_result = self.check_rule(rule_type='egress', conf=conf)
-        ingress_result = self.check_rule(rule_type='ingress', conf=conf)
-        if egress_result == CheckResult.PASSED and ingress_result == CheckResult.PASSED:
-            return CheckResult.PASSED
-        return CheckResult.FAILED
+            else:
+                return CheckResult.FAILED
+
+        return group_result
 
     def check_rule(self, rule_type, conf):
+        if rule_type == 'group_or_rule_description':
+            if 'description' in conf.keys():
+                self.evaluated_keys = 'description'
+                if conf['description']:
+                    return CheckResult.PASSED
+            else:
+                return CheckResult.FAILED
+
         if rule_type in conf.keys():
+            if isinstance(self.evaluated_keys, str):
+                self.evaluated_keys = self.evaluated_keys.split()
             for rule in conf[rule_type]:
                 if isinstance(rule, dict):
                     if 'description' not in rule.keys() or not rule['description']:

--- a/tests/terraform/checks/resource/aws/test_SecurityGroupRuleDescription.py
+++ b/tests/terraform/checks/resource/aws/test_SecurityGroupRuleDescription.py
@@ -19,14 +19,13 @@ class TestSecurityGroupRuleDescription(unittest.TestCase):
                                 self        = "false"
                                 to_port     = "0"
                               }
-                            egress {
+                              egress {
                                 cidr_blocks = ["10.0.0.0/0"]
                                 from_port   = "0"
                                 protocol    = "-1"
                                 self        = "false"
                                 to_port     = "0"
                               }
-                            
                               ingress {
                                 description = "Self Reference"
                                 from_port   = "0"
@@ -61,7 +60,8 @@ class TestSecurityGroupRuleDescription(unittest.TestCase):
                                 self        = "false"
                                 to_port     = "0"
                               }
-                            egress {
+                              egress {
+                                description = "Egress description"
                                 cidr_blocks = ["10.0.0.0/0"]
                                 from_port   = "0"
                                 protocol    = "-1"
@@ -90,9 +90,10 @@ class TestSecurityGroupRuleDescription(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-    def test_success(self):
+    def test_success_sg(self):
         hcl_res = hcl2.loads("""
                             resource "aws_security_group" "example_sg" {
+                              description = "SG description"
                               egress {
                                 description = "Allow outgoing communication"
                                 cidr_blocks = ["0.0.0.0/0"]
@@ -123,6 +124,36 @@ class TestSecurityGroupRuleDescription(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_failure_sg_rule(self):
+        hcl_res = hcl2.loads("""
+        resource "aws_security_group_rule" "example_sg_rule_failure" {
+          type = "ingress"
+          from_port = 3389
+          to_port = 3389
+          protocol = "tcp"
+          cidr_blocks = "0.0.0.0/0"
+          security_group_id = "sg-123456"
+        }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group_rule']['example_sg_rule_failure']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_sg_rule(self):
+        hcl_res = hcl2.loads("""
+        resource "aws_security_group_rule" "example_sg_rule_success" {
+          type = "ingress"
+          description = "SG rule description"
+          from_port = 3389
+          to_port = 3389
+          protocol = "tcp"
+          cidr_blocks = "0.0.0.0/0"
+          security_group_id = "sg-123456"
+        }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group_rule']['example_sg_rule_success']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR addresses an issue where `aws_security_group_rule` resources without a description would pass CKV_AWS_23. 
For example, prior to this PR this would pass:
```
resource "aws_security_group_rule" "example" {
  type = "ingress"
  from_port = 3389
  # description = "Allow inbound traffic to ElasticSearch from VPC CIDR"
  to_port = 3389
  protocol = "tcp"
  cidr_blocks = "0.0.0.0/0"
  security_group_id = "sg-123456"
}
```

Going forward, only resources that have descriptions for the "Group", "Ingress" and "Egress" blocks will pass this check as indicated in the docs - https://docs.bridgecrew.io/docs/networking_31
