### PR TITLE
add CKV2_AWS_32 for CloudFront security header

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/CloudFrontHasSecurityHeadersPolicy.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/CloudFrontHasSecurityHeadersPolicy.yaml
@@ -1,0 +1,114 @@
+# ref: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/creating-response-headers-policies.html
+metadata:
+  id: "CKV2_AWS_32"
+  name: "Ensure CloudFront distribution has a strict security headers policy attached"
+  category: "NETWORKING"
+definition:
+  and:
+    - cond_type: filter
+      value:
+        - aws_cloudfront_distribution
+      operator: within
+      attribute: resource_type
+    - cond_type: connection
+      operator: exists
+      resource_types:
+      - aws_cloudfront_distribution
+      connected_resource_types:
+      - aws_cloudfront_response_headers_policy
+
+      # Content-Security-Policy
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.content_security_policy.override
+      operator: equals
+      value: true
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.content_security_policy.content_security_policy
+      operator: contains
+      value: "default-src 'none';"
+
+      # X-Content-Type-Options
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.content_type_options.override
+      operator: equals
+      value: true
+
+      # X-Frame-Options
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.frame_options.override
+      operator: equals
+      value: true
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.frame_options.frame_option
+      operator: equals
+      value: "DENY"
+
+      # Referrer-Policy
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.referrer_policy.override
+      operator: equals
+      value: true
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.referrer_policy.referrer_policy
+      operator: equals
+      value: "same-origin"
+
+      # Strict-Transport-Security
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.strict_transport_security.override
+      operator: equals
+      value: true
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.strict_transport_security.access_control_max_age_sec
+      operator: greater_than_or_equal
+      value: 31536000
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.strict_transport_security.include_subdomains
+      operator: equals
+      value: true
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.strict_transport_security.preload
+      operator: equals
+      value: true
+
+      # X-XSS-Protection
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.xss_protection.override
+      operator: equals
+      value: true
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.xss_protection.mode_block
+      operator: equals
+      value: true
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_response_headers_policy
+      attribute: security_headers_config.xss_protection.protection
+      operator: equals
+      value: true

--- a/tests/terraform/graph/checks/resources/CloudFrontHasSecurityHeadersPolicy/expected.yaml
+++ b/tests/terraform/graph/checks/resources/CloudFrontHasSecurityHeadersPolicy/expected.yaml
@@ -1,0 +1,7 @@
+fail:
+  - "aws_cloudfront_distribution.no_response_headers_policy"
+  - "aws_cloudfront_distribution.no_security_headers_config"
+  - "aws_cloudfront_distribution.incorrect_security_headers_config"
+  - "aws_cloudfront_distribution.content_security_policy_missing_default_src_none"
+pass:
+  - "aws_cloudfront_distribution.pass"

--- a/tests/terraform/graph/checks/resources/CloudFrontHasSecurityHeadersPolicy/main.tf
+++ b/tests/terraform/graph/checks/resources/CloudFrontHasSecurityHeadersPolicy/main.tf
@@ -1,0 +1,142 @@
+# pass
+
+resource "aws_cloudfront_distribution" "pass" {
+  enabled = true
+
+  default_cache_behavior {
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.pass.id
+  }
+}
+
+resource "aws_cloudfront_response_headers_policy" "pass" {
+  name    = "test"
+
+  security_headers_config {
+    content_security_policy {
+      content_security_policy = "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; frame-ancestors 'none'"
+      override = true
+    }
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override = true
+    }
+    referrer_policy {
+      referrer_policy = "same-origin"
+      override = true
+    }
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      override                   = true
+      preload                    = true
+    }
+    xss_protection {
+      mode_block = true
+      override   = true
+      protection = true
+    }
+  }
+}
+
+# fail
+
+resource "aws_cloudfront_distribution" "no_response_headers_policy" {
+  enabled = true
+}
+
+resource "aws_cloudfront_distribution" "no_security_headers_config" {
+  enabled = true
+
+  default_cache_behavior {
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.no_security_headers_config.id
+  }
+}
+
+resource "aws_cloudfront_response_headers_policy" "no_security_headers_config" {
+  name    = "test"
+}
+
+resource "aws_cloudfront_distribution" "incorrect_security_headers_config" {
+  enabled = true
+
+  default_cache_behavior {
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.incorrect_security_headers_config.id
+  }
+}
+
+resource "aws_cloudfront_response_headers_policy" "incorrect_security_headers_config" {
+  name    = "test"
+
+  security_headers_config {
+    content_security_policy {
+      content_security_policy = "default-src 'none'"
+      override = true
+    }
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override = true
+    }
+    referrer_policy {
+      referrer_policy = "same-origin"
+      override = true
+    }
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      override                   = true
+      preload                    = true
+    }
+    xss_protection {
+      mode_block = true
+      override   = true
+      protection = false
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution" "content_security_policy_missing_default_src_none" {
+  enabled = true
+
+  default_cache_behavior {
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.content_security_policy_missing_default_src_none.id
+  }
+}
+
+resource "aws_cloudfront_response_headers_policy" "content_security_policy_missing_default_src_none" {
+  name    = "test"
+
+  security_headers_config {
+    content_security_policy {
+      content_security_policy = "default-src 'self' 'unsafe-inline' data: ws: *"
+      override = true
+    }
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override = true
+    }
+    referrer_policy {
+      referrer_policy = "same-origin"
+      override = true
+    }
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      override                   = true
+      preload                    = true
+    }
+    xss_protection {
+      mode_block = true
+      override   = true
+      protection = false
+    }
+  }
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -53,6 +53,9 @@ class TestYamlPolicies(unittest.TestCase):
     def test_VAsetPeriodicScansOnSQL(self):
         self.go("VAsetPeriodicScansOnSQL")
 
+    def test_CloudFrontHasSecurityHeadersPolicy(self):
+        self.go("CloudFrontHasSecurityHeadersPolicy")
+
     def test_CloudtrailHasCloudwatch(self):
         self.go("CloudtrailHasCloudwatch")
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I used AWS example as a great base for creating the custom CloudFront response header policy, but was a bit more strict regards to the `override` 👮 

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/creating-response-headers-policies.html