### PR TITLE
add evaluated keys to graph check results

### DIFF
--- a/checkov/common/graph/checks_infra/base_check.py
+++ b/checkov/common/graph/checks_infra/base_check.py
@@ -29,3 +29,6 @@ class BaseGraphCheck:
 
     def get_output_id(self, use_bc_ids: bool) -> str:
         return self.bc_id if self.bc_id and use_bc_ids else self.id
+
+    def get_evaluated_keys(self) -> List[str]:
+        return [self.attribute] if self.attribute else []

--- a/checkov/common/graph/checks_infra/registry.py
+++ b/checkov/common/graph/checks_infra/registry.py
@@ -26,13 +26,14 @@ class BaseRegistry:
                 continue
             logging.debug(f'Running graph check: {check.id}')
             passed, failed = check.run(graph_connector)
-            check_result = self._process_check_result(passed, [], CheckResult.PASSED)
-            check_result = self._process_check_result(failed, check_result, CheckResult.FAILED)
+            check_result = self._process_check_result(passed, [], CheckResult.PASSED, check.get_evaluated_keys())
+            check_result = self._process_check_result(failed, check_result, CheckResult.FAILED, check.get_evaluated_keys())
             check_results[check] = check_result
+            # check_results[check] = (check_result, check.get_evaluated_keys())
         return check_results
 
     @staticmethod
-    def _process_check_result(results, processed_results, result):
+    def _process_check_result(results, processed_results, result, evaluated_keys) -> List[Dict[str, Any]]:
         for vertex in results:
-            processed_results.append({"result": result, "entity": vertex})
+            processed_results.append({"result": result, "entity": vertex, "evaluated_keys": evaluated_keys})
         return processed_results

--- a/checkov/common/graph/checks_infra/registry.py
+++ b/checkov/common/graph/checks_infra/registry.py
@@ -26,10 +26,10 @@ class BaseRegistry:
                 continue
             logging.debug(f'Running graph check: {check.id}')
             passed, failed = check.run(graph_connector)
-            check_result = self._process_check_result(passed, [], CheckResult.PASSED, check.get_evaluated_keys())
-            check_result = self._process_check_result(failed, check_result, CheckResult.FAILED, check.get_evaluated_keys())
+            evaluated_keys = check.get_evaluated_keys()
+            check_result = self._process_check_result(passed, [], CheckResult.PASSED, evaluated_keys)
+            check_result = self._process_check_result(failed, check_result, CheckResult.FAILED, evaluated_keys)
             check_results[check] = check_result
-            # check_results[check] = (check_result, check.get_evaluated_keys())
         return check_results
 
     @staticmethod

--- a/tests/cloudformation/graph/checks/resources/LambdaFunction/expected.yaml
+++ b/tests/cloudformation/graph/checks/resources/LambdaFunction/expected.yaml
@@ -3,4 +3,5 @@ pass:
 fail:
   - "AWS::Lambda::Function.WrongTracingConfigValueLambdaFunction"
   - "AWS::Lambda::Function.WithoutTracingConfigLambdaFunction"
-
+evaluated_keys:
+  - "Tracing_config.Mode"

--- a/tests/cloudformation/graph/checks/resources/SagemakerNotebookEncryption/expected.yaml
+++ b/tests/cloudformation/graph/checks/resources/SagemakerNotebookEncryption/expected.yaml
@@ -2,3 +2,5 @@ pass:
   - "AWS::SageMaker::NotebookInstance.BasicNotebookInstanceGood"
 fail:
   - "AWS::SageMaker::NotebookInstance.BasicNotebookInstanceBad"
+evaluated_keys:
+  - "KmsKeyId"

--- a/tests/cloudformation/graph/checks/test_yaml_policies.py
+++ b/tests/cloudformation/graph/checks/test_yaml_policies.py
@@ -64,9 +64,11 @@ class TestYamlPolicies(unittest.TestCase):
                     expected_to_fail = expected.get('fail', [])
                     expected_to_pass = expected.get('pass', [])
                     expected_to_skip = expected.get('skip', [])
+                    expected_evaluated_keys = expected.get('evaluated_keys', [])
                     self.assert_entities(expected_to_pass, report.passed_checks, True)
                     self.assert_entities(expected_to_fail, report.failed_checks, False)
                     self.assert_entities(expected_to_skip, report.skipped_checks, True)
+                    self.assert_evaluated_keys(expected_evaluated_keys, report.passed_checks + report.failed_checks)
 
         assert found
 
@@ -82,6 +84,10 @@ class TestYamlPolicies(unittest.TestCase):
                     found = True
                     break
             self.assertTrue(found, f"expected to find entity {expected_entity}, {'passed' if assertion else 'failed'}")
+
+    def assert_evaluated_keys(self, expected_evaluated_keys: List[str], results: List[Record]):
+        for record in results:
+            self.assertEqual(expected_evaluated_keys, record.check_result["evaluated_keys"])
 
 
 def get_checks_registry():


### PR DESCRIPTION
Add evaluated keys to graph check result, the evaluated key will be the check attribute (if exist), wrapped in list.
Expend `test_yaml_policies` tests to check the evaluated_keys in the report.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.