### PR TITLE
Check/waf has rules

### DIFF
--- a/checkov/terraform/checks/resource/aws/WAFHasAnyRules.py
+++ b/checkov/terraform/checks/resource/aws/WAFHasAnyRules.py
@@ -11,13 +11,11 @@ class WAFHasAnyRules(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if "rules" not in conf.keys() and "rule" not in conf.keys():
-            return CheckResult.FAILED
-        if "rules" in conf.keys() and conf["rules"] == [{}]:
-            return CheckResult.FAILED
-        if "rule" in conf.keys() and conf["rule"] == [{}]:
-            return CheckResult.FAILED
-        return CheckResult.PASSED
+        if "rules" in conf.keys() and conf["rules"] != [{}]:
+            return CheckResult.PASSED
+        if "rule" in conf.keys() and conf["rule"] != [{}]:
+            return CheckResult.PASSED
+        return CheckResult.FAILED
 
 
 check = WAFHasAnyRules()

--- a/checkov/terraform/checks/resource/aws/WAFHasAnyRules.py
+++ b/checkov/terraform/checks/resource/aws/WAFHasAnyRules.py
@@ -1,0 +1,23 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class WAFHasAnyRules(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure WAF has any rules"
+        id = "CKV_AWS_175"
+        supported_resources = ['aws_waf_web_acl', 'aws_wafv2_web_acl']
+        categories = [CheckCategories.APPLICATION_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if "rules" not in conf.keys() and "rule" not in conf.keys():
+            return CheckResult.FAILED
+        if "rules" in conf.keys() and conf["rules"] == [{}]:
+            return CheckResult.FAILED
+        if "rule" in conf.keys() and conf["rule"] == [{}]:
+            return CheckResult.FAILED
+        return CheckResult.PASSED
+
+
+check = WAFHasAnyRules()

--- a/checkov/terraform/checks/resource/aws/WAFHasAnyRules.py
+++ b/checkov/terraform/checks/resource/aws/WAFHasAnyRules.py
@@ -4,7 +4,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 
 class WAFHasAnyRules(BaseResourceCheck):
     def __init__(self):
-        name = "Ensure WAF has any rules"
+        name = "Ensure WAF has associated rules"
         id = "CKV_AWS_175"
         supported_resources = ['aws_waf_web_acl', 'aws_wafregional_web_acl', 'aws_wafv2_web_acl']
         categories = [CheckCategories.APPLICATION_SECURITY]

--- a/checkov/terraform/checks/resource/aws/WAFHasAnyRules.py
+++ b/checkov/terraform/checks/resource/aws/WAFHasAnyRules.py
@@ -6,7 +6,7 @@ class WAFHasAnyRules(BaseResourceCheck):
     def __init__(self):
         name = "Ensure WAF has any rules"
         id = "CKV_AWS_175"
-        supported_resources = ['aws_waf_web_acl', 'aws_wafv2_web_acl']
+        supported_resources = ['aws_waf_web_acl', 'aws_wafregional_web_acl', 'aws_wafv2_web_acl']
         categories = [CheckCategories.APPLICATION_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/tests/terraform/checks/resource/aws/example_WafHasAnyRules/main.tf
+++ b/tests/terraform/checks/resource/aws/example_WafHasAnyRules/main.tf
@@ -1,0 +1,46 @@
+
+//global
+resource "aws_waf_web_acl" "fail" {
+  name        = "tfWebACL"
+  metric_name = "tfWebACL"
+
+  default_action {
+    type = "ALLOW"
+  }
+}
+
+resource "aws_waf_web_acl" "fail2" {
+  name        = "tfWebACLfail2"
+  metric_name = "tfWebACLfail2"
+
+  default_action {
+    type = "ALLOW"
+  }
+  rules {
+
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+//global
+resource "aws_waf_web_acl" "pass" {
+  name        = "tfWebACLpass"
+  metric_name = "tfWebACLpass"
+
+  default_action {
+    type = "ALLOW"
+  }
+
+  rules {
+    priority = 1
+    rule_id  = "30231cc1-ae2d-44e9-8212-dfb6185288a8"
+    type     = "REGULAR"
+
+    action {
+      type = "BLOCK"
+    }
+  }
+}

--- a/tests/terraform/checks/resource/aws/example_WafHasAnyRules/main.tf
+++ b/tests/terraform/checks/resource/aws/example_WafHasAnyRules/main.tf
@@ -44,3 +44,45 @@ resource "aws_waf_web_acl" "pass" {
     }
   }
 }
+
+resource "aws_wafregional_web_acl" "pass" {
+  name        = "tfWebACLregional"
+  metric_name = "tfWebACLregional"
+
+  default_action {
+    type = "ALLOW"
+  }
+
+  rule {
+    action {
+      type = "BLOCK"
+    }
+
+    priority = 1
+    rule_id  = aws_wafregional_rule.wafrule.id
+    type     = "REGULAR"
+  }
+}
+
+resource "aws_wafregional_web_acl" "fail" {
+  name        = "tfWebACLregionalfail"
+  metric_name = "tfWebACLregionalfail"
+
+  default_action {
+    type = "ALLOW"
+  }
+
+}
+
+resource "aws_wafregional_web_acl" "fail2" {
+  name        = "tfWebACLregionalfail2"
+  metric_name = "tfWebACLregionalfail2"
+
+  default_action {
+    type = "ALLOW"
+  }
+
+  rule {
+  }
+}
+

--- a/tests/terraform/checks/resource/aws/example_WafHasAnyRules/waf2.tf
+++ b/tests/terraform/checks/resource/aws/example_WafHasAnyRules/waf2.tf
@@ -1,0 +1,85 @@
+resource "aws_wafv2_web_acl" "pass" {
+  name        = "managed-rule-example"
+  description = "Example of a managed rule."
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        excluded_rule {
+          name = "SizeRestrictions_QUERYSTRING"
+        }
+
+        excluded_rule {
+          name = "NoUserAgent_HEADER"
+        }
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = ["US", "NL"]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_web_acl" "fail" {
+  name        = "managed-rule-example-fail"
+  description = "Example of a managed rule."
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_web_acl" "fail2" {
+  name        = "managed-rule-example"
+  description = "Example of a managed rule."
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {}
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}

--- a/tests/terraform/checks/resource/aws/test_WAFEnabled.py
+++ b/tests/terraform/checks/resource/aws/test_WAFEnabled.py
@@ -5,7 +5,7 @@ from checkov.terraform.checks.resource.aws.WAFEnabled import check
 from checkov.common.models.enums import CheckResult
 
 
-class TestS3MFADelete(unittest.TestCase):
+class TestWAFEnabled(unittest.TestCase):
 
     def test_failure(self):
         hcl_res = hcl2.loads("""

--- a/tests/terraform/checks/resource/aws/test_WAFHasAnyRules.py
+++ b/tests/terraform/checks/resource/aws/test_WAFHasAnyRules.py
@@ -5,6 +5,7 @@ from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.WAFHasAnyRules import check
 from checkov.terraform.runner import Runner
 
+
 class TestWafHasAnyRules(unittest.TestCase):
     def test(self):
         runner = Runner()
@@ -19,19 +20,23 @@ class TestWafHasAnyRules(unittest.TestCase):
         passing_resources = {
             "aws_waf_web_acl.pass",
             'aws_wafv2_web_acl.pass',
+            'aws_wafregional_web_acl.pass',
         }
+
         failing_resources = {
             "aws_waf_web_acl.fail",
             "aws_waf_web_acl.fail2",
             'aws_wafv2_web_acl.fail',
             'aws_wafv2_web_acl.fail2',
+            'aws_wafregional_web_acl.fail',
+            'aws_wafregional_web_acl.fail2',
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["failed"], 6)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/aws/test_WAFHasAnyRules.py
+++ b/tests/terraform/checks/resource/aws/test_WAFHasAnyRules.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.WAFHasAnyRules import check
+from checkov.terraform.runner import Runner
+
+class TestWafHasAnyRules(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_WafHasAnyRules"
+        report = runner.run(
+            root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
+        )
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_waf_web_acl.pass",
+            'aws_wafv2_web_acl.pass',
+        }
+        failing_resources = {
+            "aws_waf_web_acl.fail",
+            "aws_waf_web_acl.fail2",
+            'aws_wafv2_web_acl.fail',
+            'aws_wafv2_web_acl.fail2',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
You can create an AWS WAF without any rules, so it's worth SFA. This stops that.