### PR TITLE
Fixed K8S checks that mishandled Container objects with "null" command 

### DIFF
--- a/checkov/common/checks/base_check.py
+++ b/checkov/common/checks/base_check.py
@@ -68,7 +68,8 @@ class BaseCheck(metaclass=MultiSignatureMeta):
                         self.name, str(entity_configuration), scanned_file
                     )
                 )
-                raise e
+                check_result["result"] = CheckResult.UNKNOWN
+                check_result["evaluated_keys"] = []
         return check_result
 
     @multi_signature()

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -57,7 +57,7 @@ class Report:
             "passed": len(self.passed_checks),
             "failed": len(self.failed_checks),
             "skipped": len(self.skipped_checks),
-            "unknown": len(self.skipped_checks),
+            "unknown": len(self.unknown_checks),
             "parsing_errors": len(self.parsing_errors),
             "resource_count": len(self.resources),
             "checkov_version": version,

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -27,6 +27,7 @@ class Report:
         self.passed_checks: List[Record] = []
         self.failed_checks: List[Record] = []
         self.skipped_checks: List[Record] = []
+        self.unknown_checks: List[Record] = []
         self.parsing_errors: List[str] = []
         self.resources: Set[str] = set()
 
@@ -48,12 +49,15 @@ class Report:
             self.failed_checks.append(record)
         if record.check_result["result"] == CheckResult.SKIPPED:
             self.skipped_checks.append(record)
