### PR TITLE
CKV_GCP_14: Add check that ignores Cloud SQL replica instances

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleCloudSqlBackupConfiguration.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudSqlBackupConfiguration.py
@@ -1,28 +1,21 @@
 from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class GoogleCloudSqlBackupConfiguration(BaseResourceCheck):
+class GoogleCloudSqlBackupConfiguration(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure all Cloud SQL database instance have backup configuration enabled"
         id = "CKV_GCP_14"
         supported_resources = ['google_sql_database_instance']
-        categories = [CheckCategories.NETWORKING]
+        categories = [CheckCategories.BACKUP_AND_RECOVERY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
         if 'master_instance_name' in conf:
-           return CheckResult.PASSED
-        
-        if 'settings' in conf:
-            settings = conf["settings"][0]
-            if isinstance(settings, dict) and 'backup_configuration' in settings:
-                backup_configuration = settings["backup_configuration"][0]
-                if backup_configuration.get("enabled", None) == [True]:
-                    return CheckResult.PASSED
+            return CheckResult.UNKNOWN
+        return super().scan_resource_conf(conf)
 
-                return CheckResult.FAILED
-            return CheckResult.FAILED
-        return CheckResult.FAILED
+    def get_inspected_key(self):
+        return "settings/[0]/backup_configuration/[0]/enabled"
 
 check = GoogleCloudSqlBackupConfiguration()

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudSqlBackupConfiguration.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudSqlBackupConfiguration.py
@@ -1,8 +1,8 @@
-from checkov.common.models.enums import CheckCategories
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
 
 
-class GoogleCloudSqlBackupConfiguration(BaseResourceValueCheck):
+class GoogleCloudSqlBackupConfiguration(BaseResourceCheck):
     def __init__(self):
         name = "Ensure all Cloud SQL database instance have backup configuration enabled"
         id = "CKV_GCP_14"
@@ -10,8 +10,19 @@ class GoogleCloudSqlBackupConfiguration(BaseResourceValueCheck):
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return 'settings/[0]/backup_configuration/[0]/enabled'
+    def scan_resource_conf(self, conf):
+        if 'master_instance_name' in conf:
+           return CheckResult.PASSED
+        
+        if 'settings' in conf:
+            settings = conf["settings"][0]
+            if isinstance(settings, dict) and 'backup_configuration' in settings:
+                backup_configuration = settings["backup_configuration"][0]
+                if backup_configuration.get("enabled", None) == [True]:
+                    return CheckResult.PASSED
 
+                return CheckResult.FAILED
+            return CheckResult.FAILED
+        return CheckResult.FAILED
 
 check = GoogleCloudSqlBackupConfiguration()

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlBackupConfiguration.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlBackupConfiguration.py
@@ -22,11 +22,11 @@ class GoogleCloudSqlDatabaseBackupConfiguration(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-    def test_replica_success(self):
+    def test_replica_unknown(self):
         resource_conf = {'name': ['google_cluster'], 'monitoring_service': ['none'], 'master_instance_name': 'foo'}
 
         scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
 
 
 if __name__ == '__main__':

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlBackupConfiguration.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlBackupConfiguration.py
@@ -28,6 +28,5 @@ class GoogleCloudSqlDatabaseBackupConfiguration(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.UNKNOWN, scan_result)
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlBackupConfiguration.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlBackupConfiguration.py
@@ -22,6 +22,12 @@ class GoogleCloudSqlDatabaseBackupConfiguration(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_replica_success(self):
+        resource_conf = {'name': ['google_cluster'], 'monitoring_service': ['none'], 'master_instance_name': 'foo'}
+
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Solves the false positive mentioned in https://github.com/bridgecrewio/checkov/issues/727.

The `master_instance_name` attribute is used to [point the replica to a master instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#master_instance_name). So the existence of this attribute means the current resource is a replica.

This PR adds a little check that checks if the attribute exists and passes it if it does.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
