### PR TITLE
Fix `dict` verification in the loop, use `NotImplementedError` and remove unneeded default `return`

### DIFF
--- a/checkov/cloudformation/checks/utils/iam_cloudformation_document_to_policy_converter.py
+++ b/checkov/cloudformation/checks/utils/iam_cloudformation_document_to_policy_converter.py
@@ -10,7 +10,7 @@ def convert_cloudformation_conf_to_iam_policy(conf: dict_node) -> dict_node:
     result = copy.deepcopy(conf)
     if "Statement" in result.keys():
         result["Statement"] = result.pop("Statement")
-        for statement in result["Statement"]:
+        for statement in map(dict, result["Statement"]):
             if "Action" in statement:
                 statement["Action"] = str(statement.pop("Action")[0])
             if "Resource" in statement:
@@ -31,5 +31,4 @@ def convert_cloudformation_conf_to_iam_policy(conf: dict_node) -> dict_node:
                 statement["Effect"] = str(statement.pop("Effect"))
             if "Effect" not in statement:
                 statement["Effect"] = "Allow"
-            statement = dict(statement)
     return result

--- a/checkov/kubernetes/base_spec_omitted_or_value_check.py
+++ b/checkov/kubernetes/base_spec_omitted_or_value_check.py
@@ -18,7 +18,7 @@ class BaseSpecOmittedOrValueCheck(BaseK8Check):
 
     @abstractmethod
     def get_inspected_key(self):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def get_expected_value(self):
         # default expected value. can be override by derived class

--- a/checkov/kubernetes/checks/DefaultServiceAccount.py
+++ b/checkov/kubernetes/checks/DefaultServiceAccount.py
@@ -19,8 +19,6 @@ class DefaultServiceAccount(BaseK8Check):
             return "ServiceAccount.{}.{}".format(conf["metadata"]["name"], conf["metadata"]["namespace"])
         else:
             return "ServiceAccount.{}.default".format(conf["metadata"]["name"])
-        return 'ServiceAccount.automountServiceAccountToken'
-
     def scan_spec_conf(self, conf):
         if "metadata" in conf:
             if "name" in conf["metadata"]:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 - Make sure `statement` is `dict` the right way (24cc9bd)
 - `raise NotImplemented()` gives `TypeError` instead of `NotImplementedError` since `NotImplemented`'s type is `NotImplementedType` (9d799b1)
 - Remove unneeded default `return` (633812b)