### PR TITLE
EKSSecretsEncryption: Support AWS EKS Terraform module

### DIFF
--- a/checkov/terraform/checks/resource/aws/EKSSecretsEncryption.py
+++ b/checkov/terraform/checks/resource/aws/EKSSecretsEncryption.py
@@ -1,20 +1,38 @@
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
-from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckCategories, CheckResult
 
 
-class EKSSecretsEncryption(BaseResourceValueCheck):
+class EKSSecretsEncryption(BaseResourceCheck):
     def __init__(self):
         name = "Ensure EKS Cluster has Secrets Encryption Enabled"
         id = "CKV_AWS_58"
         supported_resources = ['aws_eks_cluster']
         categories = [CheckCategories.KUBERNETES]
-        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+        super().__init__(name=name, id=id, categories=categories,
+                         supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return "encryption_config/[0]/resources"
-
-    def get_expected_value(self):
-        return ["secrets"]
+    def scan_resource_conf(self, conf):
+        # AWS EKS provider uses "encryption_config"
+        # AWS EKS module uses "cluster_encryption_config"
+        encryption_config = conf.get('encryption_config') or conf.get(
+            'cluster_encryption_config')
+        if encryption_config is None:
+            return CheckResult.FAILED
+        self.evaluated_keys = ["encryption_config"]
+        if not isinstance(encryption_config, list):
+            return CheckResult.FAILED
+        node = encryption_config[0]
+        self.evaluated_keys = ["encryption_config/[0]"]
+        if not isinstance(node, dict):
+            return CheckResult.FAILED
+        resources = node.get('resources')
+        if isinstance(resources, list) and len(resources) == 1:
+            resources = resources[0]
+        if resources == ["secrets"]:
+            self.evaluated_keys = ["encryption_config/[0]/resources"]
+            return CheckResult.PASSED
+        else:
+            return CheckResult.FAILED
 
 
 check = EKSSecretsEncryption()

--- a/tests/terraform/checks/resource/aws/test_EKSSecretsEncryption.py
+++ b/tests/terraform/checks/resource/aws/test_EKSSecretsEncryption.py
@@ -18,8 +18,14 @@ class TestEKSSecretsEncryption(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-    def test_success(self):
+    def test_success_provider(self):
         resource_conf = {'name': ['good-eks2'], 'role_arn': ['${var.role_arn}'], 'vpc_config': [{'subnet_ids': [[]], 'endpoint_public_access': [True]}], 'encryption_config': [{'provider': [{'key_arn': ['${var.key_arn}']}], 'resources': [['secrets']]}]}
+
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_module(self):
+        resource_conf = {'name': ['good-eks2'], 'role_arn': ['${var.role_arn}'], 'vpc_config': [{'subnet_ids': [[]], 'endpoint_public_access': [True]}], 'cluster_encryption_config': [{'provider': [{'key_arn': ['${var.key_arn}']}], 'resources': ['secrets']}]}
 
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)


### PR DESCRIPTION
Closes #1130

[Terraform AWS EKS provider uses `encryption_config`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#encryption_config) while [AWS EKS Terraform module uses `cluster_encryption_config`](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest#input_cluster_encryption_config).

Unfortunately both of them use the same resource name (`aws_eks_cluster`), therefore AFAIK there is no way to distinguish them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
