### PR TITLE
Select correct runner for --framework terraform_plan

### DIFF
--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -189,7 +189,7 @@ class RunnerRegistry:
             return
         if self.runner_filter.framework == "all":
             return
-        self.runners = [runner for runner in self.runners if runner.check_type in self.runner_filter.framework]
+        self.runners = [runner for runner in self.runners if runner.check_type == self.runner_filter.framework]
 
     def remove_runner(self, runner: BaseRunner) -> None:
         if runner in self.runners:


### PR DESCRIPTION
This PR fixes the following problem:

If we run checkov with `--framework terraform_plan` the previous runners would include both `terraform_plan` and `terraform` because 
`runner.check_type='terraform' in self.runner_filter.framework='terraform_plan'`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
