### PR TITLE
Support name variations for Dockerfiles

### DIFF
--- a/checkov/dockerfile/parser.py
+++ b/checkov/dockerfile/parser.py
@@ -10,8 +10,9 @@ from checkov.common.comment.enum import COMMENT_REGEX
 
 
 def parse(filename):
-    dfp = DockerfileParser(path=filename)
-    return dfp_group_by_instructions(dfp)
+    with open(filename) as dockerfile:
+        dfp = DockerfileParser(fileobj=dockerfile)
+        return dfp_group_by_instructions(dfp)
 
 
 def dfp_group_by_instructions(dfp):

--- a/checkov/dockerfile/runner.py
+++ b/checkov/dockerfile/runner.py
@@ -16,8 +16,8 @@ class Runner(BaseRunner):
     check_type = "dockerfile"
 
     @staticmethod
-    def __is_docker_file(file):
-        return re.search(DOCKER_FILE_MASK, file) != None
+    def _is_docker_file(file):
+        return re.fullmatch(DOCKER_FILE_MASK, file) is not None
 
     def run(self, root_folder=None, external_checks_dir=None, files=None, runner_filter=RunnerFilter(),
             collect_skip_comments=True):
@@ -32,7 +32,7 @@ class Runner(BaseRunner):
 
         if files:
             for file in files:
-                if Runner.__is_docker_file(os.path.basename(file)):
+                if Runner._is_docker_file(os.path.basename(file)):
                     try:
                         (definitions[file], definitions_raw[file]) = parse(file)
                     except TypeError:
@@ -43,7 +43,7 @@ class Runner(BaseRunner):
                 filter_ignored_paths(root, d_names, runner_filter.excluded_paths)
                 filter_ignored_paths(root, f_names, runner_filter.excluded_paths)
                 for file in f_names:
-                    if Runner.__is_docker_file(file):
+                    if Runner._is_docker_file(file):
                         files_list.append(os.path.join(root, file))
 
             for file in files_list:

--- a/tests/dockerfile/resources/name_variations/.Dockerfile
+++ b/tests/dockerfile/resources/name_variations/.Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.14.2
+
+ENTRYPOINT [ "echo" ]
+CMD [ "Hello world!" ]

--- a/tests/dockerfile/resources/name_variations/Dockerfile.prod
+++ b/tests/dockerfile/resources/name_variations/Dockerfile.prod
@@ -1,0 +1,4 @@
+FROM alpine:3.14.2
+
+ENTRYPOINT [ "echo" ]
+CMD [ "Hello world!" ]

--- a/tests/dockerfile/resources/name_variations/prod.dockerfile
+++ b/tests/dockerfile/resources/name_variations/prod.dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.14.2
+
+ENTRYPOINT [ "echo" ]
+CMD [ "Hello world!" ]

--- a/tests/dockerfile/test_runner.py
+++ b/tests/dockerfile/test_runner.py
@@ -22,6 +22,17 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.passed_checks, [])
         self.assertEqual(report.skipped_checks, [])
         report.print_console()
+    
+    def test_runner_name_variations(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/resources/name_variations"
+        runner = Runner()
+        report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework='all'))
+        self.assertEqual(len(report.resources), 2)
+        self.assertEqual(len([file for file in report.resources if 'Dockerfile.prod' in file]), 1)
+        self.assertEqual(len([file for file in report.resources if 'prod.dockerfile' in file]), 1)
+        report.print_console()
 
     def test_runner_failing_check(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
This PR addresses: #1262

It is very common for organizations to use variations of `Dockerfile` for their Docker files, especially with the advent of mono repositories. Such alternative names could include:

- `Dockerfile.prod`
- `Dockerfile.Product1`
- `dev.Dockerfile`
- `team1.product.dockerfile`

Furthermore, the VS Code plugin for Docker has also long recognized these patterns as valid Docker files and provided syntax highlighting: microsoft/vscode-docker#1908.

For this reason, it seems reasonable for Checkov to include these variations of names when scanning for Dockerfiles to analyze. This PR changes the behavior of the Docker runner to use the following regular expression for detecting Dockerfiles:

```regex
^(?:.+\.)?[Dd]ockerfile(?:\..+)?$
```

A unit test was added to ensure that the behavior is as intended. It is entirely by intention that `.Dockerfile` is not considered a valid name. With this change, Checkov is now capable of scanning a wider range of Dockerfiles:

```
dockerfile scan results:

Passed checks: 0, Failed checks: 1, Skipped checks: 0

Check: CKV_DOCKER_7: "Ensure the base image uses a non latest version tag"
        FAILED for resource: Dockerfile.prod.FROM
        File: Dockerfile.prod:0-0
        Guide: https://docs.bridgecrew.io/docs/ensure-the-base-image-uses-a-non-latest-version-tag
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.