### PR TITLE
Write sarif to results.sarif

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -327,8 +327,13 @@ class Report:
         return sarif_template_report
 
     def write_sarif_output(self) -> None:
-        with open("results.sarif", "w") as f:
-            f.write(json.dumps(self.get_sarif_json()))
+        try:
+            with open("results.sarif", "w") as f:
+                f.write(json.dumps(self.get_sarif_json()))
+                print("\nWrote output in SARIF format to the file 'results.sarif'")
+        except EnvironmentError as e:
+            print("\nAn error occurred while writing SARIF results to file: results.sarif")
+            print(f"More details: \n {e}")
 
     @staticmethod
     def get_junit_xml_string(ts: List[TestSuite]) -> str:

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -256,6 +256,8 @@ class Report:
         results = []
         ruleset = set()
         idx = 0
+        level = "note"
+
         for record in self.failed_checks:
             rule = {
                 "id": record.check_id,
@@ -280,10 +282,16 @@ class Report:
                 record.file_line_range[0] = 1
             if record.file_line_range[1] == 0:
                 record.file_line_range[1] = 1
+
+            if record.check_result.get("result", None) == CheckResult.FAILED:
+                level = "error"
+            elif record.check_result.get("result", None) == CheckResult.SKIPPED:
+                level = "warning"
+
             result = {
                 "ruleId": record.check_id,
                 "ruleIndex": idx,
-                "level": "error",
+                "level": level,
                 "message": {"text": record.check_name},
                 "locations": [
                     {
@@ -318,8 +326,9 @@ class Report:
         }
         return sarif_template_report
 
-    def print_sarif_report(self) -> None:
-        print(json.dumps(self.get_sarif_json()))
+    def write_sarif_output(self) -> None:
+        with open("results.sarif", "w") as f:
+            f.write(json.dumps(self.get_sarif_json()))
 
     @staticmethod
     def get_junit_xml_string(ts: List[TestSuite]) -> str:

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -256,9 +256,9 @@ class Report:
         results = []
         ruleset = set()
         idx = 0
-        level = "note"
+        level = "warning"
 
-        for record in self.failed_checks:
+        for record in self.failed_checks + self.skipped_checks:
             rule = {
                 "id": record.check_id,
                 "name": record.check_name,

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -132,7 +132,6 @@ class RunnerRegistry:
                 )
                 master_report.failed_checks += report.failed_checks
                 master_report.skipped_checks += report.skipped_checks
-                master_report.parsing_errors += report.parsing_errors
             if url:
                 print("More details: {}".format(url))
             master_report.write_sarif_output()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR changes the behavior of the sarif output flag as follows:

1. Running `checkov -d xxx -o sarif` will print the CLI output to the console. 
2. A file `results.sarif` will be created in the directory where checkov is called. 
3. Default error level for every rule in the SARIF output is `error`. However, for results, level will depend on the outcome of the check. `error` for `CheckResult.FAILED` and `warning` for `CheckResult.SKIPPED`

Note that the SARIF output will not have `PASSED` checks but the console output will.  

Fixes: https://github.com/bridgecrewio/bridgecrew-action/issues/24
