### PR TITLE
Use full resource address as resource name when parsing terraform plan  (#1116)

### DIFF
--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -123,9 +123,9 @@ def parse_tf_plan(tf_plan_file: str) -> Tuple[Optional[Dict[str, Dict[str, Any]]
     :type tf_plan_file: str - path to plan file
     :rtype: tf_definition dictionary
     """
-    tf_defintions: Dict[str, Dict[str, Any]] = {}
-    tf_defintions[tf_plan_file] = {}
-    tf_defintions[tf_plan_file]["resource"] = []
+    tf_definitions: Dict[str, Dict[str, Any]] = {}
+    tf_definitions[tf_plan_file] = {}
+    tf_definitions[tf_plan_file]["resource"] = []
     template, template_lines = parse(tf_plan_file)
     if not template:
         return None, None
@@ -140,11 +140,11 @@ def parse_tf_plan(tf_plan_file: str) -> Tuple[Optional[Dict[str, Dict[str, Any]]
         )
         resource_block, prepared = _prepare_resource_block(resource, conf)
         if prepared is True:
-            tf_defintions[tf_plan_file]["resource"].append(resource_block)
+            tf_definitions[tf_plan_file]["resource"].append(resource_block)
     child_modules = template.get("planned_values", {}).get("root_module", {}).get("child_modules", [])
     # Terraform supports modules within modules so we need to search
     # in nested modules to find all resource blocks
     resource_blocks = _find_child_modules(child_modules)
     for resource in resource_blocks:
-        tf_defintions[tf_plan_file]["resource"].append(resource)
-    return tf_defintions, template_lines
+        tf_definitions[tf_plan_file]["resource"].append(resource)
+    return tf_definitions, template_lines

--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -93,7 +93,7 @@ def _prepare_resource_block(resource: DictNode, conf: Optional[DictNode]) -> Tup
     # and where *_module resources don't have values field
     if mode == "managed" and "values" in resource:
         expressions = conf.get("expressions") if conf else None
-        resource_block[resource["type"]][resource.get("name", "default")] = _hclify(resource["values"], expressions)
+        resource_block[resource["type"]][resource.get("address", "default")] = _hclify(resource["values"], expressions)
         prepared = True
     return resource_block, prepared
 
@@ -134,7 +134,7 @@ def parse_tf_plan(tf_plan_file: str) -> Tuple[Optional[Dict[str, Dict[str, Any]]
             (
                 x
                 for x in template.get("configuration", {}).get("root_module", {}).get("resources", [])
-                if x["type"] == resource["type"] and x["name"] == resource["name"]
+                if x["type"] == resource["type"] and x["address"] == resource["address"]
             ),
             None,
         )

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -126,9 +126,9 @@ class Runner(TerraformRunner):
             if resource_type in resource.keys():
                 resource_name = definition_path[1]
                 if resource_name in resource[resource_type].keys():
-                    resource_defintion = resource[resource_type][resource_name]
-                    entity_context['start_line'] = resource_defintion['start_line'][0]
-                    entity_context['end_line'] = resource_defintion['end_line'][0]
+                    resource_definition = resource[resource_type][resource_name]
+                    entity_context['start_line'] = resource_definition['start_line'][0]
+                    entity_context['end_line'] = resource_definition['end_line'][0]
                     entity_context['code_lines'] = self.template_lines[
                                                    entity_context['start_line']:entity_context['end_line']]
                     return entity_context

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -99,7 +99,7 @@ class Runner(TerraformRunner):
             for entity in entities:
                 context_parser = parser_registry.context_parsers[block_type]
                 definition_path = context_parser.get_entity_context_path(entity)
-                entity_id = ".".join(definition_path)
+                entity_id = definition_path[1]
                 # Entity can exist only once per dir, for file as well
                 entity_context = self.get_entity_context(definition_path, full_file_path)
                 entity_lines_range = [entity_context.get('start_line'), entity_context.get('end_line')]

--- a/tests/terraform/parser/resources/plan_modules/modules.tf
+++ b/tests/terraform/parser/resources/plan_modules/modules.tf
@@ -1,0 +1,8 @@
+module "mymodule_1" {
+  source = "./mymodule"
+  for_each = toset(["foo", "bar"])
+}
+
+module "mymodule_2" {
+  source = "./mymodule"
+}

--- a/tests/terraform/parser/resources/plan_modules/mymodule/module.tf
+++ b/tests/terraform/parser/resources/plan_modules/mymodule/module.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "dummy" {
+}

--- a/tests/terraform/parser/resources/plan_modules/tfplan.json
+++ b/tests/terraform/parser/resources/plan_modules/tfplan.json
@@ -1,0 +1,165 @@
+{
+  "format_version": "0.2",
+  "terraform_version": "1.0.11",
+  "planned_values": {
+    "root_module": {
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.mymodule_1[\"bar\"].null_resource.dummy",
+              "mode": "managed",
+              "type": "null_resource",
+              "name": "dummy",
+              "provider_name": "registry.terraform.io/hashicorp/null",
+              "schema_version": 0,
+              "values": {
+                "triggers": null
+              },
+              "sensitive_values": {}
+            }
+          ],
+          "address": "module.mymodule_1[\"bar\"]"
+        },
+        {
+          "resources": [
+            {
+              "address": "module.mymodule_1[\"foo\"].null_resource.dummy",
+              "mode": "managed",
+              "type": "null_resource",
+              "name": "dummy",
+              "provider_name": "registry.terraform.io/hashicorp/null",
+              "schema_version": 0,
+              "values": {
+                "triggers": null
+              },
+              "sensitive_values": {}
+            }
+          ],
+          "address": "module.mymodule_1[\"foo\"]"
+        },
+        {
+          "resources": [
+            {
+              "address": "module.mymodule_2.null_resource.dummy",
+              "mode": "managed",
+              "type": "null_resource",
+              "name": "dummy",
+              "provider_name": "registry.terraform.io/hashicorp/null",
+              "schema_version": 0,
+              "values": {
+                "triggers": null
+              },
+              "sensitive_values": {}
+            }
+          ],
+          "address": "module.mymodule_2"
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "module.mymodule_1[\"bar\"].null_resource.dummy",
+      "module_address": "module.mymodule_1[\"bar\"]",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "dummy",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "triggers": null
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "module.mymodule_1[\"foo\"].null_resource.dummy",
+      "module_address": "module.mymodule_1[\"foo\"]",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "dummy",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "triggers": null
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "module.mymodule_2.null_resource.dummy",
+      "module_address": "module.mymodule_2",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "dummy",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "triggers": null
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "configuration": {
+    "root_module": {
+      "module_calls": {
+        "mymodule_1": {
+          "source": "./mymodule",
+          "module": {
+            "resources": [
+              {
+                "address": "null_resource.dummy",
+                "mode": "managed",
+                "type": "null_resource",
+                "name": "dummy",
+                "provider_config_key": "mymodule_1:null",
+                "schema_version": 0
+              }
+            ]
+          }
+        },
+        "mymodule_2": {
+          "source": "./mymodule",
+          "module": {
+            "resources": [
+              {
+                "address": "null_resource.dummy",
+                "mode": "managed",
+                "type": "null_resource",
+                "name": "dummy",
+                "provider_config_key": "mymodule_2:null",
+                "schema_version": 0
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/terraform/parser/test_plan_parser.py
+++ b/tests/terraform/parser/test_plan_parser.py
@@ -24,6 +24,16 @@ class TestPlanFileParser(unittest.TestCase):
         # TODO: this should also verify the flattening but at least shows it parses now.
         assert True
 
+    def test_module_resources_have_unique_names(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_plan_path = current_dir + "/resources/plan_modules/tfplan.json"
+        tf_definitions, _ = parse_tf_plan(valid_plan_path)
+        resources = next(iter(tf_definitions.values()))['resource']
+        unique_resource_names = set([resource_name for resource in resources
+                          if 'null_resource' in resource.keys()
+                          for resource_name in resource['null_resource'].keys()])
+        assert len(unique_resource_names) == 3
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This makes sure that there are no colliding resources when a module is
used multiple times. Without this fix, line numbers and affected code
reported was incorrect. This also fixes #1116.


Also fixes some typos in variable name (separate commit, in order to ease reviewing).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
