### PR TITLE
ensure WAF2 has logs

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/WAF2HasLogs.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/WAF2HasLogs.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: "CKV2_AWS_31"
-  name: "Ensure WAF2 has Logs"
+  name: "Ensure WAF2 has a Logging Configuration"
   category: "LOGGING"
 definition:
   and:

--- a/checkov/terraform/checks/graph_checks/aws/WAF2HasLogs.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/WAF2HasLogs.yaml
@@ -1,0 +1,18 @@
+metadata:
+  id: "CKV2_AWS_31"
+  name: "Ensure WAF2 has Logs"
+  category: "LOGGING"
+definition:
+  and:
+    - cond_type: filter
+      value:
+        - aws_wafv2_web_acl
+      operator: within
+      attribute: resource_type
+    - or: 
+      - cond_type: connection
+        operator: exists
+        resource_types:
+        - aws_wafv2_web_acl
+        connected_resource_types:
+        - aws_wafv2_web_acl_logging_configuration

--- a/tests/terraform/graph/checks/resources/WAF2HasLogs/expected.yaml
+++ b/tests/terraform/graph/checks/resources/WAF2HasLogs/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "aws_wafv2_web_acl.pass"
+fail:
+  - "aws_wafv2_web_acl.fail"

--- a/tests/terraform/graph/checks/resources/WAF2HasLogs/main.tf
+++ b/tests/terraform/graph/checks/resources/WAF2HasLogs/main.tf
@@ -1,0 +1,124 @@
+resource "aws_wafv2_web_acl_logging_configuration" "pass" {
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.example.arn]
+  resource_arn            = aws_wafv2_web_acl.pass.arn
+  redacted_fields {
+    single_header {
+      name = "user-agent"
+    }
+  }
+}
+
+resource "aws_wafv2_web_acl" "pass" {
+  name        = "managed-rule-example-pass"
+  description = "Example of a managed rule."
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        excluded_rule {
+          name = "SizeRestrictions_QUERYSTRING"
+        }
+
+        excluded_rule {
+          name = "NoUserAgent_HEADER"
+        }
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = ["US", "NL"]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+
+
+resource "aws_wafv2_web_acl" "fail" {
+  name        = "managed-rule-example-fail"
+  description = "Example of a managed rule."
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        excluded_rule {
+          name = "SizeRestrictions_QUERYSTRING"
+        }
+
+        excluded_rule {
+          name = "NoUserAgent_HEADER"
+        }
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = ["US", "NL"]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -191,6 +191,9 @@ class TestYamlPolicies(unittest.TestCase):
     def test_SQLServerAuditingEnabled(self):
         self.go("SQLServerAuditingEnabled")
 
+    def test_WAF2HasLogs(self):
+        self.go("WAF2HasLogs")
+
     def test_registry_load(self):
         registry = Registry(parser=NXGraphCheckParser(), checks_dir=str(
             Path(__file__).parent.parent.parent.parent.parent / "checkov" / "terraform" / "checks" / "graph_checks"))


### PR DESCRIPTION
WAF2 works differently from WAF/WAFRegional in that its logging config is a separate logging resource, so this check needs to be a graph check.