### PR TITLE
Add checks for NGINX Ingress CVE-2021-25742

### DIFF
--- a/checkov/kubernetes/checks/NginxIngressCVE202125742Alias.py
+++ b/checkov/kubernetes/checks/NginxIngressCVE202125742Alias.py
@@ -1,0 +1,33 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.common.util.data_structures_utils import find_in_dict
+from checkov.kubernetes.base_spec_check import BaseK8Check
+from checkov.common.util.type_forcers import force_list
+import re
+
+
+class NginxIngressCVE202125742Alias(BaseK8Check):
+
+    def __init__(self):
+        name = "Prevent NGINX Ingress annotation snippets which contain alias statements See CVE-2021-25742"
+        id = "CKV_K8S_154"
+        supported_kind = ['Ingress']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
+
+    def get_resource_id(self, conf):
+        if "namespace" in conf["metadata"]:
+            return "{}.{}.{}".format(conf["kind"], conf["metadata"]["name"], conf["metadata"]["namespace"])
+        else:
+            return "{}.{}.default".format(conf["kind"], conf["metadata"]["name"])
+
+    def scan_spec_conf(self, conf):
+
+        if conf["metadata"]:
+            if conf["metadata"].get('annotations'):
+                for annotation in force_list(conf["metadata"]["annotations"]):
+                    for key, value in annotation.items():
+                        if "snippet" in key and "alias" in value:
+                            return CheckResult.FAILED
+        return CheckResult.PASSED
+
+check = NginxIngressCVE202125742Alias()

--- a/checkov/kubernetes/checks/NginxIngressCVE202125742AllSnippets.py
+++ b/checkov/kubernetes/checks/NginxIngressCVE202125742AllSnippets.py
@@ -23,16 +23,11 @@ class NginxIngressCVE202125742AllSnippets(BaseK8Check):
     def scan_spec_conf(self, conf):
 
         if conf["metadata"]:
-            if conf["metadata"]["annotations"]:
-                if conf["metadata"].get('annotations'):
-                    for annotation in force_list(conf["metadata"]["annotations"]):
-                        for key in annotation:
-                            if "snippet" in key:
-                                return CheckResult.FAILED
-                            else:
-                                return CheckResult.PASSED
-                else:
-                    CheckResult.PASSED
+            if conf["metadata"].get('annotations'):
+                for annotation in force_list(conf["metadata"]["annotations"]):
+                    for key in annotation:
+                        if "snippet" in key:
+                            return CheckResult.FAILED
         return CheckResult.PASSED
 
 check = NginxIngressCVE202125742AllSnippets()

--- a/checkov/kubernetes/checks/NginxIngressCVE202125742AllSnippets.py
+++ b/checkov/kubernetes/checks/NginxIngressCVE202125742AllSnippets.py
@@ -1,0 +1,38 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.common.util.data_structures_utils import find_in_dict
+from checkov.kubernetes.base_spec_check import BaseK8Check
+from checkov.common.util.type_forcers import force_list
+import re
+
+
+class NginxIngressCVE202125742AllSnippets(BaseK8Check):
+
+    def __init__(self):
+        name = "Prevent All NGINX Ingress annotation snippets. See CVE-2021-25742"
+        id = "CKV_K8S_153"
+        supported_kind = ['Ingress']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
+
+    def get_resource_id(self, conf):
+        if "namespace" in conf["metadata"]:
+            return "{}.{}.{}".format(conf["kind"], conf["metadata"]["name"], conf["metadata"]["namespace"])
+        else:
+            return "{}.{}.default".format(conf["kind"], conf["metadata"]["name"])
+
+    def scan_spec_conf(self, conf):
+
+        if conf["metadata"]:
+            if conf["metadata"]["annotations"]:
+                if conf["metadata"].get('annotations'):
+                    for annotation in force_list(conf["metadata"]["annotations"]):
+                        for key in annotation:
+                            if "snippet" in key:
+                                return CheckResult.FAILED
+                            else:
+                                return CheckResult.PASSED
+                else:
+                    CheckResult.PASSED
+        return CheckResult.PASSED
+
+check = NginxIngressCVE202125742AllSnippets()

