### PR TITLE
Add Codestar Connections Hosts to SG connection check for CKV2_AWS_5

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/SGAttachedToResource.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/SGAttachedToResource.yaml
@@ -16,6 +16,7 @@ definition:
         - aws_batch_compute_environment
         - aws_cloudwatch_event_target
         - aws_codebuild_project
+        - aws_codestarconnections_host
         - aws_db_instance
         - aws_dms_replication_instance
         - aws_docdb_cluster

--- a/tests/terraform/graph/checks/resources/SGAttachedToResource/expected.yaml
+++ b/tests/terraform/graph/checks/resources/SGAttachedToResource/expected.yaml
@@ -3,6 +3,7 @@ pass:
   - "aws_security_group.pass_batch"
   - "aws_security_group.pass_cloudwatch_event"
   - "aws_security_group.pass_codebuild"
+  - "aws_security_group.pass_codestar"
   - "aws_security_group.pass_dms"
   - "aws_security_group.pass_docdb"
   - "aws_security_group.pass_ec2_client_vpn"

--- a/tests/terraform/graph/checks/resources/SGAttachedToResource/main.tf
+++ b/tests/terraform/graph/checks/resources/SGAttachedToResource/main.tf
@@ -58,6 +58,30 @@ resource "aws_codebuild_project" "pass_codebuild" {
   }
 }
 
+# Codestar
+
+resource "aws_security_group" "pass_codestar" {
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = 0.0.0.0/0
+  }
+}
+
+resource "aws_codestarconnections_host" "pass_codestar" {
+  name              = "star"
+  provider_endpoint = "https://github.com/bridgecrewio/checkov"
+  provider_type     = "GitHubEnterpriseServer"
+  vpc_configuration {
+    vpc_id             = "aws_vpc.vpc.id"
+    security_group_ids = [aws_security_group.pass_codestar.id]
+    subnet_ids         = ["aws_subnet.public_a.id"]
+  }
+  provider = aws.primary
+}
+
 # DMS
 
 resource "aws_security_group" "pass_dms" {


### PR DESCRIPTION
Add AWS Codestar Connections Hosts to the list of resource types checked to confirm if a Security Group is attached and not orphaned
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
