### PR TITLE
Clarify log message when module download is skipped and download-external-modules is false

### DIFF
--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -79,7 +79,10 @@ def load_tf_modules(path: str, should_download_module: Callable[[str], bool] = s
                 content = module_loader_registry.load(m.source_dir, m.module_link,
                                                       "latest" if not m.version else m.version)
                 if content is None or not content.loaded():
-                    logging.warning(f'Failed to download module {m.address}')
+                    log_message = f'Failed to download module {m.address}'
+                    if not module_loader_registry.download_external_modules:
+                        log_message += ' (for external modules, the --download-external-modules flag is required)'
+                    logging.warning(log_message)
             except Exception as e:
                 logging.warning(f"Unable to load module ({m.address}): {e}")
 


### PR DESCRIPTION
The log warning is confusing - for external modules, it says "Failed to download module" even though it never tries.

[While some may count this as a failure](https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/baby-yoda-old-yoda-1574103229.jpg?crop=0.486xw:0.973xh;0.514xw,0&resize=480:*), we should be more clear.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
