### PR TITLE
CF Parsing Issues for TF Plans and Helm YAMLs

### DIFF
--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -56,6 +56,9 @@ class Runner(BaseRunner):
 
         if self.context is None or self.definitions is None or self.breadcrumbs is None:
             self.definitions, self.definitions_raw = create_definitions(root_folder, files, runner_filter, parsing_errors)
+            if self.definitions == {} and self.definitions_raw == {}:
+                logging.debug("Stopping CF Runner. Not 1 CF Template found.")
+                exit()
             if external_checks_dir:
                 for directory in external_checks_dir:
                     cfn_registry.load_external_checks(directory)

--- a/tests/cloudformation/test_cfn_utils.py
+++ b/tests/cloudformation/test_cfn_utils.py
@@ -1,0 +1,21 @@
+import os
+import unittest
+
+from checkov.cloudformation import cfn_utils
+
+class TestCFNUtils(unittest.TestCase):
+    def test_get_files_definitions_where_none_cf(self):
+        # Check for return of {}, {} when there is not a single valid CF Template provided.
+        # This will be used to stop the CF Runner up the stack.
+
+        # Simplest case: no files means no valid templates.
+        # Templates are found based on the file containing CF 'Resources'.
+        definitions, definitions_raw = cfn_utils.get_files_definitions([], {})
+
+        # Empty Dict will resolve to false.
+        self.assertFalse(definitions)
+        self.assertFalse(definitions_raw)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello,

This took hours even though it's just a few lines!

When you pass in a JSON TF Plan file then we currently get this type of error:
```
...
cloudformation scan results:

Passed checks: 0, Failed checks: 0, Skipped checks: 0, Parsing errors: 1

Error parsing file tfplan.json
```

This is because all `.json` file are considered to be potential fodder for the CloudFormation Runner unless explicitly filtered out via CLI config:

https://github.com/bridgecrewio/checkov/blob/master/checkov/cloudformation/cfn_utils.py#L18

CloudFormation templates are identified and returned when it find that the `"Resources"` field exists. If, for **all** input files, there is not a single one which is of the right format I think that it is probabilistically safe to guess the user is not trying to scan CF. Of course there _can_ be cases where the user has accidentally passed in all CF files badly formatted but I think this small change would mark an improvement and we could seek to better improve sub-type checking of input JSON and YAML over time because the same issue is currently occurring when a Helm YAML is passed in.

The `exit()` does not exit the entire program only the Cloud Formation Runner thread(?) as i've tested to ensure that if there is a valid `tf-plan.json` it will still output results as expected.

I've added the simple case unit test for _some_ testing because I can't really unit test well for an `exit` aha.

## Issues that this could resolve:
* https://github.com/bridgecrewio/checkov/issues/2046
* https://github.com/bridgecrewio/checkov/issues/1927
* https://github.com/bridgecrewio/checkov/issues/1903
* https://github.com/bridgecrewio/checkov/issues/1887
* https://github.com/bridgecrewio/checkov/issues/1768
* https://github.com/bridgecrewio/checkov/issues/1752 - partly.
* https://github.com/bridgecrewio/checkov/issues/1257 - partly.

## Additional
I figure lots can be done here but I think this is a viable thing shorter term to fix so many issues.

* Perhaps some helm, cf and tf-plan `-f` integration tests can be added. 
* Perhaps we could look into not starting a runner if the none of the input files are of the right sub-format. For example, tf-plans have `"terraform_version":"0.13.4"`, CF have `"AWSTemplateFormatVersion" : "2010-09-09"` and Helm has, well, nothing ;) (@metahertz - https://github.com/bridgecrewio/checkov/issues/1927) but you can infer something might be helm by knowing it's not CF and not a k8s yaml (api version).

There are other things I will look at with plan parsing where it can fail silently unexpectedly but I think I can look at that separately.

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
