### PR TITLE
fix: --output json returning empty array if no checks are run

### DIFF
--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -152,7 +152,9 @@ class RunnerRegistry:
             if output_formats:
                 print(OUTPUT_DELIMITER)
         if "json" in config.output:
-            if len(report_jsons) == 1:
+            if not report_jsons:
+                print(json.dumps(Report(None).get_summary(), indent=4))
+            elif len(report_jsons) == 1:
                 print(json.dumps(report_jsons[0], indent=4))
             else:
                 print(json.dumps(report_jsons, indent=4))


### PR DESCRIPTION
Fixes #743

If no checks are run (eg. with `--external-checks-dir`), a summary is returned instead of an empty JSON array, eg.
```json
{
    "passed": 0,
    "failed": 0,
    "skipped": 0,
    "parsing_errors": 0,
    "resource_count": 0,
    "checkov_version": "2.0.505"
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
