### PR TITLE
Refactor RDS/DB retention period check to be valid

### DIFF
--- a/checkov/terraform/checks/resource/aws/DBInstanceBackupRetentionPeriod.py
+++ b/checkov/terraform/checks/resource/aws/DBInstanceBackupRetentionPeriod.py
@@ -8,7 +8,7 @@ class DBInstanceBackupRetentionPeriod(BaseResourceCheck):
     def __init__(self):
         name = "Ensure that RDS instances has backup policy"
         id = "CKV_AWS_133"
-        supported_resources = ['aws_rds_cluster']
+        supported_resources = ['aws_rds_cluster','aws_db_instance']
         categories = [CheckCategories.BACKUP_AND_RECOVERY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
@@ -18,7 +18,9 @@ class DBInstanceBackupRetentionPeriod(BaseResourceCheck):
             period = force_int(conf[key][0])
             if period and 0 < period <= 35:
                 return CheckResult.PASSED
-        return CheckResult.FAILED
+            return CheckResult.FAILED
+        #Default value is 1 which passes ^^^
+        return CheckResult.PASSED
 
     def get_evaluated_keys(self) -> List[str]:
         return ['backup_retention_period']

--- a/tests/terraform/checks/resource/aws/example_DBInstanceBackupRetentionPeriod/main.tf
+++ b/tests/terraform/checks/resource/aws/example_DBInstanceBackupRetentionPeriod/main.tf
@@ -1,0 +1,31 @@
+resource "aws_rds_cluster" "pass" {
+  backup_retention_period = 35
+}
+
+resource "aws_rds_cluster" "pass2" {
+}
+
+resource "aws_rds_cluster" "fail2" {
+  backup_retention_period = 0
+}
+
+#this will fail in tf i dont know why we even bother?
+resource "aws_rds_cluster" "fail" {
+  backup_retention_period = 36
+}
+
+resource "aws_db_instance" "pass" {
+  backup_retention_period = 35
+}
+
+resource "aws_db_instance" "pass2" {
+}
+
+resource "aws_db_instance" "fail2" {
+  backup_retention_period = 0
+}
+
+#this will fail in tf i dont know why we even bother?
+resource "aws_db_instance" "fail" {
+  backup_retention_period = 36
+}

--- a/tests/terraform/checks/resource/aws/test_DBInstanceBackupRetentionPeriod.py
+++ b/tests/terraform/checks/resource/aws/test_DBInstanceBackupRetentionPeriod.py
@@ -1,55 +1,44 @@
+import os
 import unittest
-import hcl2
 
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.DBInstanceBackupRetentionPeriod import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestDBInstanceBackupRetentionPeriod(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
 
-    def test_failure(self):
-        hcl_res = hcl2.loads("""
-                            resource "aws_rds_cluster" "test" {
-                              allocated_storage     = 10
-                            }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_rds_cluster']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        test_files_dir = current_dir + "/example_DBInstanceBackupRetentionPeriod"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-    def test_failure_bad_value_min(self):
-        hcl_res = hcl2.loads("""
-                            resource "aws_rds_cluster" "test" {
-                              allocated_storage       = 10
-                              backup_retention_period = 0
-                            }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_rds_cluster']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passing_resources = {
+            "aws_rds_cluster.pass",
+            "aws_db_instance.pass",
+            "aws_rds_cluster.pass2",
+            "aws_db_instance.pass2",
+        }
+        failing_resources = {
+            "aws_rds_cluster.fail",
+            "aws_rds_cluster.fail2",
+            "aws_db_instance.fail",
+            "aws_db_instance.fail2",
+        }
 
-    def test_failure_bad_value_max(self):
-        hcl_res = hcl2.loads("""
-                            resource "aws_rds_cluster" "test" {
-                              allocated_storage       = 10
-                              backup_retention_period = 36
-                            }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_rds_cluster']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-                            resource "aws_rds_cluster" "test" {
-                              allocated_storage       = 10
-                              backup_retention_period = 35
-                            }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_rds_cluster']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(summary["passed"], 4)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

The previous check looked for not setting a value, however backup_retention_period now has a default value of 1 which is valid by this check. It also relates to aws_db_instance so iaded that and I also upgraded the tests.

There seems to be only one check here and that to ensure that the value is not 0. I dont know why it checks >35 as that value will be rejected by tf. 