### PR TITLE
Fix - External TF Registry Downloads on Windows

### DIFF
--- a/checkov/terraform/module_loading/loaders/registry_loader.py
+++ b/checkov/terraform/module_loading/loaders/registry_loader.py
@@ -31,7 +31,7 @@ class RegistryLoader(ModuleLoader):
         if os.path.exists(self.dest_dir):
             return True
 
-        self.module_version_url = os.path.join(self.REGISTRY_URL_PREFIX, self.module_source, "versions")
+        self.module_version_url = self.REGISTRY_URL_PREFIX + "/" + self.module_source + "/versions"
         if not self.module_version_url.startswith(self.REGISTRY_URL_PREFIX):
             # Local paths don't get the prefix appended
             return False
@@ -54,7 +54,7 @@ class RegistryLoader(ModuleLoader):
 
         best_version = self._find_best_version()
 
-        request_download_url = os.path.join(self.REGISTRY_URL_PREFIX, self.module_source, best_version, "download")
+        request_download_url = self.REGISTRY_URL_PREFIX + "/" + self.module_source + "/" + best_version + "/download"
         response = requests.get(url=request_download_url)
         if response.status_code != HTTPStatus.OK and response.status_code != HTTPStatus.NO_CONTENT:
             return ModuleContent(dir=None)

--- a/checkov/terraform/module_loading/loaders/registry_loader.py
+++ b/checkov/terraform/module_loading/loaders/registry_loader.py
@@ -31,7 +31,7 @@ class RegistryLoader(ModuleLoader):
         if os.path.exists(self.dest_dir):
             return True
 
-        self.module_version_url = self.REGISTRY_URL_PREFIX + "/" + self.module_source + "/versions"
+        self.module_version_url = "/".join((self.REGISTRY_URL_PREFIX, self.module_source, "versions"))
         if not self.module_version_url.startswith(self.REGISTRY_URL_PREFIX):
             # Local paths don't get the prefix appended
             return False
@@ -54,7 +54,7 @@ class RegistryLoader(ModuleLoader):
 
         best_version = self._find_best_version()
 
-        request_download_url = self.REGISTRY_URL_PREFIX + "/" + self.module_source + "/" + best_version + "/download"
+        request_download_url = "/".join((self.REGISTRY_URL_PREFIX, self.module_source, best_version, "download"))
         response = requests.get(url=request_download_url)
         if response.status_code != HTTPStatus.OK and response.status_code != HTTPStatus.NO_CONTENT:
             return ModuleContent(dir=None)


### PR DESCRIPTION
Hello 🙂,

Often you need to do `os.path.join` so that paths work regardless of underlying Operating System.

However, URL / FQDN are platform agnostic and always use `/`. So, just a little oversight here.

**Fixes**
* https://github.com/bridgecrewio/checkov/issues/2098

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
