### PR TITLE
Feature/docker line index

### DIFF
--- a/checkov/dockerfile/checks/HealthcheckExists.py
+++ b/checkov/dockerfile/checks/HealthcheckExists.py
@@ -4,7 +4,7 @@ from checkov.dockerfile.base_dockerfile_check import BaseDockerfileCheck
 
 class HealthcheckExists(BaseDockerfileCheck):
     def __init__(self):
-        name = "Ensure that HEALTHCHECK instructions have been added to container images "
+        name = "Ensure that HEALTHCHECK instructions have been added to container images"
         id = "CKV_DOCKER_2"
         supported_instructions = ["*"]
         categories = [CheckCategories.NETWORKING]

--- a/checkov/dockerfile/runner.py
+++ b/checkov/dockerfile/runner.py
@@ -67,7 +67,7 @@ class Runner(BaseRunner):
             for check, check_result in results.items():
                 result_configuration = check_result['results_configuration']
                 startline = 0
-                endline = 0
+                endline = len(definitions_raw[docker_file_path]) - 1
                 result_instruction = ""
                 if result_configuration:
                     startline = result_configuration['startline']
@@ -79,8 +79,8 @@ class Runner(BaseRunner):
                 record = Record(check_id=check.id, bc_check_id=check.bc_id, check_name=check.name, check_result=check_result,
                                 code_block=codeblock,
                                 file_path=docker_file_path,
-                                file_line_range=[startline,
-                                                 endline],
+                                file_line_range=[startline + 1,
+                                                 endline + 1],
                                 resource="{}.{}".format(docker_file_path,
                                                         result_instruction,
                                                         startline),

--- a/checkov/dockerfile/runner.py
+++ b/checkov/dockerfile/runner.py
@@ -66,8 +66,8 @@ class Runner(BaseRunner):
                                     runner_filter)
             for check, check_result in results.items():
                 result_configuration = check_result['results_configuration']
-                startline = 1
-                endline = 1
+                startline = 0
+                endline = 0
                 result_instruction = ""
                 if result_configuration:
                     startline = result_configuration['startline']
@@ -92,4 +92,4 @@ class Runner(BaseRunner):
 
     def calc_record_codeblock(self, codeblock, definitions_raw, docker_file_path, endline, startline):
         for line in range(startline, endline + 1):
-            codeblock.append((line, definitions_raw[docker_file_path][line - 1]))
+            codeblock.append((line + 1, definitions_raw[docker_file_path][line]))


### PR DESCRIPTION
This PR addresses: #1389 and #1455

The Docker scanner implementation incorrectly uses 0-indexed line numbers from the Docker file parser, while reporting assumes that line numbers are 1-indexed. This causes all reports to be off by one, showing incorrect (sometimes blank) lines when reporting failed checks.

Furthermore, the Docker scanner falls back to reporting the first line as the source of the error when no specific line is at fault (rather it is a global error across the entire Dockerfile). I have changed this confusing behavior to instead falling back to displaying the entire Dockerfile to the user.

These are but a few of the issues lurking in the Dockerfile support, some of which I may address in future PRs if my organization chooses to use Checkov moving forward.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
