### PR TITLE
fix inefficient version regex

### DIFF
--- a/checkov/terraform/module_loading/loaders/versions_parser.py
+++ b/checkov/terraform/module_loading/loaders/versions_parser.py
@@ -2,7 +2,7 @@ import re
 from typing import List
 
 from packaging import version
-VERSION_REGEX = re.compile(r'^(?P<operator>=|!=|>=|>|<=|<|~>)?(?P<version>.+)$')
+VERSION_REGEX = re.compile(r"^(?P<operator>=|!=|>=|>|<=|<|~>)?\s*(?P<version>[\d.]+-?\w*)$")
 
 
 class VersionConstraint:
@@ -34,6 +34,9 @@ class VersionConstraint:
         }[self.operator](other_version)
         return res
 
+    def __str__(self):
+        return f"{self.operator}{self.version}"
+
 
 def get_version_constraints(raw_version: str) -> List[VersionConstraint]:
     """
@@ -44,8 +47,10 @@ def get_version_constraints(raw_version: str) -> List[VersionConstraint]:
     raw_version_constraints = raw_version.split(',')
     version_constraints = []
     for constraint in raw_version_constraints:
-        constraint_parts = re.search(VERSION_REGEX, constraint).groupdict()
-        version_constraints.append(VersionConstraint(constraint_parts))
+        match = re.search(VERSION_REGEX, constraint)
+        if match:
+            constraint_parts = match.groupdict()
+            version_constraints.append(VersionConstraint(constraint_parts))
     return version_constraints
 
 

--- a/checkov/terraform/module_loading/loaders/versions_parser.py
+++ b/checkov/terraform/module_loading/loaders/versions_parser.py
@@ -2,7 +2,7 @@ import re
 from typing import List
 
 from packaging import version
-VERSION_REGEX = re.compile(r'^(?P<operator>=|!=|>=|>|<=|<|~>)*(?P<version>.+)$')
+VERSION_REGEX = re.compile(r'^(?P<operator>=|!=|>=|>|<=|<|~>)?(?P<version>.+)$')
 
 
 class VersionConstraint:

--- a/tests/terraform/module_loading/loaders/test_version_parser.py
+++ b/tests/terraform/module_loading/loaders/test_version_parser.py
@@ -1,0 +1,20 @@
+import pytest
+
+from checkov.terraform.module_loading.loaders.versions_parser import get_version_constraints
+
+
+@pytest.mark.parametrize(
+    "input_str,expected",
+    [
+        ("1.2.0", "=1.2.0"),
+        ("1.2.0-rc1", "=1.2.0rc1"),
+        (">= 1.2.0, < 2.0.0", ">=1.2.0,<2.0.0"),
+        ("not-a-version", ""),
+        ("<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=<=>=1.2.3", ""),
+    ],
+    ids=["sem_ver", "pre_release", "multi", "not_a_version", "back_tracking"],
+)
+def test_get_version_constraints(input_str: str, expected: str) -> None:
+    result = get_version_constraints(input_str)
+
+    assert ",".join(str(version) for version in result) == expected


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Not 100% sure, but this should fix one of the regex issues... I hope 😄 