### PR TITLE
Change CKV_AWS_149 (secretsmanager KMS) to look for CMK

### DIFF
--- a/checkov/terraform/checks/resource/aws/SecretManagerSecretEncrypted.py
+++ b/checkov/terraform/checks/resource/aws/SecretManagerSecretEncrypted.py
@@ -1,21 +1,28 @@
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
-from checkov.common.models.enums import CheckCategories
-from checkov.common.models.consts import ANY_VALUE
+from typing import Dict, List, Any
+
+from checkov.common.util.type_forcers import force_list
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckCategories, CheckResult
 
 
-class SecretManagerSecretEncrypted(BaseResourceValueCheck):
+class SecretManagerSecretEncrypted(BaseResourceCheck):
+
     def __init__(self):
-        name = "Ensure that Secrets Manager secret is encrypted using KMS"
+        name = "Ensure that Secrets Manager secret is encrypted using KMS CMK"
         id = "CKV_AWS_149"
         supported_resources = ["aws_secretsmanager_secret"]
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_expected_value(self):
-        return ANY_VALUE
+    def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
+        kms_key_id = force_list(conf.get('kms_key_id', []))
+        if not kms_key_id:
+            return CheckResult.FAILED
+        else:
+            return CheckResult.FAILED if 'alias/aws/' in kms_key_id[0] else CheckResult.PASSED
 
-    def get_inspected_key(self):
-        return "kms_key_id"
+    def get_evaluated_keys(self) -> List[str]:
+        return ['kms_key_id']
 
 
 check = SecretManagerSecretEncrypted()

--- a/tests/terraform/checks/resource/aws/example_SecretManagerSecretEncrypted/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SecretManagerSecretEncrypted/main.tf
@@ -1,13 +1,24 @@
 # pass
 
-resource "aws_secretsmanager_secret" "enabled" {
+resource "aws_secretsmanager_secret" "enabled1" {
   name = "secret"
 
   kms_key_id = var.kms_key_id
+}
+
+resource "aws_secretsmanager_secret" "enabled2" {
+  name = "secret"
+
+  kms_key_id = "1234"
 }
 
 # failure
 
 resource "aws_secretsmanager_secret" "default" {
   name = "secret"
+}
+
+resource "aws_secretsmanager_secret" "default_explicit" {
+  name = "secret"
+  kms_key_id = "alias/aws/secretsmanager"
 }

--- a/tests/terraform/checks/resource/aws/test_SecretManagerSecretEncrypted.py
+++ b/tests/terraform/checks/resource/aws/test_SecretManagerSecretEncrypted.py
@@ -16,17 +16,19 @@ class TestSecretManagerSecretEncrypted(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            "aws_secretsmanager_secret.enabled",
+            "aws_secretsmanager_secret.enabled1",
+            "aws_secretsmanager_secret.enabled2",
         }
         failing_resources = {
             "aws_secretsmanager_secret.default",
+            "aws_secretsmanager_secret.default_explicit",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Changes the secrets manager encryption check to explicitly check for a CMK, as encryption using an AWS key is the default.