### PR TITLE
CKV_AZURE_119: fix: public ip is not configured when public_ip_address_id is null

### DIFF
--- a/checkov/terraform/checks/resource/azure/NetworkInterfacePublicIPAddressId.py
+++ b/checkov/terraform/checks/resource/azure/NetworkInterfacePublicIPAddressId.py
@@ -15,9 +15,11 @@ class NetworkInterfacePublicIPAddressId(BaseResourceCheck):
         self.evaluated_keys = ['ip_configuration']
         for ip_configuration in ip_configurations:
             if 'public_ip_address_id' in ip_configuration:
-                self.evaluated_keys = [
-                    f'ip_configuration/[{ip_configurations.index(ip_configuration)}]/public_ip_address_id']
-                return CheckResult.FAILED
+                if ip_configuration["public_ip_address_id"][0] is not None:
+                    self.evaluated_keys = [
+                        f'ip_configuration/[{ip_configurations.index(ip_configuration)}]/public_ip_address_id']
+                    return CheckResult.FAILED
+
         return CheckResult.PASSED
 
 

--- a/tests/terraform/checks/resource/azure/test_NetworkInterfacePublicIPAddressId.py
+++ b/tests/terraform/checks/resource/azure/test_NetworkInterfacePublicIPAddressId.py
@@ -56,6 +56,32 @@ class TestNetworkInterfacePublicIPAddressId(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_success_with_null(self):
+        hcl_res = hcl2.loads("""
+                resource "azurerm_network_interface" "example" {
+                  name                = "example-nic"
+                  location            = azurerm_resource_group.example.location
+                  resource_group_name = azurerm_resource_group.example.name
+                
+                  ip_configuration {
+                    name                          = "internal"
+                    subnet_id                     = azurerm_subnet.example.id
+                    private_ip_address_allocation = "Dynamic"
+                    public_ip_address_id = null
+                  }       
+                    ip_configuration {
+                    name                          = "internal2"
+                    subnet_id                     = azurerm_subnet.example.id2
+                    private_ip_address_allocation = "Dynamic"
+                    public_ip_address_id = null
+                  }
+                  enable_ip_forwarding = false
+                }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_network_interface']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
     def test_success_no_param(self):
         hcl_res = hcl2.loads("""
                 resource "azurerm_network_interface" "example" {


### PR DESCRIPTION
This PR fixes a bug when CKV_AZURE_119 fails and the `public_ip_address_id` is null.

However the check should pass because no public interface is configured.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
