### PR TITLE
fix GlueSecurityConfiguration check to not throw an exception if S3Encryptions is not a list

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/GlueSecurityConfiguration.py
+++ b/checkov/cloudformation/checks/resource/aws/GlueSecurityConfiguration.py
@@ -1,5 +1,6 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.util.type_forcers import force_list
 
 
 class GlueSecurityConfiguration(BaseResourceCheck):
@@ -29,7 +30,7 @@ class GlueSecurityConfiguration(BaseResourceCheck):
                             book_enc = True
 
                 if 'S3Encryptions' in enc_conf.keys():
-                    for s3_encryption in enc_conf['S3Encryptions']:
+                    for s3_encryption in force_list(enc_conf['S3Encryptions']):
                         if 'S3EncryptionMode' in s3_encryption.keys():
                             if s3_encryption['S3EncryptionMode'] != 'DISABLED':
                                 s3_enc = True

--- a/tests/cloudformation/checks/resource/aws/example_GlueSecurityConfiguration/GlueSecurityConfiguration-PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_GlueSecurityConfiguration/GlueSecurityConfiguration-PASSED.yml
@@ -14,3 +14,17 @@ Resources:
         S3Encryptions: 
         - KmsKeyArn: KmsKeyArn
           S3EncryptionMode: SSE-KMS
+  Resource1:
+    Type: AWS::Glue::SecurityConfiguration
+    Properties:
+      Name: Name
+      EncryptionConfiguration:
+        CloudWatchEncryption:
+          CloudWatchEncryptionMode: SSE-KMS
+          KmsKeyArn: KmsKeyArn
+        JobBookmarksEncryption:
+          JobBookmarksEncryptionMode: CSE-KMS
+          KmsKeyArn: KmsKeyArn
+        S3Encryptions:
+          KmsKeyArn: KmsKeyArn
+          S3EncryptionMode: SSE-KMS

--- a/tests/cloudformation/checks/resource/aws/test_GlueSecurityConfiguration.py
+++ b/tests/cloudformation/checks/resource/aws/test_GlueSecurityConfiguration.py
@@ -16,7 +16,7 @@ class TestGlueSecurityConfiguration(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 4)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
