### PR TITLE
Fix arm base resource value check

### DIFF
--- a/checkov/arm/base_resource_check.py
+++ b/checkov/arm/base_resource_check.py
@@ -1,29 +1,47 @@
 from abc import abstractmethod
+from collections.abc import Iterable
+from typing import List, Optional, Dict, Any, Callable
 
 from checkov.arm.registry import arm_resource_registry
 from checkov.common.checks.base_check import BaseCheck
+from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.common.multi_signature import multi_signature
 
 
 class BaseResourceCheck(BaseCheck):
-    def __init__(self, name, id, categories, supported_resources, guideline=None):
-        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_resources,
-                         block_type="resource", guideline=guideline)
+    def __init__(
+        self,
+        name: str,
+        id: str,
+        categories: List[CheckCategories],
+        supported_resources: "Iterable[str]",
+        guideline: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            name=name,
+            id=id,
+            categories=categories,
+            supported_entities=supported_resources,
+            block_type="resource",
+            guideline=guideline,
+        )
         self.supported_resources = supported_resources
         arm_resource_registry.register(self)
 
-    def scan_entity_conf(self, conf, entity_type):
+    def scan_entity_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
+        self.entity_type = entity_type
+
         return self.scan_resource_conf(conf, entity_type)
 
     @multi_signature()
     @abstractmethod
-    def scan_resource_conf(self, conf, entity_type):
+    def scan_resource_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
         raise NotImplementedError()
 
     @classmethod
     @scan_resource_conf.add_signature(args=["self", "conf"])
-    def _scan_resource_conf_self_conf(cls, wrapped):
-        def wrapper(self, conf, entity_type=None):
+    def _scan_resource_conf_self_conf(cls, wrapped: Callable[..., CheckResult]) -> Callable[..., CheckResult]:
+        def wrapper(self: BaseCheck, conf: Dict[str, Any], entity_type: Optional[str] = None) -> CheckResult:
             # keep default argument for entity_type so old code, that doesn't set it, will work.
             return wrapped(self, conf)
 

--- a/checkov/arm/base_resource_value_check.py
+++ b/checkov/arm/base_resource_value_check.py
@@ -1,83 +1,63 @@
-from abc import abstractmethod
-import dpath.util
 import re
-from checkov.arm.base_resource_check import BaseResourceCheck
-from checkov.common.models.enums import CheckResult
-from checkov.common.models.consts import ANY_VALUE
+from abc import abstractmethod
+from collections.abc import Iterable
+from typing import Dict, Any, List, Optional
 
-VARIABLE_DEPENDANT_REGEX = r'(?:local|var)\.[^\s]+'
+from checkov.arm.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.util.data_structures_utils import find_in_dict
+
+VARIABLE_DEPENDANT_REGEX = r"(?:local|var|module)\.[^\s]+"
 
 
 class BaseResourceValueCheck(BaseResourceCheck):
-    def __init__(self, name, id, categories, supported_resources, missing_block_result=CheckResult.FAILED):
-        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+    def __init__(
+        self,
+        name: str,
+        id: str,
+        categories: List[CheckCategories],
+        supported_resources: "Iterable[str]",
+        missing_block_result: CheckResult = CheckResult.FAILED,
+        guideline: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            name=name, id=id, categories=categories, supported_resources=supported_resources, guideline=guideline
+        )
         self.missing_block_result = missing_block_result
 
     @staticmethod
-    def _filter_key_path(path):
-        """
-        Filter an attribute path to contain only named attributes by dropping array indices from the path)
-        :param path: valid JSONPath of an attribute
-        :return: List of named attributes with respect to the input JSONPath order
-        """
-        return [x for x in path.split("/") if not re.search(r'^\[?\d+\]?$', x)]
-
-    @staticmethod
-    def _is_variable_dependant(value):
+    def _is_variable_dependant(value: Any) -> bool:
         if isinstance(value, str) and re.match(VARIABLE_DEPENDANT_REGEX, value):
             return True
         return False
 
-    @staticmethod
-    def _is_nesting_key(inspected_attributes, key):
-        """
-        Resolves whether a key is a subset of the inspected nesting attributes
-        :param inspected_attributes: list of nesting attributes
-        :param key: JSONPath key of an attribute
-        :return: True/False
-        """
-        return any(x in key for x in inspected_attributes)
-
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: Dict[str, Any]) -> CheckResult:
         inspected_key = self.get_inspected_key()
         expected_values = self.get_expected_values()
-        if dpath.search(conf, inspected_key) != {}:
+        value = find_in_dict(conf, inspected_key)
+        if value:
             if ANY_VALUE in expected_values:
-                # Key is found on the configuration - if it accepts any value, the check is PASSED
+                # Key is found in the configuration - if it accepts any value, the check is PASSED
                 return CheckResult.PASSED
-            value = dpath.get(conf, inspected_key)
             if isinstance(value, list) and len(value) == 1:
                 value = value[0]
+            if value in expected_values:
+                return CheckResult.PASSED
             if self._is_variable_dependant(value):
                 # If the tested attribute is variable-dependant, then result is PASSED
                 return CheckResult.PASSED
