### PR TITLE
OCI Check that bucket is Encrypted with CMK

### DIFF
--- a/checkov/terraform/checks/resource/oci/ObjectStorageEncryption.py
+++ b/checkov/terraform/checks/resource/oci/ObjectStorageEncryption.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.consts import ANY_VALUE
+
+class ObjectStorageEncryption(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure OCI Object Storage is encrypted with Customer Managed Key"
+        id = "CKV_OCI_9"
+        supported_resources = ['oci_objectstorage_bucket']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "kms_key_id"
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = ObjectStorageEncryption()

--- a/tests/terraform/checks/resource/oci/example_ObjectStorageEncryption/main.tf
+++ b/tests/terraform/checks/resource/oci/example_ObjectStorageEncryption/main.tf
@@ -1,0 +1,51 @@
+resource "oci_objectstorage_bucket" "pass" {
+  compartment_id = var.compartment_id
+  name           = var.bucket_name
+  namespace      = var.namespace
+
+  access_type           = var.bucket_access_type
+  defined_tags          = var.defined_tags
+  freeform_tags         = var.freeform_tags
+  kms_key_id            = var.oci_kms_key.id
+  metadata              = var.metadata
+  storage_tier          = var.bucket_storage_tier
+  object_events_enabled = true
+
+  retention_rules {
+    display_name = var.retention_rule_display_name
+
+    duration {
+      time_amount = var.retention_rule_duration_time_amount
+      time_unit   = var.retention_rule_duration_time_unit
+    }
+    time_rule_locked = var.retention_rule_time_rule_locked
+  }
+
+  versioning = true
+}
+
+
+resource "oci_objectstorage_bucket" "fail" {
+  compartment_id = var.compartment_id
+  name           = var.bucket_name
+  namespace      = var.namespace
+
+  access_type           = var.bucket_access_type
+  defined_tags          = var.defined_tags
+  freeform_tags         = var.freeform_tags
+  metadata              = var.metadata
+  storage_tier          = var.bucket_storage_tier
+  object_events_enabled = false
+
+  retention_rules {
+    display_name = var.retention_rule_display_name
+
+    duration {
+      time_amount = var.retention_rule_duration_time_amount
+      time_unit   = var.retention_rule_duration_time_unit
+    }
+    time_rule_locked = var.retention_rule_time_rule_locked
+  }
+
+  versioning = false
+}

--- a/tests/terraform/checks/resource/oci/test_ObjectStorageEncryption.py
+++ b/tests/terraform/checks/resource/oci/test_ObjectStorageEncryption.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.oci.ObjectStorageEncryption import check
+from checkov.terraform.runner import Runner
+
+
+class TestObjectStorageEncryption(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ObjectStorageEncryption"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "oci_objectstorage_bucket.pass",
+        }
+        failing_resources = {
+            "oci_objectstorage_bucket.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Mirrors: OCI Object Storage Bucket is not encrypted with a Customer Managed Key (CMK)