### PR TITLE
Handle None limits for k8s checks

### DIFF
--- a/checkov/kubernetes/checks/CPULimits.py
+++ b/checkov/kubernetes/checks/CPULimits.py
@@ -18,7 +18,7 @@ class CPULimits(BaseK8Check):
     def scan_spec_conf(self, conf):
         if conf.get("resources"):
             if "limits" in conf["resources"]:
-                if "cpu" not in conf["resources"]["limits"]:
+                if not conf["resources"].get("limits") or "cpu" not in conf["resources"]["limits"]:
                     return CheckResult.FAILED
             else:
                 return CheckResult.FAILED

--- a/checkov/kubernetes/checks/MemoryLimits.py
+++ b/checkov/kubernetes/checks/MemoryLimits.py
@@ -18,7 +18,7 @@ class MemoryLimits(BaseK8Check):
     def scan_spec_conf(self, conf):
         if conf.get("resources"):
             if "limits" in conf["resources"]:
-                if "memory" not in conf["resources"]["limits"]:
+                if not conf["resources"].get("limits") or "memory" not in conf["resources"]["limits"]:
                     return CheckResult.FAILED
             else:
                 return CheckResult.FAILED


### PR DESCRIPTION
Supported a case where `conf["resources"]["limits"]` is None to avoid failures for `CKV_K8S_11` and `CKV_K8S_13`.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
