### PR TITLE
fix missing wheel files for alpine Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM python:3.9-alpine
 
 RUN apk add --no-cache git util-linux bash openssl
 
-RUN pip install --no-cache-dir -U checkov
+RUN apk add --no-cache --virtual .build_deps build-base libffi-dev \
+ && pip install --no-cache-dir -U checkov \
+ && apk del .build_deps
+
 RUN wget -q -O get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3; chmod 700 get_helm.sh; VERIFY_CHECKSUM=true ./get_helm.sh; rm ./get_helm.sh
 
 COPY ./github_action_resources/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

some of the `asyncio` packages use C extension and therefore need extra wheels for different OS. Not every package offers Alpine flavoured wheels, therefore they need to be build, like `cffi`.