### PR TITLE
Fix loading git modules with git@github.com

### DIFF
--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -74,8 +74,8 @@ class GenericGitLoader(ModuleLoader):
             raise Exception("invalid git url")
 
         username = re.match(re.compile(r"^(.*?@).*"), root_module)
-        if username:
-            root_module = root_module.replace(username[1], "") if username[1] != "git@" else root_module
+        if username and username[1] != "git@":
+            root_module = root_module.replace(username[1], "")
 
         if root_module.endswith(".git"):
             root_module = root_module[:-4]

--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -75,7 +75,7 @@ class GenericGitLoader(ModuleLoader):
 
         username = re.match(re.compile(r"^(.*?@).*"), root_module)
         if username:
-            root_module = root_module.replace(username[1], "")
+            root_module = root_module.replace(username[1], "") if username[1] != "git@" else root_module
 
         if root_module.endswith(".git"):
             root_module = root_module[:-4]

--- a/tests/terraform/module_loading/test_registry.py
+++ b/tests/terraform/module_loading/test_registry.py
@@ -167,12 +167,21 @@ def test_load_terraform_registry(
             "git::username@example.com/network.git?ref=v1.2.0",
             "",
         ),
+        (
+            "git::ssh://git@github.com/bridgecrewio/terragoat//modules/s3-encrypted",
+            "git@github.com/bridgecrewio/terragoat/HEAD/modules/s3-encrypted",
+            "ssh://git@github.com/bridgecrewio/terragoat",
+            "git@github.com/bridgecrewio/terragoat/HEAD",
+            "git::ssh://git@github.com/bridgecrewio/terragoat",
+            "modules/s3-encrypted",
+        ),
     ],
     ids=["module", "module_with_version",
          "inner_module", "inner_module_with_version",
          "module_over_ssh", "module_over_ssh_with_version",
          "module_over_ssh_without_protocol", "module_over_ssh_without_protocol_with_version",
-     ],
+         "git_username"
+        ],
 )
 @mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
 def test_load_generic_git(


### PR DESCRIPTION
Resolves https://github.com/bridgecrewio/checkov/issues/2136
This fix prevents the module source `git::ssh://git@github.com/<<org>>>/<<repo>>...`
To become the following command: `git clone -v --depth=1 ssh://github.com/<<org>>>/<<repo>>` 
and enforce it to be the following: `git clone -v --depth=1 ssh://git@github.com/<<org>>>/<<repo>>`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
