### PR TITLE
fix: handle nested blocks at any layer of configuration

### DIFF
--- a/checkov/terraform/checks/resource/base_resource_check.py
+++ b/checkov/terraform/checks/resource/base_resource_check.py
@@ -31,11 +31,24 @@ class BaseResourceCheck(BaseCheck):
         raise NotImplementedError()
 
     def handle_dynamic_values(self, conf: Dict[str, List[Any]]) -> None:
+        # recursively search for blocks that are dynamic
+        for block_name in conf.keys():
+            if isinstance(conf[block_name], dict):
+                self.handle_dynamic_values(conf[block_name])
+
+            # if the configuration is a block element, search down again.
+            if isinstance(conf[block_name], list) and len(conf[block_name]) > 0 and isinstance(conf[block_name][0], dict):
+                self.handle_dynamic_values(conf[block_name][0])
+
+        self.process_dynamic_values(conf)
+
+    def process_dynamic_values(self, conf: Dict[str, List[Any]]) -> None:
         for dynamic_element in conf.get("dynamic", {}):
             if isinstance(dynamic_element, str):
                 try:
                     dynamic_element = json.loads(dynamic_element)
                 except Exception:
                     dynamic_element = {}
+
             for element_name in dynamic_element.keys():
                 conf[element_name] = dynamic_element[element_name].get("content", [])

--- a/tests/terraform/checks/resource/azure/test_AppServiceHttpLoggingEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_AppServiceHttpLoggingEnabled.py
@@ -15,12 +15,12 @@ class TestAppServiceHttpLoggingEnabled(unittest.TestCase):
               location            = azurerm_resource_group.example.location
               resource_group_name = azurerm_resource_group.example.name
               app_service_plan_id = azurerm_app_service_plan.example.id
-            
+
               site_config {
                 dotnet_framework_version = "v4.0"
                 scm_type                 = "LocalGit"
               }
-              
+
            logs {
                application_logs {
                    azure_blob_storage {
@@ -30,11 +30,11 @@ class TestAppServiceHttpLoggingEnabled(unittest.TestCase):
                 }
             }
           }              
-            
+
               app_settings = {
                 "SOME_KEY" = "some-value"
               }
