### PR TITLE
set HCL feature flag default to true

### DIFF
--- a/checkov/common/util/config_utils.py
+++ b/checkov/common/util/config_utils.py
@@ -3,8 +3,6 @@ import os
 from pathlib import Path
 
 
-
-
 def config_file_paths(dir_path):
     return [os.path.join(dir_path, '.checkov.yaml'), os.path.join(dir_path, '.checkov.yml')]
 
@@ -28,4 +26,4 @@ def get_default_config_paths(argv):
 
 def should_scan_hcl_files():
     from checkov.common.models.consts import SCAN_HCL_FLAG  # prevent circular import
-    return os.getenv(SCAN_HCL_FLAG, default="false").lower() == "true"
+    return os.getenv(SCAN_HCL_FLAG, default="true").lower() == "true"

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -909,7 +909,16 @@ class TestRunnerValid(unittest.TestCase):
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
         dir_to_scan = os.path.join(current_dir, 'resources', 'tf_with_hcl_files')
-        orig_value = os.getenv(SCAN_HCL_FLAG)
+
+        orig_value = None  # just in case this was set in the env for some reason
+        if SCAN_HCL_FLAG in os.environ:
+            orig_value = os.getenv(SCAN_HCL_FLAG)
+            del os.environ[SCAN_HCL_FLAG]
+
+        # test default value (true)
+        runner = Runner()
+        report = runner.run(root_folder=dir_to_scan, external_checks_dir=None, files=None)
+        self.assertEqual(len(report.resources), 2)
 
         os.environ[SCAN_HCL_FLAG] = 'false'
         runner = Runner()
@@ -928,7 +937,16 @@ class TestRunnerValid(unittest.TestCase):
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
         file_to_scan = os.path.join(current_dir, 'resources', 'tf_with_hcl_files', 'example_acl_fail.hcl')
-        orig_value = os.getenv(SCAN_HCL_FLAG)
+
+        orig_value = None  # just in case this was set in the env for some reason
+        if SCAN_HCL_FLAG in os.environ:
+            orig_value = os.getenv(SCAN_HCL_FLAG)
+            del os.environ[SCAN_HCL_FLAG]
+
+        # test default value (true)
+        runner = Runner()
+        report = runner.run(root_folder=None, external_checks_dir=None, files=[file_to_scan])
+        self.assertEqual(len(report.resources), 1)
 
         os.environ[SCAN_HCL_FLAG] = 'false'
         runner = Runner()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Sets the default value for the feature flag to scan HCL files to true