### PR TITLE
Small bugs fixes secrets + IAMAdminPolicyDocument

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
@@ -2,49 +2,50 @@ from checkov.cloudformation.checks.resource.base_resource_check import BaseResou
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.common.util.type_forcers import force_list
 
+
 class IAMAdminPolicyDocument(BaseResourceCheck):
     def __init__(self):
         name = "Ensure no IAM policies that allow full \"*-*\" administrative privileges are not created"
         id = "CKV_AWS_62"
-        supported_resources = ['AWS::IAM::Policy','AWS::IAM::Group','AWS::IAM::Role','AWS::IAM::User']
+        supported_resources = ['AWS::IAM::Policy', 'AWS::IAM::Group', 'AWS::IAM::Role', 'AWS::IAM::User']
         categories = [CheckCategories.IAM]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        myproperties=conf['Properties']
+        my_properties = conf['Properties']
         type = conf['Type']
 
-        #catch for inline policies
+        # catch for inline policies
         if type != 'AWS::IAM::Policy':
-             if 'Policies' in myproperties.keys():
-                policies=myproperties['Policies']
+            if 'Policies' in my_properties.keys():
+                policies = my_properties['Policies']
                 if len(policies) > 0:
                     for policy in policies:
 
-                        result=check_policy(policy['PolicyDocument'])
-                        if result==CheckResult.FAILED:
-                           return result
+                        result = check_policy(policy['PolicyDocument'])
+                        if result == CheckResult.FAILED:
+                            return result
                     return CheckResult.PASSED
-                  # not empty and had non failing policies
+                # not empty and had non failing policies
                 return CheckResult.UNKNOWN
-        #this is just for Policy resources
-        if 'PolicyDocument' in myproperties.keys():
-            return check_policy(myproperties['PolicyDocument'])
+        # this is just for Policy resources
+        if 'PolicyDocument' in my_properties.keys():
+            return check_policy(my_properties['PolicyDocument'])
         return CheckResult.UNKNOWN
 
 
 check = IAMAdminPolicyDocument()
 
-def check_policy(policy_block):
 
-        if policy_block and 'Statement' in policy_block.keys():
-            for statement in force_list(policy_block['Statement']):
-                if 'Action' in statement:
-                    effect = statement.get('Effect', 'Allow')
-                    action = force_list(statement.get('Action', ['']))
-                    resource = force_list(statement.get('Resource', ['']))
-                    if effect == 'Allow' and '*' in action and '*' in resource:
-                        return CheckResult.FAILED
-            return CheckResult.PASSED
-        else:
-            return CheckResult.PASSED
+def check_policy(policy_block):
+    if policy_block and isinstance(policy_block, dict) and 'Statement' in policy_block.keys():
+        for statement in force_list(policy_block['Statement']):
+            if 'Action' in statement:
+                effect = statement.get('Effect', 'Allow')
+                action = force_list(statement.get('Action', ['']))
+                resource = force_list(statement.get('Resource', ['']))
+                if effect == 'Allow' and '*' in action and '*' in resource:
+                    return CheckResult.FAILED
+        return CheckResult.PASSED
+    else:
+        return CheckResult.PASSED

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -155,7 +155,7 @@ class Runner(BaseRunner):
                     continue
                 result: _CheckResult = {'result': CheckResult.FAILED}
                 line_text = linecache.getline(secret.filename, secret.line_number)
-                if " " in line_text and line_text.split()[0] == 'git_commit':
+                if line_text != "" and len(line_text.split()) > 0 and line_text.split()[0] == 'git_commit':
                     continue
                 result = self.search_for_suppression(
                     check_id=check_id,

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -155,7 +155,7 @@ class Runner(BaseRunner):
                     continue
                 result: _CheckResult = {'result': CheckResult.FAILED}
                 line_text = linecache.getline(secret.filename, secret.line_number)
-                if line_text != "" and line_text.split()[0] == 'git_commit':
+                if " " in line_text and line_text.split()[0] == 'git_commit':
                     continue
                 result = self.search_for_suppression(
                     check_id=check_id,

--- a/tests/cloudformation/checks/resource/aws/example_IAMRoleAllowAssumeFromAccount/example_IAMRoleAllowAssumeFromAccount-PASSED-2.yml
+++ b/tests/cloudformation/checks/resource/aws/example_IAMRoleAllowAssumeFromAccount/example_IAMRoleAllowAssumeFromAccount-PASSED-2.yml
@@ -756,5 +756,5 @@ Resources:
 
       Handler: index.lambda_handler
       Role: !GetAtt ScalingLambdaRole.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 10


### PR DESCRIPTION
Fixed small bugs:
1. In `secrets/runner.py` - validate that a string split is valid before accessing it.
2. Validate `policy_block` is dict in `IAMAdminPolicyDocument`
3. Fixed cfn lint error in test file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
