### PR TITLE
allow custom policies to use a custom guideline url

### DIFF
--- a/checkov/arm/base_parameter_check.py
+++ b/checkov/arm/base_parameter_check.py
@@ -6,9 +6,9 @@ from checkov.common.multi_signature import multi_signature
 
 
 class BaseParameterCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_resources):
+    def __init__(self, name, id, categories, supported_resources, **kwargs):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_resources,
-                         block_type="parameter")
+                         block_type="parameter", **kwargs)
         self.supported_resources = supported_resources
         arm_parameter_registry.register(self)
 

--- a/checkov/arm/base_resource_check.py
+++ b/checkov/arm/base_resource_check.py
@@ -6,9 +6,9 @@ from checkov.common.multi_signature import multi_signature
 
 
 class BaseResourceCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_resources):
+    def __init__(self, name, id, categories, supported_resources, **kwargs):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_resources,
-                         block_type="resource")
+                         block_type="resource", **kwargs)
         self.supported_resources = supported_resources
         arm_resource_registry.register(self)
 

--- a/checkov/arm/runner.py
+++ b/checkov/arm/runner.py
@@ -103,7 +103,8 @@ class Runner(BaseRunner):
                                                 code_block=entity_code_lines, file_path=arm_file,
                                                 file_line_range=entity_lines_range,
                                                 resource=resource_id, evaluations=variable_evaluations,
-                                                check_class=check.__class__.__module__, file_abs_path=file_abs_path)
+                                                check_class=check.__class__.__module__, file_abs_path=file_abs_path,
+                                                guideline=check.guideline)
                                 report.add_record(record=record)
 
                 if 'parameters' in definitions[arm_file].keys():
@@ -124,7 +125,8 @@ class Runner(BaseRunner):
                                                 code_block=entity_code_lines, file_path=arm_file,
                                                 file_line_range=entity_lines_range,
                                                 resource=resource_id, evaluations=variable_evaluations,
-                                                check_class=check.__class__.__module__, file_abs_path=file_abs_path)
+                                                check_class=check.__class__.__module__, file_abs_path=file_abs_path,
+                                                guideline=check.guideline)
                                 report.add_record(record=record)
 
         return report

--- a/checkov/cloudformation/checks/resource/base_resource_check.py
+++ b/checkov/cloudformation/checks/resource/base_resource_check.py
@@ -8,9 +8,11 @@ from checkov.common.multi_signature import multi_signature
 
 
 class BaseResourceCheck(BaseCheck):
-    def __init__(self, name: str, id: str, categories: List[CheckCategories], supported_resources: List[str]) -> None:
+    def __init__(self, name: str, id: str, categories: List[CheckCategories], supported_resources: List[str],
+                 **kwargs) -> None:
         super().__init__(
-            name=name, id=id, categories=categories, supported_entities=supported_resources, block_type="resource"
+            name=name, id=id, categories=categories, supported_entities=supported_resources,
+            block_type="resource", **kwargs
         )
         self.supported_resources = supported_resources
         cfn_registry.register(self)

--- a/checkov/cloudformation/checks/test_base_resource_check.py
+++ b/checkov/cloudformation/checks/test_base_resource_check.py
@@ -1,0 +1,18 @@
+import unittest
+from typing import Dict, Any
+
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckResult
+
+
+class TestBaseResourceCheck(unittest.TestCase):
+    def test_base_check_accepts_variable_kwargs_for_future_proofing(self):
+        class SubclassWithNewKwarg(BaseResourceCheck):
+            def __init__(self):
+                super().__init__(name="Example check", id="CKV_T_1", categories=[], supported_resources=["AWS::Any"],
+                                 unused_kwarg="any")
+
+            def scan_resource_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
+                pass
+
+        SubclassWithNewKwarg()

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -159,6 +159,7 @@ class Runner(BaseRunner):
                     check_class=check.__class__.__module__,
                     file_abs_path=entity_file_abs_path,
                     entity_tags={} if not entity.get("Tags") else cfn_utils.parse_entity_tags(entity.get("Tags")),
