### PR TITLE
Add tool name for sarif output

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -250,13 +250,15 @@ class Report:
         xml_string = self.get_junit_xml_string(ts)
         print(xml_string)
 
-    def get_sarif_json(self) -> Dict[str, Any]:
+    def get_sarif_json(self, tool) -> Dict[str, Any]:
         runs = []
         rules = []
         results = []
         ruleset = set()
         idx = 0
         level = "warning"
+        tool = tool if tool else "Bridgecrew"
+        information_uri = "https://docs.bridgecrew.io" if tool.lower() == "bridgecrew" else "https://checkov.io"
 
         for record in self.failed_checks + self.skipped_checks:
             rule = {
@@ -310,9 +312,9 @@ class Report:
         runs.append({
             "tool": {
                 "driver": {
-                    "name": "checkov",
+                    "name": tool,
                     "version": version,
-                    "informationUri": "https://github.com/bridgecrewio/checkov/",
+                    "informationUri": information_uri,
                     "rules": rules,
                     "organization": "bridgecrew",
                 }
@@ -326,10 +328,10 @@ class Report:
         }
         return sarif_template_report
 
-    def write_sarif_output(self) -> None:
+    def write_sarif_output(self, tool) -> None:
         try:
             with open("results.sarif", "w") as f:
-                f.write(json.dumps(self.get_sarif_json()))
+                f.write(json.dumps(self.get_sarif_json(tool)))
                 print("\nWrote output in SARIF format to the file 'results.sarif'")
         except EnvironmentError as e:
             print("\nAn error occurred while writing SARIF results to file: results.sarif")

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -20,7 +20,6 @@ from checkov.terraform.context_parsers.registry import parser_registry
 from checkov.terraform.runner import Runner as tf_runner
 from checkov.terraform.parser import Parser
 from checkov.common.parallelizer.parallel_runner import parallel_runner
-from checkov.common.util.banner import banner
 
 
 CHECK_BLOCK_TYPES = frozenset(["resource", "data", "provider", "module"])
@@ -32,12 +31,14 @@ class RunnerRegistry:
     runners: List[BaseRunner] = []
     scan_reports: List[Report] = []
     banner = ""
+    tool = ""
 
-    def __init__(self, banner: str, runner_filter: RunnerFilter, *runners: BaseRunner) -> None:
+    def __init__(self, banner: str, tool: str, runner_filter: RunnerFilter, *runners: BaseRunner) -> None:
         self.logger = logging.getLogger(__name__)
         self.runner_filter = runner_filter
         self.runners = list(runners)
         self.banner = banner
+        self.tool = tool
         self.scan_reports = []
         self.filter_runner_framework()
 
@@ -121,7 +122,7 @@ class RunnerRegistry:
 
         if "sarif" in config.output:
             master_report = Report("merged")
-            print(banner)
+            print(self.banner)
             for report in sarif_reports:
                 report.print_console(
                         is_quiet=config.quiet,
@@ -134,7 +135,7 @@ class RunnerRegistry:
                 master_report.skipped_checks += report.skipped_checks
             if url:
                 print("More details: {}".format(url))
-            master_report.write_sarif_output()
+            master_report.write_sarif_output(self.tool)
             output_formats.remove("sarif")
             if output_formats:
                 print(OUTPUT_DELIMITER)

--- a/checkov/common/util/banner.py
+++ b/checkov/common/util/banner.py
@@ -3,6 +3,7 @@ from termcolor import colored
 from checkov.version import version
 from checkov.common.version_manager import check_for_update
 
+tool = "checkov"
 banner = r"""
        _               _              
    ___| |__   ___  ___| | _______   __

--- a/checkov/common/util/banner.py
+++ b/checkov/common/util/banner.py
@@ -3,7 +3,7 @@ from termcolor import colored
 from checkov.version import version
 from checkov.common.version_manager import check_for_update
 
-tool = "checkov"
+tool = "Checkov"
 banner = r"""
        _               _              
    ___| |__   ___  ___| | _______   __

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -23,6 +23,7 @@ from checkov.common.output.baseline import Baseline
 from checkov.common.runners.runner_registry import RunnerRegistry, OUTPUT_CHOICES
 from checkov.common.checks.base_check_registry import BaseCheckRegistry
 from checkov.common.util.banner import banner as checkov_banner
+from checkov.common.util.banner import tool as tool_name
 from checkov.common.util.config_utils import get_default_config_paths
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 from checkov.common.util.docs_generator import print_checks
@@ -53,7 +54,7 @@ DEFAULT_RUNNERS = (tf_graph_runner(), cfn_runner(), k8_runner(),
                    dockerfile_runner(), secrets_runner(), json_runner())
 
 
-def run(banner=checkov_banner, argv=sys.argv[1:]):
+def run(banner=checkov_banner, tool=tool_name, argv=sys.argv[1:]):
     default_config_paths = get_default_config_paths(sys.argv[1:])
     parser = ExtArgumentParser(description='Infrastructure as code static analysis',
                                default_config_files=default_config_paths,
@@ -91,7 +92,7 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
         runner_registry = outer_registry
         runner_registry.runner_filter = runner_filter
     else:
-        runner_registry = RunnerRegistry(banner, runner_filter, *DEFAULT_RUNNERS)
+        runner_registry = RunnerRegistry(banner, tool, runner_filter, *DEFAULT_RUNNERS)
 
     runnerDependencyHandler = RunnerDependencyHandler(runner_registry)
     runnerDependencyHandler.validate_runner_deps()

--- a/tests/common/output/test_cyclonedx_report.py
+++ b/tests/common/output/test_cyclonedx_report.py
@@ -11,7 +11,7 @@ class TestCycloneDxReport(unittest.TestCase):
 
     def test_valid_cyclonedx_bom(self):
         runners = (tf_graph_runner(), tf_plan_runner(),)
-        registry = RunnerRegistry(None, RunnerFilter(), *runners)
+        registry = RunnerRegistry("", "", RunnerFilter(), *runners)
         scan_reports = registry.run(files=[
             join(dirname(__file__), 'fixtures/main.tf')
         ])

--- a/tests/common/output/test_sarif_report.py
+++ b/tests/common/output/test_sarif_report.py
@@ -42,7 +42,7 @@ class TestSarifReport(unittest.TestCase):
         r.add_record(record=record1)
         r.add_record(record=record2)
         ts = r.get_test_suites()
-        json_structure = r.get_sarif_json()
+        json_structure = r.get_sarif_json("")
         print(json.dumps(json_structure))
         self.assertEqual(
             None,
@@ -187,7 +187,7 @@ class TestSarifReport(unittest.TestCase):
         r.add_record(record=record8)
         r.add_record(record=record9)
         r.get_test_suites()
-        json_structure = r.get_sarif_json()
+        json_structure = r.get_sarif_json("")
         print(json.dumps(json_structure))
         self.assertEqual(
             None,

--- a/tests/common/runner_registry/test_runner_registry.py
+++ b/tests/common/runner_registry/test_runner_registry.py
@@ -17,7 +17,7 @@ class TestRunnerRegistry(unittest.TestCase):
         test_files_dir = current_dir + "/example_multi_iac"
         runner_filter = RunnerFilter(framework=None, checks=None, skip_checks=None)
         runner_registry = RunnerRegistry(
-            banner, runner_filter, tf_runner(), cfn_runner(), k8_runner()
+            banner, "", runner_filter, tf_runner(), cfn_runner(), k8_runner()
         )
         reports = runner_registry.run(root_folder=test_files_dir)
         for report in reports:
@@ -28,7 +28,7 @@ class TestRunnerRegistry(unittest.TestCase):
         test_files_dir = current_dir + "/example_multi_iac"
         runner_filter = RunnerFilter(framework=None, checks=None, skip_checks=None)
         runner_registry = RunnerRegistry(
-            banner, runner_filter, tf_runner(), cfn_runner(), k8_runner()
+            banner, "", runner_filter, tf_runner(), cfn_runner(), k8_runner()
         )
         reports = runner_registry.run(root_folder=test_files_dir)
 
@@ -65,7 +65,7 @@ class TestRunnerRegistry(unittest.TestCase):
     def verify_empty_report(self, test_files_dir, files=None):
         runner_filter = RunnerFilter(framework=None, checks=None, skip_checks=None)
         runner_registry = RunnerRegistry(
-            banner, runner_filter, tf_runner(), cfn_runner(), k8_runner()
+            banner, "", runner_filter, tf_runner(), cfn_runner(), k8_runner()
         )
         reports = runner_registry.run(root_folder=test_files_dir, files=files)
         for report in reports:

--- a/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
+++ b/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
@@ -13,7 +13,7 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
     def test_enrichment_of_plan_report(self):
         allowed_checks = ["CKV_AWS_19", "CKV_AWS_20", "CKV_AWS_28", "CKV_AWS_63", "CKV_AWS_119"]
         runner_registry = RunnerRegistry(
-            banner, RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
+            banner, "", RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
         )
 
         repo_root = Path(__file__).parent / "plan_with_hcl_for_enrichment"
@@ -105,7 +105,7 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
     def test_enrichment_of_plan_report_with_modules(self):
         allowed_checks = ["CKV_AWS_66", "CKV_AWS_158"]
         runner_registry = RunnerRegistry(
-            banner, RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
+            banner, "", RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
         )
 
         repo_root = Path(__file__).parent / "plan_with_tf_modules_for_enrichment"
@@ -143,7 +143,7 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
     def test_skip_check(self):
         allowed_checks = ["CKV_AWS_20", "CKV_AWS_28"]
         runner_registry = RunnerRegistry(
-            banner, RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
+            banner, "", RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
         )
 
         repo_root = Path(__file__).parent / "plan_with_hcl_for_enrichment"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR adds the ability to use the right `tool` and `informationUri` in the SARIF output for `checkov` and `bridgecrew-py`