### PR TITLE
run bc-api-key tests only for ubuntu os

### DIFF
--- a/integration_tests/prepare_data.sh
+++ b/integration_tests/prepare_data.sh
@@ -23,7 +23,7 @@ else
   pipenv run checkov -s -d terragoat/terraform/ --config-file integration_tests/example_config_files/config.yaml -o json > checkov_config_report_terragoat.json
 fi
 
-if [[ "$2" == "3.7" ]]
+if [[ "$2" == "3.7" && "$1" == "ubuntu-latest" ]]
 then
   pipenv run checkov -s -f terragoat/terraform/aws/s3.tf --bc-api-key $BC_KEY > checkov_report_s3_singlefile_api_key_terragoat.txt
   pipenv run checkov -s -d terragoat/terraform/azure/ --bc-api-key $BC_KEY > checkov_report_azuredir_api_key_terragoat.txt

--- a/integration_tests/test_checkov_cli_integration_report.py
+++ b/integration_tests/test_checkov_cli_integration_report.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 import unittest
 
@@ -16,7 +17,7 @@ class TestCheckovJsonReport(unittest.TestCase):
         self.validate_report(os.path.abspath(report_path))
 
     def validate_report(self, report_path):
-        if sys.version_info[1] == 7:
+        if sys.version_info[1] == 7 and platform.system() == 'Linux':
             platform_url_found = False
             with open(report_path) as f:
                 if 'More details: https://www.bridgecrew.cloud/projects?' in f.read():


### PR DESCRIPTION
Update `prepare_data.sh` to run checkov with bc-api-key only for `ubuntu-latest`
Update `integration_tests/test_checkov_cli_integration_report.py` tests to validate report only for ubuntu os.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.