### PR TITLE
Fixes #2077 - use CKV_PKG_DIRECTORY and CKV_TEST_DIRECTORY environment variables to set custom directories for generating rules.

### DIFF
--- a/checkov/common/util/prompt.py
+++ b/checkov/common/util/prompt.py
@@ -9,8 +9,24 @@ import os
 import yaml
 import importlib
 
-CHECKOV_ROOT_DIRECTORY = os.path.join(".", "checkov")
-TEMPLATE_DIRECTORY = os.path.join(os.path.dirname(__file__), "templates")
+
+if not os.environ.get('CKV_PKG_DIRECTORY'):
+# CKV_PKG_DIRECTORY is used to determine where the generated files are stored
+    CKV_PKG_DIRECTORY = os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir, os.path.pardir, "checkov")
+else:
+    CKV_PKG_DIRECTORY = os.environ['CKV_PKG_DIRECTORY']
+
+# The root of the tests folder, if it is not in the root of the project
+if not os.environ.get('CKV_TEST_DIRECTORY'):
+    CKV_TEST_DIRECTORY = os.path.join(CKV_PKG_DIRECTORY, os.path.pardir, "tests")
+else:
+    CKV_TEST_DIRECTORY = os.environ['CKV_TEST_DIRECTORY']
+
+# TEMPLATE_DIRECTORY - where the Jinja2 templates for rule files and test files are stored
+if not os.environ.get('CKV_TEMPLATE_DIRECTORY'):
+    CKV_TEMPLATE_DIRECTORY = os.path.join(os.path.dirname(__file__), "templates")
+else:
+    CKV_TEMPLATE_DIRECTORY = os.environ['CKV_TEMPLATE_DIRECTORY']
 
 
 class Prompt():
@@ -163,7 +179,7 @@ class Prompt():
                         self.prompt(sub_prompt, prompt_if=p)
 
     def template_env(self):
-        template_loader = jinja2.FileSystemLoader(searchpath=TEMPLATE_DIRECTORY)
+        template_loader = jinja2.FileSystemLoader(searchpath=CKV_TEMPLATE_DIRECTORY)
         return jinja2.Environment(loader=template_loader, autoescape=True)
 
 
@@ -229,7 +245,7 @@ class Check(Prompt):
 
     def create_check(self):
         # Create check in the checks directory
-        ck_loc = os.path.abspath(os.path.join(CHECKOV_ROOT_DIRECTORY,
+        ck_loc = os.path.abspath(os.path.join(CKV_PKG_DIRECTORY,
                                               self.check_class, "checks", self.context, self.provider.lower()))
         print(f"Creating Check {self.title}.py in {ck_loc}")
 
@@ -244,8 +260,8 @@ class Check(Prompt):
         print(f"\tSuccessfully created {full_path}")
 
     def create_unit_test_stubs(self):
-        base = os.path.abspath(os.path.join(CHECKOV_ROOT_DIRECTORY, os.path.pardir,
-                                            "tests", self.check_class, "checks", self.context, self.provider.lower()))
+        base = os.path.abspath(os.path.join(CKV_TEST_DIRECTORY, self.check_class, "checks", self.context,
+                                            self.provider.lower()))
         print(f"Creating Unit Test Stubs for {self.title} in {base}")
 
         # Create Terraform stub from Template

--- a/checkov/common/util/prompt.py
+++ b/checkov/common/util/prompt.py
@@ -10,11 +10,8 @@ import yaml
 import importlib
 
 
-if not os.environ.get('CKV_PKG_DIRECTORY'):
 # CKV_PKG_DIRECTORY is used to determine where the generated files are stored
-    CKV_PKG_DIRECTORY = os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir, os.path.pardir, "checkov")
-else:
-    CKV_PKG_DIRECTORY = os.environ['CKV_PKG_DIRECTORY']
+CKV_PKG_DIRECTORY = os.getenv('CKV_PKG_DIRECTORY') or os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir, os.path.pardir, "checkov")
 
 # The root of the tests folder, if it is not in the root of the project
 if not os.environ.get('CKV_TEST_DIRECTORY'):

--- a/checkov/common/util/prompt.py
+++ b/checkov/common/util/prompt.py
@@ -14,10 +14,7 @@ import importlib
 CKV_PKG_DIRECTORY = os.getenv('CKV_PKG_DIRECTORY') or os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir, os.path.pardir, "checkov")
 
 # The root of the tests folder, if it is not in the root of the project
-if not os.environ.get('CKV_TEST_DIRECTORY'):
-    CKV_TEST_DIRECTORY = os.path.join(CKV_PKG_DIRECTORY, os.path.pardir, "tests")
-else:
-    CKV_TEST_DIRECTORY = os.environ['CKV_TEST_DIRECTORY']
+CKV_TEST_DIRECTORY = os.getenv('CKV_TEST_DIRECTORY') or os.path.join(CKV_PKG_DIRECTORY, os.path.pardir, "tests")
 
 # TEMPLATE_DIRECTORY - where the Jinja2 templates for rule files and test files are stored
 CKV_TEMPLATE_DIRECTORY = os.getenv('CKV_TEMPLATE_DIRECTORY') or os.path.join(os.path.dirname(__file__), "templates")

--- a/checkov/common/util/prompt.py
+++ b/checkov/common/util/prompt.py
@@ -20,10 +20,7 @@ else:
     CKV_TEST_DIRECTORY = os.environ['CKV_TEST_DIRECTORY']
 
 # TEMPLATE_DIRECTORY - where the Jinja2 templates for rule files and test files are stored
