### PR TITLE
fix bug in kubernetes runner

### DIFF
--- a/checkov/common/util/data_structures_utils.py
+++ b/checkov/common/util/data_structures_utils.py
@@ -1,5 +1,4 @@
 from typing import Generator, Any, Union
-from checkov.common.util.type_forcers import force_list
 
 
 def get_inner_dict(source_dict, path_as_list):
@@ -39,8 +38,7 @@ def search_deep_keys(searchText, obj, path):
             pathprop = path[:]
             pathprop.append(key)
             if key == searchText:
-                obj_to_add = force_list(obj[key])
-                pathprop.append(obj_to_add)
+                pathprop.append(obj[key])
                 keys.append(pathprop)
                 # pop the last element off for nesting of found elements for
                 # dict and list checks

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -127,6 +127,7 @@ class Runner(BaseRunner):
                             namespace = "default"
                         containerDef["containers"] = containers.pop()
                         if containerDef["containers"] is not None:
+                            containerDef["containers"] = force_list(containerDef["containers"])
                             for cd in containerDef["containers"]:
                                 i = containerDef["containers"].index(cd)
                                 containerDef["containers"][i]["apiVersion"] = entity_conf["apiVersion"]


### PR DESCRIPTION
the kubernetes runner fails when the value of containerDef["containers"] wasn't a list because of the for loop in line 131

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
