### PR TITLE
adjust CKV_AZURE_43 to ignore names, if they could not be evaluated

### DIFF
--- a/checkov/terraform/checks/resource/azure/StorageAccountName.py
+++ b/checkov/terraform/checks/resource/azure/StorageAccountName.py
@@ -1,31 +1,41 @@
+import re
+from typing import List, Dict, Any
+
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.common.models.enums import CheckResult, CheckCategories
-import re
-from typing import List
 
-STO_NAME_REGEX = re.compile('^[a-z0-9]{3,24}$')
+STO_NAME_REGEX = re.compile(r"^[a-z0-9]{3,24}$")
+VARIABLE_REFS = ("local.", "module.", "var.")
 
 
 class StorageAccountName(BaseResourceCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure Storage Accounts adhere to the naming rules"
         id = "CKV_AZURE_43"
-        supported_resources = ['azurerm_storage_account']
+        supported_resources = ["azurerm_storage_account"]
         categories = [CheckCategories.CONVENTION]
-        super().__init__(name=name, id=id, categories=categories,
-                         supported_resources=supported_resources)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: Dict[str, Any]) -> CheckResult:
         """
             The Storage Account naming reference:
             https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview#naming-storage-accounts
         :param conf: azurerm_storage_account configuration
         :return: <CheckResult>
         """
-        return CheckResult.PASSED if conf.get('name') and re.findall(STO_NAME_REGEX, str(conf['name'][0])) else CheckResult.FAILED
+        name = conf.get("name")
+        if name:
+            name = name[0]
+            if any(x in name for x in VARIABLE_REFS):
+                # in the case we couldn't evaluate the name, just ignore
+                return CheckResult.UNKNOWN
+            if re.findall(STO_NAME_REGEX, str(conf["name"][0])):
+                return CheckResult.PASSED
+
+        return CheckResult.FAILED
 
     def get_evaluated_keys(self) -> List[str]:
-        return ['name']
+        return ["name"]
 
 
 check = StorageAccountName()

--- a/tests/terraform/checks/resource/azure/example_StorageAccountName/main.tf
+++ b/tests/terraform/checks/resource/azure/example_StorageAccountName/main.tf
@@ -1,0 +1,61 @@
+# pass
+
+resource "azurerm_storage_account" "pass" {
+  name                     = "storageaccountname"
+  resource_group_name      = "azurerm_resource_group.example.name"
+  location                 = "azurerm_resource_group.example.location"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+# fail
+
+resource "azurerm_storage_account" "camel_case" {
+  name                     = "thisIsWrong"
+  resource_group_name      = "azurerm_resource_group.example.name"
+  location                 = "azurerm_resource_group.example.location"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_storage_account" "kebab_case" {
+  name                     = "this-is-wrong"
+  resource_group_name      = "azurerm_resource_group.example.name"
+  location                 = "azurerm_resource_group.example.location"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_storage_account" "too_long" {
+  name                     = "thisiswayyyyyytoooloooong"
+  resource_group_name      = "azurerm_resource_group.example.name"
+  location                 = "azurerm_resource_group.example.location"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+# unknown
+
+resource "azurerm_storage_account" "local" {
+  name                     = "${local.prefix}example"
+  resource_group_name      = "azurerm_resource_group.example.name"
+  location                 = "azurerm_resource_group.example.location"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_storage_account" "module" {
+  name                     = "${module.something.prefix}example"
+  resource_group_name      = "azurerm_resource_group.example.name"
+  location                 = "azurerm_resource_group.example.location"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_storage_account" "var" {
+  name                     = "${var.prefix}example"
+  resource_group_name      = "azurerm_resource_group.example.name"
+  location                 = "azurerm_resource_group.example.location"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}

--- a/tests/terraform/checks/resource/azure/test_StorageAccountName.py
+++ b/tests/terraform/checks/resource/azure/test_StorageAccountName.py
@@ -1,78 +1,43 @@
 import unittest
+from pathlib import Path
 
-import hcl2
-
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.azure.StorageAccountName import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
-class TestAzureStorageAccountNamingRule(unittest.TestCase):
+class TestStorageAccountName(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_StorageAccountName"
 
-    def test_failure_dash(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_storage_account" "example" {
-              name                     = "this-is-wrong"
-              resource_group_name      = data.azurerm_resource_group.example.name
-              location                 = data.azurerm_resource_group.example.location
-              account_tier             = "Standard"
-              account_replication_type = "GRS"
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
 
-    def test_failure_length(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_storage_account" "example" {
-              name                     = "thisiswayyyyyytoooloooong"
-              resource_group_name      = data.azurerm_resource_group.example.name
-              location                 = data.azurerm_resource_group.example.location
-              account_tier             = "Standard"
-              account_replication_type = "GRS"
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        # then
+        summary = report.get_summary()
 
-    def test_failure_case(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_storage_account" "example" {
-              name                     = "thisIsWrong"
-              resource_group_name      = data.azurerm_resource_group.example.name
-              location                 = data.azurerm_resource_group.example.location
-              account_tier             = "Standard"
-              account_replication_type = "GRS"
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passing_resources = {
+            "azurerm_storage_account.pass",
+        }
+        failing_resources = {
+            "azurerm_storage_account.camel_case",
+            "azurerm_storage_account.kebab_case",
+            "azurerm_storage_account.too_long",
+        }
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_storage_account" "example" {
-              name                     = "stomyexample"
-              resource_group_name      = data.azurerm_resource_group.example.name
-              location                 = data.azurerm_resource_group.example.location
-              account_tier             = "Standard"
-              account_replication_type = "GRS"
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
 
-    def test_failure_empty_configuration(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_storage_account" "example" {
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_storage_account']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+        self.assertEqual(summary["resource_count"], 7)  # 3 unknown
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #741 

If we can't evaluate the typical references, we should just ignore it and flag it as `UNKNOWN`.