### PR TITLE
Handle module suppression enrichments

### DIFF
--- a/checkov/common/output/graph_record.py
+++ b/checkov/common/output/graph_record.py
@@ -8,6 +8,6 @@ class GraphRecord(Record):
         super().__init__(record.check_id, record.check_name, record.check_result, record.code_block, record.file_path,
                          record.file_line_range, record.resource, record.evaluations, record.check_class,
                          record.file_abs_path, record.entity_tags, record.caller_file_path,
-                         record.caller_file_line_range, bc_check_id=record.bc_check_id)
+                         record.caller_file_line_range, bc_check_id=record.bc_check_id, resource_address=record.resource_address)
         self.fixed_definition = record.fixed_definition
         self.breadcrumbs = breadcrumbs

--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -29,7 +29,7 @@ class Record:
 
     def __init__(self, check_id, check_name, check_result, code_block, file_path, file_line_range, resource,
                  evaluations, check_class, file_abs_path, entity_tags=None,
-                 caller_file_path=None, caller_file_line_range=None, bc_check_id=None):
+                 caller_file_path=None, caller_file_line_range=None, bc_check_id=None, resource_address=None):
         """
         :param evaluations: A dict with the key being the variable name, value being a dict containing:
                              - 'var_file'
@@ -52,6 +52,7 @@ class Record:
         self.entity_tags = entity_tags
         self.caller_file_path = caller_file_path
         self.caller_file_line_range = caller_file_line_range
+        self.resource_address = resource_address
 
     @staticmethod
     def _determine_repo_file_path(file_path: Union[str, "os.PathLike[str]"]) -> str:

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -433,6 +433,16 @@ class Report:
                     record.check_result["suppress_comment"] = skip["suppress_comment"]
                     report.add_record(record)
 
+            if record.resource_address and record.resource_address.startswith("module."):
+                module_path = record.resource_address[0:record.resource_address.index('.', len("module.") + 1)]
+                module_enrichments = enriched_resources.get(module_path, {})
+                for module_skip in module_enrichments.get("skipped_checks", []):
+                    if record.check_id in module_skip["id"]:
+                        skip_records.append(record)
+                        record.check_result["result"] = CheckResult.SKIPPED
+                        record.check_result["suppress_comment"] = module_skip["suppress_comment"]
+                        report.add_record(record)
+
         for record in skip_records:
             if record in report.failed_checks:
                 report.failed_checks.remove(record)

--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -94,6 +94,7 @@ def _prepare_resource_block(resource: DictNode, conf: Optional[DictNode]) -> Tup
     if mode == "managed" and "values" in resource:
         expressions = conf.get("expressions") if conf else None
         resource_block[resource["type"]][resource.get("name", "default")] = _hclify(resource["values"], expressions)
+        resource_block[resource["type"]][resource.get("name", "default")]["__address__"] = resource.get("address")
         prepared = True
     return resource_block, prepared
 

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -104,12 +104,14 @@ class Runner(TerraformRunner):
                 entity_context = self.get_entity_context(definition_path, full_file_path)
                 entity_lines_range = [entity_context.get('start_line'), entity_context.get('end_line')]
                 entity_code_lines = entity_context.get('code_lines')
+                entity_address = entity_context.get('address')
+
                 results = registry.scan(scanned_file, entity, [], runner_filter)
                 for check, check_result in results.items():
                     record = Record(check_id=check.id, bc_check_id=check.bc_id, check_name=check.name, check_result=check_result,
                                     code_block=entity_code_lines, file_path=scanned_file,
                                     file_line_range=entity_lines_range,
-                                    resource=entity_id, evaluations=None,
+                                    resource=entity_id, resource_address=entity_address, evaluations=None,
                                     check_class=check.__class__.__module__, file_abs_path=full_file_path)
                     record.set_guideline(check.guideline)
                     report.add_record(record=record)
@@ -131,5 +133,6 @@ class Runner(TerraformRunner):
                     entity_context['end_line'] = resource_defintion['end_line'][0]
                     entity_context['code_lines'] = self.template_lines[
                                                    entity_context['start_line']:entity_context['end_line']]
+                    entity_context['address'] = resource_defintion['__address__']
                     return entity_context
         return entity_context

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -145,7 +145,8 @@ class Runner(BaseRunner):
                         entity_tags=entity.get('tags', {}),
                         evaluations=entity_evaluations,
                         check_class=check.__class__.__module__,
-                        file_abs_path=os.path.abspath(full_file_path)
+                        file_abs_path=os.path.abspath(full_file_path),
+                        resource_address=entity_context.get('address')
                     )
                     if self.breadcrumbs:
                         breadcrumb = self.breadcrumbs.get(record.file_path, {}).get(record.resource)

--- a/tests/common/runner_registry/plan_module_skip_for_enrichment/mod_ref/main.tf
+++ b/tests/common/runner_registry/plan_module_skip_for_enrichment/mod_ref/main.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "b1" {
+  bucket = "bc-test-bucket-1"
+}

--- a/tests/common/runner_registry/plan_module_skip_for_enrichment/tf/main.tf
+++ b/tests/common/runner_registry/plan_module_skip_for_enrichment/tf/main.tf
@@ -2,5 +2,5 @@
 module "m" {
   # checkov:skip=CKV_AWS_19: ADD REASON
   # checkov:skip=CKV2_AWS_6: ADD REASON
-  source = "..\/mod_ref"
+  source = "../mod_ref"
 }

--- a/tests/common/runner_registry/plan_module_skip_for_enrichment/tf/main.tf
+++ b/tests/common/runner_registry/plan_module_skip_for_enrichment/tf/main.tf
@@ -1,0 +1,6 @@
+
+module "m" {
+  # checkov:skip=CKV_AWS_19: ADD REASON
+  # checkov:skip=CKV2_AWS_6: ADD REASON
+  source = "..\/mod_ref"
+}

--- a/tests/common/runner_registry/plan_module_skip_for_enrichment/tf/tfplan.json
+++ b/tests/common/runner_registry/plan_module_skip_for_enrichment/tf/tfplan.json
@@ -1,0 +1,155 @@
+{
+    "format_version": "0.1",
+    "terraform_version": "0.15.5",
+    "variables": {
+        "region": {
+            "value": "us-west-2"
+        }
+    },
+    "planned_values": {
+        "root_module": {
+            "child_modules": [
+                {
+                    "resources": [
+                        {
+                            "address": "module.m.aws_s3_bucket.b1",
+                            "mode": "managed",
+                            "type": "aws_s3_bucket",
+                            "name": "b1",
+                            "provider_name": "registry.terraform.io/hashicorp/aws",
+                            "schema_version": 0,
+                            "values": {
+                                "acl": "private",
+                                "bucket": "bc-test-bucket-1",
+                                "bucket_prefix": null,
+                                "cors_rule": [],
+                                "force_destroy": false,
+                                "grant": [],
+                                "lifecycle_rule": [],
+                                "logging": [],
+                                "object_lock_configuration": [],
+                                "policy": null,
+                                "replication_configuration": [],
+                                "server_side_encryption_configuration": [],
+                                "tags": null,
+                                "website": []
+                            }
+                        }
+                    ],
+                    "address": "module.m"
+                }
+            ]
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "module.m.aws_s3_bucket.b1",
+            "module_address": "module.m",
+            "mode": "managed",
+            "type": "aws_s3_bucket",
+            "name": "b1",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "acl": "private",
+                    "bucket": "bc-test-bucket-1",
+                    "bucket_prefix": null,
+                    "cors_rule": [],
+                    "force_destroy": false,
+                    "grant": [],
+                    "lifecycle_rule": [],
+                    "logging": [],
+                    "object_lock_configuration": [],
+                    "policy": null,
+                    "replication_configuration": [],
+                    "server_side_encryption_configuration": [],
+                    "tags": null,
+                    "website": []
+                },
+                "after_unknown": {
+                    "acceleration_status": true,
+                    "arn": true,
+                    "bucket_domain_name": true,
+                    "bucket_regional_domain_name": true,
+                    "cors_rule": [],
+                    "grant": [],
+                    "hosted_zone_id": true,
+                    "id": true,
+                    "lifecycle_rule": [],
+                    "logging": [],
+                    "object_lock_configuration": [],
+                    "region": true,
+                    "replication_configuration": [],
+                    "request_payer": true,
+                    "server_side_encryption_configuration": [],
+                    "tags_all": true,
+                    "versioning": true,
+                    "website": [],
+                    "website_domain": true,
+                    "website_endpoint": true
+                },
+                "before_sensitive": false,
+                "after_sensitive": {
+                    "cors_rule": [],
+                    "grant": [],
+                    "lifecycle_rule": [],
+                    "logging": [],
+                    "object_lock_configuration": [],
+                    "replication_configuration": [],
+                    "server_side_encryption_configuration": [],
+                    "tags_all": {},
+                    "versioning": [],
+                    "website": []
+                }
+            }
+        }
+    ],
+    "configuration": {
+        "provider_config": {
+            "aws": {
+                "name": "aws",
+                "expressions": {
+                    "region": {
+                        "references": [
+                            "var.region"
+                        ]
+                    }
+                }
+            }
+        },
+        "root_module": {
+            "module_calls": {
+                "m": {
+                    "source": "../mod_ref",
+                    "module": {
+                        "resources": [
+                            {
+                                "address": "aws_s3_bucket.b1",
+                                "mode": "managed",
+                                "type": "aws_s3_bucket",
+                                "name": "b1",
+                                "provider_config_key": "m:aws",
+                                "expressions": {
+                                    "bucket": {
+                                        "constant_value": "bc-test-bucket-1"
+                                    }
+                                },
+                                "schema_version": 0
+                            }
+                        ]
+                    }
+                }
+            },
+            "variables": {
+                "region": {
+                    "default": "us-west-2",
+                    "description": "The provider region to use"
+                }
+            }
+        }
+    }
+}

--- a/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
+++ b/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
@@ -159,6 +159,25 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
         self.assertEqual(len(skipped_check_ids), 2)
         self.assertEqual(skipped_check_ids, expected_skipped_check_ids)
 
+    def test_skip_check_in_module(self):
+        allowed_checks = ["CKV_AWS_19", "CKV2_AWS_6"]
+        runner_registry = RunnerRegistry(
+            banner, RunnerFilter(checks=allowed_checks, framework="terraform_plan"), tf_plan_runner()
+        )
+
+        repo_root = Path(__file__).parent / "plan_module_skip_for_enrichment" / "tf"
+        valid_plan_path = repo_root / "tfplan.json"
+
+        report = runner_registry.run(repo_root_for_plan_enrichment=[repo_root], files=[valid_plan_path])[0]
+
+        failed_check_ids = {c.check_id for c in report.failed_checks}
+        skipped_check_ids = {c.check_id for c in report.skipped_checks}
+        expected_skipped_check_ids = set(allowed_checks)
+
+        self.assertEqual(len(failed_check_ids), 0)
+        self.assertEqual(len(skipped_check_ids), 2)
+        self.assertEqual(skipped_check_ids, expected_skipped_check_ids)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes https://github.com/bridgecrewio/checkov/issues/2047 by saving the resource address in a TF plan run and then using that address to look up suppressions for the module during the enrichment phase.

I could think of one alternative approach to this that seemed like a little less of a hack, but was also probably overkill. That approach would be to replace this line with logic to repeat the entire parsing and graph building logic and reconstruct the entire module structure from scratch. Then use the logic introduced in that PR I reference in the issue to push suppressions down to the resources in the same way.

However, that seemed like overkill, and avoiding unnecessarily building a graph seems like a good idea due to performance concerns.

I do not think this approach will work with nested modules, but I don't think the original fix does either, so we can leave that until someone complains.