### PR TITLE
Performance tests

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -98,13 +98,11 @@ jobs:
       - uses: actions/setup-node@v2
       - uses: azure/setup-helm@v1
       - uses: dschep/install-pipenv-action@v1
-      - name: Build & install checkov package
+      - name: Install dependencies
         run: |
-          pipenv --python ${{ matrix.python }}
+          pipenv --python 3.7
           pipenv run pip install --upgrade pip==21.1.1
           pipenv run pip install pytest pytest-benchmark
-          pipenv run python setup.py sdist bdist_wheel
-          bash -c 'pipenv run pip install dist/checkov-*.whl'
       - name: Clone terraform-aws-components
         run: git clone --branch 0.182.0 https://github.com/cloudposse/terraform-aws-components.git
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -91,10 +91,9 @@ jobs:
       fail-fast: true
       matrix:
         python: ["3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       working-directory: ./performance_tests
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -119,7 +118,7 @@ jobs:
       - name: Clone aws-cloudformation-templates
         run: git clone --branch 0.0.1 https://github.com/awslabs/aws-cloudformation-templates.git
         working-directory: ${{ env.working-directory }}
-      - name: Clone aws-samples/eks-workshop
+      - name: Clone kubernetes-yaml-templates
         run: git clone https://github.com/dennyzhang/kubernetes-yaml-templates.git
         working-directory: ${{ env.working-directory }}
       - name: Run performance tests

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -98,11 +98,13 @@ jobs:
       - uses: actions/setup-node@v2
       - uses: azure/setup-helm@v1
       - uses: dschep/install-pipenv-action@v1
-      - name: Install dependencies
+      - name: Build & install checkov package
         run: |
-          pipenv --python 3.7
+          pipenv --python ${{ matrix.python }}
           pipenv run pip install --upgrade pip==21.1.1
           pipenv run pip install pytest pytest-benchmark
+          pipenv run python setup.py sdist bdist_wheel
+          bash -c 'pipenv run pip install dist/checkov-*.whl'
       - name: Clone terraform-aws-components
         run: git clone --branch 0.182.0 https://github.com/cloudposse/terraform-aws-components.git
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -85,3 +85,38 @@ jobs:
       - name: Run integration tests
         run: |
           pipenv run pytest integration_tests -k 'not api_key'
+
+  performance-tests:
+    strategy:
+      fail-fast: true
+      matrix:
+        python: ["3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      working-directory: ./performance_tests
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/setup-node@v2
+      - uses: azure/setup-helm@v1
+      - uses: dschep/install-pipenv-action@v1
+        with:
+          # version 2021.11.5, 2021.11.5.post0 do not work
+          version: 2021.5.29
+      - name: Build & install checkov package
+        run: |
+          pipenv --python ${{ matrix.python }}
+          pipenv run pip install --upgrade pip==21.1.1
+          pipenv run pip install pytest pytest-benchmark
+          pipenv run python setup.py sdist bdist_wheel
+          bash -c 'pipenv run pip install dist/checkov-*.whl'
+      - name: Clone Terragoat - vulnerable terraform
+        run: git clone https://github.com/bridgecrewio/terragoat
+        working-directory: ${{ env.working-directory }}
+      - name: Run performance tests
+        run: |
+          pipenv run pytest
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -119,9 +119,6 @@ jobs:
       - name: Clone aws-cloudformation-templates
         run: git clone --branch 0.0.1 https://github.com/awslabs/aws-cloudformation-templates.git
         working-directory: ${{ env.working-directory }}
-      - name: Clone terraform-aws-components
-        run: git clone --branch 0.182.0 https://github.com/cloudposse/terraform-aws-components.git
-        working-directory: ${{ env.working-directory }}
       - name: Clone aws-samples/eks-workshop
         run: git clone https://github.com/dennyzhang/kubernetes-yaml-templates.git
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -113,8 +113,17 @@ jobs:
           pipenv run pip install pytest pytest-benchmark
           pipenv run python setup.py sdist bdist_wheel
           bash -c 'pipenv run pip install dist/checkov-*.whl'
-      - name: Clone Terragoat - vulnerable terraform
-        run: git clone https://github.com/bridgecrewio/terragoat
+      - name: Clone terraform-aws-components
+        run: git clone --branch 0.182.0 https://github.com/cloudposse/terraform-aws-components.git
+        working-directory: ${{ env.working-directory }}
+      - name: Clone aws-cloudformation-templates
+        run: git clone --branch 0.0.1 https://github.com/awslabs/aws-cloudformation-templates.git
+        working-directory: ${{ env.working-directory }}
+      - name: Clone terraform-aws-components
+        run: git clone --branch 0.182.0 https://github.com/cloudposse/terraform-aws-components.git
+        working-directory: ${{ env.working-directory }}
+      - name: Clone aws-samples/eks-workshop
+        run: git clone https://github.com/dennyzhang/kubernetes-yaml-templates.git
         working-directory: ${{ env.working-directory }}
       - name: Run performance tests
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7"]
     env:
       working-directory: ./performance_tests
     runs-on: ubuntu-latest
@@ -102,9 +102,6 @@ jobs:
       - uses: actions/setup-node@v2
       - uses: azure/setup-helm@v1
       - uses: dschep/install-pipenv-action@v1
-        with:
-          # version 2021.11.5, 2021.11.5.post0 do not work
-          version: 2021.5.29
       - name: Build & install checkov package
         run: |
           pipenv --python ${{ matrix.python }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -89,18 +89,19 @@ jobs:
   performance-tests:
     env:
       working-directory: ./performance_tests
+      python-version: 3.7
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ env.python-version }}
       - uses: actions/setup-node@v2
       - uses: azure/setup-helm@v1
       - uses: dschep/install-pipenv-action@v1
       - name: Build & install checkov package
         run: |
-          pipenv --python ${{ matrix.python }}
+          pipenv --python ${{ env.python-version }}
           pipenv run pip install --upgrade pip==21.1.1
           pipenv run pip install pytest pytest-benchmark
           pipenv run python setup.py sdist bdist_wheel

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -87,10 +87,6 @@ jobs:
           pipenv run pytest integration_tests -k 'not api_key'
 
   performance-tests:
-    strategy:
-      fail-fast: true
-      matrix:
-        python: ["3.7"]
     env:
       working-directory: ./performance_tests
     runs-on: ubuntu-latest
@@ -98,7 +94,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.7
       - uses: actions/setup-node@v2
       - uses: azure/setup-helm@v1
       - uses: dschep/install-pipenv-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ fabric.properties
 
 # Checkov baseline file
 .checkov.baseline
+
+# pytest-benchmarks output directory
+.benchmarks/

--- a/performance_tests/pytest.ini
+++ b/performance_tests/pytest.ini
@@ -1,2 +1,2 @@
-# Empty pytest conf file to not use pytest-xdist args from root pytest configurations
+# Empty pytest conf file to not use pytest-xdist args from root folder pytest configuration
 [pytest]

--- a/performance_tests/pytest.ini
+++ b/performance_tests/pytest.ini
@@ -1,0 +1,2 @@
+# Empty pytest conf file to not use pytest-xdist args from root pytest configurations
+[pytest]

--- a/performance_tests/test_checkov_performance.py
+++ b/performance_tests/test_checkov_performance.py
@@ -10,19 +10,19 @@ from checkov.runner_filter import RunnerFilter
 from checkov.terraform.runner import Runner as tf_runner
 
 # Ensure repo_name is a cloned repository into performance_tests directory.
-# Thresholds are in ms, and are set to the current maximum duration
+# Thresholds are in ms, and are set to the current maximum duration of checkov on the repository
 performance_configurations = {
     'terraform': {
         'repo_name': 'terraform-aws-components',
-        'threshold': 32.6493
+        'threshold': 28.5597
     },
     'cloudformation': {
-        'repo_name': 'terraform-aws-components',
-        'threshold': 66.5699
+        'repo_name': 'aws-cloudformation-templates',
+        'threshold': 746.7401
     },
     'kubernetes': {
         'repo_name': 'kubernetes-yaml-templates',
-        'threshold': 673.8789
+        'threshold': 631.3357
     }
 }
 

--- a/performance_tests/test_checkov_performance.py
+++ b/performance_tests/test_checkov_performance.py
@@ -1,10 +1,6 @@
-import math
 import os
-
 import pytest
 import time
-
-from pytest_benchmark.plugin import benchmark
 
 from checkov.cloudformation.runner import Runner as cfn_runner
 from checkov.common.runners.runner_registry import RunnerRegistry
@@ -13,22 +9,95 @@ from checkov.kubernetes.runner import Runner as k8_runner
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.runner import Runner as tf_runner
 
+# Ensure repo_name is a cloned repository into performance_tests directory.
+# Thresholds are in ms, and are set to the current maximum duration
+performance_configurations = {
+    'terraform': {
+        'repo_name': 'terraform-aws-components',
+        'threshold': 32.6493
+    },
+    'cloudformation': {
+        'repo_name': 'terraform-aws-components',
+        'threshold': 66.5699
+    },
+    'kubernetes': {
+        'repo_name': 'kubernetes-yaml-templates',
+        'threshold': 673.8789
+    }
+}
+
+deviation_percent = 10
+
+
 @pytest.mark.benchmark(
-    group="performance-tests",
-    min_time=0,
-    max_time=120,
-    min_rounds=1,
-    timer=time.time,
+    group="terraform-performance-tests",
     disable_gc=True,
-    warmup=False
+    min_time=0.1,
+    max_time=0.5,
+    min_rounds=5,
+    timer=time.time,
+    warmup=False,
 )
-def test_performance(benchmark):
-    def test_terragoat():
+def test_terraform_performance(benchmark):
+    repo_name = performance_configurations['terraform']['repo_name']
+    repo_threshold = performance_configurations['terraform']['threshold']
+
+    def run_terraform_scan():
         current_dir = os.path.dirname(os.path.realpath(__file__))
-        test_files_dir = "/Users/tronxd/clones/tronxd/terragoat"  # TODO run on forked data
+        test_files_dir = os.path.join(current_dir, repo_name)
         runner_filter = RunnerFilter()
         runner_registry = RunnerRegistry(banner, runner_filter, tf_runner())
         reports = runner_registry.run(root_folder=test_files_dir)
         assert len(reports) > 0
 
-    benchmark(test_terragoat)
+    benchmark(run_terraform_scan)
+    assert benchmark.stats.stats.mean <= repo_threshold + (deviation_percent / 100.0) * repo_threshold
+
+
+@pytest.mark.benchmark(
+    group="cloudformation-performance-tests",
+    disable_gc=True,
+    min_time=0.1,
+    max_time=0.5,
+    min_rounds=5,
+    timer=time.time,
+    warmup=False
+)
+def test_cloudformation_performance(benchmark):
+    repo_name = performance_configurations['cloudformation']['repo_name']
+    repo_threshold = performance_configurations['cloudformation']['threshold']
+
+    def run_cloudformation_scan():
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        test_files_dir = os.path.join(current_dir, repo_name)
+        runner_filter = RunnerFilter()
+        runner_registry = RunnerRegistry(banner, runner_filter, cfn_runner())
+        reports = runner_registry.run(root_folder=test_files_dir)
+        assert len(reports) > 0
+
+    benchmark(run_cloudformation_scan)
+    assert benchmark.stats.stats.mean <= repo_threshold + (deviation_percent / 100) * repo_threshold
+
+@pytest.mark.benchmark(
+    group="kubernetes-performance-tests",
+    disable_gc=True,
+    min_time=0.1,
+    max_time=0.5,
+    min_rounds=5,
+    timer=time.time,
+    warmup=False
+)
+def test_k8_performance(benchmark):
+    repo_name = performance_configurations['kubernetes']['repo_name']
+    repo_threshold = performance_configurations['kubernetes']['threshold']
+
+    def run_kubernetes_scan():
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        test_files_dir = os.path.join(current_dir, repo_name)
+        runner_filter = RunnerFilter()
+        runner_registry = RunnerRegistry(banner, runner_filter, k8_runner())
+        reports = runner_registry.run(root_folder=test_files_dir)
+        assert len(reports) > 0
+
+    benchmark(run_kubernetes_scan)
+    assert benchmark.stats.stats.mean <= repo_threshold + (deviation_percent / 100) * repo_threshold

--- a/performance_tests/test_checkov_performance.py
+++ b/performance_tests/test_checkov_performance.py
@@ -1,0 +1,34 @@
+import math
+import os
+
+import pytest
+import time
+
+from pytest_benchmark.plugin import benchmark
+
+from checkov.cloudformation.runner import Runner as cfn_runner
+from checkov.common.runners.runner_registry import RunnerRegistry
+from checkov.common.util.banner import banner
+from checkov.kubernetes.runner import Runner as k8_runner
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner as tf_runner
+
+@pytest.mark.benchmark(
+    group="performance-tests",
+    min_time=0,
+    max_time=120,
+    min_rounds=1,
+    timer=time.time,
+    disable_gc=True,
+    warmup=False
+)
+def test_performance(benchmark):
+    def test_terragoat():
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        test_files_dir = "/Users/tronxd/clones/tronxd/terragoat"  # TODO run on forked data
+        runner_filter = RunnerFilter()
+        runner_registry = RunnerRegistry(banner, runner_filter, tf_runner())
+        reports = runner_registry.run(root_folder=test_files_dir)
+        assert len(reports) > 0
+
+    benchmark(test_terragoat)


### PR DESCRIPTION
- Use `pytest-benchmark` plugin to evaluate execution times of different IaC runners on known benchmarks.

- Performance tests will fail if they deviate by a configurable percecnt from the maximum duration of the tested branch against the data. 
- Thresholds are set according to current execution on the data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
