### PR TITLE
expanding terraform plan example

### DIFF
--- a/docs/4.Integrations/Terraform Scanning.md
+++ b/docs/4.Integrations/Terraform Scanning.md
@@ -24,7 +24,6 @@ Note: The Terraform show output file `tf.json` will be a single line. For that r
 If you have installed jq, you can convert a JSON file into multiple lines making it easier to read the scan result.
 
 ```json
-terraform plan --out tfplan.binary
 terraform show -json tfplan.binary | jq '.' > tfplan.json
 
 checkov -f tfplan.json

--- a/docs/4.Integrations/Terraform Scanning.md
+++ b/docs/4.Integrations/Terraform Scanning.md
@@ -20,8 +20,30 @@ terraform show -json tfplan.binary > tfplan.json
 checkov -f tfplan.json
 ```
 
+Note: The Terraform show output file `tf.json` will be a single line. For that reason Checkov will report all findings as line number 0.
+If you have installed jq, you can convert a JSON file into multiple lines making it easier to read the scan result.
+
+```json
+terraform init
+terraform plan --out tfplan.binary
+terraform show -json tfplan.binary | jq '.' > tfplan.json
+
+checkov -f tfplan.json
+```
+
 The output would look like:
-![](terraform-plan-output)
+```
+checkov -f tf.json
+Check: CKV_AWS_21: "Ensure all data stored in the S3 bucket have versioning enabled"
+	FAILED for resource: aws_s3_bucket.customer
+	File: /tf/tf1.json:224-268
+	Guide: https://docs.bridgecrew.io/docs/s3_16-enable-versioning
+
+		225 |               "values": {
+		226 |                 "acceleration_status": "",
+		227 |                 "acl": "private",
+		228 |                 "arn": "arn:aws:s3:::mybucket",
+```
 
 ## Scanning Third-Party Terraform Modules
 Third-party Terraform modules often reduce complexity for deploying services made up of many objects.

--- a/docs/4.Integrations/Terraform Scanning.md
+++ b/docs/4.Integrations/Terraform Scanning.md
@@ -24,7 +24,6 @@ Note: The Terraform show output file `tf.json` will be a single line. For that r
 If you have installed jq, you can convert a JSON file into multiple lines making it easier to read the scan result.
 
 ```json
-terraform init
 terraform plan --out tfplan.binary
 terraform show -json tfplan.binary | jq '.' > tfplan.json
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

The example in the Terraform Plan section didn't have an example showing the use of `jq` which is actually pretty important when scanning plan files. Also, there was a broken example image which I replaced with a code snippet which I felt was better than nothing.