### PR TITLE
Restore postgres engine filter for CKV2_AWS_27

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/PostgresRDSHasQueryLoggingEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/PostgresRDSHasQueryLoggingEnabled.yaml
@@ -9,6 +9,12 @@ definition:
    value:
    - aws_rds_cluster
    operator: within
+ - cond_type: filter
+   resource_types:
+   - aws_rds_cluster
+   attribute: engine
+   operator: within
+   value: "aurora-postgresql"
  - cond_type: connection
    resource_types:
    - aws_rds_cluster


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Replaces #1784 

The possible values according to [tf docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#engine):
`aurora, aurora-mysql, aurora-postgresql`. So filtering on aurora-postgresql

CC: @acdha  
