### PR TITLE
Use tool only for report prints

### DIFF
--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -31,14 +31,12 @@ class RunnerRegistry:
     runners: List[BaseRunner] = []
     scan_reports: List[Report] = []
     banner = ""
-    tool = ""
 
-    def __init__(self, banner: str, tool: str, runner_filter: RunnerFilter, *runners: BaseRunner) -> None:
+    def __init__(self, banner: str, runner_filter: RunnerFilter, *runners: BaseRunner) -> None:
         self.logger = logging.getLogger(__name__)
         self.runner_filter = runner_filter
         self.runners = list(runners)
         self.banner = banner
-        self.tool = tool
         self.scan_reports = []
         self.filter_runner_framework()
 
@@ -79,6 +77,7 @@ class RunnerRegistry:
         self,
         scan_reports: List[Report],
         config: argparse.Namespace,
+        tool: str,
         url: Optional[str] = None,
         created_baseline_path: Optional[str] = None,
         baseline: Optional[Baseline] = None,
@@ -135,7 +134,7 @@ class RunnerRegistry:
                 master_report.skipped_checks += report.skipped_checks
             if url:
                 print("More details: {}".format(url))
-            master_report.write_sarif_output(self.tool)
+            master_report.write_sarif_output(tool)
             output_formats.remove("sarif")
             if output_formats:
                 print(OUTPUT_DELIMITER)

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -20,7 +20,7 @@ from checkov.terraform.context_parsers.registry import parser_registry
 from checkov.terraform.runner import Runner as tf_runner
 from checkov.terraform.parser import Parser
 from checkov.common.parallelizer.parallel_runner import parallel_runner
-
+from checkov.common.util.banner import tool as tool_name
 
 CHECK_BLOCK_TYPES = frozenset(["resource", "data", "provider", "module"])
 OUTPUT_CHOICES = ["cli", "cyclonedx", "json", "junitxml", "github_failed_only", "sarif"]
@@ -77,7 +77,6 @@ class RunnerRegistry:
         self,
         scan_reports: List[Report],
         config: argparse.Namespace,
-        tool: str,
         url: Optional[str] = None,
         created_baseline_path: Optional[str] = None,
         baseline: Optional[Baseline] = None,
@@ -134,7 +133,7 @@ class RunnerRegistry:
                 master_report.skipped_checks += report.skipped_checks
             if url:
                 print("More details: {}".format(url))
-            master_report.write_sarif_output(tool)
+            master_report.write_sarif_output(tool_name)
             output_formats.remove("sarif")
             if output_formats:
                 print(OUTPUT_DELIMITER)

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -92,7 +92,7 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
         runner_registry = outer_registry
         runner_registry.runner_filter = runner_filter
     else:
-        runner_registry = RunnerRegistry(banner, tool_name, runner_filter, *DEFAULT_RUNNERS)
+        runner_registry = RunnerRegistry(banner, runner_filter, *DEFAULT_RUNNERS)
 
     runnerDependencyHandler = RunnerDependencyHandler(runner_registry)
     runnerDependencyHandler.validate_runner_deps()

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -54,7 +54,7 @@ DEFAULT_RUNNERS = (tf_graph_runner(), cfn_runner(), k8_runner(),
                    dockerfile_runner(), secrets_runner(), json_runner())
 
 
-def run(banner=checkov_banner, tool=tool_name, argv=sys.argv[1:]):
+def run(banner=checkov_banner, argv=sys.argv[1:]):
     default_config_paths = get_default_config_paths(sys.argv[1:])
     parser = ExtArgumentParser(description='Infrastructure as code static analysis',
                                default_config_files=default_config_paths,
@@ -92,7 +92,7 @@ def run(banner=checkov_banner, tool=tool_name, argv=sys.argv[1:]):
         runner_registry = outer_registry
         runner_registry.runner_filter = runner_filter
     else:
-        runner_registry = RunnerRegistry(banner, tool, runner_filter, *DEFAULT_RUNNERS)
+        runner_registry = RunnerRegistry(banner, tool_name, runner_filter, *DEFAULT_RUNNERS)
 
     runnerDependencyHandler = RunnerDependencyHandler(runner_registry)
     runnerDependencyHandler.validate_runner_deps()
@@ -196,7 +196,7 @@ def run(banner=checkov_banner, tool=tool_name, argv=sys.argv[1:]):
                 created_baseline_path = os.path.join(os.path.abspath(root_folder), '.checkov.baseline')
                 with open(created_baseline_path, 'w') as f:
                     json.dump(overall_baseline.to_dict(), f, indent=4)
-            exit_codes.append(runner_registry.print_reports(scan_reports, config, url=url, created_baseline_path=created_baseline_path, baseline=baseline))
+            exit_codes.append(runner_registry.print_reports(scan_reports, config, url=url, created_baseline_path=created_baseline_path, baseline=baseline, tool=tool_name))
         exit_code = 1 if 1 in exit_codes else 0
         return exit_code
     elif config.file:
@@ -220,7 +220,7 @@ def run(banner=checkov_banner, tool=tool_name, argv=sys.argv[1:]):
             bc_integration.persist_scan_results(scan_reports)
             url = bc_integration.commit_repository(config.branch)
         return runner_registry.print_reports(scan_reports, config, url=url, created_baseline_path=created_baseline_path,
-                                             baseline=baseline)
+                                             baseline=baseline, tool=tool_name)
     elif config.docker_image:
         if config.bc_api_key is None:
             parser.error("--bc-api-key argument is required when using --docker-image")

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -23,7 +23,6 @@ from checkov.common.output.baseline import Baseline
 from checkov.common.runners.runner_registry import RunnerRegistry, OUTPUT_CHOICES
 from checkov.common.checks.base_check_registry import BaseCheckRegistry
 from checkov.common.util.banner import banner as checkov_banner
