### PR TITLE
Fixes - use the record absolute file path instead of recalculating it

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
@@ -38,14 +38,12 @@ class FixesIntegration(BaseIntegrationFeature):
         # with repo size issues. Because the primary use case for this at the moment is VSCode integration, which
         # runs one file at a time, this can wait.
 
-        sorted_by_file = sorted(scan_report.failed_checks, key=lambda c: c.repo_file_path)
-        for file, failed_checks in groupby(sorted_by_file, key=lambda c: c.repo_file_path):
+        sorted_by_file = sorted(scan_report.failed_checks, key=lambda c: c.file_abs_path)
+        for file, failed_checks in groupby(sorted_by_file, key=lambda c: c.file_abs_path):
             failed_checks = [fc for fc in failed_checks if fc.check_id in self.bc_integration.ckv_to_bc_id_mapping]
             if not failed_checks:
                 continue
-            # file path always starts with /
-            file_abs_path = os.path.abspath(os.path.join(os.getcwd(), file[1:]))
-            with open(file_abs_path, 'r') as reader:
+            with open(file, 'r') as reader:
                 file_contents = reader.read()
 
             fixes = self._get_fixes_for_file(scan_report.check_type, file, file_contents, failed_checks)


### PR DESCRIPTION
This fixes an issue where the absolute path to read the file to send to the fixes API was being incorrectly calculated on Windows, which made the fixes logic not work

Example scan file path: `d:\Dev\bridgecrew\terragoat\terraform\aws\s3.tf`

File path that the fixes logic tries to read: `d:\\Dev\\bridgecrew\\terragoat\\Dev\\bridgecrew\\terragoat\\terraform\\aws\\s3.tf`

Calculating abs path isn't necessary here anyways, as each record already has it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
