### PR TITLE
Updated deprecated method assertEquals

### DIFF
--- a/tests/cloudformation/graph/graph_builder/test_blocks.py
+++ b/tests/cloudformation/graph/graph_builder/test_blocks.py
@@ -17,4 +17,4 @@ class TestBlocks(TestCase):
 
         block.update_attribute(attribute_key="labels.app.kubernetes.io/name", change_origin_id=0,
                                            attribute_value="dummy value", previous_breadcrumbs=[], attribute_at_dest="")
-        self.assertEquals("dummy value", block.attributes["labels.app.kubernetes.io/name"])
+        self.assertEqual("dummy value", block.attributes["labels.app.kubernetes.io/name"])

--- a/tests/terraform/graph/graph_builder/graph_components/test_blocks.py
+++ b/tests/terraform/graph/graph_builder/graph_components/test_blocks.py
@@ -132,7 +132,7 @@ class TestBlocks(TestCase):
 
         block.update_inner_attribute(attribute_key="labels.app.kubernetes.io/name", nested_attributes=attributes,
                                            value_to_update="dummy value")
-        self.assertEquals("dummy value", block.attributes["labels.app.kubernetes.io/name"])
+        self.assertEqual("dummy value", block.attributes["labels.app.kubernetes.io/name"])
 
     def test_update_complex_key2(self):
         config = {}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

`assertEquals` has been deprecated. Changed it to standardized `assertEqual` instead.