### PR TITLE
Add terraform github ssh module loader

### DIFF
--- a/checkov/terraform/module_loading/loaders/github_loader.py
+++ b/checkov/terraform/module_loading/loaders/github_loader.py
@@ -7,6 +7,10 @@ class GithubLoader(GenericGitLoader):
         if self.module_source.startswith("github.com"):
             self.module_source = f"git::https://{self.module_source}"
             return True
+        if self.module_source.startswith("git@github.com"):
+            source = self.module_source.replace(":", "/")
+            self.module_source = f"git::ssh://{source}"
+            return True
         return False
 
 


### PR DESCRIPTION
The current approach works for terraform modules on Github, publicly accessible
using the HTTPS scheme. This change also adds support for private Github repositories,
accessible using the SSH scheme.

https://www.terraform.io/docs/language/modules/sources.html#github

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
