### PR TITLE
use prisma auth token for fetching data

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -58,7 +58,7 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
 
     def _get_policies_from_platform(self):
         headers = merge_dicts(get_default_get_headers(self.bc_integration.bc_source, self.bc_integration.bc_source_version),
-                              get_auth_header(self.bc_integration.bc_api_key))
+                              get_auth_header(self.bc_integration.get_auth_token()))
         response = requests.request('GET', self.policies_url, headers=headers)
 
         if response.status_code != 200:

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -113,7 +113,7 @@ class SuppressionsIntegration(BaseIntegrationFeature):
 
     def _get_suppressions_from_platform(self):
         headers = merge_dicts(get_default_get_headers(self.bc_integration.bc_source, self.bc_integration.bc_source_version),
-                              get_auth_header(self.bc_integration.bc_api_key))
+                              get_auth_header(self.bc_integration.get_auth_token()))
         response = requests.request('GET', self.suppressions_url, headers=headers)
 
         if response.status_code != 200:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes 2 platform integrations that did not use the Prisma auth token when fetching data.