+                    guideline=check.guideline
                 )
                 if self.breadcrumbs:
                     breadcrumb = self.breadcrumbs.get(record.file_path, {}).get(record.resource)

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -126,6 +126,7 @@ class Runner(BaseRunner):
                                     check_class=check.__class__.__module__,
                                     file_abs_path=file_abs_path,
                                     entity_tags=tags,
+                                    guideline=check.guideline
                                 )
                                 breadcrumb = self.breadcrumbs.get(record.file_path, {}).get(record.resource)
                                 if breadcrumb:

--- a/checkov/common/checks/base_check.py
+++ b/checkov/common/checks/base_check.py
@@ -15,7 +15,8 @@ class BaseCheck(metaclass=MultiSignatureMeta):
     supported_entities: List[str] = []
 
     def __init__(
-        self, name: str, id: str, categories: List[CheckCategories], supported_entities: List[str], block_type: str, bc_id: Optional[str] = None
+        self, name: str, id: str, categories: List[CheckCategories], supported_entities: List[str],
+            block_type: str, bc_id: Optional[str] = None, guideline: Optional[str] = None, **_
     ) -> None:
         self.name = name
         self.id = id
@@ -26,6 +27,7 @@ class BaseCheck(metaclass=MultiSignatureMeta):
         self.logger = logging.getLogger("{}".format(self.__module__))
         self.evaluated_keys: List[str] = []
         self.entity_path = ""
