### PR TITLE
fix AbsSecurityGroupUnrestrictedIngress check failure

### DIFF
--- a/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
@@ -71,7 +71,7 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
 
         if from_port is not None and to_port is not None and (from_port <= self.port <= to_port):
             conf_cidr_blocks = conf.get('cidr_blocks', [[]])
-            if len(conf_cidr_blocks) > 0:
+            if conf_cidr_blocks and len(conf_cidr_blocks) > 0:
                 conf_cidr_blocks = conf_cidr_blocks[0]
             cidr_blocks = force_list(conf_cidr_blocks)
             if "0.0.0.0/0" in cidr_blocks:

--- a/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngress22.py
+++ b/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngress22.py
@@ -138,6 +138,33 @@ resource "aws_security_group" "bar-sg" {
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_success_null_cidr(self):
+        hcl_res = hcl2.loads("""
+    resource "aws_security_group" "bar-sg" {
+      name   = "sg-bar"
+      vpc_id = aws_vpc.main.id
+
+      ingress = [{
+        from_port = 22
+        to_port   = 22
+        protocol  = "tcp"
+        security_groups = [aws_security_group.foo-sg.id]
+        description = "foo"
+        cidr_blocks = null
+      }]
+
+      egress = [{
+        from_port = 0
+        to_port   = 0
+        protocol  = "-1"
+        cidr_blocks = null
+      }]
+    }
+            """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
     def test_success_cidr(self):
         hcl_res = hcl2.loads("""
 resource "aws_security_group" "bar-sg" {


### PR DESCRIPTION
Fix AbsSecurityGroupUnrestrictedIngress check failure if cidr_blocks sets to null.
Add test for this use-case.

In the previous an exception was throws for this use-case: `TypeError: object of type 'NoneType' has no len()`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
