### PR TITLE
feat(azure): check that network interfaces to not use public ips

### DIFF
--- a/checkov/terraform/checks/graph_checks/azure/AzureNetworkInterfacePublicIPAddressId.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/AzureNetworkInterfacePublicIPAddressId.yaml
@@ -1,0 +1,18 @@
+metadata:
+  id: "CKV2_AZURE_22"
+  name: "Ensure that Network Interfaces don't use public IPs"
+  category: "NETWORKING"
+definition:
+  and:
+    - cond_type: connection
+      operator:  not_exists
+      resource_types:
+        - azurerm_network_interface
+      connected_resource_types:
+        - azurerm_public_ip
+    - cond_type: filter
+      attribute: resource_type
+      value:
+        - azurerm_network_interface
+      operator: within
+

--- a/tests/terraform/graph/checks/resources/AzureNetworkInterfacePublicIPAddressId/expected.yaml
+++ b/tests/terraform/graph/checks/resources/AzureNetworkInterfacePublicIPAddressId/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "azurerm_network_interface.good"
+fail:
+  - "azurerm_network_interface.bad"

--- a/tests/terraform/graph/checks/resources/AzureNetworkInterfacePublicIPAddressId/main.tf
+++ b/tests/terraform/graph/checks/resources/AzureNetworkInterfacePublicIPAddressId/main.tf
@@ -1,0 +1,55 @@
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "good" {
+  name                = "good-nic"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.example.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+
+resource "azurerm_network_interface" "bad" {
+  name                = "bad-nic"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.example.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.bad.id
+  }
+}
+
+resource "azurerm_public_ip" "bad" {
+  name                = "bad"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  allocation_method   = "Static"
+
+  tags = {
+    environment = "Production"
+  }
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -77,6 +77,9 @@ class TestYamlPolicies(unittest.TestCase):
     def test_AzureUnattachedDisksAreEncrypted(self):
         self.go("AzureUnattachedDisksAreEncrypted")
 
+    def test_AzureNetworkInterfacePublicIPAddressId(self):
+        self.go("AzureNetworkInterfacePublicIPAddressId")
+
     def test_AzureAntimalwareIsConfiguredWithAutoUpdatesForVMs(self):
         self.go("AzureAntimalwareIsConfiguredWithAutoUpdatesForVMs")
 


### PR DESCRIPTION
The existing rule `CKV_AZURE_119` will fail when any of these are passed into `public_ip_address_id`:
- a variable, i.e. `var.public_ip_address`
- an output from resource id, i.e. `azurerm_public_ip.something.id`
- an output from a module, i.e. `module.something.public_ip`

However, when a **variable** is used it needs to be evaluated to determine if it's valid or not.

This PR creates a new check using the graph definition to overcome the above behavior.

I would suggest that we deprecate `CKV_AZURE_119` in favour of `CKV2_AZURE_22`, but I'm not sure on the process.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
