### PR TITLE
adjust framework and skip-framework CLI parameter to handlemultiple entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ checkov --config-file path/to/config.yaml
 ```
 Users can also create a config file using the `--create-config` command, which takes the current command line args and writes them out to a given path. For example:
 ```sh
-checkov --compact --directory test-dir --docker-image sample-image --dockerfile-path Dockerfile --download-external-modules True --external-checks-dir sample-dir --no-guide --quiet --repo-id bridgecrew/sample-repo --skip-check CKV_DOCKER_3,CKV_DOCKER_2 --skip-fixes --skip-framework dockerfile --skip-suppressions --soft-fail --branch develop --check CKV_DOCKER_1 --create-config /Users/sample/config.yml
+checkov --compact --directory test-dir --docker-image sample-image --dockerfile-path Dockerfile --download-external-modules True --external-checks-dir sample-dir --no-guide --quiet --repo-id bridgecrew/sample-repo --skip-check CKV_DOCKER_3,CKV_DOCKER_2 --skip-fixes --skip-framework dockerfile secrets --skip-suppressions --soft-fail --branch develop --check CKV_DOCKER_1 --create-config /Users/sample/config.yml
 ```
 Will create a `config.yaml` file which looks like this:
 ```yaml
@@ -342,7 +342,8 @@ evaluate-variables: true
 external-checks-dir: 
   - sample-dir 
 external-modules-download-path: .external_modules 
-framework: all 
+framework:
+  - all 
 no-guide: true 
 output: cli 
 quiet: true 
@@ -351,7 +352,9 @@ skip-check:
   - CKV_DOCKER_3 
   - CKV_DOCKER_2 
 skip-fixes: true 
