### PR TITLE
add env var to also scan .hcl files as if they were tf

### DIFF
--- a/checkov/common/models/consts.py
+++ b/checkov/common/models/consts.py
@@ -1,4 +1,9 @@
+from checkov.common.util.config_utils import should_scan_hcl_files
+
+SCAN_HCL_FLAG = "CKV_SCAN_HCL"
 SUPPORTED_FILE_EXTENSIONS = [".tf", ".yml", ".yaml", ".json", ".template"]
+if should_scan_hcl_files():
+    SUPPORTED_FILE_EXTENSIONS.append(".hcl")
 ANY_VALUE = "CKV_ANY"
 DOCKER_IMAGE_REGEX = r'(?:[^\s\/]+/)?([^\s:]+):?([^\s]*)'
 access_key_pattern = "(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])" # nosec

--- a/checkov/common/util/config_utils.py
+++ b/checkov/common/util/config_utils.py
@@ -3,6 +3,8 @@ import os
 from pathlib import Path
 
 
+
+
 def config_file_paths(dir_path):
     return [os.path.join(dir_path, '.checkov.yaml'), os.path.join(dir_path, '.checkov.yml')]
 
@@ -22,3 +24,8 @@ def get_default_config_paths(argv):
         if v in ['-d', '--directory']:
             dir_paths += config_file_paths(argv[i + 1])
     return dir_paths + cwd_path + home_paths
+
+
+def should_scan_hcl_files():
+    from checkov.common.models.consts import SCAN_HCL_FLAG  # prevent circular import
+    return os.getenv(SCAN_HCL_FLAG, default="false").lower() == "true"

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -16,6 +16,7 @@ import hcl2
 from lark import Tree
 
 from checkov.common.runners.base_runner import filter_ignored_paths
+from checkov.common.util.config_utils import should_scan_hcl_files
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR, RESOLVED_MODULE_ENTRY_NAME
 from checkov.common.variables.context import EvaluationContext
 from checkov.terraform.checks.utils.dependency_path_handler import unify_dependency_path
@@ -71,6 +72,7 @@ class Parser:
         self.download_external_modules = download_external_modules
         self.external_modules_download_path = external_modules_download_path
         self.tf_var_files = tf_var_files
+        self.scan_hcl = should_scan_hcl_files()
 
         if self.out_evaluations_context is None:
             self.out_evaluations_context = {}
@@ -208,7 +210,7 @@ class Parser:
                 continue
 
             # Resource files
-            if file.name.endswith(".tf"):  # TODO: add support for .tf.json
+            if file.name.endswith(".tf") or (self.scan_hcl and file.name.endswith('.hcl')):  # TODO: add support for .tf.json
                 data = _load_or_die_quietly(file, self.out_parsing_errors)
             else:
                 continue

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -14,6 +14,7 @@ from checkov.common.output.record import Record
 from checkov.common.output.report import Report, merge_reports, remove_duplicate_results
 from checkov.common.runners.base_runner import BaseRunner
 from checkov.common.util import data_structures_utils
+from checkov.common.util.config_utils import should_scan_hcl_files
 from checkov.common.variables.context import EvaluationContext
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.data.registry import data_registry
@@ -63,6 +64,7 @@ class Runner(BaseRunner):
         report = Report(self.check_type)
         parsing_errors = {}
         self.load_external_checks(external_checks_dir)
+        scan_hcl = should_scan_hcl_files()
 
         if self.context is None or self.definitions is None or self.breadcrumbs is None:
             self.definitions = {}
@@ -84,7 +86,7 @@ class Runner(BaseRunner):
                 root_folder = os.path.split(os.path.commonprefix(files))[0]
                 self.parser.evaluate_variables = False
                 for file in files:
-                    if file.endswith(".tf"):
+                    if file.endswith(".tf") or (scan_hcl and file.endswith(".hcl")):
                         file_parsing_errors = {}
                         parse_result = self.parser.parse_file(file=file, parsing_errors=file_parsing_errors)
                         if parse_result is not None:

--- a/tests/common/utils/test_utils.py
+++ b/tests/common/utils/test_utils.py
@@ -1,5 +1,8 @@
+import os
 import unittest
 
+from checkov.common.models.consts import SCAN_HCL_FLAG
+from checkov.common.util.config_utils import should_scan_hcl_files
 from checkov.common.util.data_structures_utils import merge_dicts
 
 
@@ -33,6 +36,22 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(len(res), 2)
         self.assertEqual(res['a'], '1')
         self.assertEqual(res['b'], '2')
+
+
+    def test_should_scan_hcl_env_var(self):
+        orig_value = os.getenv(SCAN_HCL_FLAG)
+
+        os.unsetenv(SCAN_HCL_FLAG)
+        self.assertFalse(should_scan_hcl_files())
+
+        os.environ[SCAN_HCL_FLAG] = 'FALSE'
+        self.assertFalse(should_scan_hcl_files())
+
+        os.environ[SCAN_HCL_FLAG] = 'TrUe'
+        self.assertTrue(should_scan_hcl_files())
+
+        if orig_value:
+            os.environ[SCAN_HCL_FLAG] = orig_value
 
 
 if __name__ == '__main__':

--- a/tests/terraform/runner/resources/tf_with_hcl_files/example_acl_fail.hcl
+++ b/tests/terraform/runner/resources/tf_with_hcl_files/example_acl_fail.hcl
@@ -1,0 +1,26 @@
+resource "aws_s3_bucket" "foo-bucket-hcl" {
+  region        = var.region
+  bucket        = local.bucket_name
+  force_destroy = true
+
+  tags = {
+    Name = "foo-${data.aws_caller_identity.current.account_id}"
+  }
+  versioning {
+    enabled = true
+  }
+  logging {
+    target_bucket = "${aws_s3_bucket.log_bucket.id}"
+    target_prefix = "log/"
+  }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = "${aws_kms_key.mykey.arn}"
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+  acl           = "public-read"
+}
+data "aws_caller_identity" "current" {}

--- a/tests/terraform/runner/resources/tf_with_hcl_files/example_acl_fail.tf
+++ b/tests/terraform/runner/resources/tf_with_hcl_files/example_acl_fail.tf
@@ -1,0 +1,26 @@
+resource "aws_s3_bucket" "foo-bucket" {
+  region        = var.region
+  bucket        = local.bucket_name
+  force_destroy = true
+
+  tags = {
+    Name = "foo-${data.aws_caller_identity.current.account_id}"
+  }
+  versioning {
+    enabled = true
+  }
+  logging {
+    target_bucket = "${aws_s3_bucket.log_bucket.id}"
+    target_prefix = "log/"
+  }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = "${aws_kms_key.mykey.arn}"
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+  acl           = "public-read"
+}
+data "aws_caller_identity" "current" {}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This may allow us to usefully process .hcl files in certain cases that would otherwise be ignored