### PR TITLE
Multiprocessing bug fixes

### DIFF
--- a/checkov/common/parallelizer/parallel_runner.py
+++ b/checkov/common/parallelizer/parallel_runner.py
@@ -38,7 +38,10 @@ class ParallelRunner:
 
         for process, parent_conn, group_len in processes:
             for _ in range(group_len):
-                yield parent_conn.recv()
+                try:
+                    yield parent_conn.recv()
+                except EOFError:
+                    pass
 
     def _run_function_multithreaded(self, func: Callable[[Any], Any], items: List[Any]) -> Iterator:
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.workers_number) as executor:

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -239,7 +239,7 @@ def _parse_files(files, definitions, definitions_raw, filepath_fn=None):
         try:
             return filename, parse(filename)
         except (TypeError, ValueError) as e:
-            logging.warning(f"Kubernetes skipping {file} as it is not a valid Kubernetes template\n{e}")
+            logging.warning(f"Kubernetes skipping {filename} as it is not a valid Kubernetes template\n{e}")
 
     results = parallel_runner.run_function(_parse_file, files)
     for result in results:

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -170,8 +170,15 @@ class Runner(BaseRunner):
     @staticmethod
     def _scan_files(files_to_scan, secrets):
         # implemented the scan function like secrets.scan_files
+        def _safe_scan(f):
+            try:
+                return list(scan.scan_file(os.path.join(secrets.root, f)))
+            except Exception as err:
+                logging.warning(f"Secret scanning:could not process file {f}, {err}")
+                return list()
+
         results = parallel_runner.run_function(
-            lambda f: list(scan.scan_file(os.path.join(secrets.root, f))), files_to_scan)
+            lambda f: list(_safe_scan(f)), files_to_scan)
         for secrets_results in results:
             for secret in secrets_results:
                 secrets[os.path.relpath(secret.filename, secrets.root)].add(secret)

--- a/checkov/terraform/checks/resource/azure/CutsomRoleDefinitionSubscriptionOwner.py
+++ b/checkov/terraform/checks/resource/azure/CutsomRoleDefinitionSubscriptionOwner.py
@@ -12,7 +12,8 @@ class CustomRoleDefinitionSubscriptionOwner(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if "*" in conf.get("permissions", [{}])[0].get("actions", [""])[0]:
+        actions = conf.get("permissions", [{}])[0].get("actions", [""])
+        if actions and "*" in actions[0]:
             return CheckResult.FAILED
         return CheckResult.PASSED
 


### PR DESCRIPTION
Fixed a number of different bugs:

1. General multiprocessing - pass on EOF errors on yield when running a multiprocess function.
2. Secrets - added a safe running function to catch errors in scanning without causing run timeouts.
3. K8s - Fixed warning message to use correct param.
4. Terraform - unrelated bugfix in check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