+        self.guideline = guideline
 
     def run(
         self,
@@ -55,6 +57,7 @@ class BaseCheck(metaclass=MultiSignatureMeta):
                 self.entity_path = f"{scanned_file}:{entity_type}:{entity_name}"
                 check_result["result"] = self.scan_entity_conf(entity_configuration, entity_type)
                 check_result["evaluated_keys"] = self.get_evaluated_keys()
+                check_result["guideline"] = self.guideline
                 message = 'File {}, {}  "{}.{}" check "{}" Result: {} '.format(
                     scanned_file, self.block_type, entity_type, entity_name, self.name, check_result
                 )

--- a/checkov/common/graph/checks_infra/base_check.py
+++ b/checkov/common/graph/checks_infra/base_check.py
@@ -19,6 +19,7 @@ class BaseGraphCheck:
         self.sub_checks: List["BaseGraphCheck"] = []
         self.type: Optional[SolverType] = None
         self.solver: Optional[BaseSolver] = None
+        self.guideline: Optional[str] = None
 
     def set_solver(self, solver: BaseSolver) -> None:
         self.solver = solver

--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -27,7 +27,7 @@ class Record:
 
     def __init__(self, check_id, check_name, check_result, code_block, file_path, file_line_range, resource,
                  evaluations, check_class, file_abs_path, entity_tags=None,
-                 caller_file_path=None, caller_file_line_range=None, bc_check_id=None):
+                 caller_file_path=None, caller_file_line_range=None, bc_check_id=None, guideline=None):
         """
         :param evaluations: A dict with the key being the variable name, value being a dict containing:
                              - 'var_file'
@@ -50,6 +50,7 @@ class Record:
         self.entity_tags = entity_tags
         self.caller_file_path = caller_file_path
         self.caller_file_line_range = caller_file_line_range
+        self.guideline = guideline
 
     def set_guideline(self, guideline):
         self.guideline = guideline

--- a/checkov/dockerfile/base_dockerfile_check.py
+++ b/checkov/dockerfile/base_dockerfile_check.py
@@ -2,10 +2,11 @@ from checkov.common.checks.base_check import BaseCheck
 
 from checkov.dockerfile.registry import registry
 
+
 class BaseDockerfileCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_instructions):
+    def __init__(self, name, id, categories, supported_instructions, **kwargs):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_instructions,
-                         block_type="dockerfile")
+                         block_type="dockerfile", **kwargs)
         self.supported_instructions = supported_instructions
         registry.register(self)
 

--- a/checkov/dockerfile/runner.py
+++ b/checkov/dockerfile/runner.py
@@ -85,7 +85,7 @@ class Runner(BaseRunner):
                                                         result_instruction,
                                                         startline),
                                 evaluations=None, check_class=check.__class__.__module__,
-                                file_abs_path=file_abs_path, entity_tags=None)
+                                file_abs_path=file_abs_path, entity_tags=None, guideline=check.guideline)
                 report.add_record(record=record)
 
         return report

--- a/checkov/kubernetes/base_spec_check.py
+++ b/checkov/kubernetes/base_spec_check.py
@@ -6,9 +6,9 @@ from checkov.kubernetes.registry import registry
 
 
 class BaseK8Check(BaseCheck):
-    def __init__(self, name, id, categories, supported_entities):
+    def __init__(self, name, id, categories, supported_entities, **kwargs):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities,
-                         block_type="k8")
+                         block_type="k8", **kwargs)
         self.supported_specs = supported_entities
         registry.register(self)
 

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -193,7 +193,8 @@ class Runner(BaseRunner):
                                         code_block=entity_code_lines, file_path=k8_file,
                                         file_line_range=entity_lines_range,
                                         resource=resource_id, evaluations=variable_evaluations,
-                                        check_class=check.__class__.__module__, file_abs_path=file_abs_path)
+                                        check_class=check.__class__.__module__, file_abs_path=file_abs_path,
+                                        guideline=check.guideline)
                         report.add_record(record=record)
 
         return report

--- a/checkov/serverless/checks/complete/base_complete_check.py
+++ b/checkov/serverless/checks/complete/base_complete_check.py
@@ -5,9 +5,9 @@ from checkov.serverless.checks.complete.registry import complete_registry
 
 
 class BaseCompleteCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_entities):
+    def __init__(self, name, id, categories, supported_entities, **kwargs):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities,
-                         block_type="serverless")
+                         block_type="serverless", **kwargs)
         complete_registry.register(self)
 
     def scan_entity_conf(self, conf, entity_type):

--- a/checkov/serverless/checks/custom/base_custom_check.py
+++ b/checkov/serverless/checks/custom/base_custom_check.py
@@ -5,9 +5,9 @@ from checkov.serverless.checks.custom.registry import custom_registry
 
 
 class BaseCustomCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_entities):
+    def __init__(self, name, id, categories, supported_entities, **kwargs):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities,
-                         block_type="serverless")
+                         block_type="serverless", **kwargs)
         custom_registry.register(self)
 
     def scan_entity_conf(self, conf, entity_type):

--- a/checkov/serverless/checks/function/base_function_check.py
+++ b/checkov/serverless/checks/function/base_function_check.py
@@ -6,9 +6,9 @@ from checkov.serverless.checks.function.registry import function_registry
 
 
 class BaseFunctionCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_entities):
+    def __init__(self, name, id, categories, supported_entities, **kwargs):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities,
-                         block_type="serverless")
+                         block_type="serverless", **kwargs)
         function_registry.register(self)
 
     def scan_entity_conf(self, conf, entity_type):

--- a/checkov/serverless/checks/layer/base_layer_check.py
+++ b/checkov/serverless/checks/layer/base_layer_check.py
@@ -5,9 +5,9 @@ from checkov.serverless.checks.layer.registry import layer_registry
 
 
 class BaseLayerCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_entities):
+    def __init__(self, name, id, categories, supported_entities, **kwargs):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities,
-                         block_type="serverless")
+                         block_type="serverless", **kwargs)
         layer_registry.register(self)
 
     def scan_entity_conf(self, conf, entity_type):

--- a/checkov/serverless/checks/package/base_package_check.py
+++ b/checkov/serverless/checks/package/base_package_check.py
@@ -5,9 +5,9 @@ from checkov.serverless.checks.package.registry import package_registry
 
 
 class BasePackageCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_entities):
+    def __init__(self, name, id, categories, supported_entities, **kwargs):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities,
-                         block_type="serverless")
+                         block_type="serverless", **kwargs)
         package_registry.register(self)
 
     def scan_entity_conf(self, conf, entity_type):

--- a/checkov/serverless/checks/plugin/base_plugin_check.py
+++ b/checkov/serverless/checks/plugin/base_plugin_check.py
@@ -5,10 +5,10 @@ from checkov.serverless.checks.plugin.registry import plugin_registry
 
 
 class BasePluginCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_entities):
+    def __init__(self, name, id, categories, supported_entities, **kwargs):
         super().__init__(name=name, id=id, categories=categories,
                          supported_entities=supported_entities,
-                         block_type="serverless")
+                         block_type="serverless", **kwargs)
         plugin_registry.register(self)
 
     def scan_entity_conf(self, conf, entity_type):

--- a/checkov/serverless/checks/provider/base_provider_check.py
+++ b/checkov/serverless/checks/provider/base_provider_check.py
@@ -5,9 +5,9 @@ from checkov.serverless.checks.provider.registry import provider_registry
 
 
 class BaseProviderCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_entities):
+    def __init__(self, name, id, categories, supported_entities, **kwargs):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities,
-                         block_type="serverless")
+                         block_type="serverless", **kwargs)
         provider_registry.register(self)
 
     def scan_entity_conf(self, conf, entity_type):

--- a/checkov/serverless/checks/service/base_service_check.py
+++ b/checkov/serverless/checks/service/base_service_check.py
@@ -5,9 +5,9 @@ from checkov.serverless.checks.service.registry import service_registry
 
 
 class BaseServiceCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_entities):
+    def __init__(self, name, id, categories, supported_entities, **kwargs):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities,
-                         block_type="serverless")
+                         block_type="serverless", **kwargs)
         service_registry.register(self)
 
     def scan_entity_conf(self, conf, entity_type):

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -129,7 +129,8 @@ class Runner(BaseRunner):
                                             code_block=entity_code_lines, file_path=sls_file,
                                             file_line_range=entity_lines_range,
                                             resource=cf_resource_id, evaluations=variable_evaluations,
-                                            check_class=check.__class__.__module__, file_abs_path=file_abs_path, entity_tags=tags)
+                                            check_class=check.__class__.__module__, file_abs_path=file_abs_path,
+                                            entity_tags=tags, guideline=check.guideline)
                             report.add_record(record=record)
 
             sls_context_parser = SlsContextParser(sls_file, sls_file_data, definitions_raw[sls_file])
@@ -159,7 +160,8 @@ class Runner(BaseRunner):
                                             code_block=entity_code_lines, file_path=sls_file,
                                             file_line_range=entity_lines_range,
                                             resource=item_name, evaluations=variable_evaluations,
-                                            check_class=check.__class__.__module__, file_abs_path=file_abs_path, entity_tags=tags)
+                                            check_class=check.__class__.__module__, file_abs_path=file_abs_path,
+                                            entity_tags=tags, guideline=check.guideline)
                             report.add_record(record=record)
             # Sub-sections that are a single item
             for token, registry in SINGLE_ITEM_SECTIONS:
@@ -180,7 +182,8 @@ class Runner(BaseRunner):
                                     code_block=entity_code_lines, file_path=sls_file,
                                     file_line_range=entity_lines_range,
                                     resource=token, evaluations=variable_evaluations,
-                                    check_class=check.__class__.__module__, file_abs_path=file_abs_path, entity_tags=tags)
+                                    check_class=check.__class__.__module__, file_abs_path=file_abs_path,
+                                    entity_tags=tags, guideline=check.guideline)
                     report.add_record(record=record)
 
             # "Complete" checks
@@ -199,7 +202,8 @@ class Runner(BaseRunner):
                                     file_line_range=entity_lines_range,
                                     resource="complete",        # Weird, not sure what to put where
                                     evaluations=variable_evaluations,
-                                    check_class=check.__class__.__module__, file_abs_path=file_abs_path, entity_tags=tags)
+                                    check_class=check.__class__.__module__, file_abs_path=file_abs_path,
+                                    entity_tags=tags, guideline=check.guideline)
                     report.add_record(record=record)
 
         return report

--- a/checkov/terraform/checks/data/base_check.py
+++ b/checkov/terraform/checks/data/base_check.py
@@ -8,8 +8,9 @@ from checkov.terraform.checks.data.registry import data_registry
 
 
 class BaseDataCheck(BaseCheck):
-    def __init__(self, name: str, id: str, categories: List[CheckCategories], supported_data: List[str]) -> None:
-        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_data, block_type="data")
+    def __init__(self, name: str, id: str, categories: List[CheckCategories], supported_data: List[str], **kwargs) -> None:
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_data,
+                         block_type="data", **kwargs)
         self.supported_data = supported_data
         data_registry.register(self)
 

--- a/checkov/terraform/checks/module/base_module_check.py
+++ b/checkov/terraform/checks/module/base_module_check.py
@@ -8,8 +8,8 @@ from checkov.terraform.checks.module.registry import module_registry
 
 class BaseModuleCheck(BaseCheck):
     def __init__(
-        self, name: str, id: str, categories: List[CheckCategories], supported_resources: Optional[List[str]] = None
-    ) -> None:
+        self, name: str, id: str, categories: List[CheckCategories], supported_resources: Optional[List[str]] = None,
+            **kwargs) -> None:
         """
         Base class for terraform module call related checks.
 
