### PR TITLE
Auth error handling

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -178,10 +178,9 @@ class BcPlatformIntegration(object):
         token = self.get_auth_token()
         request = self.http.request("POST", self.integrations_api_url, body=json.dumps({"repoId": repo_id}),
                                     headers={"Authorization": token, "Content-Type": "application/json"})
-        response_data = request.data.decode("utf8")
         if request.status == 403:
             raise BridgecrewAuthError()
-        response = json.loads(response_data)
+        response = json.loads(request.data.decode("utf8"))
         while ('Message' in response or 'message' in response):
             if 'Message' in response and response['Message'] == UNAUTHORIZED_MESSAGE:
                 raise BridgecrewAuthError()

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -27,6 +27,7 @@ from checkov.common.bridgecrew.wrapper import reduce_scan_reports, persist_check
     enrich_and_persist_checks_metadata
 from checkov.common.models.consts import SUPPORTED_FILE_EXTENSIONS
 from checkov.common.runners.base_runner import filter_ignored_paths
+from checkov.common.util.http_utils import normalize_prisma_url
 from checkov.version import version as checkov_version
 
 EMAIL_PATTERN = r"[^@]+@[^@]+\.[^@]+"
@@ -62,7 +63,7 @@ class BcPlatformIntegration(object):
         self.timestamp = None
         self.scan_reports = []
         self.api_url = os.getenv('BC_API_URL', "https://www.bridgecrew.cloud")
-        self.prisma_url = os.getenv("PRISMA_API_URL")
+        self.prisma_url = normalize_prisma_url(os.getenv("PRISMA_API_URL"))
         if self.prisma_url:
             self.api_url = f"{self.prisma_url}/bridgecrew"
         self.bc_source = None
@@ -97,6 +98,8 @@ class BcPlatformIntegration(object):
         request = self.http.request("POST", f"{self.prisma_url}/login",
                                     body=json.dumps({"username": username, "password": password}),
                                     headers={"Content-Type": "application/json"})
+        if request.status == 401:
+            raise BridgecrewAuthError()
         token = json.loads(request.data.decode("utf8"))['token']
         return token
 
@@ -135,6 +138,9 @@ class BcPlatformIntegration(object):
         self.bc_source = source
         self.bc_source_version = source_version
 
+        if self.prisma_url:
+            logging.info(f'Using Prisma API URL: {self.prisma_url}')
+
         if self.bc_source.upload_results:
             try:
                 self.skip_fixes = True  # no need to run fixes on CI integration
@@ -160,6 +166,9 @@ class BcPlatformIntegration(object):
             except JSONDecodeError as e:
                 logging.error(f"Response of {self.integrations_api_url} is not a valid JSON\n{e}")
                 raise e
+            except BridgecrewAuthError as e:
+                logging.error("Received an error response during authentication")
+                raise e
 
         self.get_id_mapping()
 
@@ -169,7 +178,10 @@ class BcPlatformIntegration(object):
         token = self.get_auth_token()
         request = self.http.request("POST", self.integrations_api_url, body=json.dumps({"repoId": repo_id}),
                                     headers={"Authorization": token, "Content-Type": "application/json"})
-        response = json.loads(request.data.decode("utf8"))
+        response_data = request.data.decode("utf8")
+        if request.status == 403:
+            raise BridgecrewAuthError()
+        response = json.loads(response_data)
         while ('Message' in response or 'message' in response):
             if 'Message' in response and response['Message'] == UNAUTHORIZED_MESSAGE:
                 raise BridgecrewAuthError()

--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -10,6 +10,12 @@ from checkov.version import version as checkov_version
 logger = logging.getLogger(__name__)
 
 
+def normalize_prisma_url(prisma_url: str):
+    if not prisma_url:
+        return None
+    return prisma_url[0:-1] if prisma_url.endswith('/') else prisma_url
+
+
 def extract_error_message(response: requests.Response):
     if response.content:
         try:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -143,8 +143,17 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
             platform_excluded_paths = bc_integration.get_excluded_paths() or []
             runner_filter.excluded_paths = runner_filter.excluded_paths + platform_excluded_paths
         except Exception as e:
-            logger.error('An error occurred setting up the Bridgecrew platform integration. Please check your API token'
-                         ' and try again.', exc_info=True)
+            if bc_integration.prisma_url:
+                message = 'An error occurred setting up the Bridgecrew platform integration. Please check your API ' \
+                          'token and PRISMA_API_URL environment variable and try again. The PRISMA_API_URL value ' \
+                          'should be similar to: `https://api0.prismacloud.io`'
+            else:
+                message = 'An error occurred setting up the Bridgecrew platform integration. Please check your API ' \
+                          'token and try again.'
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(message, exc_info=True)
+            else:
+                logger.error(message)
             return
     else:
         logger.debug('No API key found. Scanning locally only.')

--- a/tests/common/utils/test_utils.py
+++ b/tests/common/utils/test_utils.py
@@ -4,6 +4,7 @@ import unittest
 from checkov.common.models.consts import SCAN_HCL_FLAG
 from checkov.common.util.config_utils import should_scan_hcl_files
 from checkov.common.util.data_structures_utils import merge_dicts
+from checkov.common.util.http_utils import normalize_prisma_url
 
 
 class TestUtils(unittest.TestCase):
@@ -52,6 +53,13 @@ class TestUtils(unittest.TestCase):
 
         if orig_value:
             os.environ[SCAN_HCL_FLAG] = orig_value
+
+
+    def test_normalize_prisma_url(self):
+        self.assertEqual('https://api0.prismacloud.io', normalize_prisma_url('https://api0.prismacloud.io'))
+        self.assertEqual('https://api0.prismacloud.io', normalize_prisma_url('https://api0.prismacloud.io/'))
+        self.assertIsNone(normalize_prisma_url(''))
+        self.assertIsNone(normalize_prisma_url(None))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Adds some better error handling and messaging around auth errors, which are causing users a lot of trouble in the beta.

Also trims a trailing slash off the Prisma API URL, which causes 404s.