### PR TITLE
Handle None metadata by definition gracefully for k8s graph

### DIFF
--- a/checkov/kubernetes/graph_builder/local_graph.py
+++ b/checkov/kubernetes/graph_builder/local_graph.py
@@ -24,7 +24,7 @@ class KubernetesLocalGraph(LocalGraph):
 
             for resource in file_conf:
                 resource_type = resource.get('kind')
-                metadata = resource.get('metadata', {})
+                metadata = resource.get('metadata') or {}
                 # TODO: add support for generateName
                 name = metadata.get('name')
                 if is_invalid_k8_definition(resource) or metadata.get("ownerReferences") or not name:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Ran into a situation where the metadata was `None`. Then, this:
```python
metadata = d.get('metadata', {})  # metadata is None, not {}
```

This handles it