### PR TITLE
add CKV_AZURE_134 to check for log4shell prevention in Application Gateway WAF

### DIFF
--- a/checkov/terraform/checks/resource/azure/AppGatewayWAFACLCVE202144228.py
+++ b/checkov/terraform/checks/resource/azure/AppGatewayWAFACLCVE202144228.py
@@ -8,7 +8,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 class AppGatewayWAFACLCVE202144228(BaseResourceCheck):
     def __init__(self) -> None:
         name = "Ensure Application Gateway WAF prevents message lookup in Log4j2. See CVE-2021-44228 aka log4jshell"
-        id = "CKV_AZURE_134"
+        id = "CKV_AZURE_135"
         supported_resources = ("azurerm_web_application_firewall_policy",)
         categories = (CheckCategories.APPLICATION_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/checkov/terraform/checks/resource/azure/AppGatewayWAFACLCVE202144228.py
+++ b/checkov/terraform/checks/resource/azure/AppGatewayWAFACLCVE202144228.py
@@ -1,0 +1,45 @@
+from typing import Dict, Any
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.common.util.type_forcers import force_list
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class AppGatewayWAFACLCVE202144228(BaseResourceCheck):
+    def __init__(self) -> None:
+        name = "Ensure Application Gateway WAF prevents message lookup in Log4j2. See CVE-2021-44228 aka log4jshell"
+        id = "CKV_AZURE_134"
+        supported_resources = ("azurerm_web_application_firewall_policy",)
+        categories = (CheckCategories.APPLICATION_SECURITY,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: Dict[str, Any]) -> CheckResult:
+        self.evaluated_keys = ["managed_rules"]
+        managed_rules = conf.get("managed_rules")
+        if managed_rules:
+            managed_rule_sets = managed_rules[0].get("managed_rule_set") or []
+            for idx_rule_set, rule_set in enumerate(force_list(managed_rule_sets)):
+                self.evaluated_keys = [
+                    f"managed_rules/[0]/managed_rule_set[{idx_rule_set}]/type",
+                    f"managed_rules/[0]/managed_rule_set[{idx_rule_set}]/version",
+                ]
+                if rule_set.get("type", ["OWASP"]) == ["OWASP"] and rule_set.get("version") in (["3.1"], ["3.2"]):
+                    rule_overrides = rule_set.get("rule_group_override") or []
+                    for idx_override, rule_override in enumerate(force_list(rule_overrides)):
+                        self.evaluated_keys.extend(
+                            [
+                                f"managed_rules/[0]/managed_rule_set[{idx_rule_set}]/rule_group_override/[{idx_override}]/rule_group_name",
+                                f"managed_rules/[0]/managed_rule_set[{idx_rule_set}]/rule_group_override/[{idx_override}]/disabled_rules",
+                            ]
+                        )
+                        if rule_override.get("rule_group_name") == ["REQUEST-944-APPLICATION-ATTACK-JAVA"]:
+                            disabled_rules = rule_override.get("disabled_rules") or []
+                            if isinstance(disabled_rules, list) and "944240" in force_list(disabled_rules[0]):
+                                return CheckResult.FAILED
+
+                    return CheckResult.PASSED
+
+        return CheckResult.FAILED
+
+
+check = AppGatewayWAFACLCVE202144228()

--- a/tests/terraform/checks/resource/azure/example_AppGatewayWAFACLCVE202144228/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AppGatewayWAFACLCVE202144228/main.tf
@@ -1,0 +1,108 @@
+# pass
+
+resource "azurerm_web_application_firewall_policy" "owasp_3_1_default" {
+  location            = "germanywestcentral"
+  name                = "example"
+  resource_group_name = "example"
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.1"
+    }
+  }
+
+  policy_settings {}
+}
+
+resource "azurerm_web_application_firewall_policy" "owasp_3_2_default" {
+  location            = "germanywestcentral"
+  name                = "example"
+  resource_group_name = "example"
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+
+  policy_settings {}
+}
+
+resource "azurerm_web_application_firewall_policy" "version_3_1_default" {
+  location            = "germanywestcentral"
+  name                = "example"
+  resource_group_name = "example"
+
+  managed_rules {
+    managed_rule_set {
+      version = "3.2"
+    }
+  }
+
+  policy_settings {}
+}
+
+resource "azurerm_web_application_firewall_policy" "owasp_3_1_disabled_different" {
+  location            = "germanywestcentral"
+  name                = "example"
+  resource_group_name = "example"
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.1"
+
+      rule_group_override {
+        rule_group_name = "REQUEST-944-APPLICATION-ATTACK-JAVA"
+        disabled_rules = [
+          "944200",
+          "944210"
+        ]
+      }
+    }
+  }
+
+  policy_settings {}
+}
+
+# fail
+
+resource "azurerm_web_application_firewall_policy" "owasp_3_0" {
+  location            = "germanywestcentral"
+  name                = "example"
+  resource_group_name = "example"
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.0"
+    }
+  }
+
+  policy_settings {}
+}
+
+resource "azurerm_web_application_firewall_policy" "owasp_3_1_disabled" {
+  location            = "germanywestcentral"
+  name                = "example"
+  resource_group_name = "example"
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.1"
+
+      rule_group_override {
+        rule_group_name = "REQUEST-944-APPLICATION-ATTACK-JAVA"
+        disabled_rules = [
+          "944200",
+          "944240"
+        ]
+      }
+    }
+  }
+
+  policy_settings {}
+}

--- a/tests/terraform/checks/resource/azure/test_AppGatewayWAFACLCVE202144228.py
+++ b/tests/terraform/checks/resource/azure/test_AppGatewayWAFACLCVE202144228.py
@@ -1,0 +1,58 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.azure.AppGatewayWAFACLCVE202144228 import check
+from checkov.terraform.runner import Runner
+
+
+class TestAppGatewayWAFACLCVE202144228(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_AppGatewayWAFACLCVE202144228"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "azurerm_web_application_firewall_policy.owasp_3_1_default",
+            "azurerm_web_application_firewall_policy.owasp_3_2_default",
+            "azurerm_web_application_firewall_policy.version_3_1_default",
+            "azurerm_web_application_firewall_policy.owasp_3_1_disabled_different",
+        }
+        failing_resources = {
+            "azurerm_web_application_firewall_policy.owasp_3_0",
+            "azurerm_web_application_firewall_policy.owasp_3_1_disabled",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 4)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+        # check especially for the evaluated keys
+        actual_evaluated_keys = next(
+            c.check_result["evaluated_keys"]
+            for c in report.failed_checks
+            if c.resource == "azurerm_web_application_firewall_policy.owasp_3_1_disabled"
+        )
+        expected_evaluated_keys = [
+            "managed_rules/[0]/managed_rule_set[0]/type",
+            "managed_rules/[0]/managed_rule_set[0]/version",
+            "managed_rules/[0]/managed_rule_set[0]/rule_group_override/[0]/rule_group_name",
+            "managed_rules/[0]/managed_rule_set[0]/rule_group_override/[0]/disabled_rules",
+        ]
+        self.assertCountEqual(expected_evaluated_keys, actual_evaluated_keys)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

added a check to look for the log4shell mitigation in the Azure Application Gateway firewall.