### PR TITLE
Removed unnecessary `apk update`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-alpine
 
-RUN apk update && apk add --no-cache git util-linux bash openssl
+RUN apk add --no-cache git util-linux bash openssl
 
 RUN pip install --no-cache-dir -U checkov
 RUN wget -q -O get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3; chmod 700 get_helm.sh; VERIFY_CHECKSUM=true ./get_helm.sh; rm ./get_helm.sh


### PR DESCRIPTION
# Description
- When using `apk add --no-cache`  unnecessary `apk update`

## FYI
- https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
