### PR TITLE
Fix attribute updates for attributes with dots

### DIFF
--- a/checkov/cloudformation/graph_builder/graph_components/blocks.py
+++ b/checkov/cloudformation/graph_builder/graph_components/blocks.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Union
 
 from checkov.common.graph.graph_builder.graph_components.blocks import Block
 from checkov.common.graph.graph_builder.variable_rendering.breadcrumb_metadata import BreadcrumbMetadata
@@ -35,10 +35,15 @@ class CloudformationBlock(Block):
         if attribute_key_parts:
             obj_to_update = self.attributes
             key_to_update = attribute_key_parts.pop()
-            for key in attribute_key_parts:
+            for i, key in enumerate(attribute_key_parts):
                 if isinstance(obj_to_update, list):
                     key = int(key)
-                obj_to_update = obj_to_update[key]
+                try:
+                    obj_to_update = obj_to_update[key]
+                except KeyError:
+                    attribute_key_parts.append(key_to_update)
+                    key_to_update = ".".join(attribute_key_parts[i:])
+                    break
 
             if isinstance(obj_to_update, list):
                 key_to_update = int(key_to_update)

--- a/checkov/cloudformation/graph_builder/graph_components/blocks.py
+++ b/checkov/cloudformation/graph_builder/graph_components/blocks.py
@@ -38,9 +38,11 @@ class CloudformationBlock(Block):
             for i, key in enumerate(attribute_key_parts):
                 if isinstance(obj_to_update, list):
                     key = int(key)
-                try:
+                if (isinstance(obj_to_update, dict) and key in obj_to_update) or \
+                        (isinstance(obj_to_update, list) and isinstance(key, int) and 0 <= key < len(
+                            obj_to_update)):
                     obj_to_update = obj_to_update[key]
-                except KeyError:
+                else:
                     attribute_key_parts.append(key_to_update)
                     key_to_update = ".".join(attribute_key_parts[i:])
                     break

--- a/tests/cloudformation/graph/graph_builder/test_blocks.py
+++ b/tests/cloudformation/graph/graph_builder/test_blocks.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from checkov.cloudformation.graph_builder.graph_components.block_types import BlockType
+from checkov.cloudformation.graph_builder.graph_components.blocks import CloudformationBlock
+
+
+class TestBlocks(TestCase):
+    def test_update_complex_key(self):
+        config = {'labels': [{'app.kubernetes.io/name': '${local.name}', 'app.kubernetes.io/instance': 'hpa',
+                              'app.kubernetes.io/version': '1.0.0', 'app.kubernetes.io/managed-by': 'terraform'}]}
+        attributes = {'labels': {'app.kubernetes.io/name': '${local.name}', 'app.kubernetes.io/instance': 'hpa',
+                                 'app.kubernetes.io/version': '1.0.0', 'app.kubernetes.io/managed-by': 'terraform'},
+                      'labels.app.kubernetes.io/name': '${local.name}', 'labels.app.kubernetes.io/instance': 'hpa',
+                      'labels.app.kubernetes.io/version': '1.0.0', 'labels.app.kubernetes.io/managed-by': 'terraform'}
+        block = CloudformationBlock(name='test_local_name', config=config, path='', block_type=BlockType.RESOURCE,
+                               attributes=attributes)
+
+        block.update_attribute(attribute_key="labels.app.kubernetes.io/name", change_origin_id=0,
+                                           attribute_value="dummy value", previous_breadcrumbs=[], attribute_at_dest="")
+        self.assertEquals("dummy value", block.attributes["labels.app.kubernetes.io/name"])


### PR DESCRIPTION
Handle attributes that are originally composed with a dot, like in the provided test case `app.kubernetes.io/name`. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
