### PR TITLE
output summary regardless of # resources checked

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -198,19 +198,17 @@ class Report:
     ) -> None:
         summary = self.get_summary()
         print(colored(f"{self.check_type} scan results:", "blue"))
-        if self.parsing_errors:
-            message = "\nPassed checks: {}, Failed checks: {}, Skipped checks: {}, Parsing errors: {}\n".format(
-                summary["passed"],
-                summary["failed"],
-                summary["skipped"],
-                summary["parsing_errors"],
-            )
-        else:
-            message = (
-                "\nPassed checks: {}, Failed checks: {}, Skipped checks: {}\n".format(
-                    summary["passed"], summary["failed"], summary["skipped"]
-                )
-            )
+        message = "\nPassed checks: {}, Failed checks: {}, Skipped checks: {}, Parsing errors: {}\n".format(
+            summary["passed"],
+            summary["failed"],
+            summary["skipped"],
+            summary["parsing_errors"],
+        )
+        # message = (
+        #     "\nPassed checks: {}, Failed checks: {}, Skipped checks: {}\n".format(
+        #         summary["passed"], summary["failed"], summary["skipped"]
+        #     )
+        )
         print(colored(message, "cyan"))
         if not is_quiet:
             for record in self.passed_checks:


### PR DESCRIPTION
JSON output results in 2 very different outputs depending on the resources scanned.

resource > 0
```
{
    "check_type": "terraform",
    "results": {
        "failed_checks": [
          {...}
        ]
    },
    "summary": {
        "passed": 0,
        "failed": 1,
        "skipped": 0,
        "parsing_errors": 0,
        "resource_count": 22,
        "checkov_version": "2.0.505"
    }
}
```

resource = 0 
```
[]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