-            if value in expected_values:
-                return CheckResult.PASSED
-        else:
-            # Look for the configuration in a bottom-up fashion
-            inspected_attributes = self._filter_key_path(inspected_key)
-            for attribute in reversed(inspected_attributes):
-                for sub_key, sub_conf in dpath.search(conf, f'**/{attribute}', yielded=True):
-                    filtered_sub_key = self._filter_key_path(sub_key)
-                    if self._is_nesting_key(inspected_attributes, filtered_sub_key):
-                        if isinstance(sub_conf, list) and len(sub_conf) == 1:
-                            sub_conf = sub_conf[0]
-                        if sub_conf in self.get_expected_values():
-                            return CheckResult.PASSED
-                        if self._is_variable_dependant(sub_conf):
-                            # If the tested attribute is variable-dependant, then result is PASSED
-                            return CheckResult.PASSED
 
         return self.missing_block_result
 
     @abstractmethod
-    def get_inspected_key(self):
+    def get_inspected_key(self) -> str:
         """
         :return: JSONPath syntax path of the checked attribute
         """
         raise NotImplementedError()
 
-    def get_expected_values(self):
+    def get_expected_values(self) -> List[Any]:
         """
         Override the method with the list of acceptable values if the check has more than one possible expected value, given
         the inspected key
@@ -85,7 +65,7 @@ class BaseResourceValueCheck(BaseResourceCheck):
         """
         return [self.get_expected_value()]
 
-    def get_expected_value(self):
+    def get_expected_value(self) -> Any:
         """
         Returns the default expected value, governed by provider best practices
         """

