### PR TITLE
Restore Postgres engine filter for CKV2_AWS_27

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/PostgresRDSHasQueryLoggingEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/PostgresRDSHasQueryLoggingEnabled.yaml
@@ -9,6 +9,12 @@ definition:
    value:
    - aws_rds_cluster
    operator: within
+ - cond_type: filter
+   resource_types:
+   - aws_rds_cluster
+   attribute: engine
+   operator: within
+   value: "postgres"     
  - cond_type: connection
    resource_types:
    - aws_rds_cluster


### PR DESCRIPTION
2ee945f2b5d20f969267162b71b7432f25749f78 in #1651 appears to have introduced a regression for #1460. I first noticed this when the Postgres-specific CKV2_AWS_27 was triggering on my Aurora MySQL instances:

> Ensure Postgres RDS as aws_rds_cluster has Query Logging enabled

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