--- a/checkov/kubernetes/checks/NginxIngressCVE202125742Lua.py
+++ b/checkov/kubernetes/checks/NginxIngressCVE202125742Lua.py
@@ -24,17 +24,11 @@ class NginxIngressCVE202125742Lua(BaseK8Check):
         badInjectionPatterns = "\\blua_|_lua\\b|_lua_|\\bkubernetes\\.io\\b"
 
         if conf["metadata"]:
-            if conf["metadata"]["annotations"]:
-                if conf["metadata"].get('annotations'):
-                    for annotation in force_list(conf["metadata"]["annotations"]):
-                        for key in annotation:
-                            if "snippet" in key:
-                                if re.match(badInjectionPatterns ,annotation[key]):
-                                    return CheckResult.FAILED
-                            else:
-                                return CheckResult.PASSED
-                else:
-                    CheckResult.PASSED
+            if conf["metadata"].get('annotations'):
+                for annotation in force_list(conf["metadata"]["annotations"]):
+                    for key, value in annotation.items():
+                        if "snippet" in key and  re.match(badInjectionPatterns, value):
+                            return CheckResult.FAILED
         return CheckResult.PASSED
 
 check = NginxIngressCVE202125742Lua()

--- a/checkov/kubernetes/checks/NginxIngressCVE202125742Lua.py
+++ b/checkov/kubernetes/checks/NginxIngressCVE202125742Lua.py
@@ -1,0 +1,40 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.common.util.data_structures_utils import find_in_dict
+from checkov.kubernetes.base_spec_check import BaseK8Check
+from checkov.common.util.type_forcers import force_list
+import re
+
+
+class NginxIngressCVE202125742Lua(BaseK8Check):
+
+    def __init__(self):
+        name = "Prevent NGINX Ingress annotation snippets which contain LUA code execution. See CVE-2021-25742"
+        id = "CKV_K8S_152"
+        supported_kind = ['Ingress']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
+
+    def get_resource_id(self, conf):
+        if "namespace" in conf["metadata"]:
+            return "{}.{}.{}".format(conf["kind"], conf["metadata"]["name"], conf["metadata"]["namespace"])
+        else:
+            return "{}.{}.default".format(conf["kind"], conf["metadata"]["name"])
+
+    def scan_spec_conf(self, conf):
+        badInjectionPatterns = "\\blua_|_lua\\b|_lua_|\\bkubernetes\\.io\\b"
+
+        if conf["metadata"]:
+            if conf["metadata"]["annotations"]:
+                if conf["metadata"].get('annotations'):
+                    for annotation in force_list(conf["metadata"]["annotations"]):
+                        for key in annotation:
+                            if "snippet" in key:
+                                if re.match(badInjectionPatterns ,annotation[key]):
+                                    return CheckResult.FAILED
+                            else:
+                                return CheckResult.PASSED
+                else:
+                    CheckResult.PASSED
+        return CheckResult.PASSED
+
+check = NginxIngressCVE202125742Lua()

--- a/tests/kubernetes/checks/example_NginxIngressCVE202125742/annotation1-FAILED.yaml
+++ b/tests/kubernetes/checks/example_NginxIngressCVE202125742/annotation1-FAILED.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app-ingress
+  annotations:  
+    nginx.ingress.kubernetes.io/server-snippet: |    
+      lua_package_path  "/etc/nginx/lua/?.lua;;";
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - http:    
+    paths:      
+      - path: /exp        
+        pathType: Prefix        
+        backend:          
+          service:            
+            name: some-service            
+            port:              
+              number: 1234

--- a/tests/kubernetes/checks/example_NginxIngressCVE202125742/annotation2-nollua-PASSESONEFAILSONE.yaml
+++ b/tests/kubernetes/checks/example_NginxIngressCVE202125742/annotation2-nollua-PASSESONEFAILSONE.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app-ingress
+  annotations:  
+    nginx.ingress.kubernetes.io/server-snippet: |    
+      location / {      
+        return 200 'OK';    
+      }  
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - http:    
+    paths:      
+      - path: /exp        
+        pathType: Prefix        
+        backend:          
+          service:            
+            name: some-service            
+            port:              
+              number: 1234

