### PR TITLE
Fix Filter Example in YAML Custom Policies

### DIFF
--- a/docs/3.Custom Policies/YAML Custom Policies.md
+++ b/docs/3.Custom Policies/YAML Custom Policies.md
@@ -161,13 +161,13 @@ The Custom Policy in this example ensures that all ELBs are attached to security
 | Not Exists | `not_exists` |
 
 ```yaml
-defintion:
+definition:
  and:
       - cond_type: "filter"
-        resource_types:
+        attribute: "resource_type"
+        value:
            - "aws_elb"
-        attribute: “resource_type”
-        operator: "within”
+        operator: "within"
       - cond_type: "connection"
         resource_types:
            - "aws_elb"


### PR DESCRIPTION
`Filter Example` in `YAML Custom Policies` has 2 mistakes:
- typo in `definition`
- wrongly uses `resource_types` instead of `value` for `filter` `cond_type`
- uses Unicode double quotation marks (`“`/`”`) instead of ASCII double quotation marks (`"`)

[Preview Before](https://github.com/bridgecrewio/checkov/blob/master/docs/3.Custom%20Policies/YAML%20Custom%20Policies.md#user-content-filter-example)

[Preview After](https://github.com/bridgecrewio/checkov/blob/884f82e42a90049c77b9fc4e25d6ec1b99cdefbb/docs/3.Custom%20Policies/YAML%20Custom%20Policies.md#user-content-filter-example)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
