### PR TITLE
skip graph scan for tf plans, if not exists

### DIFF
--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -70,11 +70,12 @@ class Runner(TerraformRunner):
 
         report.add_parsing_errors(list(parsing_errors.keys()))
 
-        graph = self.graph_manager.build_graph_from_definitions(self.tf_definitions, render_variables=False)
-        self.graph_manager.save_graph(graph)
+        if self.tf_definitions:
+            graph = self.graph_manager.build_graph_from_definitions(self.tf_definitions, render_variables=False)
+            self.graph_manager.save_graph(graph)
 
-        graph_report = self.get_graph_checks_report(root_folder, runner_filter)
-        merge_reports(report, graph_report)
+            graph_report = self.get_graph_checks_report(root_folder, runner_filter)
+            merge_reports(report, graph_report)
 
         return report
 

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from pathlib import Path
 
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.plan_runner import Runner
@@ -314,6 +315,27 @@ class TestRunnerValid(unittest.TestCase):
 
         self.assertEqual(report.get_summary()["failed"], 0)
         self.assertEqual(report.get_summary()["passed"], 1)
+
+    def test_runner_skip_graph_when_no_plan_exists(self):
+        # given
+        tf_file_path = Path(__file__).parent / "resource/example/example.tf"
+
+        # when
+        report = Runner().run(
+            root_folder=None,
+            files=[str(tf_file_path)],
+            external_checks_dir=None,
+            runner_filter=RunnerFilter(framework="terraform_plan"),
+        )
+
+        # then
+        summary = report.get_summary()
+
+        self.assertEqual(report.get_summary()["failed"], 0)
+        self.assertEqual(report.get_summary()["passed"], 0)
+        self.assertEqual(report.get_summary()["skipped"], 0)
+        self.assertEqual(report.get_summary()["parsing_errors"], 0)
+        self.assertEqual(report.get_summary()["resource_count"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

no need to check for graph, if there is no Terraform plan file 😄 