### PR TITLE
Add instance_template and instance_from_template to supported resources

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleComputeBlockProjectSSH.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeBlockProjectSSH.py
@@ -6,7 +6,7 @@ class GoogleComputeBlockProjectSSH(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure 'Block Project-wide SSH keys' is enabled for VM instances"
         id = "CKV_GCP_32"
-        supported_resources = ['google_compute_instance']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeBlockProjectSSH.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeBlockProjectSSH.py
@@ -1,4 +1,4 @@
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
@@ -6,9 +6,22 @@ class GoogleComputeBlockProjectSSH(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure 'Block Project-wide SSH keys' is enabled for VM instances"
         id = "CKV_GCP_32"
-        supported_resources = ['google_compute_instance', 'google_compute_instance_template']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template',
+                               'google_compute_instance_from_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf) -> CheckResult:
+        if ('source_instance_template' in conf.keys() and 'metadata' not in conf.keys()) or \
+                ('source_instance_template' in conf.keys() and 'block-project-ssh-keys' not in
+                 conf['metadata'][0].keys()):
+            # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
+            # and block-project-ssh-keys is not present, then this check cannot PASS, since we don't know what the
+            # underlying source template looks like.
+            return CheckResult.UNKNOWN
+        else:
+            # in all other cases, pass/fail the check if block-project-ssh-keys is true/false or not present.
+            return super().scan_resource_conf(conf)
 
     def get_inspected_key(self):
         return 'metadata/block-project-ssh-keys'

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccount.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccount.py
@@ -9,7 +9,8 @@ class GoogleComputeDefaultServiceAccount(BaseResourceCheck):
     def __init__(self):
         name = "Ensure that instances are not configured to use the default service account"
         id = "CKV_GCP_30"
-        supported_resources = ['google_compute_instance']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_from_template',
+                               'google_compute_instance_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccount.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccount.py
@@ -29,6 +29,10 @@ class GoogleComputeDefaultServiceAccount(BaseResourceCheck):
             self.evaluated_keys = ['name']
             return CheckResult.PASSED
         self.evaluated_keys = ['service_account/[0]/email', 'name']
+        if 'source_instance_template' in conf.keys() and 'service_account' not in conf.keys():
+            # the absence of service_account from a 'google_compute_instance_from_template' definition does not imply
+            # usage of the default service account.
+            return CheckResult.UNKNOWN
         return CheckResult.FAILED
 
 

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccountFullAccess.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccountFullAccess.py
@@ -11,7 +11,8 @@ class GoogleComputeDefaultServiceAccountFullAccess(BaseResourceCheck):
         name = "Ensure that instances are not configured to use the default service account with full access" \
                " to all Cloud APIs"
         id = "CKV_GCP_31"
-        supported_resources = ['google_compute_instance']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_from_template',
+                               'google_compute_instance_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccountFullAccess.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeDefaultServiceAccountFullAccess.py
@@ -26,6 +26,12 @@ class GoogleComputeDefaultServiceAccountFullAccess(BaseResourceCheck):
         if 'name' in conf and conf['name'][0].startswith('gke-'):
             self.evaluated_keys = ['name']
             return CheckResult.PASSED
+
+        if 'source_instance_template' in conf.keys() and 'service_account' not in conf.keys():
+            # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
+            # and service_account is not present, then this check cannot PASS, since we don't know what the
+            # underlying source template looks like.
+            return CheckResult.UNKNOWN
         if 'service_account' in conf.keys():
             service_account_conf = conf['service_account'][0]
             self.evaluated_keys = ['service_account']

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeExternalIP.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeExternalIP.py
@@ -1,6 +1,6 @@
 from checkov.common.models.consts import ANY_VALUE
 from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class GoogleComputeExternalIP(BaseResourceNegativeValueCheck):
@@ -11,6 +11,16 @@ class GoogleComputeExternalIP(BaseResourceNegativeValueCheck):
                                'google_compute_instance_from_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf) -> CheckResult:
+        if 'source_instance_template' in conf.keys() and 'access_config' not in conf.keys():
+            # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
+            # and the access_config block is not present, then this check cannot PASS, since we don't know what the
+            # underlying source template looks like.
+            return CheckResult.UNKNOWN
+        else:
+            # in all other cases, pass/fail the check if block-project-ssh-keys is true/false or not present.
+            return super().scan_resource_conf(conf)
 
     def get_inspected_key(self):
         return 'access_config'

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeExternalIP.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeExternalIP.py
@@ -7,7 +7,8 @@ class GoogleComputeExternalIP(BaseResourceNegativeValueCheck):
     def __init__(self):
         name = "Ensure that Compute instances do not have public IP addresses"
         id = "CKV_GCP_40"
-        supported_resources = ['google_compute_instance']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template',
+                               'google_compute_instance_from_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeIPForward.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeIPForward.py
@@ -6,7 +6,8 @@ class GoogleComputeIPForward(BaseResourceNegativeValueCheck):
     def __init__(self):
         name = "Ensure that IP forwarding is not enabled on Instances"
         id = "CKV_GCP_36"
-        supported_resources = ['google_compute_instance']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template',
+                               'google_compute_instance_from_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeInstanceOSLogin.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeInstanceOSLogin.py
@@ -1,5 +1,5 @@
 from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class GoogleComputeInstanceOSLogin(BaseResourceNegativeValueCheck):
@@ -7,9 +7,22 @@ class GoogleComputeInstanceOSLogin(BaseResourceNegativeValueCheck):
         name = "Ensure that no instance in the project overrides the project setting for enabling OSLogin" \
                "(OSLogin needs to be enabled in project metadata for all instances)"
         id = "CKV_GCP_34"
-        supported_resources = ['google_compute_instance', 'google_compute_instance_template', 'google_compute_instance_from_template']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template',
+                               'google_compute_instance_from_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf) -> CheckResult:
+        if ('source_instance_template' in conf.keys() and 'metadata' not in conf.keys()) or \
+                ('source_instance_template' in conf.keys() and 'enable-oslogin' not in
+                 conf['metadata'][0].keys()):
+            # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
+            # and enable-oslogin is not present, then this check cannot PASS, since we don't know what the
+            # underlying source template looks like.
+            return CheckResult.UNKNOWN
+        else:
+            # in all other cases, pass/fail the check if block-project-ssh-keys is true/false or not present.
+            return super().scan_resource_conf(conf)
 
     def get_inspected_key(self):
         return 'metadata/[0]/enable-oslogin'

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeInstanceOSLogin.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeInstanceOSLogin.py
@@ -7,7 +7,7 @@ class GoogleComputeInstanceOSLogin(BaseResourceNegativeValueCheck):
         name = "Ensure that no instance in the project overrides the project setting for enabling OSLogin" \
                "(OSLogin needs to be enabled in project metadata for all instances)"
         id = "CKV_GCP_34"
-        supported_resources = ['google_compute_instance', 'google_compute_instance_template']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template', 'google_compute_instance_from_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeInstanceOSLogin.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeInstanceOSLogin.py
@@ -7,7 +7,7 @@ class GoogleComputeInstanceOSLogin(BaseResourceNegativeValueCheck):
         name = "Ensure that no instance in the project overrides the project setting for enabling OSLogin" \
                "(OSLogin needs to be enabled in project metadata for all instances)"
         id = "CKV_GCP_34"
-        supported_resources = ['google_compute_instance']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeSerialPorts.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeSerialPorts.py
@@ -1,14 +1,27 @@
 from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class GoogleComputeSerialPorts(BaseResourceNegativeValueCheck):
     def __init__(self):
         name = "Ensure 'Enable connecting to serial ports' is not enabled for VM Instance"
         id = "CKV_GCP_35"
-        supported_resources = ['google_compute_instance', 'google_compute_instance_template', 'google_compute_instance_from_template']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template',
+                               'google_compute_instance_from_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf) -> CheckResult:
+        if ('source_instance_template' in conf.keys() and 'metadata' not in conf.keys()) or \
+                ('source_instance_template' in conf.keys() and 'serial-port-enable' not in
+                 conf['metadata'][0].keys()):
+            # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
+            # and serial-port-enable is not present, then this check cannot PASS, since we don't know what the
+            # underlying source template looks like.
+            return CheckResult.UNKNOWN
+        else:
+            # in all other cases, pass/fail the check if block-project-ssh-keys is true/false or not present.
+            return super().scan_resource_conf(conf)
 
     def get_inspected_key(self):
         return 'metadata/[0]/serial-port-enable'

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeSerialPorts.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeSerialPorts.py
@@ -6,7 +6,7 @@ class GoogleComputeSerialPorts(BaseResourceNegativeValueCheck):
     def __init__(self):
         name = "Ensure 'Enable connecting to serial ports' is not enabled for VM Instance"
         id = "CKV_GCP_35"
-        supported_resources = ['google_compute_instance', 'google_compute_instance_template']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template', 'google_compute_instance_from_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeSerialPorts.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeSerialPorts.py
@@ -6,7 +6,7 @@ class GoogleComputeSerialPorts(BaseResourceNegativeValueCheck):
     def __init__(self):
         name = "Ensure 'Enable connecting to serial ports' is not enabled for VM Instance"
         id = "CKV_GCP_35"
-        supported_resources = ['google_compute_instance']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeShieldedVM.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeShieldedVM.py
@@ -6,7 +6,7 @@ class GoogleComputeShieldedVM(BaseResourceCheck):
     def __init__(self):
         name = "Ensure Compute instances are launched with Shielded VM enabled"
         id = "CKV_GCP_39"
-        supported_resources = ['google_compute_instance']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeShieldedVM.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeShieldedVM.py
@@ -6,7 +6,8 @@ class GoogleComputeShieldedVM(BaseResourceCheck):
     def __init__(self):
         name = "Ensure Compute instances are launched with Shielded VM enabled"
         id = "CKV_GCP_39"
-        supported_resources = ['google_compute_instance', 'google_compute_instance_template']
+        supported_resources = ['google_compute_instance', 'google_compute_instance_template',
+                               'google_compute_instance_from_template']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
@@ -17,7 +18,11 @@ class GoogleComputeShieldedVM(BaseResourceCheck):
         :param conf:
         :return: <checkResult>
         """
-
+        if 'source_instance_template' in conf.keys() and 'shielded_instance_config' not in conf.keys():
+            # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
+            # and shielded_instance_config is not present, then this check cannot FAIL, since we don't know what the
+            # underlying source template looks like.
+            return CheckResult.UNKNOWN
         if 'shielded_instance_config' in conf.keys():
             self.evaluated_keys = ['shielded_instance_config', 'shielded_instance_config/[0]/enable_vtpm',
                                    'shielded_instance_config/[0]/enable_integrity_monitoring']

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeBlockProjectSSH.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeBlockProjectSSH.py
@@ -20,7 +20,92 @@ class TestGoogleComputeBlockProjectSSH(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-    def test_success(self):
+    def test_failure_1(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              metadata = {
+                 block-project-ssh-keys = false
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_2(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+              metadata {
+                foo = "bar"
+                hey = "oh"
+                block-project-ssh-keys = false
+                }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_3(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default_template" {
+              name         = "test"
+              machine_type = "e2-medium"
+
+              disk {
+                source_image = "debian-cloud/debian-9"
+                auto_delete  = true
+                disk_size_gb = 100
+                boot         = true
+              }
+
+              network_interface {
+                network = "default"
+              }
+
+              metadata = {
+                foo = "bar"
+              }
+
+              can_ip_forward = true
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default_template']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_unknown_1(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+              metadata {
+                foo = "bar"
+                hey = "oh"
+                }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+
+    def test_unknown_2(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+
+    def test_success_1(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance" "default" {
               name         = "test"
@@ -35,35 +120,7 @@ class TestGoogleComputeBlockProjectSSH(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-    def test_instance_template_failure(self):
-        hcl_res = hcl2.loads("""
-            resource "google_compute_instance_template" "default_template" {
-              name         = "test"
-              machine_type = "e2-medium"
-            
-              disk {
-                source_image = "debian-cloud/debian-9"
-                auto_delete  = true
-                disk_size_gb = 100
-                boot         = true
-              }
-            
-              network_interface {
-                network = "default"
-              }
-            
-              metadata = {
-                foo = "bar"
-              }
-            
-              can_ip_forward = true
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default_template']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
-
-    def test_instance_template_success(self):
+    def test_success_2(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance_template" "default_template" {
               name         = "test"
@@ -92,10 +149,21 @@ class TestGoogleComputeBlockProjectSSH(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-    def test_no_from_template_support(self):
-        if 'google_compute_instance_from_template' in check.supported_resources:
-            self.fail("This policy should not support 'google_compute_instance_from_template' resources since it isn't "
-                      "possible to scan values inherited from the 'source_instance_template'.")
+    def test_success_3(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+              metadata {
+                foo = "bar"
+                hey = "oh"
+                block-project-ssh-keys = true
+                }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
 
 
 if __name__ == '__main__':

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeBlockProjectSSH.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeBlockProjectSSH.py
@@ -35,6 +35,68 @@ class TestGoogleComputeBlockProjectSSH(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_instance_template_failure(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default_template" {
+              name         = "test"
+              machine_type = "e2-medium"
+            
+              disk {
+                source_image = "debian-cloud/debian-9"
+                auto_delete  = true
+                disk_size_gb = 100
+                boot         = true
+              }
+            
+              network_interface {
+                network = "default"
+              }
+            
+              metadata = {
+                foo = "bar"
+              }
+            
+              can_ip_forward = true
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default_template']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_instance_template_success(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default_template" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+                              
+              disk {
+                source_image = "debian-cloud/debian-9"
+                auto_delete  = true
+                disk_size_gb = 100
+                boot         = true
+              }
+            
+              network_interface {
+                network = "default"
+              }
+              
+              can_ip_forward = true
+              metadata = {
+                foo                    = "bar",
+                block-project-ssh-keys = true
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default_template']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_no_from_template_support(self):
+        if 'google_compute_instance_from_template' in check.supported_resources:
+            self.fail("This policy should not support 'google_compute_instance_from_template' resources since it isn't "
+                      "possible to scan values inherited from the 'source_instance_template'.")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeDefaultServiceAccount.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeDefaultServiceAccount.py
@@ -36,6 +36,32 @@ class TestGoogleComputeDefaultServiceAccount(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_3(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name                     = "instance_from_template"
+              source_instance_template = google_compute_instance_template.default.id
+              service_account {
+                scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+                email  =  "123456789-compute@developer.gserviceaccount.com"
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_unknown(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name                     = "instance_from_template"
+              source_instance_template = google_compute_instance_template.default.id
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+
     def test_success_1(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance" "default" {
@@ -65,6 +91,37 @@ class TestGoogleComputeDefaultServiceAccount(unittest.TestCase):
             }
                 """)
         resource_conf = hcl_res['resource'][0]['google_compute_instance']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_3(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "account"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              service_account {
+                scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+                email  = "example@email.com"
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_4(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name                     = "instance_from_template"
+              source_instance_template = google_compute_instance_template.default.id
+              service_account {
+                scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+                email  = "example@email.com"
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeDefaultServiceAccountFullAccess.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeDefaultServiceAccountFullAccess.py
@@ -112,6 +112,17 @@ class TestGoogleComputeDefaultServiceAccount(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_unknown(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.tpl.id
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeDefaultServiceAccountFullAccess.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeDefaultServiceAccountFullAccess.py
@@ -39,6 +39,38 @@ class TestGoogleComputeDefaultServiceAccount(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_3(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              service_account {
+                scopes = ["https://www.googleapis.com/auth/cloud-platform", "compute-ro", "storage-ro"]
+                email  =  "123456789-compute@developer.gserviceaccount.com"
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_4(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.tpl.id
+  
+              service_account {
+                scopes = ["https://www.googleapis.com/auth/cloud-platform", "compute-ro", "storage-ro"]
+                email  =  "123456789-compute@developer.gserviceaccount.com"
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_success_1(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance" "default" {

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeExternalIP.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeExternalIP.py
@@ -80,7 +80,7 @@ class TestGoogleComputeExternalIP(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-    def test_success_2(self):
+    def test_unknown(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance_from_template" "default" {
               name         = "test"
@@ -89,7 +89,7 @@ class TestGoogleComputeExternalIP(unittest.TestCase):
                 """)
         resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
         scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
 
 
 if __name__ == '__main__':

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeExternalIP.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeExternalIP.py
@@ -24,6 +24,36 @@ class TestGoogleComputeExternalIP(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_1(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              boot_disk {}
+              access_config {
+                network_tier = "STANDARD"
+                }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_2(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+              access_config {
+                network_tier = "STANDARD"
+                }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_success(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance" "default" {
@@ -34,6 +64,30 @@ class TestGoogleComputeExternalIP(unittest.TestCase):
             }
                 """)
         resource_conf = hcl_res['resource'][0]['google_compute_instance']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_1(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              boot_disk {}
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_2(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeIPForward.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeIPForward.py
@@ -89,11 +89,24 @@ class TestGoogleComputeIPForward(unittest.TestCase):
             resource "google_compute_instance_from_template" "default" {
               name         = "test"
               source_instance_template = google_compute_instance_template.default.id
+              can_ip_forward = false
+
             }
                 """)
         resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_unknown(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
 
 
 if __name__ == '__main__':

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeIPForward.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeIPForward.py
@@ -21,6 +21,31 @@ class TestGoogleComputeIPForward(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_1(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              can_ip_forward = true
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_2(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+              can_ip_forward = true
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_success(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance" "default" {
@@ -43,6 +68,30 @@ class TestGoogleComputeIPForward(unittest.TestCase):
             }
                 """)
         resource_conf = hcl_res['resource'][0]['google_compute_instance']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_3(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              boot_disk {}
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_4(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeInstanceOSLogin.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeInstanceOSLogin.py
@@ -24,6 +24,35 @@ class TestGoogleComputeInstanceOSLogin(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_1(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              metadata = {
+                 enable-oslogin = false
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_2(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+              metadata = {
+                 enable-oslogin = false
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_success_1(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance" "default" {
@@ -53,6 +82,30 @@ class TestGoogleComputeInstanceOSLogin(unittest.TestCase):
             }
                 """)
         resource_conf = hcl_res['resource'][0]['google_compute_instance']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_3(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              boot_disk {}
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_4(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeInstanceOSLogin.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeInstanceOSLogin.py
@@ -98,7 +98,7 @@ class TestGoogleComputeInstanceOSLogin(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-    def test_success_4(self):
+    def test_unknown_1(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance_from_template" "default" {
               name         = "test"
@@ -107,7 +107,21 @@ class TestGoogleComputeInstanceOSLogin(unittest.TestCase):
                 """)
         resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
         scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+
+    def test_unknown_2(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+              metadata = {
+                 foo = "bar"
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
 
 
 if __name__ == '__main__':

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeSerialPorts.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeSerialPorts.py
@@ -24,6 +24,35 @@ class TestGoogleComputeSerialPorts(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_2(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              metadata = {
+                 serial-port-enable = true
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_3(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+              metadata = {
+                 serial-port-enable = true
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_success_1(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance" "default" {
@@ -50,6 +79,30 @@ class TestGoogleComputeSerialPorts(unittest.TestCase):
             }
                 """)
         resource_conf = hcl_res['resource'][0]['google_compute_instance']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_3(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              boot_disk {}
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_4(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeSerialPorts.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeSerialPorts.py
@@ -53,6 +53,31 @@ class TestGoogleComputeSerialPorts(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_unknown_1(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+              metadata = {
+                 foo = true
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+
+    def test_unknown_2(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+
     def test_success_1(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance" "default" {
@@ -92,17 +117,6 @@ class TestGoogleComputeSerialPorts(unittest.TestCase):
             }
                 """)
         resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
-
-    def test_success_4(self):
-        hcl_res = hcl2.loads("""
-            resource "google_compute_instance_from_template" "default" {
-              name         = "test"
-              source_instance_template = google_compute_instance_template.default.id
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeShieldedVM.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeShieldedVM.py
@@ -37,6 +37,22 @@ class TestGoogleComputeShieldedVM (unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_3(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              boot_disk {}
+                shielded_instance_config {
+                    enable_integrity_monitoring = false
+                    }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_success(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance" "default" {
@@ -50,6 +66,25 @@ class TestGoogleComputeShieldedVM (unittest.TestCase):
         resource_conf = hcl_res['resource'][0]['google_compute_instance']['default']
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_1(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_template" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              boot_disk {}
+              shielded_instance_config {}
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_no_from_template_support(self):
+        if 'google_compute_instance_from_template' in check.supported_resources:
+            self.fail("This policy should not support 'google_compute_instance_from_template' resources since it isn't "
+                      "possible to scan values inherited from the 'source_instance_template'.")
 
 
 if __name__ == '__main__':

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeShieldedVM.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeShieldedVM.py
@@ -53,6 +53,20 @@ class TestGoogleComputeShieldedVM (unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_4(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+              shielded_instance_config {
+                enable_integrity_monitoring = false
+                }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_success(self):
         hcl_res = hcl2.loads("""
             resource "google_compute_instance" "default" {
@@ -81,10 +95,63 @@ class TestGoogleComputeShieldedVM (unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-    def test_no_from_template_support(self):
-        if 'google_compute_instance_from_template' in check.supported_resources:
-            self.fail("This policy should not support 'google_compute_instance_from_template' resources since it isn't "
-                      "possible to scan values inherited from the 'source_instance_template'.")
+    def test_success_2(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              boot_disk {}
+              shielded_instance_config {
+                enable_vtpm = true
+                enable_integrity_monitoring = true
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_3(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance" "default" {
+              name         = "test"
+              machine_type = "n1-standard-1"
+              zone         = "us-central1-a"
+              boot_disk {}
+              shielded_instance_config {
+                enable_vtpm = true
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_4(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+              shielded_instance_config {
+                enable_vtpm = true
+              }
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_unknown_1(self):
+        hcl_res = hcl2.loads("""
+            resource "google_compute_instance_from_template" "default" {
+              name         = "test"
+              source_instance_template = google_compute_instance_template.default.id
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Adds support for `google_compute_instance_template` and `google_compute_instance_from_template` to checks for `google_compute_instance`. 