-skip-framework: dockerfile 
+skip-framework:
+  - dockerfile
+  - secrets
 skip-suppressions: true 
 soft-fail: true
 ```
@@ -371,7 +374,7 @@ Config File (/Users/sample/.checkov.yml):
   skip-check:        ['CKV_DOCKER_3', 'CKV_DOCKER_2']
 Defaults:
   --output:          cli
-  --framework:       all
+  --framework:       ['all']
   --download-external-modules:False
   --external-modules-download-path:.external_modules
   --evaluate-variables:True

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -198,11 +198,11 @@ class RunnerRegistry:
     def filter_runner_framework(self) -> None:
         if not self.runner_filter:
             return
-        if self.runner_filter.framework is None:
+        if not self.runner_filter.framework:
             return
-        if self.runner_filter.framework == "all":
+        if "all" in self.runner_filter.framework:
             return
-        self.runners = [runner for runner in self.runners if runner.check_type == self.runner_filter.framework]
+        self.runners = [runner for runner in self.runners if runner.check_type in self.runner_filter.framework]
 
     def remove_runner(self, runner: BaseRunner) -> None:
         if runner in self.runners:

--- a/checkov/common/util/docs_generator.py
+++ b/checkov/common/util/docs_generator.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import re
+from typing import List, Optional, Tuple, Union
+
 from tabulate import tabulate
 
 from checkov.arm.registry import arm_resource_registry, arm_parameter_registry
@@ -30,28 +32,30 @@ def get_compare_key(c):
     return res
 
 
-def print_checks(framework="all", use_bc_ids=False):
-    printable_checks_list = get_checks(framework, use_bc_ids=use_bc_ids)
+def print_checks(frameworks: Optional[List[str]] = None, use_bc_ids: bool = False) -> None:
+    framework_list = frameworks if frameworks else ["all"]
+    printable_checks_list = get_checks(framework_list, use_bc_ids=use_bc_ids)
     print(
         tabulate(printable_checks_list, headers=["Id", "Type", "Entity", "Policy", "IaC"], tablefmt="github",
                  showindex=True))
     print("\n\n---\n\n")
 
 
-def get_checks(framework="all", use_bc_ids=False):
+def get_checks(frameworks: Optional[List[str]] = None, use_bc_ids: bool = False) -> List[Tuple[str, str, str, str, str]]:
+    framework_list = frameworks if frameworks else ["all"]
     printable_checks_list = []
 
-    def add_from_repository(registry, checked_type: str, iac: str):
+    def add_from_repository(registry: Union[BaseCheckRegistry, BaseGraphRegistry], checked_type: str, iac: str) -> None:
         nonlocal printable_checks_list
         if isinstance(registry, BaseCheckRegistry):
             for entity, check in registry.all_checks():
-                printable_checks_list.append([check.get_output_id(use_bc_ids), checked_type, entity, check.name, iac])
+                printable_checks_list.append((check.get_output_id(use_bc_ids), checked_type, entity, check.name, iac))
         elif isinstance(registry, BaseGraphRegistry):
             for check in registry.checks:
                 for rt in check.resource_types:
-                    printable_checks_list.append([check.get_output_id(use_bc_ids), checked_type, rt, check.name, iac])
+                    printable_checks_list.append((check.get_output_id(use_bc_ids), checked_type, rt, check.name, iac))
 
-    if framework == "terraform" or framework == "all":
+    if any(x in framework_list for x in ("all", "terraform")):
         add_from_repository(resource_registry, "resource", "Terraform")
         add_from_repository(data_registry, "data", "Terraform")
         add_from_repository(provider_registry, "provider", "Terraform")
@@ -60,18 +64,18 @@ def get_checks(framework="all", use_bc_ids=False):
         graph_registry = get_graph_checks_registry("terraform")
         graph_registry.load_checks()
         add_from_repository(graph_registry, "resource", "Terraform")
-    if framework == "cloudformation" or framework == "all":
+    if any(x in framework_list for x in ("all", "cloudformation")):
         add_from_repository(cfn_registry, "resource", "Cloudformation")
-    if framework == "kubernetes" or framework == "all":
+    if any(x in framework_list for x in ("all", "kubernetes")):
         add_from_repository(k8_registry, "resource", "Kubernetes")
-    if framework == "serverless" or framework == "all":
+    if any(x in framework_list for x in ("all", "serverless")):
         add_from_repository(sls_registry, "resource", "serverless")
-    if framework == "dockerfile" or framework == "all":
+    if any(x in framework_list for x in ("all", "dockerfile")):
         add_from_repository(dockerfile_registry, "dockerfile", "dockerfile")
-    if framework == "arm" or framework == "all":
+    if any(x in framework_list for x in ("all", "arm")):
         add_from_repository(arm_resource_registry, "resource", "arm")
         add_from_repository(arm_parameter_registry, "parameter", "arm")
-    if framework == "secrets" or framework == "all":
+    if any(x in framework_list for x in ("all", "secrets")):
         for check_id, check_type in CHECK_ID_TO_SECRET_TYPE.items():
             printable_checks_list.append((check_id, check_type, "secrets", check_type, "secrets"))
     return sorted(printable_checks_list, key=get_compare_key)

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -300,14 +300,18 @@ def add_parser_args(parser):
     parser.add('--compact', action='store_true',
                default=False,
                help='in case of CLI output, do not display code blocks')
-    parser.add('--framework', help='filter scan to run only on a specific infrastructure code frameworks',
+    parser.add('--framework',
+               help='filter scan to run only on specific infrastructure code frameworks',
                choices=checkov_runners + ["all"],
-               default='all')
-    parser.add('--skip-framework', help='filter scan to skip specific infrastructure code frameworks. \n'
-                                        'will be included automatically for some frameworks if system dependencies '
-                                        'are missing.',
+               default=['all'],
+               nargs="+")
+    parser.add('--skip-framework',
+               help='filter scan to skip specific infrastructure code frameworks. \n'
+                    'will be included automatically for some frameworks if system dependencies '
+                    'are missing.',
                choices=checkov_runners,
-               default=None)
+               default=None,
+               nargs="+")
     parser.add('-c', '--check',
                help='filter scan to run only on a specific check identifier(allowlist), You can '
                     'specify multiple checks separated by comma delimiter', action='append', default=None)

--- a/tests/terraform/util/test_doc_generator.py
+++ b/tests/terraform/util/test_doc_generator.py
@@ -1,17 +1,37 @@
 import unittest
+from typing import List, Set, Optional
+
+import pytest
 
 from checkov.common.util.docs_generator import get_checks
 
 
-class TestDocGenerator(unittest.TestCase):
+def test_get_checks_returned_check_number():
+    checks = get_checks(["all"])
+    assert len(checks) > 0
 
-    def test_doc_generator_initiation(self):
-        checks = get_checks("all")
-        self.assertGreater(len(checks), 0)
-        checks = get_checks()
-        self.assertGreater(len(checks), 0)
+    checks = get_checks()
+    assert len(checks) > 0
+
+    checks = get_checks(["example"])
+    assert len(checks) == 0
 
 
+@pytest.mark.parametrize(
+    "input_frameworks,expected_frameworks",
+    [
+        (["all"], {"arm", "Cloudformation", "dockerfile", "Kubernetes", "secrets", "serverless", "Terraform"}),
+        (None, {"arm", "Cloudformation", "dockerfile", "Kubernetes", "secrets", "serverless", "Terraform"}),
+        (["terraform"], {"Terraform"}),
+        (["cloudformation", "serverless"], {"Cloudformation", "serverless"}),
+    ],
+    ids=["all", "none", "terraform", "multiple"],
+)
+def test_get_checks_returned_frameworks(input_frameworks: Optional[List[str]], expected_frameworks: Set[str]):
+    # when
+    checks = get_checks(input_frameworks)
 
-if __name__ == '__main__':
-    unittest.main()
+    # then
+    actual_frameworks = {c[4] for c in checks}
+
+    assert actual_frameworks == expected_frameworks

--- a/tests/test_runner_filter.py
+++ b/tests/test_runner_filter.py
@@ -1,0 +1,45 @@
+from typing import Optional, List, Set
+
+import pytest
+
+from checkov.main import checkov_runners
+from checkov.runner_filter import RunnerFilter
+
+
+@pytest.mark.parametrize(
+    "input_frameworks,input_skip_frameworks,expected_frameworks",
+    [
+        (["all"], None, {"all"}),
+        (None, None, {"all"}),
+        (["terraform"], None, {"terraform"}),
+        (["cloudformation", "serverless"], None, {"cloudformation", "serverless"}),
+        (
+            ["all"],
+            ["terraform", "secrets"],
+            {
+                "arm",
+                "cloudformation",
+                "dockerfile",
+                "helm",
+                "json",
+                "kubernetes",
+                "serverless",
+                "terraform_plan",
+            },
+        ),
+        (["cloudformation", "serverless"], ["serverless", "secrets"], {"cloudformation"}),
+    ],
+    ids=["all", "none", "terraform", "multiple", "all_with_skip", "multiple_with_skip"],
+)
+def test_runner_filter_constructor_framework(
+    input_frameworks: Optional[List[str]], input_skip_frameworks: Optional[List[str]], expected_frameworks: Set[str]
+):
+    # when
+    runner_filter = RunnerFilter(
+        framework=input_frameworks,
+        runners=checkov_runners,
+        skip_framework=input_skip_frameworks,
+    )
+
+    # then
+    assert set(runner_filter.framework) == expected_frameworks


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #1996 

Added the possibility to specify multiple frameworks (+ skipping them) to the CLI via the existing flags. Due to the nature of the used `choices` parameter those framework have to be inputed with a space in between.
```shell
$ checkov --framework terraform kubernetes -d .
$ checkov --skip-framework secrets terraform_plan -d .
```
I also checked and already existing config files will still work, so no breaking change to be expected 😅 