### PR TITLE
remove parallelize from external modules

### DIFF
--- a/checkov/common/parallelizer/parallel_runner.py
+++ b/checkov/common/parallelizer/parallel_runner.py
@@ -12,7 +12,7 @@ class ParallelRunner:
 
     def run_function(self, func: Callable[[Any], Any], items: List[Any], group_size: Optional[int]=None) -> Iterator:
         if self.os == 'Windows':
-            return self.run_function_multithreaded(func, items)
+            return self._run_function_multithreaded(func, items)
         else:
             return self._run_function_multiprocess(func, items, group_size)
 
@@ -43,7 +43,7 @@ class ParallelRunner:
                 except EOFError:
                     pass
 
-    def run_function_multithreaded(self, func: Callable[[Any], Any], items: List[Any]) -> Iterator:
+    def _run_function_multithreaded(self, func: Callable[[Any], Any], items: List[Any]) -> Iterator:
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.workers_number) as executor:
             return executor.map(func, items)
 

--- a/checkov/common/parallelizer/parallel_runner.py
+++ b/checkov/common/parallelizer/parallel_runner.py
@@ -12,7 +12,7 @@ class ParallelRunner:
 
     def run_function(self, func: Callable[[Any], Any], items: List[Any], group_size: Optional[int]=None) -> Iterator:
         if self.os == 'Windows':
-            return self._run_function_multithreaded(func, items)
+            return self.run_function_multithreaded(func, items)
         else:
             return self._run_function_multiprocess(func, items, group_size)
 
@@ -43,7 +43,7 @@ class ParallelRunner:
                 except EOFError:
                     pass
 
-    def _run_function_multithreaded(self, func: Callable[[Any], Any], items: List[Any]) -> Iterator:
+    def run_function_multithreaded(self, func: Callable[[Any], Any], items: List[Any]) -> Iterator:
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.workers_number) as executor:
             return executor.map(func, items)
 

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -87,7 +87,7 @@ def load_tf_modules(path: str, should_download_module: Callable[[str], bool] = s
     distinct_modules = list({m.address: m for m in modules_to_load}.values())
 
     if run_parallel:
-        list(parallel_runner.run_function(_download_module, distinct_modules))
+        list(parallel_runner.run_function_multithreaded(_download_module, distinct_modules))
     else:
         for m in distinct_modules:
             _download_module(m)

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -68,7 +68,7 @@ def should_download(path: str) -> bool:
     return not (path.startswith('./') or path.startswith('../') or path.startswith('/'))
 
 
-def load_tf_modules(path: str, should_download_module: Callable[[str], bool] = should_download, run_parallel=True):
+def load_tf_modules(path: str, should_download_module: Callable[[str], bool] = should_download, run_parallel=False):
     module_loader_registry.root_dir = path
     modules_to_load = find_modules(path)
 
@@ -87,7 +87,7 @@ def load_tf_modules(path: str, should_download_module: Callable[[str], bool] = s
     distinct_modules = list({m.address: m for m in modules_to_load}.values())
 
     if run_parallel:
-        list(parallel_runner.run_function_multithreaded(_download_module, distinct_modules))
+        list(parallel_runner.run_function(_download_module, distinct_modules))
     else:
         for m in distinct_modules:
             _download_module(m)


### PR DESCRIPTION
Change run_parallel default value in loading external modules to false because of runtime errors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