@@ -24,7 +24,8 @@ class BaseModuleCheck(BaseCheck):
         if supported_resources is None:
             supported_resources = ["module"]
         super().__init__(
-            name=name, id=id, categories=categories, supported_entities=supported_resources, block_type="module"
+            name=name, id=id, categories=categories, supported_entities=supported_resources,
+            block_type="module", **kwargs
         )
         self.supported_resources = supported_resources
         module_registry.register(self)

--- a/checkov/terraform/checks/provider/base_check.py
+++ b/checkov/terraform/checks/provider/base_check.py
@@ -7,9 +7,11 @@ from checkov.terraform.checks.provider.registry import provider_registry
 
 
 class BaseProviderCheck(BaseCheck):
-    def __init__(self, name: str, id: str, categories: List[CheckCategories], supported_provider: List[str]) -> None:
+    def __init__(self, name: str, id: str, categories: List[CheckCategories],
+                 supported_provider: List[str], **kwargs) -> None:
         super().__init__(
-            name=name, id=id, categories=categories, supported_entities=supported_provider, block_type="provider"
+            name=name, id=id, categories=categories, supported_entities=supported_provider,
+            block_type="provider", **kwargs
         )
         self.supported_provider = supported_provider
         provider_registry.register(self)

--- a/checkov/terraform/checks/resource/base_resource_check.py
+++ b/checkov/terraform/checks/resource/base_resource_check.py
@@ -8,9 +8,11 @@ from checkov.terraform.checks.resource.registry import resource_registry
 
 
 class BaseResourceCheck(BaseCheck):
