### PR TITLE
CF - Check - SecretManagerSecretEncrypted

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/SecretManagerSecretEncrypted.py
+++ b/checkov/cloudformation/checks/resource/aws/SecretManagerSecretEncrypted.py
@@ -16,8 +16,7 @@ class SecretManagerSecretEncrypted(BaseResourceCheck):
         properties = conf.get("Properties")
         if properties:
             kms_key_id = properties.get("KmsKeyId")
-            if kms_key_id:
-                if aws_kms_alias not in kms_key_id:
+            if kms_key_id and aws_kms_alias not in kms_key_id:
                     return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/checkov/cloudformation/checks/resource/aws/SecretManagerSecretEncrypted.py
+++ b/checkov/cloudformation/checks/resource/aws/SecretManagerSecretEncrypted.py
@@ -1,0 +1,25 @@
+from checkov.common.parsers.node import DictNode
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class SecretManagerSecretEncrypted(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure that Secrets Manager secret is encrypted using KMS CMK"
+        id = "CKV_AWS_149"
+        supported_resources = ["AWS::SecretsManager::Secret"]
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: DictNode) -> CheckResult:
+        aws_kms_alias = "aws/"
+        properties = conf.get("Properties")
+        if properties:
+            kms_key_id = properties.get("KmsKeyId")
+            if kms_key_id:
+                if aws_kms_alias not in kms_key_id:
+                    return CheckResult.PASSED
+        return CheckResult.FAILED
+
+
+check = SecretManagerSecretEncrypted()

--- a/checkov/terraform/checks/resource/aws/SecretManagerSecretEncrypted.py
+++ b/checkov/terraform/checks/resource/aws/SecretManagerSecretEncrypted.py
@@ -15,11 +15,12 @@ class SecretManagerSecretEncrypted(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
+        aws_kms_alias = 'aws/'
         kms_key_id = force_list(conf.get('kms_key_id', []))
         if not kms_key_id:
             return CheckResult.FAILED
         else:
-            return CheckResult.FAILED if 'alias/aws/' in kms_key_id[0] else CheckResult.PASSED
+            return CheckResult.FAILED if aws_kms_alias in kms_key_id[0] else CheckResult.PASSED
 
     def get_evaluated_keys(self) -> List[str]:
         return ['kms_key_id']

--- a/tests/cloudformation/checks/resource/aws/example_SecretManagerSecretEncrypted/FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_SecretManagerSecretEncrypted/FAIL.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources: 
+  NoKMS:
+    Type: AWS::SecretsManager::Secret
+    Properties: 
+      Name: test
+  AWSKMS0:
+    Type: AWS::SecretsManager::Secret
+    Properties: 
+      Name: test
+      KmsKeyId: aws/secretsmanager
+  AWSKMS1:
+    Type: AWS::SecretsManager::Secret
+    Properties: 
+      Name: test
+      KmsKeyId: alias/aws/secretsmanager

--- a/tests/cloudformation/checks/resource/aws/example_SecretManagerSecretEncrypted/PASS.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_SecretManagerSecretEncrypted/PASS.yaml
@@ -1,0 +1,7 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources: 
+  MyCMK:
+    Type: AWS::SecretsManager::Secret
+    Properties: 
+      Name: test
+      KmsKeyId: test-key

--- a/tests/cloudformation/checks/resource/aws/test_SecretManagerSecretEncrypted.py
+++ b/tests/cloudformation/checks/resource/aws/test_SecretManagerSecretEncrypted.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.SecretManagerSecretEncrypted import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestSecretManagerSecretEncrypted(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_SecretManagerSecretEncrypted"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::SecretsManager::Secret.MyCMK",
+        }
+        failing_resources = {
+            "AWS::SecretsManager::Secret.NoKMS",
+            "AWS::SecretsManager::Secret.AWSKMS0",
+            "AWS::SecretsManager::Secret.AWSKMS1",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hello,

I'm back to slowly trying to catch the CF checks up with TF.

Tried to follow latest conventions but just lemme know if need to change anything.

TF Check: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/SecretManagerSecretEncrypted.py
TF Doc: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret
CF Doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secret.html

If you see i'm instead checking if the field matches the pattern `"aws/"` instead of `"alias/aws/"` because I am under the impression that if you miss out the 'alias' part CF / TF / the AWS CLI still infer that it should use aws/* KMS Key.

I could be wrong but I figured this was a safer bet because otherwise `aws/secretsmanager` would be accepted (and I think it would work!).

No CMK can use `aws/` in a user defined alias: https://docs.aws.amazon.com/kms/latest/developerguide/alias-manage.html#alias-create


**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.