-from checkov.common.util.banner import tool as tool_name
 from checkov.common.util.config_utils import get_default_config_paths
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 from checkov.common.util.docs_generator import print_checks
@@ -196,7 +195,7 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
                 created_baseline_path = os.path.join(os.path.abspath(root_folder), '.checkov.baseline')
                 with open(created_baseline_path, 'w') as f:
                     json.dump(overall_baseline.to_dict(), f, indent=4)
-            exit_codes.append(runner_registry.print_reports(scan_reports, config, url=url, created_baseline_path=created_baseline_path, baseline=baseline, tool=tool_name))
+            exit_codes.append(runner_registry.print_reports(scan_reports, config, url=url, created_baseline_path=created_baseline_path, baseline=baseline))
         exit_code = 1 if 1 in exit_codes else 0
         return exit_code
     elif config.file:
@@ -220,7 +219,7 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
             bc_integration.persist_scan_results(scan_reports)
             url = bc_integration.commit_repository(config.branch)
         return runner_registry.print_reports(scan_reports, config, url=url, created_baseline_path=created_baseline_path,
-                                             baseline=baseline, tool=tool_name)
+                                             baseline=baseline)
     elif config.docker_image:
         if config.bc_api_key is None:
             parser.error("--bc-api-key argument is required when using --docker-image")

--- a/tests/common/output/test_cyclonedx_report.py
+++ b/tests/common/output/test_cyclonedx_report.py
@@ -11,7 +11,7 @@ class TestCycloneDxReport(unittest.TestCase):
 
     def test_valid_cyclonedx_bom(self):
         runners = (tf_graph_runner(), tf_plan_runner(),)
-        registry = RunnerRegistry("", "", RunnerFilter(), *runners)
+        registry = RunnerRegistry("", RunnerFilter(), *runners)
         scan_reports = registry.run(files=[
             join(dirname(__file__), 'fixtures/main.tf')
         ])

--- a/tests/common/runner_registry/test_runner_registry.py
+++ b/tests/common/runner_registry/test_runner_registry.py
@@ -17,7 +17,7 @@ class TestRunnerRegistry(unittest.TestCase):
         test_files_dir = current_dir + "/example_multi_iac"
         runner_filter = RunnerFilter(framework=None, checks=None, skip_checks=None)
         runner_registry = RunnerRegistry(
-            banner, "", runner_filter, tf_runner(), cfn_runner(), k8_runner()
+            banner, runner_filter, tf_runner(), cfn_runner(), k8_runner()
         )
         reports = runner_registry.run(root_folder=test_files_dir)
         for report in reports:
@@ -28,7 +28,7 @@ class TestRunnerRegistry(unittest.TestCase):
         test_files_dir = current_dir + "/example_multi_iac"
         runner_filter = RunnerFilter(framework=None, checks=None, skip_checks=None)
         runner_registry = RunnerRegistry(
-            banner, "", runner_filter, tf_runner(), cfn_runner(), k8_runner()
+            banner, runner_filter, tf_runner(), cfn_runner(), k8_runner()
         )
         reports = runner_registry.run(root_folder=test_files_dir)
 
@@ -65,7 +65,7 @@ class TestRunnerRegistry(unittest.TestCase):
     def verify_empty_report(self, test_files_dir, files=None):
         runner_filter = RunnerFilter(framework=None, checks=None, skip_checks=None)
         runner_registry = RunnerRegistry(
-            banner, "", runner_filter, tf_runner(), cfn_runner(), k8_runner()
+            banner, runner_filter, tf_runner(), cfn_runner(), k8_runner()
         )
         reports = runner_registry.run(root_folder=test_files_dir, files=files)
         for report in reports:

--- a/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
+++ b/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
@@ -13,7 +13,7 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
     def test_enrichment_of_plan_report(self):
         allowed_checks = ["CKV_AWS_19", "CKV_AWS_20", "CKV_AWS_28", "CKV_AWS_63", "CKV_AWS_119"]
         runner_registry = RunnerRegistry(
-            banner, "", RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
+            banner, RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
         )
 
         repo_root = Path(__file__).parent / "plan_with_hcl_for_enrichment"
@@ -105,7 +105,7 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
     def test_enrichment_of_plan_report_with_modules(self):
         allowed_checks = ["CKV_AWS_66", "CKV_AWS_158"]
         runner_registry = RunnerRegistry(
-            banner, "", RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
+            banner, RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
         )
 
         repo_root = Path(__file__).parent / "plan_with_tf_modules_for_enrichment"
@@ -143,7 +143,7 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
     def test_skip_check(self):
         allowed_checks = ["CKV_AWS_20", "CKV_AWS_28"]
         runner_registry = RunnerRegistry(
-            banner, "", RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
+            banner, RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
         )
 
         repo_root = Path(__file__).parent / "plan_with_hcl_for_enrichment"


### PR DESCRIPTION
Removed the added `tool` argument in the `RunnerRegistry` constructor, and passed it directly to the print function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