+        if record.check_result["result"] == CheckResult.UNKNOWN:
+            self.unknown_checks.append(record)
 
     def get_summary(self) -> Dict[str, Union[int, str]]:
         return {
             "passed": len(self.passed_checks),
             "failed": len(self.failed_checks),
             "skipped": len(self.skipped_checks),
+            "unknown": len(self.skipped_checks),
             "parsing_errors": len(self.parsing_errors),
             "resource_count": len(self.resources),
             "checkov_version": version,
@@ -199,10 +203,11 @@ class Report:
         summary = self.get_summary()
         print(colored(f"{self.check_type} scan results:", "blue"))
         if self.parsing_errors:
-            message = "\nPassed checks: {}, Failed checks: {}, Skipped checks: {}, Parsing errors: {}\n".format(
+            message = "\nPassed checks: {}, Failed checks: {}, Skipped checks: {}, Checks with Unknown result: {}, Parsing errors: {}\n".format(
                 summary["passed"],
                 summary["failed"],
                 summary["skipped"],
+                summary["unknown"],
                 summary["parsing_errors"],
             )
         else:

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -190,7 +190,7 @@ class RunnerRegistry:
             return
         if self.runner_filter.framework == "all":
             return
-        self.runners = [runner for runner in self.runners if runner.check_type == self.runner_filter.framework]
+        self.runners = [runner for runner in self.runners if runner.check_type in self.runner_filter.framework]
 
     def remove_runner(self, runner: BaseRunner) -> None:
         if runner in self.runners:

--- a/checkov/kubernetes/checks/ApiServerAdmissionControlAlwaysAdmit.py
+++ b/checkov/kubernetes/checks/ApiServerAdmissionControlAlwaysAdmit.py
@@ -13,7 +13,7 @@ class ApiServerAdmissionControlAlwaysAdmit(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if conf.get("command"):
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 for cmd in conf["command"]:
                     if cmd == "--enable-admission-plugins":

--- a/checkov/kubernetes/checks/ApiServerAlwaysPullImagesPlugin.py
+++ b/checkov/kubernetes/checks/ApiServerAlwaysPullImagesPlugin.py
@@ -13,7 +13,7 @@ class ApiServerAlwaysPullImagesPlugin(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 for cmd in conf["command"]:
                     if cmd == "--enable-admission-plugins":

--- a/checkov/kubernetes/checks/ApiServerAnonymousAuth.py
+++ b/checkov/kubernetes/checks/ApiServerAnonymousAuth.py
@@ -14,7 +14,7 @@ class ApiServerAnonymousAuth(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 if "--anonymous-auth=true" in conf["command"] or "--anonymous-auth=false" not in conf["command"]:
                     return CheckResult.FAILED

--- a/checkov/kubernetes/checks/ApiServerBasicAuthFile.py
+++ b/checkov/kubernetes/checks/ApiServerBasicAuthFile.py
@@ -14,7 +14,7 @@ class ApiServerBasicAuthFile(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 if any(x.startswith('--basic-auth-file') for x in conf["command"]):
                     return CheckResult.FAILED

--- a/checkov/kubernetes/checks/ApiServerInsecureBindAddress.py
+++ b/checkov/kubernetes/checks/ApiServerInsecureBindAddress.py
@@ -13,7 +13,7 @@ class ApiServerInsecureBindAddress(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 strippedArgs = [arg.split("=")[0] for arg in conf["command"]]
                 if "--insecure-bind-address" in strippedArgs:

--- a/checkov/kubernetes/checks/ApiServerInsecurePort.py
+++ b/checkov/kubernetes/checks/ApiServerInsecurePort.py
@@ -13,7 +13,7 @@ class ApiServerInsecurePort(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 if "--insecure-port=0" not in conf["command"]:
                     return CheckResult.FAILED

--- a/checkov/kubernetes/checks/ApiServerNamespaceLifecyclePlugin.py
+++ b/checkov/kubernetes/checks/ApiServerNamespaceLifecyclePlugin.py
@@ -13,7 +13,7 @@ class ApiServerNamespaceLifecyclePlugin(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 for cmd in conf["command"]:
                     if cmd == "--enable-admission-plugins":

--- a/checkov/kubernetes/checks/ApiServerNodeRestrictionPlugin.py
+++ b/checkov/kubernetes/checks/ApiServerNodeRestrictionPlugin.py
@@ -13,7 +13,7 @@ class ApiServerNodeRestrictionPlugin(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 for cmd in conf["command"]:
                     if cmd == "--enable-admission-plugins":

--- a/checkov/kubernetes/checks/ApiServerPodSecurityPolicyPlugin.py
+++ b/checkov/kubernetes/checks/ApiServerPodSecurityPolicyPlugin.py
@@ -13,7 +13,7 @@ class ApiServerPodSecurityPolicyPlugin(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 for cmd in conf["command"]:
                     if cmd == "--enable-admission-plugins":

--- a/checkov/kubernetes/checks/ApiServerRequestTimeout.py
+++ b/checkov/kubernetes/checks/ApiServerRequestTimeout.py
@@ -15,7 +15,7 @@ class ApiServerRequestTimeout(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 for cmd in conf["command"]:
                     if cmd == "--request-timeout":

--- a/checkov/kubernetes/checks/ApiServerSecurePort.py
+++ b/checkov/kubernetes/checks/ApiServerSecurePort.py
@@ -13,7 +13,7 @@ class ApiServerSecurePort(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 if "--secure-port=0" in conf["command"]:
                     return CheckResult.FAILED

--- a/checkov/kubernetes/checks/ApiServerSecurityContextDenyPlugin.py
+++ b/checkov/kubernetes/checks/ApiServerSecurityContextDenyPlugin.py
@@ -13,7 +13,7 @@ class ApiServerSecurityContextDenyPlugin(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 for cmd in conf["command"]:
                     if cmd == "--enable-admission-plugins":

--- a/checkov/kubernetes/checks/ApiServerServiceAccountKeyFile.py
+++ b/checkov/kubernetes/checks/ApiServerServiceAccountKeyFile.py
@@ -15,7 +15,7 @@ class ApiServerServiceAccountKeyFile(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 for cmd in conf["command"]:
                     if cmd == "--service-account-key-file":

--- a/checkov/kubernetes/checks/ApiServerServiceAccountPlugin.py
+++ b/checkov/kubernetes/checks/ApiServerServiceAccountPlugin.py
@@ -13,7 +13,7 @@ class ApiServerServiceAccountPlugin(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 for cmd in conf["command"]:
                     if cmd == "--enable-admission-plugins":

--- a/checkov/kubernetes/checks/ApiServerStrongCryptographicCiphers.py
+++ b/checkov/kubernetes/checks/ApiServerStrongCryptographicCiphers.py
@@ -17,7 +17,7 @@ class ApiServerStrongCryptographicCiphers(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 for command in conf["command"]:
                     if command.startswith("--tls-cipher-suites"):

--- a/checkov/kubernetes/checks/ControllerManagerBindAddress.py
+++ b/checkov/kubernetes/checks/ControllerManagerBindAddress.py
@@ -14,7 +14,7 @@ class ControllerManagerBindAddress(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-controller-manager" in conf["command"]:
                 for cmd in conf["command"]:
                     if "=" in cmd:

--- a/checkov/kubernetes/checks/EtcdAutoTls.py
+++ b/checkov/kubernetes/checks/EtcdAutoTls.py
@@ -16,7 +16,9 @@ class EtcdAutoTls(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "etcd" in conf.get("command", []) and "--auto-tls=true" in conf.get("command", []):
+        if conf.get("command") is not None and (
+            "etcd" in conf["command"] and "--auto-tls=true" in conf["command"]
+        ):
             return CheckResult.FAILED
 
         return CheckResult.PASSED

--- a/checkov/kubernetes/checks/EtcdClientCertAuth.py
+++ b/checkov/kubernetes/checks/EtcdClientCertAuth.py
@@ -14,7 +14,9 @@ class EtcdClientCertAuth(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "etcd" in conf.get("command", []) and "--client-cert-auth=true" not in conf.get("command", []):
+        if conf.get("command") is not None and (
+            "etcd" in conf["command"] and "--client-cert-auth=true" not in conf["command"]
+        ):
             return CheckResult.FAILED
            
         return CheckResult.PASSED

--- a/checkov/kubernetes/checks/KubeControllerManagerRotateKubeletServerCertificate.py
+++ b/checkov/kubernetes/checks/KubeControllerManagerRotateKubeletServerCertificate.py
@@ -16,7 +16,7 @@ class KubeControllerManagerRotateKubeletServerCertificate(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-controller-manager" in conf["command"]:
                 for cmd in conf["command"]:
                     if cmd.startswith("--feature-gates"):

--- a/checkov/kubernetes/checks/KubeletAnonymousAuth.py
+++ b/checkov/kubernetes/checks/KubeletAnonymousAuth.py
@@ -15,7 +15,7 @@ class KubeletAnonymousAuth(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kubelet" in conf["command"]:            
                 if "--anonymous-auth=true" in conf["command"] or "--anonymous-auth=false" not in conf["command"]:
                     return CheckResult.FAILED

--- a/checkov/kubernetes/checks/KubeletClientCa.py
+++ b/checkov/kubernetes/checks/KubeletClientCa.py
@@ -16,7 +16,7 @@ class KubeletClientCa(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kubelet" in conf["command"]:            
                 for command in conf["command"]:
                     if command.startswith('--root-ca-file'):

--- a/checkov/kubernetes/checks/KubeletCryptographicCiphers.py
+++ b/checkov/kubernetes/checks/KubeletCryptographicCiphers.py
@@ -16,7 +16,7 @@ class KubeletCryptographicCiphers(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kubelet" in conf["command"]:
                 for command in conf["command"]:
                     if command.startswith("--tls-cipher-suites"):

--- a/checkov/kubernetes/checks/KubeletHostnameOverride.py
+++ b/checkov/kubernetes/checks/KubeletHostnameOverride.py
@@ -15,7 +15,7 @@ class KubeletHostnameOverride(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kubelet" in conf["command"]:            
                 if "--hostname-override" in [arg.split("=")[0] for arg in conf["command"]]:
                     return CheckResult.FAILED

--- a/checkov/kubernetes/checks/KubeletMakeIptablesUtilChains.py
+++ b/checkov/kubernetes/checks/KubeletMakeIptablesUtilChains.py
@@ -16,7 +16,7 @@ class KubeletMakeIptablesUtilChains(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kubelet" in conf["command"]:            
                 if "--make-iptables-util-chains=true" not in conf["command"]:
                     return CheckResult.FAILED

--- a/checkov/kubernetes/checks/KubeletProtectKernelDefaults.py
+++ b/checkov/kubernetes/checks/KubeletProtectKernelDefaults.py
@@ -16,7 +16,7 @@ class KubeletProtectKernelDefaults(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kubelet" in conf["command"]:            
                 if "--protect-kernel-defaults=true" not in conf["command"]:
                     return CheckResult.FAILED

--- a/checkov/kubernetes/checks/KubeletStreamingConnectionIdleTimeout.py
+++ b/checkov/kubernetes/checks/KubeletStreamingConnectionIdleTimeout.py
@@ -16,7 +16,7 @@ class KubeletStreamingConnectionIdleTimeout(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kubelet" in conf["command"]:            
                 if "--streaming-connection-idle-timeout=0" in conf["command"]:
                     return CheckResult.FAILED

--- a/checkov/kubernetes/checks/KubletEventCapture.py
+++ b/checkov/kubernetes/checks/KubletEventCapture.py
@@ -17,7 +17,7 @@ class KubletEventCapture(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kubelet" in conf["command"]:
                 for cmd in conf["command"]:
                     if "=" in cmd:

--- a/checkov/kubernetes/checks/KubletRotateCertificates.py
+++ b/checkov/kubernetes/checks/KubletRotateCertificates.py
@@ -16,7 +16,7 @@ class KubletRotateCertificates(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kubelet" in conf["command"]:
                 if "--rotate-certificates=false" in conf["command"]:
                     return CheckResult.FAILED

--- a/checkov/kubernetes/checks/KubletRotateKubeletServerCertificate.py
+++ b/checkov/kubernetes/checks/KubletRotateKubeletServerCertificate.py
@@ -16,7 +16,7 @@ class KubletRotateKubeletServerCertificate(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kubelet" in conf["command"]:
                 for cmd in conf["command"]:
                     if cmd.startswith("--feature-gates"):

--- a/checkov/kubernetes/checks/SchedulerBindAddress.py
+++ b/checkov/kubernetes/checks/SchedulerBindAddress.py
@@ -15,7 +15,7 @@ class SchedulerBindAddress(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-scheduler" in conf["command"]:
                 for cmd in conf["command"]:
                     if "=" in cmd:

--- a/checkov/kubernetes/checks/SchedulerProfiling.py
+++ b/checkov/kubernetes/checks/SchedulerProfiling.py
@@ -15,7 +15,7 @@ class SchedulerProfiling(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}' if conf.get('name') else conf["parent"]
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if conf.get("command") is not None:
             if "kube-scheduler" in conf["command"]:
                 if "--profiling=false" not in conf["command"]:
                     return CheckResult.FAILED

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -293,7 +293,6 @@ def add_parser_args(parser):
     parser.add('--skip-framework', help='filter scan to skip specific infrastructure code frameworks. \n'
                                         'will be included automatically for some frameworks if system dependencies '
                                         'are missing.',
-               choices=checkov_runners,
                default=None)
     parser.add('-c', '--check',
                help='filter scan to run only on a specific check identifier(allowlist), You can '

--- a/tests/kubernetes/checks/example_ApiServerAlwaysPullImagesPlugin/ApiServerAlwaysPullImagesPlugin-default-command-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerAlwaysPullImagesPlugin/ApiServerAlwaysPullImagesPlugin-default-command-PASSED.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/test_ApiServerAlwaysPullImagesPlugin.py
+++ b/tests/kubernetes/checks/test_ApiServerAlwaysPullImagesPlugin.py
@@ -17,7 +17,7 @@ class TestApiServerAlwaysPullImagesPlugin(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
         
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 1)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
- Fixed K8S checks that mishandled Container objects with null (None in Python) command attribute in Container objects
- Improved handling of uncaught exceptions if a runtime exception occurs
- Fixed bug preventing --skip-framework from working properly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.