--- a/checkov/arm/checks/resource/MariaDBSSLEnforcementEnabled.py
+++ b/checkov/arm/checks/resource/MariaDBSSLEnforcementEnabled.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class MariaDBSSLEnforcementEnabled(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure 'Enforce SSL connection' is set to 'ENABLED' for MariaDB servers"
+        id = "CKV_AZURE_47"
+        supported_resources = ["Microsoft.DBforMariaDB/servers"]
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "properties/sslEnforcement"
+
+    def get_expected_value(self) -> Any:
+        return "Enabled"
+
+
+check = MariaDBSSLEnforcementEnabled()

--- a/checkov/arm/checks/resource/MySQLServerSSLEnforcementEnabled.py
+++ b/checkov/arm/checks/resource/MySQLServerSSLEnforcementEnabled.py
@@ -1,19 +1,22 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.arm.base_resource_check import BaseResourceCheck
+from typing import Any
 
-class MySQLServerSSLEnforcementEnabled(BaseResourceCheck):
-    def __init__(self):
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class MySQLServerSSLEnforcementEnabled(BaseResourceValueCheck):
+    def __init__(self) -> None:
         name = "Ensure 'Enforce SSL connection' is set to 'ENABLED' for MySQL Database Server"
         id = "CKV_AZURE_28"
-        supported_resources = ['Microsoft.DBforMySQL/servers']
+        supported_resources = ["Microsoft.DBforMySQL/servers"]
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        if "properties" in conf:
-            if "sslEnforcement" in conf["properties"]:
-                if str(conf["properties"]["sslEnforcement"]).lower() == "enabled":
-                    return CheckResult.PASSED
-        return CheckResult.FAILED
+    def get_inspected_key(self) -> str:
+        return "properties/sslEnforcement"
+
+    def get_expected_value(self) -> Any:
+        return "Enabled"
+
 
 check = MySQLServerSSLEnforcementEnabled()

--- a/checkov/arm/checks/resource/PostgreSQLServerSSLEnforcementEnabled.py
+++ b/checkov/arm/checks/resource/PostgreSQLServerSSLEnforcementEnabled.py
@@ -1,19 +1,22 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.arm.base_resource_check import BaseResourceCheck
+from typing import Any
 
-class PostgreSQLServerSSLEnforcementEnabled(BaseResourceCheck):
-    def __init__(self):
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class PostgreSQLServerSSLEnforcementEnabled(BaseResourceValueCheck):
+    def __init__(self) -> None:
         name = "Ensure 'Enforce SSL connection' is set to 'ENABLED' for PostgreSQL Database Server"
         id = "CKV_AZURE_29"
-        supported_resources = ['Microsoft.DBforPostgreSQL/servers']
+        supported_resources = ["Microsoft.DBforPostgreSQL/servers"]
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        if "properties" in conf:
-            if "sslEnforcement" in conf["properties"]:
-                if str(conf["properties"]["sslEnforcement"]).lower() == "enabled":
-                    return CheckResult.PASSED
-        return CheckResult.FAILED
+    def get_inspected_key(self) -> str:
+        return "properties/sslEnforcement"
+
+    def get_expected_value(self) -> Any:
+        return "Enabled"
+
 
 check = PostgreSQLServerSSLEnforcementEnabled()

--- a/checkov/common/util/data_structures_utils.py
+++ b/checkov/common/util/data_structures_utils.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Generator, Any, Union, Dict
 
 
@@ -61,11 +62,27 @@ def search_deep_keys(searchText, obj, path):
     return keys
 
 
-def find_in_dict(obj: dict, key_path: str) -> Any:
-    val = obj
+def find_in_dict(input_dict: Dict[str, Any], key_path: str) -> Any:
+    """Tries to retrieve the value under the given 'key_path', otherwise returns None."""
+
+    value = input_dict
     key_list = key_path.split("/")
-    for key in key_list:
-        val = val.get(key)
-        if val is None:
-            return None
-    return val
+
+    try:
+        for key in key_list:
+            if key.startswith("[") and key.endswith("]"):
+                if isinstance(value, list):
+                    idx = int(key[1:-1])
+                    value = value[idx]
+                    continue
+                else:
+                    return None
+
+            value = value.get(key)
+            if value is None:
+                return None
+    except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+        logging.debug(f"Could not find {key_path} in dict")
+        return None
+
+    return value

--- a/tests/arm/checks/resource/example_MariaDBSSLEnforcementEnabled/FAILED.json
+++ b/tests/arm/checks/resource/example_MariaDBSSLEnforcementEnabled/FAILED.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "apiVersion": "2018-06-01",
+      "type": "Microsoft.DBforMariaDB/servers",
+      "location": "West Europe",
+      "name": "default",
+      "sku": {
+        "name": "B_Gen5_2",
+        "size": "5120"
+      },
+      "properties": {
+        "version": "10.3",
+        "administratorLogin": "admin",
+        "administratorLoginPassword": "admin123",
+        "storageProfile": {
+          "storageMB": "5120"
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_MariaDBSSLEnforcementEnabled/FAILED_2.json
+++ b/tests/arm/checks/resource/example_MariaDBSSLEnforcementEnabled/FAILED_2.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "apiVersion": "2018-06-01",
+      "type": "Microsoft.DBforMariaDB/servers",
+      "location": "West Europe",
+      "name": "disabled",
+      "sku": {
+        "name": "B_Gen5_2",
+        "size": "5120"
+      },
+      "properties": {
+        "version": "10.3",
+        "administratorLogin": "admin",
+        "administratorLoginPassword": "admin123",
+        "storageProfile": {
+          "storageMB": "5120"
+        },
+        "sslEnforcement": "Disabled"
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_MariaDBSSLEnforcementEnabled/PASSED.json
+++ b/tests/arm/checks/resource/example_MariaDBSSLEnforcementEnabled/PASSED.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "apiVersion": "2018-06-01",
+      "type": "Microsoft.DBforMariaDB/servers",
+      "location": "West Europe",
+      "name": "enabled",
+      "sku": {
+        "name": "B_Gen5_2",
+        "size": "5120"
+      },
+      "properties": {
+        "version": "10.3",
+        "administratorLogin": "admin",
+        "administratorLoginPassword": "admin123",
+        "storageProfile": {
+          "storageMB": "5120"
+        },
+        "sslEnforcement": "Enabled"
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/test_MariaDBSSLEnforcementEnabled.py
+++ b/tests/arm/checks/resource/test_MariaDBSSLEnforcementEnabled.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+from pathlib import Path
+
+from checkov.arm.checks.resource.MariaDBSSLEnforcementEnabled import check
+from checkov.arm.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestMariaDBSSLEnforcementEnabled(unittest.TestCase):
+    def test_summary(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_MariaDBSSLEnforcementEnabled"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "Microsoft.DBforMariaDB/servers.enabled",
+        }
+        failing_resources = {
+            "Microsoft.DBforMariaDB/servers.default",
+            "Microsoft.DBforMariaDB/servers.disabled",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/common/utils/test_data_structures_utils.py
+++ b/tests/common/utils/test_data_structures_utils.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+import pytest
+
+from checkov.common.util.data_structures_utils import find_in_dict
+
+
+@pytest.mark.parametrize(
+    "key_path,expected_value",
+    [
+        ("key_99", None),
+        ("key_1/key_2/key_3", None),
+        ("key_1/key_2/[10]/key_3", None),
+        ("key_1/key_5", "string"),
+        ("key_1/key_2/[0]/key_3", 1),
+        ("key_1/key_2/[1]/key_4", True),
+    ],
+    ids=["key_not_exists", "nested_key_not_exists", "index_not_exists", "key", "index", "index_1"],
+)
+def test_find_in_dict(key_path: str, expected_value: Any) -> None:
+    input_dict = {
+        "key_1": {
+            "key_2": [
+                {
+                    "key_3": 1,
+                },
+                {
+                    "key_4": True,
+                },
+            ],
+            "key_5": "string",
+        }
+    }
+
+    # when
+    actual_value = find_in_dict(input_dict, key_path)
+
+    # then
+    assert actual_value == expected_value


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #432 

- added the missing `CKV_AZURE_47` check for ARM
- fixed the `BaseResourceValueCheck` class for ARM and without using `dpath`
- also adjusted `CKV_AZURE_28` & `CKV_AZURE_28` to use the `BaseResourceValueCheck` class
- adjusted `find_in_dict()` to also handle index search and couple of exception more gracefully