### PR TITLE
port of prisma check OCI IAM password policy for local (non-federated) users does not have minimum 14 characters 

### DIFF
--- a/checkov/terraform/checks/resource/oci/IAMPasswordLength.py
+++ b/checkov/terraform/checks/resource/oci/IAMPasswordLength.py
@@ -12,10 +12,12 @@ class IAMPasswordLength(BaseResourceCheck):
 
     def scan_resource_conf(self, conf):
         if 'password_policy' in conf.keys():
+            self.evaluated_keys = ["password_policy"]
             rules = conf.get("password_policy")[0]
             if 'minimum_password_length' in rules:
-                passwordlength=rules.get("minimum_password_length")
+                passwordlength = rules.get("minimum_password_length")
                 if passwordlength[0] < 14:
+                    self.evaluated_keys = ["password_policy/minimum_password_length"]
                     return CheckResult.FAILED
                 return CheckResult.PASSED
             return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/oci/IAMPasswordLength.py
+++ b/checkov/terraform/checks/resource/oci/IAMPasswordLength.py
@@ -1,0 +1,24 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class IAMPasswordLength(BaseResourceCheck):
+    def __init__(self):
+        name = "OCI IAM password policy for local (non-federated) users has a minimum 14 characters"
+        id = "CKV_OCI_18"
+        supported_resources = ['oci_identity_authentication_policy']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'password_policy' in conf.keys():
+            rules = conf.get("password_policy")[0]
+            if 'minimum_password_length' in rules:
+                passwordlength=rules.get("minimum_password_length")
+                if passwordlength[0] < 14:
+                    return CheckResult.FAILED
+                return CheckResult.PASSED
+            return CheckResult.FAILED
+        return CheckResult.FAILED
+
+check = IAMPasswordLength()

--- a/tests/terraform/checks/resource/oci/example_IAMPasswordLength/main.tf
+++ b/tests/terraform/checks/resource/oci/example_IAMPasswordLength/main.tf
@@ -1,0 +1,46 @@
+resource "oci_identity_authentication_policy" "pass" {
+
+  compartment_id = var.tenancy_id
+
+  password_policy {
+    is_lowercase_characters_required = true
+    is_numeric_characters_required   = var.authentication_policy_password_policy_is_numeric_characters_required
+    is_special_characters_required   = var.authentication_policy_password_policy_is_special_characters_required
+    is_uppercase_characters_required = var.authentication_policy_password_policy_is_uppercase_characters_required
+    is_username_containment_allowed  = var.authentication_policy_password_policy_is_username_containment_allowed
+    minimum_password_length          = 14
+  }
+}
+
+resource "oci_identity_authentication_policy" "fail" {
+
+  compartment_id = var.tenancy_id
+
+  password_policy {
+    is_lowercase_characters_required = false
+    is_numeric_characters_required   = var.authentication_policy_password_policy_is_numeric_characters_required
+    is_special_characters_required   = var.authentication_policy_password_policy_is_special_characters_required
+    is_uppercase_characters_required = var.authentication_policy_password_policy_is_uppercase_characters_required
+    is_username_containment_allowed  = var.authentication_policy_password_policy_is_username_containment_allowed
+    minimum_password_length          = 13
+  }
+}
+
+resource "oci_identity_authentication_policy" "fail2" {
+
+  compartment_id = var.tenancy_id
+
+  password_policy {
+    is_lowercase_characters_required = false
+    is_numeric_characters_required   = var.authentication_policy_password_policy_is_numeric_characters_required
+    is_special_characters_required   = var.authentication_policy_password_policy_is_special_characters_required
+    is_uppercase_characters_required = var.authentication_policy_password_policy_is_uppercase_characters_required
+    is_username_containment_allowed  = var.authentication_policy_password_policy_is_username_containment_allowed
+  }
+}
+
+resource "oci_identity_authentication_policy" "fail3" {
+
+  compartment_id = var.tenancy_id
+
+}

--- a/tests/terraform/checks/resource/oci/test_IAMPasswordLength.py
+++ b/tests/terraform/checks/resource/oci/test_IAMPasswordLength.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.oci.IAMPasswordLength import check
+from checkov.terraform.runner import Runner
+
+
+class TestIAMPasswordLength(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_IAMPasswordLength"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "oci_identity_authentication_policy.pass",
+        }
+        failing_resources = {
+            "oci_identity_authentication_policy.fail",
+            "oci_identity_authentication_policy.fail3",
+            "oci_identity_authentication_policy.fail2"
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Addresses #1969

Looks to see that the policy is set to 14 or more.