### PR TITLE
Fixes for CFN Policies checks & edges creation

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
@@ -21,10 +21,10 @@ class IAMAdminPolicyDocument(BaseResourceCheck):
                 policies = my_properties['Policies']
                 if len(policies) > 0:
                     for policy in policies:
-
-                        result = check_policy(policy['PolicyDocument'])
-                        if result == CheckResult.FAILED:
-                            return result
+                        if 'PolicyDocument' in policy:
+                            result = check_policy(policy['PolicyDocument'])
+                            if result == CheckResult.FAILED:
+                                return result
                     return CheckResult.PASSED
                 # not empty and had non failing policies
                 return CheckResult.UNKNOWN

--- a/checkov/cloudformation/checks/resource/aws/IAMStarActionPolicyDocument.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMStarActionPolicyDocument.py
@@ -1,6 +1,7 @@
 from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.common.util.type_forcers import force_list
+import ast
 
 class IAMStarActionPolicyDocument(BaseResourceCheck):
     def __init__(self):
@@ -20,9 +21,10 @@ class IAMStarActionPolicyDocument(BaseResourceCheck):
                 policies=myproperties['Policies']
                 if len(policies) > 0:
                     for policy in policies:
-                        result=check_policy(policy['PolicyDocument'])
-                        if result==CheckResult.FAILED:
-                           return result
+                        if 'PolicyDocument' in policy:
+                            result=check_policy(policy['PolicyDocument'])
+                            if result==CheckResult.FAILED:
+                               return result
                     return CheckResult.PASSED
                   # not empty and had non failing policies
                 return CheckResult.UNKNOWN
@@ -35,13 +37,17 @@ class IAMStarActionPolicyDocument(BaseResourceCheck):
 check = IAMStarActionPolicyDocument()
 
 def check_policy(policy_block):
-    if policy_block and 'Statement' in policy_block.keys():
-        for statement in force_list(policy_block['Statement']):
-            if 'Action' in statement and statement.get('Effect', ['Allow']) == 'Allow' and '*' in force_list(statement['Action']):
-                return CheckResult.FAILED
+    if policy_block:
+        if isinstance(policy_block, str):
+            policy_block = ast.literal_eval(policy_block)
+        if 'Statement' in policy_block.keys():
+            for statement in force_list(policy_block['Statement']):
+                if 'Action' in statement and statement.get('Effect', ['Allow']) == 'Allow' and '*' in force_list(statement['Action']):
+                    return CheckResult.FAILED
+                return CheckResult.PASSED
+        else:
             return CheckResult.PASSED
     else:
         return CheckResult.PASSED
 
 
-        

--- a/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
@@ -55,7 +55,7 @@ class CloudformationVariableRenderer(VariableRenderer):
                 if isinstance(evaluated_condition, bool):
                     # evaluated the condition successfully, add the result to the origin vertex
                     origin_vertex.condition = evaluated_condition
-        else:
+        elif isinstance(val_to_eval, dict):
             # Ref, GetAtt, FindInMap, If, Sub connections
             cfn_evaluation_function = None
             for curr_evaluation_function in self.EDGE_EVALUATION_CFN_FUNCTIONS:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. renderer.py - val_to_eval must be a dict but in some cases it is not (and should be skipped in order to prevent exceptions)
2. IAMAdminPolicyDocument.py - In some cases the policy is not evaluated so 'PolicyDocument' is not a key of the policy
3. IAMStarActionPolicyDocument.py - Same case as item 2 + policy_block variable might be a string representing a dict so we transform it into a dict first