-            
+
               connection_string {
                 name  = "Database"
                 type  = "SQLServer"
@@ -81,18 +81,20 @@ class TestAppServiceHttpLoggingEnabled(unittest.TestCase):
               location            = azurerm_resource_group.example.location
               resource_group_name = azurerm_resource_group.example.name
               app_service_plan_id = azurerm_app_service_plan.example.id
-            
+
               logs {
                 http_logs {
+                  file_system {
                     retention_in_days = 4
                     retention_in_mb = 10
+                  }
                 }
               }
-            
+
               app_settings = {
                 "SOME_KEY" = "some-value"
               }
-            
+
               connection_string {
                 name  = "Database"
                 type  = "SQLServer"
@@ -111,30 +113,109 @@ class TestAppServiceHttpLoggingEnabled(unittest.TestCase):
               location            = azurerm_resource_group.example.location
               resource_group_name = azurerm_resource_group.example.name
               app_service_plan_id = azurerm_app_service_plan.example.id
-            
+
               site_config {
                 dotnet_framework_version = "v4.0"
                 scm_type                 = "LocalGit"
               }
-              
+
                logs {
-                   application_logs {
-                       azure_blob_storage {
-                       level = "warning"
-                       sas_url = "www.example.com"
-                       retention_in_days = 4
-                    }
+                  application_logs {
+                    azure_blob_storage {
+                    level = "warning"
+                    sas_url = "www.example.com"
+                    retention_in_days = 4
+                  }
                 }
-                    http_logs {
-                        retention_in_days = 4
-                        retention_in_mb = 10
-                    }
+
+                http_logs {
+                  file_system {
+                    retention_in_days = 4
+                    retention_in_mb = 10
+                  }
+                }
               }
-            
+
               app_settings = {
                 "SOME_KEY" = "some-value"
               }
-            
+
+              connection_string {
+                name  = "Database"
+                type  = "SQLServer"
+                value = "Server=some-server.mydomain.com;Integrated Security=SSPI"
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_app_service']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success3(self):
+        hcl_res = hcl2.loads("""
+            variable "enable_http_logs" {
+              type = bool
+              default = true
+            }
+
+            variable "enable_http_logs_file_system" {
+              type = bool
+              default = true
+            }
+
+            variable "http_logs_azure_blob_storage" {
+              type = bool
+              default = true
+            }
+
+            resource "azurerm_app_service" "example" {
+              name                = "example-app-service"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              app_service_plan_id = azurerm_app_service_plan.example.id
+
+              site_config {
+                dotnet_framework_version = "v4.0"
+                scm_type                 = "LocalGit"
+              }
+
+              logs {
+                application_logs {
+                  azure_blob_storage {
+                    level = "warning"
+                    sas_url = "www.example.com"
+                    retention_in_days = 4
+                  }
+                }
+
+                dynamic "http_logs" {
+                  for_each = var.enable_http_logs ? [1] : []
+
+                  content {
+                    dynamic "file_system" {
+                      for_each = var.enable_http_logs_file_system ? [1] : []
+
+                      content {
+                        retention_in_days = 4
+                        retention_in_mb = 10
+                      }
+                    }
+
+                    dynamic "azure_blob_storage" {
+                      for_each = var.http_logs_azure_blob_storage != null ? [1] : []
+                      content {
+                        retention_in_days = 10
+                        sas_url           = "https://something.com"
+                      }
+                    }
+                  }
+                }
+              }
+
+              app_settings = {
+                "SOME_KEY" = "some-value"
+              }
+
               connection_string {
                 name  = "Database"
                 type  = "SQLServer"

--- a/tests/terraform/checks/resource/test_base_resource_dynamic_value_check.py
+++ b/tests/terraform/checks/resource/test_base_resource_dynamic_value_check.py
@@ -1,0 +1,138 @@
+import unittest
+
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.terraform.checks.resource.registry import resource_registry
+
+class TestDynamicCheck(BaseResourceValueCheck):
+    # for pytest not to collect this class as tests
+    __test__ = False
+
+    def __init__(self):
+        super().__init__("Ensure it ain't broke", "test/TestDynamicCheck", [], ["doesnt_matter"])
+
+    def get_inspected_key(self):
+        return "dynamic_block_name/[0]/foo"
+
+    def get_expected_value(self):
+        return "bar"
+
+class TestNestedDynamicCheck(BaseResourceValueCheck):
+    # for pytest not to collect this class as tests
+    __test__ = False
+
+    def __init__(self):
+        super().__init__("Ensure it ain't broke", "test/TestNestedDynamicCheck", [], ["doesnt_matter"])
+
+    def get_inspected_key(self):
+        return "outside/dynamic_block_name/[0]/foo"
+
+    def get_expected_value(self):
+        return "bar"
+
+
+class TestNestedMultipleDynamicCheckBlock1(BaseResourceValueCheck):
+    # for pytest not to collect this class as tests
+    __test__ = False
+
+    def __init__(self):
+        super().__init__("Ensure it ain't broke", "test/TestNestedMultipleDynamicCheckBlock1", [], ["doesnt_matter"])
+
+    def get_inspected_key(self):
+        return "outside/dynamic_block_name/[0]/dynamic_block_1/[0]/key"
+
+    def get_expected_value(self):
+        return 1
+
+class TestNestedMultipleDynamicCheckBlock2(BaseResourceValueCheck):
+    # for pytest not to collect this class as tests
+    __test__ = False
+
+    def __init__(self):
+        super().__init__("Ensure it ain't broke", "test/TestNestedMultipleDynamicCheckBlock2", [], ["doesnt_matter"])
+
+    def get_inspected_key(self):
+        return "outside/dynamic_block_name/[0]/dynamic_block_2/[0]/key"
+
+    def get_expected_value(self):
+        return "2"
+
+class Test(unittest.TestCase):
+    def test_dynamic(self):
+        data = {
+            "dynamic": [{
+                "dynamic_block_name": {
+                    "content": {
+                        "foo": "bar"
+                    }
+                }
+            }]
+        }
+
+        result = self._check(TestDynamicCheck(),data)
+        self.assertEqual(result, CheckResult.PASSED)
+
+    def test_dynamic_nested(self):
+        data = {
+            "outside": {
+                "dynamic": [{
+                    "dynamic_block_name": {
+                        "content": {
+                            "foo": "bar"
+                        }
+                    }
+                }]
+            }
+        }
+
+        result = self._check(TestNestedDynamicCheck(), data)
+        self.assertEqual(result, CheckResult.PASSED)
+
+    def multipleDynamicBlockData(self):
+        return {
+            "outside": {
+                "dynamic": [{
+                    "dynamic_block_name": {
+                        "content": {
+                            "dynamic": [{
+                                "dynamic_block_1": {
+                                    "content": {
+                                        "key": 1
+                                    }
+                                },
+                                "dynamic_block_2": {
+                                    "content": {
+                                        "key": "2"
+                                    }
+                                }
+                            }]
+                        }
+                    }
+                }]
+            }
+        }
+
+    def test_nested_multiple_dynamic_block_1(self):
+        result = self._check(TestNestedMultipleDynamicCheckBlock1(), self.multipleDynamicBlockData())
+        self.assertEqual(result, CheckResult.PASSED)
+
+    def test_nested_multiple_dynamic_block_2(self):
+        result = self._check(TestNestedMultipleDynamicCheckBlock2(), self.multipleDynamicBlockData())
+        self.assertEqual(result, CheckResult.PASSED)
+
+
+    @staticmethod
+    def _check(check, data):
+        return check.scan_resource_conf(data)
+
+    # This will install a custom check, so setUp/tearDown will ensure the check list is unchanged
+    # globally by our changes.
+    def setUp(self) -> None:
+        self.check_list_before = resource_registry.checks.copy()  # copy
+        super().setUp()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        resource_registry.checks = self.check_list_before
+        self.check_list_before = None


### PR DESCRIPTION
Currently, dynamic blocks are only handled when they are defined at the root level of a resource.
When a dynamic block is defined a nested block, rules will return a fail.
When a dynamic block is inside another dynamic block, rules will fail.

This PR implements a recursive search to search for dynamic blocks and process them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
