### PR TITLE
fix in IAMPasswordLength check

### DIFF
--- a/checkov/terraform/checks/resource/oci/IAMPasswordLength.py
+++ b/checkov/terraform/checks/resource/oci/IAMPasswordLength.py
@@ -16,7 +16,7 @@ class IAMPasswordLength(BaseResourceCheck):
             rules = conf.get("password_policy")[0]
             if 'minimum_password_length' in rules:
                 passwordlength = rules.get("minimum_password_length")
-                if passwordlength[0] < 14:
+                if isinstance(passwordlength[0], int) and passwordlength[0] < 14:
                     self.evaluated_keys = ["password_policy/minimum_password_length"]
                     return CheckResult.FAILED
                 return CheckResult.PASSED


### PR DESCRIPTION
check if minimum_password_length attribute is int before compere it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