-if not os.environ.get('CKV_TEMPLATE_DIRECTORY'):
-    CKV_TEMPLATE_DIRECTORY = os.path.join(os.path.dirname(__file__), "templates")
-else:
-    CKV_TEMPLATE_DIRECTORY = os.environ['CKV_TEMPLATE_DIRECTORY']
+CKV_TEMPLATE_DIRECTORY = os.getenv('CKV_TEMPLATE_DIRECTORY') or os.path.join(os.path.dirname(__file__), "templates")
 
 
 class Prompt():

--- a/tests/common/utils/test_prompt.py
+++ b/tests/common/utils/test_prompt.py
@@ -1,17 +1,13 @@
-from pathlib import Path
-from unittest import mock
+import os
 from unittest.mock import MagicMock
-
 import click
-import pytest
 from _pytest.capture import CaptureFixture
 from checkov.common.util import prompt
 
 
-@pytest.fixture(autouse=True)
-def checkov_root_mock(tmp_path: Path):
-    with mock.patch("checkov.common.util.prompt.CHECKOV_ROOT_DIRECTORY", str(tmp_path / "checkov")):
-        yield
+repo_root = os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir, os.path.pardir)
+resource_tests_directory = os.path.join(repo_root, "tests", "terraform", "checks", "resource")
+resource_check_directory = os.path.join(repo_root, "checkov", "terraform", "checks", "resource")
 
 
 def test_prompt_terraform_aws_resource(capsys: CaptureFixture[str]):
@@ -46,6 +42,13 @@ def test_prompt_terraform_aws_resource(capsys: CaptureFixture[str]):
     for exp in expected:
         assert exp in captured.out
 
+    # Remove unit test files
+    os.remove(os.path.join(resource_tests_directory, "aws", f"test_{test_name}.py"))
+    os.remove(os.path.join(resource_tests_directory, "aws", f"example_{test_name}/{test_name}.tf"))
+    os.removedirs(os.path.join(resource_tests_directory, "aws", f"example_{test_name}"))
+    # Remove check files
+    os.remove(os.path.join(resource_check_directory, "aws", f"{test_name}.py"))
+
 
 def test_prompt_terraform_azure_resource(capsys: CaptureFixture[str]):
     test_name = "AzureTestPromptUnitTest"
@@ -78,6 +81,12 @@ def test_prompt_terraform_azure_resource(capsys: CaptureFixture[str]):
 
     for exp in expected:
         assert exp in captured.out
+    # Remove unit test files
+    os.remove(os.path.join(resource_tests_directory, "azure", f"test_{test_name}.py"))
+    os.remove(os.path.join(resource_tests_directory, "azure", f"example_{test_name}/{test_name}.tf"))
+    os.removedirs(os.path.join(resource_tests_directory, "azure", f"example_{test_name}"))
+    # Remove check files
+    os.remove(os.path.join(resource_check_directory, "azure", f"{test_name}.py"))
 
 
 def test_prompt_terraform_gcp_resource(capsys: CaptureFixture[str]):
@@ -111,3 +120,9 @@ def test_prompt_terraform_gcp_resource(capsys: CaptureFixture[str]):
 
     for exp in expected:
         assert exp in captured.out
+    # Remove unit test files
+    os.remove(os.path.join(resource_tests_directory, "gcp", f"test_{test_name}.py"))
+    os.remove(os.path.join(resource_tests_directory, "gcp", f"example_{test_name}/{test_name}.tf"))
+    os.removedirs(os.path.join(resource_tests_directory, "gcp", f"example_{test_name}"))
+    # Remove check files
+    os.remove(os.path.join(resource_check_directory, "gcp", f"{test_name}.py"))

--- a/tests/common/utils/test_prompt_custom_dir.py
+++ b/tests/common/utils/test_prompt_custom_dir.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+from unittest.mock import MagicMock
+import click
+from _pytest.capture import CaptureFixture
+
+
+def test_generated_rules_custom_directories(capsys: CaptureFixture[str]):
+    checkov_pkg_dir_mock = os.path.join(os.path.dirname(__file__), "tmp")
+    checkov_test_dir_mock = os.path.join(os.path.dirname(__file__), "tmp_tests")
+    os.makedirs(checkov_pkg_dir_mock, exist_ok=True)
+    os.makedirs(checkov_test_dir_mock, exist_ok=True)
+    os.environ["CKV_PKG_DIRECTORY"] = checkov_pkg_dir_mock
+    os.environ["CKV_TEST_DIRECTORY"] = checkov_test_dir_mock
+    # Need to re-import the module to get the environment variable to work
+    from checkov.common.util import prompt
+
+    test_name = "AWSTestPromptUnitTest"
+    choices = [
+        "add",
+        f"{test_name}",
+        "iam",
+        "Tests for the AWS Prompt Unit Test",
+        "terraform",
+        "aws",
+        "resource",
+        "aws_iam_policy",
+    ]
+
+    mock_click = click
+    mock_click.prompt = MagicMock(name="prompt", side_effect=choices)
+    resp = prompt.Prompt()
+    check = prompt.Check(resp.responses)
+    check.action()
+
+    captured = capsys.readouterr()
+    print(captured.out)
+    target_test_dir = os.path.join(checkov_test_dir_mock, "terraform", "checks", "resource", "aws")
+    assert(os.path.exists(os.path.join(target_test_dir, f"test_{test_name}.py")))
+    assert(os.path.exists(os.path.join(target_test_dir, f"example_{test_name}", f"{test_name}.tf")))
+    shutil.rmtree(checkov_pkg_dir_mock)
+    shutil.rmtree(checkov_test_dir_mock)
+


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR allows us to set custom directories for the Checkov rule generator functionality. The current Checkov wrapper assumes certain directory paths, but this allows it to be somewhat flexible. This way, we can create a script on our end that wraps that functionality and pumps the files into our own directories.

Please let me know if you have any questions. Thanks!

CC: @ac-square, @jmeredith16 