### PR TITLE
OCI Password policy - must have special characters

### DIFF
--- a/checkov/terraform/checks/resource/oci/IAMPasswordPolicySpecialCharacters.py
+++ b/checkov/terraform/checks/resource/oci/IAMPasswordPolicySpecialCharacters.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class IAMPasswordPolicySpecialCharacters(BaseResourceValueCheck):
+    def __init__(self):
+        name = "OCI IAM password policy - must contain Special characters"
+        id = "CKV_OCI_13"
+        supported_resources = ['oci_identity_authentication_policy']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'password_policy/[0]/is_special_characters_required'
+
+    def get_expected_value(self):
+        return True
+
+
+check = IAMPasswordPolicySpecialCharacters()

--- a/tests/terraform/checks/resource/oci/example_IAMPasswordPolicySpecialCharacters/main.tf
+++ b/tests/terraform/checks/resource/oci/example_IAMPasswordPolicySpecialCharacters/main.tf
@@ -1,0 +1,27 @@
+resource "oci_identity_authentication_policy" "pass" {
+
+  compartment_id = var.tenancy_id
+
+  password_policy {
+    is_lowercase_characters_required = true
+    is_numeric_characters_required   = true
+    is_special_characters_required   = true
+    is_uppercase_characters_required = var.authentication_policy_password_policy_is_uppercase_characters_required
+    is_username_containment_allowed  = var.authentication_policy_password_policy_is_username_containment_allowed
+    minimum_password_length          = var.authentication_policy_password_policy_minimum_password_length
+  }
+}
+
+resource "oci_identity_authentication_policy" "fail" {
+
+  compartment_id = var.tenancy_id
+
+  password_policy {
+    is_lowercase_characters_required = false
+    is_numeric_characters_required   = false
+    is_special_characters_required   = false
+    is_uppercase_characters_required = var.authentication_policy_password_policy_is_uppercase_characters_required
+    is_username_containment_allowed  = var.authentication_policy_password_policy_is_username_containment_allowed
+    minimum_password_length          = var.authentication_policy_password_policy_minimum_password_length
+  }
+}

--- a/tests/terraform/checks/resource/oci/test_IAMPasswordPolicySpecialCharacters.py
+++ b/tests/terraform/checks/resource/oci/test_IAMPasswordPolicySpecialCharacters.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.oci.IAMPasswordPolicySpecialCharacters import check
+from checkov.terraform.runner import Runner
+
+
+class TestIAMPasswordPolicySpecialCharacters(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_IAMPasswordPolicySpecialCharacters"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "oci_identity_authentication_policy.pass",
+        }
+        failing_resources = {
+            "oci_identity_authentication_policy.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
parity with "OCI IAM password policy for local (non-federated) users does not have a symbol"