--- a/tests/kubernetes/checks/example_NginxIngressCVE202125742/annotation3-alias.yaml
+++ b/tests/kubernetes/checks/example_NginxIngressCVE202125742/annotation3-alias.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-ingress
+  namespace: developer
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location ^~ "/test" {
+        default_type 'text/plain';
+        alias /var/run;
+      }
+spec:
+  rules:
+  - http:
+      paths:
+        - path: /test
+          pathType: Prefix
+          backend:
+            service:
+              name: web
+              port:
+                number: 8080

--- a/tests/kubernetes/checks/example_NginxIngressCVE202125742/noannotations-PASSED.yaml
+++ b/tests/kubernetes/checks/example_NginxIngressCVE202125742/noannotations-PASSED.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app-ingress
+  annotations:  
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - http:    
+    paths:      
+      - path: /exp        
+        pathType: Prefix        
+        backend:          
+          service:            
+            name: some-service            
+            port:              
+              number: 1234

--- a/tests/kubernetes/checks/test_NginxIngressCVE202125742Alias.py
+++ b/tests/kubernetes/checks/test_NginxIngressCVE202125742Alias.py
@@ -1,12 +1,12 @@
 import os
 import unittest
 
-from checkov.kubernetes.checks.NginxIngressCVE202125742AllSnippets import check
+from checkov.kubernetes.checks.NginxIngressCVE202125742Alias import check
 from checkov.kubernetes.runner import Runner
 from checkov.runner_filter import RunnerFilter
 
 
-class TestNginxIngressCVE202125742AllSnippets(unittest.TestCase):
+class TestNginxIngressCVE202125742Alias(unittest.TestCase):
 
     def test_summary(self):
         runner = Runner()
@@ -16,8 +16,8 @@ class TestNginxIngressCVE202125742AllSnippets(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 3)
+        self.assertEqual(summary['passed'], 3)
+        self.assertEqual(summary['failed'], 1)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/kubernetes/checks/test_NginxIngressCVE202125742AllSnippets.py
+++ b/tests/kubernetes/checks/test_NginxIngressCVE202125742AllSnippets.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.kubernetes.checks.NginxIngressCVE202125742AllSnippets import check
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestNginxIngressCVE202125742AllSnippets(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_NginxIngressCVE202125742"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/kubernetes/checks/test_NginxIngressCVE202125742Lua.py
+++ b/tests/kubernetes/checks/test_NginxIngressCVE202125742Lua.py
@@ -16,7 +16,7 @@ class TestNginxIngressCVE202125742Lua(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['passed'], 3)
         self.assertEqual(summary['failed'], 1)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/kubernetes/checks/test_NginxIngressCVE202125742Lua.py
+++ b/tests/kubernetes/checks/test_NginxIngressCVE202125742Lua.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.kubernetes.checks.NginxIngressCVE202125742Lua import check
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestNginxIngressCVE202125742Lua(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_NginxIngressCVE202125742"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR Contains two new Kubernetes checks based on detecting CVE-2021-25742.
(More details on the CVE Here: https://github.com/kubernetes/ingress-nginx/issues/7837).

The first check fails if there are annotations containing configuration snippets **AND** it looks like those snippets contain lua-related directives or access the kubernetes.io secrets/config paths.

The second check is wider, and will fail if there are any annotations related to nginx configuration snippets.

This gives users a choice, as conversations in https://github.com/kubernetes/ingress-nginx/issues/7837 suggest that fully blocking snippets in annotations works well, but for others they need snippets and just want to block lua script directives.

A user could chose which they need by either `--skip-checks CKV_K8S_152` or `--skip-checks CKV_K8S_153` globally on the `checkov` command line, or use the `SKIP_CHECK` annotations for checkov directly in their k8s manifests or helm/kustomize charts.

@eurogig Would love some feedback/other examples for the tests directory if you have anything more creative ;)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
