### PR TITLE
Added url parameter to report for json

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -108,7 +108,9 @@ class Report:
 
         return bom
 
-    def get_dict(self, is_quiet=False) -> dict:
+    def get_dict(self, is_quiet=False, url="") -> dict:
+        if not url:
+            url = "Add an api key '--bc-api-key <api-key>' to see more detailed insights via https://bridgecrew.cloud"
         if is_quiet:
             return {
                 "check_type": self.check_type,
@@ -127,6 +129,7 @@ class Report:
                     "parsing_errors": list(self.parsing_errors),
                 },
                 "summary": self.get_summary(),
+                "url": url,
             }
 
     def get_exit_code(

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -91,7 +91,7 @@ class RunnerRegistry:
         for report in scan_reports:
             if not report.is_empty():
                 if "json" in config.output:
-                    report_jsons.append(report.get_dict(is_quiet=config.quiet))
+                    report_jsons.append(report.get_dict(is_quiet=config.quiet, url=url))
                 if "junitxml" in config.output:
                     junit_reports.append(report)
                     # report.print_junit_xml()


### PR DESCRIPTION
Added the URL to the json report structure (or an alternative message to us an api-key) as the URL is useful for creating custom message via the more machine consumable json output.  Please check that this won't break other things.  
I've tested it on the cli.