### PR TITLE
consolidate custom json encoder

### DIFF
--- a/.github/exclude-patterns.txt
+++ b/.github/exclude-patterns.txt
@@ -4,7 +4,7 @@ tests/serverless/checks/aws/example_AWSCredentials/AWSCredentials-FAILED-provide
 tests/serverless/checks/aws/example_AWSCredentials/AWSCredentials-FAILED-func_level/serverless.yml
 tests/serverless/checks/aws/example_AWSCredentials/AWSCredentials-FAILED-provider_level/serverless.yml
 tests/cloudformation/checks/resource/aws/example_EC2Credentials/EC2Credentials-FAILED.yaml
-tests/terraform/checks/resource/aws/test_LambdaEnvironmentCredentials.py
+tests/terraform/checks/resource/aws/example_LambdaEnvironmentCredentials/main.tf
 tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentCredentials/LambdaEnvironmentCredentials.yaml
 tests/terraform/runner/resources/example/example.tf
 .*Pipfile.lock

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -15,6 +15,7 @@ from checkov.common.output.baseline import Baseline
 from checkov.common.output.report import Report
 from checkov.common.runners.base_runner import BaseRunner
 from checkov.common.util import data_structures_utils
+from checkov.common.util.json_utils import CustomJSONEncoder
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.context_parsers.registry import parser_registry
 from checkov.terraform.runner import Runner as tf_runner
@@ -27,15 +28,6 @@ CHECK_BLOCK_TYPES = frozenset(["resource", "data", "provider", "module"])
 OUTPUT_CHOICES = ["cli", "cyclonedx", "json", "junitxml", "github_failed_only", "sarif"]
 OUTPUT_DELIMITER = "\n--- OUTPUT DELIMITER ---\n"
 
-class OutputEncoder(JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, set):
-            return list(obj)
-        elif isinstance(obj, Tree):
-            return str(obj)
-        elif isinstance(obj, datetime.date):
-            return str(obj)
-        return super().default(obj)
 
 class RunnerRegistry:
     runners: List[BaseRunner] = []
@@ -156,9 +148,9 @@ class RunnerRegistry:
             if not report_jsons:
                 print(dumps(Report(None).get_summary(), indent=4))
             elif len(report_jsons) == 1:
-                print(dumps(report_jsons[0], indent=4, cls=OutputEncoder))
+                print(dumps(report_jsons[0], indent=4, cls=CustomJSONEncoder))
             else:
-                print(dumps(report_jsons, indent=4, cls=OutputEncoder))
+                print(dumps(report_jsons, indent=4, cls=CustomJSONEncoder))
             output_formats.remove("json")
             if output_formats:
                 print(OUTPUT_DELIMITER)

--- a/checkov/common/util/json_utils.py
+++ b/checkov/common/util/json_utils.py
@@ -1,9 +1,17 @@
+import datetime
 import json
+from typing import Any
+
+from lark import Tree
 
 
 class CustomJSONEncoder(json.JSONEncoder):
-    def default(self, o):
+    def default(self, o: Any) -> Any:
         if isinstance(o, set):
             return list(o)
+        elif isinstance(o, Tree):
+            return str(o)
+        elif isinstance(o, datetime.date):
+            return str(o)
         else:
             return json.JSONEncoder.default(self, o)

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -16,6 +16,7 @@ from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.runners.base_runner import filter_ignored_paths
 from checkov.common.util.config_utils import should_scan_hcl_files
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR, RESOLVED_MODULE_ENTRY_NAME
+from checkov.common.util.json_utils import CustomJSONEncoder
 from checkov.common.variables.context import EvaluationContext
 from checkov.terraform.checks.utils.dependency_path_handler import unify_dependency_path
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
@@ -27,17 +28,6 @@ from checkov.terraform.module_loading.registry import module_loader_registry as 
 from checkov.terraform.parser_utils import eval_string, find_var_blocks
 
 external_modules_download_path = os.environ.get('EXTERNAL_MODULES_DIR', DEFAULT_EXTERNAL_MODULES_DIR)
-
-
-class DefinitionsEncoder(JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, set):
-            return list(obj)
-        elif isinstance(obj, Tree):
-            return str(obj)
-        elif isinstance(obj, datetime.date):
-            return str(obj)
-        return super().default(obj)
 
 
 def _filter_ignored_paths(root, paths, excluded_paths):
@@ -584,7 +574,7 @@ class Parser:
 
     @staticmethod
     def _serialize_definitions(tf_definitions):
-        return loads(dumps(tf_definitions, cls=DefinitionsEncoder))
+        return loads(dumps(tf_definitions, cls=CustomJSONEncoder))
 
     @staticmethod
     def get_next_vertices(evaluated_files: list, unevaluated_files: list) -> (list, list):

--- a/tests/common/utils/test_json_utils.py
+++ b/tests/common/utils/test_json_utils.py
@@ -1,0 +1,26 @@
+import json
+from datetime import datetime
+from typing import Dict, Any
+
+import pytest
+from lark import Tree
+
+from checkov.common.util.json_utils import CustomJSONEncoder
+
+
+@pytest.mark.parametrize(
+    "input_dict",
+    [
+        ({"key": {"v", "val", "value"}}),
+        ({"key": datetime.now()}),
+        ({"key": Tree("data", ["child_1", "child_2"])}),
+    ],
+    ids=["set", "date", "lark_tree"],
+)
+def test_custom_json_encoder(input_dict: Dict[str, Any]):
+    # when
+    result = json.dumps(input_dict, cls=CustomJSONEncoder)
+
+    # then
+    # this assertion should never fail, but json.dumps() could
+    assert isinstance(result, str)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

from 3 `JSONEncoders` make 1 😄 

there was no real elegant way to write a `pytest` test, which checks, that no exception was raised. Happy for some suggestion, except using `try ... except ...` 😄 