### PR TITLE
Adding aws_db_instance connect resource type

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/Route53ARecordAttachedResource.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/Route53ARecordAttachedResource.yaml
@@ -43,5 +43,6 @@ definition:
               - aws_vpc_endpoint
               - aws_globalaccelerator_accelerator
               - aws_cloudfront_distribution
+              - aws_db_instance
            operator: exists
            attribute: networking


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

The following fails `CKV2_AWS_23` as `aws_db_instance` isn't in the `connected_resource_types` list

```
resource "aws_route53_record" "rds" {
  zone_id = data.aws_route53_zone.default.zone_id
  name    = "myrecord"
  type    = "A"

  alias {
    name                   = aws_db_instance.rds.address
    zone_id                = aws_db_instance.rds.hosted_zone_id
    evaluate_target_health = false
  }
}
```