### PR TITLE
Convert double underscore warning to debug

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -185,7 +185,7 @@ SAFE_EVAL_DICT["jsonencode"] = lambda arg: arg
 
 def evaluate(input_str: str) -> Any:
     if "__" in input_str:
-        logging.warning(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")
+        logging.debug(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")
         return input_str
     evaluated = eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
     return evaluated if not isinstance(evaluated, str) else remove_unicode_null(evaluated)


### PR DESCRIPTION
Replace the warning of `got a substring with double underscore, which is not allowed` with `debug`.

Resolves https://github.com/bridgecrewio/checkov/issues/2082

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
