### PR TITLE
fix CKV_AZURE_50 to check the correct resources

### DIFF
--- a/checkov/terraform/checks/resource/azure/AzureInstanceExtensions.py
+++ b/checkov/terraform/checks/resource/azure/AzureInstanceExtensions.py
@@ -1,20 +1,21 @@
-from checkov.common.models.enums import CheckCategories, CheckResult
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
 class AzureInstanceExtensions(BaseResourceValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure Virtual Machine Extensions are not Installed"
         id = "CKV_AZURE_50"
-        supported_resources = ['azurerm_virtual_machine', 'azurerm_linux_virtual_machine']
+        supported_resources = ["azurerm_linux_virtual_machine", "azurerm_windows_virtual_machine"]
         categories = [CheckCategories.GENERAL_SECURITY]
-        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
-                         missing_block_result=CheckResult.PASSED)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return 'allow_extension_operations'
+    def get_inspected_key(self) -> str:
+        return "allow_extension_operations"
 
-    def get_expected_value(self):
+    def get_expected_value(self) -> Any:
         return False
 
 

--- a/tests/terraform/checks/resource/azure/example_AzureInstanceExtensions/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AzureInstanceExtensions/main.tf
@@ -1,0 +1,119 @@
+# pass
+
+resource "azurerm_linux_virtual_machine" "disabled" {
+  admin_password      = "admin"
+  admin_username      = "admin123"
+  location            = "azurerm_resource_group.test.location"
+  name                = "linux-vm"
+  resource_group_name = "azurerm_resource_group.test.name"
+  size                = "Standard_F2"
+
+  network_interface_ids = [
+    "azurerm_network_interface.test.id"
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  allow_extension_operations = false
+}
+
+resource "azurerm_windows_virtual_machine" "disabled" {
+  admin_password      = "admin"
+  admin_username      = "admin123"
+  location            = "azurerm_resource_group.test.location"
+  name                = "win-vm"
+  resource_group_name = "azurerm_resource_group.test.name"
+  size                = "Standard_F2"
+
+  network_interface_ids = [
+    "azurerm_network_interface.test.id"
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  allow_extension_operations = false
+}
+
+# fail
+
+resource "azurerm_linux_virtual_machine" "default" {
+  admin_password      = "admin"
+  admin_username      = "admin123"
+  location            = "azurerm_resource_group.test.location"
+  name                = "linux-vm"
+  resource_group_name = "azurerm_resource_group.test.name"
+  size                = "Standard_F2"
+
+  network_interface_ids = [
+    "azurerm_network_interface.test.id"
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "enabled" {
+  admin_password      = "admin"
+  admin_username      = "admin123"
+  location            = "azurerm_resource_group.test.location"
+  name                = "linux-vm"
+  resource_group_name = "azurerm_resource_group.test.name"
+  size                = "Standard_F2"
+
+  network_interface_ids = [
+    "azurerm_network_interface.test.id"
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  allow_extension_operations = true
+}
+
+resource "azurerm_windows_virtual_machine" "default" {
+  admin_password      = "admin"
+  admin_username      = "admin123"
+  location            = "azurerm_resource_group.test.location"
+  name                = "win-vm"
+  resource_group_name = "azurerm_resource_group.test.name"
+  size                = "Standard_F2"
+
+  network_interface_ids = [
+    "azurerm_network_interface.test.id"
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "enabled" {
+  admin_password      = "admin"
+  admin_username      = "admin123"
+  location            = "azurerm_resource_group.test.location"
+  name                = "win-vm"
+  resource_group_name = "azurerm_resource_group.test.name"
+  size                = "Standard_F2"
+
+  network_interface_ids = [
+    "azurerm_network_interface.test.id"
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  allow_extension_operations = true
+}

--- a/tests/terraform/checks/resource/azure/test_AzureInstanceExtensions.py
+++ b/tests/terraform/checks/resource/azure/test_AzureInstanceExtensions.py
@@ -1,80 +1,40 @@
 import unittest
+from pathlib import Path
 
-import hcl2
-
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.azure.AzureInstanceExtensions import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestAzureInstanceExtensions(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_AzureInstanceExtensions"
 
-    def test_failure(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_linux_virtual_machine" "example" {
-              name                = "example-machine"
-              resource_group_name = azurerm_resource_group.example.name
-              location            = azurerm_resource_group.example.location
-              size                = "Standard_F2"
-              admin_username      = "adminuser"
-              allow_extension_operations=true
-              }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_linux_virtual_machine']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_linux_virtual_machine" "example" {
-              name                = "example-machine"
-              resource_group_name = azurerm_resource_group.example.name
-              location            = azurerm_resource_group.example.location
-              size                = "Standard_F2"
-              admin_username      = "adminuser"
-              allow_extension_operations=false
-              }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_linux_virtual_machine']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passing_resources = {
+            "azurerm_linux_virtual_machine.disabled",
+            "azurerm_windows_virtual_machine.disabled",
+        }
+        failing_resources = {
+            "azurerm_linux_virtual_machine.default",
+            "azurerm_linux_virtual_machine.enabled",
+            "azurerm_windows_virtual_machine.default",
+            "azurerm_windows_virtual_machine.enabled",
+        }
 
-    def test_winfailure(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_windows_virtual_machine" "example" {
-              name                       = "example-machine"
-              resource_group_name        = azurerm_resource_group.example.name
-              location                   = azurerm_resource_group.example.location
-              size                       = "Standard_F2"
-              admin_username             = "adminuser"
-              admin_password             = "P@$$w0rd1234!"  
-              allow_extension_operations = true
-              network_interface_ids = [
-                azurerm_network_interface.example.id,
-                ]
-              }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_windows_virtual_machine']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
 
-    def test_winsuccess(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_windows_virtual_machine" "example" {
-              name                       = "example-machine"
-              resource_group_name        = azurerm_resource_group.example.name
-              location                   = azurerm_resource_group.example.location
-              size                       = "Standard_F2"
-              admin_username             = "adminuser"
-              admin_password             = "P@$$w0rd1234!"
-              network_interface_ids = [
-                azurerm_network_interface.example.id,
-                ]
-              }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_windows_virtual_machine']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #2022 

Resource `azurerm_virtual_machine` is actually a deprecated resource and their specific flavours `windows` and `linux` should be used instead. I also adjusted the tests to newer syntax.
