### PR TITLE
fix in module loader

### DIFF
--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -87,7 +87,7 @@ def load_tf_modules(path: str, should_download_module: Callable[[str], bool] = s
     distinct_modules = list({m.address: m for m in modules_to_load}.values())
 
     if run_parallel:
-        parallel_runner.run_function(_download_module, distinct_modules)
+        list(parallel_runner.run_function(_download_module, distinct_modules))
     else:
         for m in distinct_modules:
             _download_module(m)

--- a/tests/terraform/module_loading/test_tf_module_finder.py
+++ b/tests/terraform/module_loading/test_tf_module_finder.py
@@ -29,7 +29,7 @@ class TestModuleFinder(unittest.TestCase):
 
         remote_modules = [m for m in modules if should_download(m.module_link)]
         module_loader_registry.download_external_modules = True
-        load_tf_modules(os.path.join(self.get_src_dir()), run_parallel=False)
+        load_tf_modules(os.path.join(self.get_src_dir()), run_parallel=True)
         downloaded_modules = os.listdir(os.path.join(self.get_src_dir(), DEFAULT_EXTERNAL_MODULES_DIR))
         distinct_roots = {md.module_link.split('/')[0] for md in remote_modules}
         shutil.rmtree(os.path.join(self.get_src_dir(), DEFAULT_EXTERNAL_MODULES_DIR))


### PR DESCRIPTION
update module loader to wait for all modules loading when running parallel

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
