### PR TITLE
Fix loading of module sources without explicit ssh://

### DIFF
--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -64,14 +64,19 @@ class GenericGitLoader(ModuleLoader):
         else:
             version = "HEAD"
 
-        if len(module_source_components) == 2:
+        if len(module_source_components) < 3:
+            root_module = module_source_components[-1]
             inner_module = ""
         elif len(module_source_components) == 3:
+            root_module = module_source_components[1]
             inner_module = module_source_components[2]
         else:
             raise Exception("invalid git url")
 
-        root_module = module_source_components[1]
+        username = re.match(r"^(.*?@).*", root_module)
+        if username:
+            root_module = root_module.replace(username[1], "")
+
         if root_module.endswith(".git"):
             root_module = root_module[:-4]
 
@@ -98,10 +103,6 @@ class GenericGitLoader(ModuleLoader):
                     self.external_modules_folder_name, module_source.root_module, module_source.version
                 )
             )
-
-        username = re.match(r"^git::ssh://(.*?@).*", self.module_source)
-        if username:
-            self.dest_dir = self.dest_dir.replace(username[1], "")
 
 
 loader = GenericGitLoader()

--- a/tests/terraform/module_loading/test_registry.py
+++ b/tests/terraform/module_loading/test_registry.py
@@ -104,73 +104,6 @@ def test_load_terraform_registry(
     "source, expected_content_path, expected_git_url, expected_dest_dir, expected_module_source, expected_inner_module",
     [
         (
-            "git::https://example.com/network.git",
-            "example.com/network/HEAD",
-            "https://example.com/network.git",
-            "example.com/network/HEAD",
-            "git::https://example.com/network.git",
-            "",
-        ),
-        (
-            "git::https://example.com/network.git?ref=v1.2.0",
-            "example.com/network/v1.2.0",
-            "https://example.com/network.git?ref=v1.2.0",
-            "example.com/network/v1.2.0",
-            "git::https://example.com/network.git?ref=v1.2.0",
-            "",
-        ),
-        (
-            "git::https://example.com/network.git//modules/vpc",
-            "example.com/network/HEAD/modules/vpc",
-            "https://example.com/network",
-            "example.com/network/HEAD",
-            "git::https://example.com/network",
-            "modules/vpc",
-        ),
-        (
-            "git::https://example.com/network.git//modules/vpc?ref=v1.2.0",
-            "example.com/network/v1.2.0/modules/vpc",
-            "https://example.com/network?ref=v1.2.0",
-            "example.com/network/v1.2.0",
-            "git::https://example.com/network?ref=v1.2.0",
-            "modules/vpc",
-        ),
-    ],
-    ids=["module", "module_with_version", "inner_module", "inner_module_with_version"],
-)
-@mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
-def test_load_generic_git(
-    git_getter,
-    source,
-    expected_content_path,
-    expected_git_url,
-    expected_dest_dir,
-    expected_module_source,
-    expected_inner_module,
-):
-    # given
-    current_dir = Path(__file__).parent / "tmp"
-    registry = ModuleLoaderRegistry(download_external_modules=True)
-
-    # when
-    content = registry.load(current_dir=str(current_dir), source=source, source_version="latest")
-
-    # then
-    assert content.loaded()
-    assert content.path() == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_content_path)
-
-    git_getter.assert_called_once_with(expected_git_url, mock.ANY)
-
-    git_loader = next(loader for loader in registry.loaders if isinstance(loader, GenericGitLoader))
-    assert git_loader.dest_dir == str(current_dir / DEFAULT_EXTERNAL_MODULES_DIR / expected_dest_dir)
-    assert git_loader.module_source == expected_module_source
-    assert git_loader.inner_module == expected_inner_module
-
-
-@pytest.mark.parametrize(
-    "source, expected_content_path, expected_git_url, expected_dest_dir, expected_module_source, expected_inner_module",
-    [
-        (
             "github.com/terraform-aws-modules/terraform-aws-security-group",
             "github.com/terraform-aws-modules/terraform-aws-security-group/HEAD",
             "https://github.com/terraform-aws-modules/terraform-aws-security-group",
@@ -417,8 +350,44 @@ def test_load_terraform_registry(
             "git::https://example.com/network?ref=v1.2.0",
             "modules/vpc",
         ),
+        (
+            "git::ssh://username@example.com/network.git",
+            "example.com/network/HEAD",
+            "ssh://username@example.com/network.git",
+            "example.com/network/HEAD",
+            "git::ssh://username@example.com/network.git",
+            "",
+        ),
+        (
+            "git::ssh://username@example.com/network.git?ref=v1.2.0",
+            "example.com/network/v1.2.0",
+            "ssh://username@example.com/network.git?ref=v1.2.0",
+            "example.com/network/v1.2.0",
+            "git::ssh://username@example.com/network.git?ref=v1.2.0",
+            "",
+        ),
+        (
+            "git::username@example.com/network.git",
+            "example.com/network/HEAD",
+            "username@example.com/network.git",
+            "example.com/network/HEAD",
+            "git::username@example.com/network.git",
+            "",
+        ),
+        (
+            "git::username@example.com/network.git?ref=v1.2.0",
+            "example.com/network/v1.2.0",
+            "username@example.com/network.git?ref=v1.2.0",
+            "example.com/network/v1.2.0",
+            "git::username@example.com/network.git?ref=v1.2.0",
+            "",
+        ),
     ],
-    ids=["module", "module_with_version", "inner_module", "inner_module_with_version"],
+    ids=["module", "module_with_version",
+         "inner_module", "inner_module_with_version",
+         "module_over_ssh", "module_over_ssh_with_version",
+         "module_over_ssh_without_protocol", "module_over_ssh_without_protocol_with_version",
+     ],
 )
 @mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
 def test_load_generic_git(


### PR DESCRIPTION
This also removes a duplicated test function and adds tests for modules
that are loaded via ssh in general.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
