### PR TITLE
Empty strings as ANY_VALUE + Handle dynamic blocks

### DIFF
--- a/checkov/cloudformation/checks/resource/base_resource_value_check.py
+++ b/checkov/cloudformation/checks/resource/base_resource_value_check.py
@@ -67,7 +67,7 @@ class BaseResourceValueCheck(BaseResourceCheck):
                 if match[:-1] == path_elements:
                     # Inspected key exists
                     value = match[-1]
-                    if ANY_VALUE in expected_values and value is not None and (not isinstance(value, str) or len(value) > 0):
+                    if ANY_VALUE in expected_values and value is not None and (not isinstance(value, str) or value):
                         # Key is found on the configuration - if it accepts any value, the check is PASSED
                         return CheckResult.PASSED
                     if isinstance(value, list) and len(value) == 1:

--- a/checkov/cloudformation/checks/resource/base_resource_value_check.py
+++ b/checkov/cloudformation/checks/resource/base_resource_value_check.py
@@ -66,10 +66,10 @@ class BaseResourceValueCheck(BaseResourceCheck):
 
                 if match[:-1] == path_elements:
                     # Inspected key exists
-                    if ANY_VALUE in expected_values:
+                    value = match[-1]
+                    if ANY_VALUE in expected_values and value is not None and (not isinstance(value, str) or len(value) > 0):
                         # Key is found on the configuration - if it accepts any value, the check is PASSED
                         return CheckResult.PASSED
-                    value = match[-1]
                     if isinstance(value, list) and len(value) == 1:
                         value = value[0]
                     if self._is_variable_dependant(value):

--- a/checkov/terraform/checks/resource/aws/SQSQueueEncryption.py
+++ b/checkov/terraform/checks/resource/aws/SQSQueueEncryption.py
@@ -14,11 +14,8 @@ class SQSQueueEncryption(BaseResourceValueCheck):
     def get_inspected_key(self):
         return 'kms_master_key_id'
 
-    def get_expected_values(self):
-        return [ANY_VALUE]
-
     def get_expected_value(self):
-        return 'alias/aws/sqs'
+        return ANY_VALUE
 
 
 check = SQSQueueEncryption()

--- a/checkov/terraform/checks/resource/base_resource_check.py
+++ b/checkov/terraform/checks/resource/base_resource_check.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Any
 from checkov.common.checks.base_check import BaseCheck
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.registry import resource_registry
+from checkov.terraform.parser_functions import handle_dynamic_values
 
 
 class BaseResourceCheck(BaseCheck):
@@ -21,7 +22,7 @@ class BaseResourceCheck(BaseCheck):
         if conf.get("count") == [0]:
             return CheckResult.UNKNOWN
 
-        self.handle_dynamic_values(conf)
+        handle_dynamic_values(conf)
         return self.scan_resource_conf(conf)
 
     @abstractmethod
