### PR TITLE
Added two checks for Azure Cognitive Services

### DIFF
--- a/checkov/terraform/checks/graph_checks/azure/CognitiveServicesCustomerManagedKey.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/CognitiveServicesCustomerManagedKey.yaml
@@ -1,0 +1,23 @@
+metadata:
+  id: "CKV2_AZURE_22"
+  name: "Ensure that Cognitive Services enables customer-managed key for encryption"
+  category: "ENCRYPTION"
+definition:
+  and:
+    - resource_types:
+        - azurerm_cognitive_account
+      connected_resource_types:
+        - azurerm_cognitive_account_customer_managed_key
+      operator:  exists
+      cond_type: connection
+    - resource_types:
+        - azurerm_cognitive_account_customer_managed_key
+      connected_resource_types:
+        - azurerm_key_vault_key
+      operator:  exists
+      cond_type: connection
+    - cond_type: filter
+      attribute: resource_type
+      value:
+        - azurerm_cognitive_account
+      operator: within

--- a/checkov/terraform/checks/resource/azure/CognitiveServicesDisablesPublicNetwork.py
+++ b/checkov/terraform/checks/resource/azure/CognitiveServicesDisablesPublicNetwork.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class CognitiveServicesDisablesPublicNetwork(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure that Cognitive Services accounts disable public network access"
+        id = "CKV_AZURE_134"
+        supported_resources = ['azurerm_cognitive_account']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'public_network_access_enabled'
+
+    def get_expected_value(self):
+        return False
+
+
+check = CognitiveServicesDisablesPublicNetwork()

--- a/tests/terraform/checks/resource/azure/test_CognitiveServicesDisablesPublicNetwork.py
+++ b/tests/terraform/checks/resource/azure/test_CognitiveServicesDisablesPublicNetwork.py
@@ -1,0 +1,62 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.azure.CognitiveServicesDisablesPublicNetwork import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestCognitiveServicesDisablesPublicNetwork(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_cognitive_account" "examplea" {
+  name                = "example-account"
+  location            = var.resource_group.location
+  resource_group_name = var.resource_group.name
+  kind                = "Face"
+
+  public_network_access_enabled = true
+
+  sku_name = "S0"
+}
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_cognitive_account']['examplea']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_missing_failure(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_cognitive_account" "examplea" {
+  name                = "example-account"
+  location            = var.resource_group.location
+  resource_group_name = var.resource_group.name
+  kind                = "Face"
+
+  sku_name = "S0"
+}
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_cognitive_account']['examplea']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+        
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+resource "azurerm_cognitive_account" "examplea" {
+  name                = "example-account"
+  location            = var.resource_group.location
+  resource_group_name = var.resource_group.name
+  kind                = "Face"
+
+  public_network_access_enabled = false
+
+  sku_name = "S0"
+}
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_cognitive_account']['examplea']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/graph/checks/resources/AzureCognitiveServicesCustomerManagedKey/expected.yaml
+++ b/tests/terraform/graph/checks/resources/AzureCognitiveServicesCustomerManagedKey/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "azurerm_cognitive_account.cognitive_account_good"
+fail:
+  - "azurerm_cognitive_account.cognitive_account_bad"

--- a/tests/terraform/graph/checks/resources/AzureCognitiveServicesCustomerManagedKey/main.tf
+++ b/tests/terraform/graph/checks/resources/AzureCognitiveServicesCustomerManagedKey/main.tf
@@ -1,0 +1,47 @@
+data "azurerm_client_config" "current" {}
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West US"
+}
+
+
+#fail
+resource "azurerm_cognitive_account" "cognitive_account_bad" {
+  name                = "example-account"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  kind                = "Face"
+  sku_name            = "S0"
+}
+
+
+#pass
+resource "azurerm_cognitive_account" "cognitive_account_good" {
+  name                  = "example-account"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  kind                  = "Face"
+  sku_name              = "E0"
+  public_network_access_enabled = false
+}
+
+resource "azurerm_key_vault" "good_vault" {
+  name                     = "example-vault"
+  location                 = azurerm_resource_group.example.location
+  resource_group_name      = azurerm_resource_group.example.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+}
+
+resource "azurerm_key_vault_key" "good_key" {
+  name         = "example-key"
+  key_vault_id = azurerm_key_vault.good_vault.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+}
+
+resource "azurerm_cognitive_account_customer_managed_key" "good_cmk" {
+  cognitive_account_id = azurerm_cognitive_account.cognitive_account_good.id
+  key_vault_key_id     = azurerm_key_vault_key.good_key.id
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

These two policies are based on this resource: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cognitive_account

And are based on the checks for other similar services.