### PR TITLE
Fix ApiServerServiceAccountKeyFile.py regex to avoid backtracking

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/ApiServerServiceAccountKeyFile.py
+++ b/checkov/kubernetes/checks/resource/k8s/ApiServerServiceAccountKeyFile.py
@@ -22,7 +22,7 @@ class ApiServerServiceAccountKeyFile(BaseK8sContainerCheck):
                         [field, value, *_] = cmd.split("=")
                         if field == "--service-account-key-file":
                             # should be a valid path and to end with .pem
-                            regex = r"^([\/|\.\/]?[a-z_\-\s0-9\.]+)+\.(pem)$"
+                            regex = r"^((?:[^\/]*\/)*)(.*)\.pem$"
                             matches = re.match(regex, value)
                             if not matches:
                                 return CheckResult.FAILED


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
