### PR TITLE
check embedded policy on aws_sqs_queue

### DIFF
--- a/checkov/terraform/checks/resource/aws/SQSQueuePolicyAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/SQSQueuePolicyAnyPrincipal.py
@@ -10,7 +10,7 @@ class SQSQueuePolicyAnyPrincipal(BaseResourceCheck):
     def __init__(self):
         name = "Ensure SQS queue policy is not public by only allowing specific services or principals to access it"
         id = "CKV_AWS_168"
-        supported_resources = ['aws_sqs_queue_policy']
+        supported_resources = ['aws_sqs_queue_policy', 'aws_sqs_queue']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/tests/terraform/checks/resource/aws/example_SQSQueuePolicyAnyPrincipal/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SQSQueuePolicyAnyPrincipal/main.tf
@@ -127,3 +127,124 @@ resource "aws_sqs_queue_policy" "q7" {
 
   policy = data.aws_iam_policy_document.bucket_policy.json
 }
+
+
+# now test aws_sqs_queue
+# pass
+resource "aws_sqs_queue" "aq1" {
+
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": "*",
+          "Effect": "Deny",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sqs_queue" "aq2" {
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+           "Principal": {
+            "AWS": [
+                "arn:aws:iam::123456789101:role/sqs",
+                "*"
+            ]
+          },
+          "Effect": "Allow",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sqs_queue" "aq3" {
+
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": {
+            "AWS": "arn:aws:iam::*:role/sqs"
+          },
+          "Effect": "Allow",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sqs_queue" "aq4" {
+
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+           "Principal": {
+            "AWS": "*"
+          },
+          "Effect": "Allow",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# fail
+resource "aws_sqs_queue" "aq5" {
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": "*",
+          "Effect": "Allow",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# pass
+resource "aws_sqs_queue" "aq6" {
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": "arn:aws:iam::123456789101:role/sqs",
+          "Effect": "Allow",
+          "Action": "sqs:SendMessage",
+          "Resource": "${aws_sqs_queue_policy.q.arn}"
+       }
+    ]
+}
+POLICY
+}
+
+# unknown
+resource "aws_sqs_queue" "aq7" {
+  policy = data.aws_iam_policy_document.bucket_policy.json
+}

--- a/tests/terraform/checks/resource/aws/test_SQSQueuePolicyAnyPrincipal.py
+++ b/tests/terraform/checks/resource/aws/test_SQSQueuePolicyAnyPrincipal.py
@@ -18,19 +18,25 @@ class TestBackupVaultEncrypted(unittest.TestCase):
         passing_resources = {
             "aws_sqs_queue_policy.q1",
             "aws_sqs_queue_policy.q6",
+            "aws_sqs_queue.aq1",
+            "aws_sqs_queue.aq6"
         }
         failing_resources = {
             "aws_sqs_queue_policy.q2",
             "aws_sqs_queue_policy.q3",
             "aws_sqs_queue_policy.q4",
             "aws_sqs_queue_policy.q5",
+            "aws_sqs_queue.aq2",
+            "aws_sqs_queue.aq3",
+            "aws_sqs_queue.aq4",
+            "aws_sqs_queue.aq5",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["passed"], 4)
+        self.assertEqual(summary["failed"], 8)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Updates the public SQS queue policy to work on both queue_policy and queue resources