### PR TITLE
add try-catch block for hcl2.loads failure in ProviderContextParser

### DIFF
--- a/checkov/terraform/context_parsers/parsers/provider_context_parser.py
+++ b/checkov/terraform/context_parsers/parsers/provider_context_parser.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, Any, List
 
 import hcl2
@@ -30,7 +31,8 @@ class ProviderContextParser(BaseContextParser):
                     map(lambda obj: obj[1], self.file_lines[line_num - 1 : end_line if end_line > line_num else line_num])
                 )
             )["provider"][0]
-        except Exception:
+        except Exception as e:
+            logging.info(f'got exception while loading file {self.tf_file}\n {e}')
             return False
         alias = provider_obj[provider_type].get("alias", ["default"])
         return super()._is_block_signature(line_num, line_tokens + alias, entity_context_path)

--- a/checkov/terraform/context_parsers/parsers/provider_context_parser.py
+++ b/checkov/terraform/context_parsers/parsers/provider_context_parser.py
@@ -24,11 +24,14 @@ class ProviderContextParser(BaseContextParser):
 
         end_line = self._compute_definition_end_line(line_num)
         provider_type = entity_context_path[0]
-        provider_obj = hcl2.loads(
-            "\n".join(
-                map(lambda obj: obj[1], self.file_lines[line_num - 1 : end_line if end_line > line_num else line_num])
-            )
-        )["provider"][0]
+        try:
+            provider_obj = hcl2.loads(
+                "\n".join(
+                    map(lambda obj: obj[1], self.file_lines[line_num - 1 : end_line if end_line > line_num else line_num])
+                )
+            )["provider"][0]
+        except Exception:
+            return False
         alias = provider_obj[provider_type].get("alias", ["default"])
         return super()._is_block_signature(line_num, line_tokens + alias, entity_context_path)
 


### PR DESCRIPTION
return False for `_is_block_signature` function in `ProviderContextParser` if the terraform file isn't valid

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
