### PR TITLE
Incomplete URL substring sanitization

### DIFF
--- a/checkov/terraform/module_loading/loaders/bitbucket_loader.py
+++ b/checkov/terraform/module_loading/loaders/bitbucket_loader.py
@@ -1,16 +1,14 @@
 from checkov.terraform.module_loading.loaders.git_loader import GenericGitLoader
+from flask import Flask, request, redirect
 
 
 class BitbucketLoader(GenericGitLoader):
-    def _is_matching_loader(self):
+    def _is_matching_loader(resquest):
+        allowlist = ["bitbucket.org/product", "bitbucket.org/login"]
         # https://www.terraform.io/docs/modules/sources.html#bitbucket
-        if 'bitbucket.org' in self.module_source:
-            if not self.module_source.startswith('https://') or not self.module_source.startswith('http://'):
-                self.module_source = 'https://' + self.module_source
-            if not self.module_source.endswith('.git'):
-                self.module_source = self.module_source + '.git'
-            return True
-        return False
+        target = request.args.get('target', '')
+        if target in allowlist:
+            return redirect(target)
 
 
 loader = BitbucketLoader()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Sanitizing untrusted URLs is a common technique for preventing attacks such as to request forgeries and malicious redirections. Usually, this is done by checking that the host of a URL is in a set of allowed hosts.

However, treating the URL as a string and checking if one of the allowed hosts is a substring of the URL is very prone to errors. Malicious URLs can bypass such security checks by embedding one of the allowed hosts in an unexpected location.

Even if the substring check is not used in a security-critical context, the incomplete check may still cause undesirable behaviors when the check succeeds accidentally.