### PR TITLE
CKV2_GCP3: Reverse test logic for GCP service account key check

### DIFF
--- a/checkov/terraform/checks/graph_checks/gcp/ServiceAccountHasGCPmanagedKey.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/ServiceAccountHasGCPmanagedKey.yaml
@@ -10,7 +10,7 @@ definition:
         - google_service_account
       connected_resource_types:
         - google_service_account_key
-      operator:  exists
+      operator:  not_exists
       cond_type: connection
     - cond_type: filter
       attribute: resource_type

--- a/checkov/terraform/checks/graph_checks/gcp/ServiceAccountHasGCPmanagedKey.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/ServiceAccountHasGCPmanagedKey.yaml
@@ -7,13 +7,7 @@ scope:
 definition:
   and:
     - resource_types:
-        - google_service_account
-      connected_resource_types:
         - google_service_account_key
-      operator:  not_exists
-      cond_type: connection
-    - cond_type: filter
-      attribute: resource_type
-      value:
-        - google_service_account
-      operator: within
+      operator: not_exists
+      attribute: public_key_data
+      cond_type: attribute

--- a/tests/terraform/graph/checks/resources/ServiceAccountHasGCPmanagedKey/expected.yaml
+++ b/tests/terraform/graph/checks/resources/ServiceAccountHasGCPmanagedKey/expected.yaml
@@ -1,4 +1,4 @@
 pass:
-  - "google_service_account.account_ok"
+  - "google_service_account_key.account_ok"
 fail:
-  - "google_service_account.account_bad"
+  - "google_service_account_key.account_bad"

--- a/tests/terraform/graph/checks/resources/ServiceAccountHasGCPmanagedKey/main.tf
+++ b/tests/terraform/graph/checks/resources/ServiceAccountHasGCPmanagedKey/main.tf
@@ -1,11 +1,12 @@
-resource "google_service_account" "account_ok" {
+resource "google_service_account" "account" {
   account_id = "dev-foo-account"
 }
 
-resource "google_service_account" "account_bad" {
-  account_id = "dev-foo-account"
+resource "google_service_account_key" "account_ok" {
+  service_account_id = google_service_account.account.name
 }
 
 resource "google_service_account_key" "account_bad" {
-  service_account_id = google_service_account.account_bad.name
+  service_account_id = google_service_account.account.name
+  public_key_data = "foo"
 }

--- a/tests/terraform/graph/checks/resources/ServiceAccountHasGCPmanagedKey/main.tf
+++ b/tests/terraform/graph/checks/resources/ServiceAccountHasGCPmanagedKey/main.tf
@@ -2,10 +2,10 @@ resource "google_service_account" "account_ok" {
   account_id = "dev-foo-account"
 }
 
-resource "google_service_account_key" "ok_key" {
-  service_account_id = google_service_account.account_ok.name
-}
-
 resource "google_service_account" "account_bad" {
   account_id = "dev-foo-account"
+}
+
+resource "google_service_account_key" "account_bad" {
+  service_account_id = google_service_account.account_bad.name
 }


### PR DESCRIPTION
Fix for https://github.com/bridgecrewio/checkov/issues/1416.

As mentioned in issue above, it's indeed the case that Google does not recommend using service account keys if possible. However looking at the code I am wondering if the checks are looking for [user-managed service account keys](https://cloud.google.com/iam/docs/service-accounts#user-managed_keys). Either way, they should be avoided.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
