### PR TITLE
Handle UnicodeDecodeError in JSON parser

### DIFF
--- a/checkov/common/parsers/json/__init__.py
+++ b/checkov/common/parsers/json/__init__.py
@@ -40,5 +40,7 @@ def parse(filename, allow_nulls=True):
         # not even begin parsing with our custom logic that throws the exception above,
         # and will fail with this exception instead.
         pass
+    except UnicodeDecodeError:
+        pass
 
     return (template, template_lines)


### PR DESCRIPTION
This can happen when reading a file with different or invalid byte marks. The exception is not handled and the runner crashes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