-    def __init__(self, name: str, id: str, categories: List[CheckCategories], supported_resources: List[str]) -> None:
+    def __init__(self, name: str, id: str, categories: List[CheckCategories], supported_resources: List[str],
+                 **kwargs) -> None:
         super().__init__(
-            name=name, id=id, categories=categories, supported_entities=supported_resources, block_type="resource"
+            name=name, id=id, categories=categories, supported_entities=supported_resources,
+            block_type="resource", **kwargs
         )
         self.supported_resources = supported_resources
         resource_registry.register(self)

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -109,7 +109,8 @@ class Runner(TerraformRunner):
                                     code_block=entity_code_lines, file_path=scanned_file,
                                     file_line_range=entity_lines_range,
                                     resource=entity_id, evaluations=None,
-                                    check_class=check.__class__.__module__, file_abs_path=full_file_path)
+                                    check_class=check.__class__.__module__, file_abs_path=full_file_path,
+                                    guideline=check.guideline)
                     report.add_record(record=record)
 
     def get_entity_context(self, definition_path, full_file_path):

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -139,19 +139,22 @@ class Runner(BaseRunner):
                             copy_of_check_result['suppress_comment'] = skipped_check['suppress_comment']
                             break
                     copy_of_check_result['entity'] = entity.get(CustomAttributes.CONFIG)