@@ -31,26 +32,3 @@ class BaseResourceCheck(BaseCheck):
         If not relevant it should be set to an empty array so the previous check's value gets overridden in the report.
         """
         raise NotImplementedError()
-
-    def handle_dynamic_values(self, conf: Dict[str, List[Any]]) -> None:
-        # recursively search for blocks that are dynamic
-        for block_name in conf.keys():
-            if isinstance(conf[block_name], dict):
-                self.handle_dynamic_values(conf[block_name])
-
-            # if the configuration is a block element, search down again.
-            if isinstance(conf[block_name], list) and len(conf[block_name]) > 0 and isinstance(conf[block_name][0], dict):
-                self.handle_dynamic_values(conf[block_name][0])
-
-        self.process_dynamic_values(conf)
-
-    def process_dynamic_values(self, conf: Dict[str, List[Any]]) -> None:
-        for dynamic_element in conf.get("dynamic", {}):
-            if isinstance(dynamic_element, str):
-                try:
-                    dynamic_element = json.loads(dynamic_element)
-                except Exception:
-                    dynamic_element = {}
-
-            for element_name in dynamic_element.keys():
-                conf[element_name] = dynamic_element[element_name].get("content", [])

--- a/checkov/terraform/checks/resource/base_resource_negative_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_negative_value_check.py
@@ -8,6 +8,7 @@ from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.common.util.type_forcers import force_list
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.terraform.graph_builder.utils import get_referenced_vertices_in_value
+from checkov.terraform.parser_functions import handle_dynamic_values
 
 
 class BaseResourceNegativeValueCheck(BaseResourceCheck):
@@ -23,7 +24,7 @@ class BaseResourceNegativeValueCheck(BaseResourceCheck):
         self.missing_attribute_result = missing_attribute_result
 
     def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
-        self.handle_dynamic_values(conf)
+        handle_dynamic_values(conf)
 
         excluded_key = self.get_excluded_key()
         if excluded_key is not None:

--- a/checkov/terraform/checks/resource/base_resource_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_value_check.py
@@ -64,7 +64,7 @@ class BaseResourceValueCheck(BaseResourceCheck):
             value = dpath.get(conf, inspected_key)
             if isinstance(value, list) and len(value) == 1:
                 value = value[0]
-            if ANY_VALUE in expected_values and value is not None and (not isinstance(value, str) or len(value) > 0):
+            if ANY_VALUE in expected_values and value is not None and (not isinstance(value, str) or value):
                 # Key is found on the configuration - if it accepts any value, the check is PASSED
                 return CheckResult.PASSED
             if self._is_variable_dependant(value):

--- a/checkov/terraform/checks/resource/base_resource_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_value_check.py
@@ -63,7 +63,7 @@ class BaseResourceValueCheck(BaseResourceCheck):
             value = dpath.get(conf, inspected_key)
             if isinstance(value, list) and len(value) == 1:
                 value = value[0]
-            if ANY_VALUE in expected_values and value is not None:
+            if ANY_VALUE in expected_values and value is not None and (not isinstance(value, str) or len(value) > 0):
                 # Key is found on the configuration - if it accepts any value, the check is PASSED
                 return CheckResult.PASSED
             if self._is_variable_dependant(value):

--- a/checkov/terraform/checks/resource/base_resource_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_value_check.py
@@ -8,6 +8,7 @@ from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.common.models.consts import ANY_VALUE
 from checkov.common.util.type_forcers import force_list
 from checkov.terraform.graph_builder.utils import get_referenced_vertices_in_value
+from checkov.terraform.parser_functions import handle_dynamic_values
 from checkov.terraform.parser_utils import find_var_blocks
 
 
@@ -55,7 +56,7 @@ class BaseResourceValueCheck(BaseResourceCheck):
         return any(x in key for x in inspected_attributes)
 
     def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
-        self.handle_dynamic_values(conf)
+        handle_dynamic_values(conf)
         inspected_key = self.get_inspected_key()
         expected_values = self.get_expected_values()
         if dpath.search(conf, inspected_key) != {}:

--- a/checkov/terraform/graph_builder/graph_components/module.py
+++ b/checkov/terraform/graph_builder/graph_components/module.py
@@ -7,6 +7,7 @@ from checkov.terraform.checks.utils.dependency_path_handler import unify_depende
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 from checkov.terraform.graph_builder.graph_components.blocks import TerraformBlock
 from checkov.common.graph.graph_builder.graph_components.blocks import get_inner_attributes
+from checkov.terraform.parser_functions import handle_dynamic_values
 
 
 class Module:
@@ -139,6 +140,7 @@ class Module:
                     attributes = self.clean_bad_characters(resource_conf)
                     if not isinstance(attributes, dict):
                         continue
+                    handle_dynamic_values(attributes)
                     provisioner = attributes.get("provisioner")
                     if provisioner:
                         self._handle_provisioner(provisioner, attributes)

--- a/checkov/terraform/parser_functions.py
+++ b/checkov/terraform/parser_functions.py
@@ -177,7 +177,7 @@ def handle_dynamic_values(conf: Dict[str, List[Any]]) -> None:
             handle_dynamic_values(conf[block_name])
 
         # if the configuration is a block element, search down again.
-        if isinstance(conf[block_name], list) and len(conf[block_name]) > 0 and isinstance(conf[block_name][0], dict):
+        if isinstance(conf[block_name], list) and conf[block_name] and isinstance(conf[block_name][0], dict):
             handle_dynamic_values(conf[block_name][0])
 
     process_dynamic_values(conf)

--- a/checkov/terraform/parser_functions.py
+++ b/checkov/terraform/parser_functions.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Dict, List, Union, Any
 
@@ -167,3 +168,28 @@ def _check_map_type_consistency(value: Dict) -> Dict:
     if had_string and had_something_else:
         value = {k: to_string(v) for k, v in value.items()}
     return value
+
+
+def handle_dynamic_values(conf: Dict[str, List[Any]]) -> None:
+    # recursively search for blocks that are dynamic
+    for block_name in conf.keys():
+        if isinstance(conf[block_name], dict):
+            handle_dynamic_values(conf[block_name])
+
+        # if the configuration is a block element, search down again.
+        if isinstance(conf[block_name], list) and len(conf[block_name]) > 0 and isinstance(conf[block_name][0], dict):
+            handle_dynamic_values(conf[block_name][0])
+
+    process_dynamic_values(conf)
+
+
+def process_dynamic_values(conf: Dict[str, List[Any]]) -> None:
+    for dynamic_element in conf.get("dynamic", {}):
+        if isinstance(dynamic_element, str):
+            try:
+                dynamic_element = json.loads(dynamic_element)
+            except Exception:
+                dynamic_element = {}
+
+        for element_name in dynamic_element.keys():
+            conf[element_name] = dynamic_element[element_name].get("content", [])

--- a/tests/cloudformation/checks/resource/aws/example_SQSQueueEncryption/test_SQSQueueEncryption-FAILED2.yml
+++ b/tests/cloudformation/checks/resource/aws/example_SQSQueueEncryption/test_SQSQueueEncryption-FAILED2.yml
@@ -6,4 +6,3 @@ Resources:
       RedrivePolicy:
         deadLetterTargetArn: "example_arn"
         maxReceiveCount: 5
-      KmsMasterKeyId: ""

--- a/tests/cloudformation/checks/resource/aws/test_SQSQueueEncryption.py
+++ b/tests/cloudformation/checks/resource/aws/test_SQSQueueEncryption.py
@@ -17,7 +17,7 @@ class TestSQSQueueEncryption(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/terraform/checks/resource/aws/test_SQSQueueEncryption.py
+++ b/tests/terraform/checks/resource/aws/test_SQSQueueEncryption.py
@@ -17,6 +17,12 @@ class TestS3Encryption(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_failure2(self):
+        resource_conf = {'name': ['terraform-example-queue'], 'kms_master_key_id': [''],
+                         'kms_data_key_reuse_period_seconds': [300]}
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/terraform/graph/graph_builder/test_graph_builder.py
+++ b/tests/terraform/graph/graph_builder/test_graph_builder.py
@@ -192,3 +192,11 @@ class TestGraphBuilder(TestCase):
                     self.assertFalse(conf['versioning'][0]['enabled'][0])
                     found_results += 1
         self.assertEqual(found_results, 3)
+
+    def test_build_graph_with_dynamic_blocks(self):
+        resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME, '../resources/dynamic_lambda_function'))
+
+        graph_manager = TerraformGraphManager(NetworkxConnector())
+        local_graph, tf = graph_manager.build_graph_from_source_directory(resources_dir, render_variables=True)
+        lambda_attributes = local_graph.vertices[0].attributes
+        self.assertTrue("dead_letter_config" in lambda_attributes.keys())

--- a/tests/terraform/graph/resources/dynamic_lambda_function/lambda.tf
+++ b/tests/terraform/graph/resources/dynamic_lambda_function/lambda.tf
@@ -1,0 +1,12 @@
+resource "aws_lambda_function" "lambda" {
+
+  function_name                  = "test"
+  role = ""
+
+  dynamic "dead_letter_config" {
+    for_each = var.dlc == null ? [] : [var.dlc]
+    content {
+      target_arn = dead_letter_config.value.target_arn
+    }
+  }
+}


### PR DESCRIPTION
This PR has two improvements:

**Stop identifying empty strings as ANY_VALUE**
Until now, if a check had `ANY_VALUE` as the expected value, if the value is `""` the check passed, while it should have failed.
I added a validation that if the value is a string and it is empty, fail the check.
Added tests for it, under `test_SQSQueueEncryption`.

**Add terraform dynamic blocks to the graph vertices**
I extracted `handle_dynamic_values` from `base_resource_check` to `parser_functions` and use it when creating the resources graph vertices.
Added a test for it in `test_graph_builder`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
