### PR TITLE
clear module_content_cache before the test

### DIFF
--- a/tests/terraform/parser/test_parser_modules.py
+++ b/tests/terraform/parser/test_parser_modules.py
@@ -19,6 +19,11 @@ def tmp_path(request, tmp_path: Path):
 class TestParserInternals(unittest.TestCase):
 
     def setUp(self) -> None:
+        from checkov.terraform.module_loading.registry import ModuleLoaderRegistry
+
+        # needs to be reset, because the cache belongs to the class not instance
+        ModuleLoaderRegistry.module_content_cache = {}
+
         self.resources_dir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                                            "./resources"))
         self.external_module_path = ''


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

the cache is used for all the tests and therefore fills up with data from other tests.