-                    record = Record(check_id=check.id,
-                                    bc_check_id=check.bc_id,
-                                    check_name=check.name,
-                                    check_result=copy_of_check_result,
-                                    code_block=entity_context.get('code_lines'),
-                                    file_path=f"/{os.path.relpath(full_file_path, root_folder)}",
-                                    file_line_range=[entity_context.get('start_line'),
-                                                     entity_context.get('end_line')],
-                                    resource=".".join(entity_context['definition_path']),
-                                    entity_tags=entity.get('tags', {}),
-                                    evaluations=entity_evaluations,
-                                    check_class=check.__class__.__module__,
-                                    file_abs_path=os.path.abspath(full_file_path))
+                    record = Record(
+                        check_id=check.id,
+                        bc_check_id=check.bc_id,
+                        check_name=check.name,
+                        check_result=copy_of_check_result,
+                        code_block=entity_context.get('code_lines'),
+                        file_path=f"/{os.path.relpath(full_file_path, root_folder)}",
+                        file_line_range=[entity_context.get('start_line'),
+                                         entity_context.get('end_line')],
+                        resource=".".join(entity_context['definition_path']),
+                        entity_tags=entity.get('tags', {}),
+                        evaluations=entity_evaluations,
+                        check_class=check.__class__.__module__,
+                        file_abs_path=os.path.abspath(full_file_path),
+                        guideline=check.guideline
+                    )
                     if self.breadcrumbs:
                         breadcrumb = self.breadcrumbs.get(record.file_path, {}).get(record.resource)
                         if breadcrumb:
@@ -291,7 +294,8 @@ class Runner(BaseRunner):
                                 check_class=check.__class__.__module__, file_abs_path=absolut_scanned_file_path,
                                 entity_tags=tags,
                                 caller_file_path=caller_file_path,
-                                caller_file_line_range=caller_file_line_range)
+                                caller_file_line_range=caller_file_line_range,
+                                guideline=check.guideline)
                 breadcrumb = self.breadcrumbs.get(record.file_path, {}).get('.'.join([entity_type, entity_name]))
                 if breadcrumb:
                     record = GraphRecord(record, breadcrumb)

--- a/tests/cloudformation/runner/resources/fail.yaml
+++ b/tests/cloudformation/runner/resources/fail.yaml
@@ -1,0 +1,5 @@
+Resources:
+  UnencryptedQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: any

--- a/tests/cloudformation/runner/test_runner.py
+++ b/tests/cloudformation/runner/test_runner.py
@@ -3,9 +3,12 @@ import inspect
 import os
 import unittest
 from pathlib import Path
+from typing import Dict, Any, List
 
 from checkov.cloudformation import cfn_utils
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.cloudformation.parser import parse
+from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.runner_filter import RunnerFilter
 from checkov.cloudformation.runner import Runner
 from checkov.common.output.report import Report
@@ -102,6 +105,34 @@ class TestRunnerValid(unittest.TestCase):
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
+
+    def test_record_includes_custom_guideline(self):
+        custom_guideline_url = "https://my.custom.url"
+        custom_check_id = "MY_CUSTOM_CHECK"
+
+        class AnyFailingCheck(BaseResourceCheck):
+            def __init__(self, *_, **__) -> None:
+                super().__init__(
+                    "this should fail",
+                    custom_check_id,
+                    [CheckCategories.ENCRYPTION],
+                    ["AWS::SQS::Queue"],
+                    guideline=custom_guideline_url
+                )
+
+            def scan_resource_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
+                return CheckResult.FAILED
+
+        AnyFailingCheck()
+        scan_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "resources", "fail.yaml")
+
+        report = Runner().run(
+            None,
+            files=[scan_file_path],
+            runner_filter=RunnerFilter(framework='cloudformation', checks=[custom_check_id])
+        )
+
+        self.assertEqual(report.failed_checks[0].guideline, custom_guideline_url)
 
     def test_get_tags(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))

