### PR TITLE
Check if policy is dict before accessing it

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
@@ -21,7 +21,9 @@ class IAMAdminPolicyDocument(BaseResourceCheck):
                 policies = my_properties['Policies']
                 if len(policies) > 0:
                     for policy in policies:
-                        if isinstance(policy, dict) and policy.get('PolicyDocument'):
+                        if not isinstance(policy, dict):
+                            return CheckResult.UNKNOWN
+                        if policy.get('PolicyDocument'):
                             result = check_policy(policy['PolicyDocument'])
                             if result == CheckResult.FAILED:
                                 return result

--- a/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
@@ -21,7 +21,7 @@ class IAMAdminPolicyDocument(BaseResourceCheck):
                 policies = my_properties['Policies']
                 if len(policies) > 0:
                     for policy in policies:
-                        if policy.get('PolicyDocument'):
+                        if isinstance(policy, dict) and policy.get('PolicyDocument'):
                             result = check_policy(policy['PolicyDocument'])
                             if result == CheckResult.FAILED:
                                 return result

--- a/checkov/cloudformation/checks/resource/aws/IAMStarActionPolicyDocument.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMStarActionPolicyDocument.py
@@ -22,7 +22,7 @@ class IAMStarActionPolicyDocument(BaseResourceCheck):
                 policies = myproperties['Policies']
                 if len(policies) > 0:
                     for policy in policies:
-                        if policy.get('PolicyDocument'):
+                        if isinstance(policy, dict) and policy.get('PolicyDocument'):
                             result = check_policy(policy['PolicyDocument'])
                             if result == CheckResult.FAILED:
                                 return result

--- a/checkov/cloudformation/checks/resource/aws/IAMStarActionPolicyDocument.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMStarActionPolicyDocument.py
@@ -22,7 +22,9 @@ class IAMStarActionPolicyDocument(BaseResourceCheck):
                 policies = myproperties['Policies']
                 if len(policies) > 0:
                     for policy in policies:
-                        if isinstance(policy, dict) and policy.get('PolicyDocument'):
+                        if not isinstance(policy, dict):
+                            return CheckResult.UNKNOWN
+                        if policy.get('PolicyDocument'):
                             result = check_policy(policy['PolicyDocument'])
                             if result == CheckResult.FAILED:
                                 return result

--- a/checkov/cloudformation/parser/__init__.py
+++ b/checkov/cloudformation/parser/__init__.py
@@ -31,10 +31,10 @@ def parse(filename: str, out_parsing_errors: Dict[str, str] = {}) -> Union[Tuple
             error = f"Permission denied when accessing template file: {filename} - {err}"
             LOGGER.error(error)
     except UnicodeDecodeError as err:
-        error = f"Cannot read file contents: {filename}"
+        error = f"Cannot read file contents: {filename} - {err}"
         LOGGER.error(error)
     except cfn_yaml.CfnParseError as err:
-        error = f"Parsing error in file {filename}"
+        error = f"Parsing error in file: {filename} - {err}"
         LOGGER.info(error)
     except ScannerError as err:
         if err.problem in ["found character '\\t' that cannot start any token", "found unknown escape character"]:

--- a/tests/cloudformation/checks/resource/aws/example_IAMAdminPolicyDocument/iam_role.unknown.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_IAMAdminPolicyDocument/iam_role.unknown.yaml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: "2010-09-09"
 
 
 Conditions:
-  CreateExecPolicy: true
+  CreateExecPolicy: !Equals [0, 0]
 
 Resources:
   ExecRole:

--- a/tests/cloudformation/checks/resource/aws/example_IAMAdminPolicyDocument/iam_role.unknown.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_IAMAdminPolicyDocument/iam_role.unknown.yaml
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+
+Conditions:
+  CreateExecPolicy: true
+
+Resources:
+  ExecRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies: !If
+        - CreateExecPolicy
+        - - PolicyName: root
+            PolicyDocument: !Sub |
+              { "Version": "2012-10-17", "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": "*",
+                  "Resource": "*"
+                }
+              ]}
+        - !Ref AWS::NoValue

--- a/tests/cloudformation/checks/resource/aws/example_IAMStarActionPolicyDocument/iam_role.unknown.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_IAMStarActionPolicyDocument/iam_role.unknown.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 
 Conditions:
-  CreateExecPolicy: true
+  CreateExecPolicy: !Equals [0, 0]
 
 Resources:
   RootRole:

--- a/tests/cloudformation/checks/resource/aws/example_IAMStarActionPolicyDocument/iam_role.unknown.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_IAMStarActionPolicyDocument/iam_role.unknown.yaml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Conditions:
+  CreateExecPolicy: true
+
+Resources:
+  RootRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies: !If
+        - CreateExecPolicy
+        - - PolicyName: root
+            PolicyDocument: !Sub |
+              { "Version": "2012-10-17", "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": "*",
+                  "Resource": "*"
+                }
+              ]}
+        - !Ref AWS::NoValue
+  RootInstanceProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Path: /
+      Roles:
+        - !Ref RootRole


### PR DESCRIPTION
Added validation in `IAMStarActionPolicyDocument` and `IAMAdminPolicyDocument` for accessing only dict policies and not strings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
