### PR TITLE
OCI Encryption Check for CMK on file system resource

### DIFF
--- a/checkov/terraform/checks/resource/oci/FileSystemEncryption.py
+++ b/checkov/terraform/checks/resource/oci/FileSystemEncryption.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.consts import ANY_VALUE
+
+class FileSystemEncryption(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure OCI File System is Encrypted with a customer Managed Key"
+        id = "CKV_OCI_15"
+        supported_resources = ['oci_file_storage_file_system']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'kms_key_id'
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = FileSystemEncryption()

--- a/tests/terraform/checks/resource/oci/example_FileSystemEncryption/main.tf
+++ b/tests/terraform/checks/resource/oci/example_FileSystemEncryption/main.tf
@@ -1,0 +1,21 @@
+resource "oci_file_storage_file_system" "pass" {
+  availability_domain = var.file_system_availability_domain
+  compartment_id      = var.compartment_id
+
+  defined_tags       = { "Operations.CostCenter" = "42" }
+  display_name       = var.file_system_display_name
+  freeform_tags      = { "Department" = "Finance" }
+  kms_key_id         = oci_kms_key.test_key.id
+  source_snapshot_id = oci_file_storage_snapshot.test_snapshot.id
+}
+
+
+resource "oci_file_storage_file_system" "fail" {
+  availability_domain = var.file_system_availability_domain
+  compartment_id      = var.compartment_id
+
+  defined_tags       = { "Operations.CostCenter" = "42" }
+  display_name       = var.file_system_display_name
+  freeform_tags      = { "Department" = "Finance" }
+  source_snapshot_id = oci_file_storage_snapshot.test_snapshot.id
+}

--- a/tests/terraform/checks/resource/oci/test_FileSystemEncryption.py
+++ b/tests/terraform/checks/resource/oci/test_FileSystemEncryption.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.oci.FileSystemEncryption import check
+from checkov.terraform.runner import Runner
+
+
+class TestFileSystemEncryption(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_FileSystemEncryption"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "oci_file_storage_file_system.pass",
+        }
+        failing_resources = {
+            "oci_file_storage_file_system.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Parity with :"OCI File Storage File Systems are not encrypted with a Customer Managed Key (CMK)"