--- a/tests/cloudformation/test_graph_manager.py
+++ b/tests/cloudformation/test_graph_manager.py
@@ -40,9 +40,12 @@ class TestCloudformationGraphManager(TestCase):
                 "AWS::EKS::Cluster.eksCluster",
                 "Custom::acmeSnsCustomResource.acmeSnsCustomResource",
                 ],
+            os.path.join(root_dir, "fail.yaml"): [
+                "AWS::SQS::Queue.UnencryptedQueue"
+            ]
         }
-        self.assertEqual(40, len(local_graph.vertices))
-        self.assertEqual(20, len(local_graph.vertices_by_block_type[BlockType.RESOURCE]))
+        self.assertEqual(41, len(local_graph.vertices))
+        self.assertEqual(21, len(local_graph.vertices_by_block_type[BlockType.RESOURCE]))
         self.assertEqual(9, len(local_graph.vertices_by_block_type[BlockType.PARAMETERS]))
         self.assertEqual(6, len(local_graph.vertices_by_block_type[BlockType.OUTPUTS]))
         self.assertEqual(4, len(local_graph.vertices_by_block_type[BlockType.CONDITIONS]))

--- a/tests/common/checks/test_base_check.py
+++ b/tests/common/checks/test_base_check.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Dict, Any
 
 from checkov.common.checks.base_check import BaseCheck
 from checkov.common.checks.base_check_registry import BaseCheckRegistry
@@ -67,6 +68,17 @@ class TestBaseCheck(unittest.TestCase):
             "is not supported.",
             context.exception.args[0]
         )
+
+    def test_base_check_accepts_variable_kwargs_for_future_proofing(self):
+        class SubclassWithNewKwarg(BaseCheck):
+            def __init__(self):
+                super().__init__(name="Example check", id="CKV_T_1", categories=[], supported_entities=["module"],
+                                 block_type="module", unused_kwarg="any")
+
+            def scan_entity_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
+                pass
+
+        SubclassWithNewKwarg()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR addresses: https://github.com/bridgecrewio/checkov/issues/1595

The majority of the change and the reason this touches many files here is purely plumbing.  `Record` already contained the `guideline` property and the existing code was handling including the guideline url in the output / report.  Prior to this PR those guidelines were exclusively being set (separately) by https://github.com/bridgecrewio/checkov/blob/master/checkov/common/runners/runner_registry.py#L162.  This change allows subclasses of `BaseCheck` and `BaseGraphCheck` to propagate a custom guideline into the check itself, whereby the `Runner` implementations can then leverage `check.guideline` to include in the `Record`.

The hurdle here was that there are so many subclasses of `BaseCheck` and each one (prior) had explicit keyword args without allowing for variable kwargs.  I have added that, future-proofing subclasses from explicitly needing to know what kwargs `BaseCheck` may need.   

I believe I have modified each of the relevant `Runner`s to handle adding the guideline to the `Record`.  Notable exceptions include the runners for _helm_ and _secrets_.  Helm delegates to the _kubernetes_ runner and the _secrets_ implementation does not follow the same inheritance pattern with `BaseCheck` etc.  Presumably the intent was not for users of checkov to use the baked in secrets tools for scanning and not necessarily implement their own.

I have two questions around your desired testing around this functionality, given that it's mostly plumbing.  
- I wrote one example test showing how I would test the propagation of the `**kwargs` back to the `BaseCheck`.  Do you want me to include this?  Do you want me to write this for the other subclasses as well?
- Likewise, I wrote one example test showing how I would test that a runner is setting `guideline=check.guideline` on each `Record`.  Do you want me to include this?  For all of them?  This one is a little more tricky given that some of the runners have a number of logic paths that each end up crafting `Record`s in a loop.  Thoughts on this? 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
