### PR TITLE
add Terraform attribute null case behaviour

### DIFF
--- a/checkov/terraform/checks/resource/aws/EBSDefaultEncryption.py
+++ b/checkov/terraform/checks/resource/aws/EBSDefaultEncryption.py
@@ -3,16 +3,21 @@ from checkov.terraform.checks.resource.base_resource_value_check import BaseReso
 
 
 class EBSDefaultEncryption(BaseResourceValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure EBS default encryption is enabled"
         id = "CKV_AWS_106"
-        supported_resources = ["aws_ebs_encryption_by_default"]
-        categories = [CheckCategories.ENCRYPTION]
-        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
-                         missing_block_result=CheckResult.PASSED)
+        supported_resources = ("aws_ebs_encryption_by_default",)
+        categories = (CheckCategories.ENCRYPTION,)
+        super().__init__(
+            name=name,
+            id=id,
+            categories=categories,
+            supported_resources=supported_resources,
+            missing_block_result=CheckResult.PASSED,
+        )
 
     def get_inspected_key(self) -> str:
-        return 'enabled'
+        return "enabled"
 
 
 check = EBSDefaultEncryption()

--- a/checkov/terraform/checks/resource/aws/IAMPolicyAttachedToGroupOrRoles.py
+++ b/checkov/terraform/checks/resource/aws/IAMPolicyAttachedToGroupOrRoles.py
@@ -1,28 +1,29 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
-from typing import List
+from typing import List, Any
+
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
 
 
-class IAMPolicyAttachedToGroupOrRoles(BaseResourceCheck):
-    def __init__(self):
+class IAMPolicyAttachedToGroupOrRoles(BaseResourceNegativeValueCheck):
+    def __init__(self) -> None:
         name = "Ensure IAM policies are attached only to groups or roles (Reducing access management complexity may " \
                "in-turn reduce opportunity for a principal to inadvertently receive or retain excessive privileges.)"
         id = "CKV_AWS_40"
-        supported_resources = ['aws_iam_user_policy_attachment', 'aws_iam_user_policy', 'aws_iam_policy_attachment']
-        categories = [CheckCategories.IAM]
+        supported_resources = ('aws_iam_user_policy_attachment', 'aws_iam_user_policy', 'aws_iam_policy_attachment')
+        categories = (CheckCategories.IAM,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        if 'user' in conf.keys():
-            return CheckResult.FAILED
-        if 'users' in conf.keys() and conf['users'][0] is None: #"users": null case 
-            return CheckResult.PASSED
-        if 'users' in conf.keys() and len(conf['users'][0]) > 0:
-            return CheckResult.FAILED
-        return CheckResult.PASSED
+    def get_inspected_key(self) -> str:
+        if self.entity_type == "aws_iam_policy_attachment":
+            return "users"
+        elif self.entity_type in ("aws_iam_user_policy", "aws_iam_user_policy_attachment"):
+            return "user"
 
-    def get_evaluated_keys(self) -> List[str]:
-        return ['user', 'users']
+        return ""
+
+    def get_forbidden_values(self) -> List[Any]:
+        return [ANY_VALUE]
 
 
 check = IAMPolicyAttachedToGroupOrRoles()

--- a/checkov/terraform/checks/resource/base_resource_negative_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_negative_value_check.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from collections.abc import Iterable
 from typing import List, Dict, Any, Optional
 
 import dpath
@@ -16,8 +17,8 @@ class BaseResourceNegativeValueCheck(BaseResourceCheck):
         self,
         name: str,
         id: str,
-        categories: List[CheckCategories],
-        supported_resources: List[str],
+        categories: "Iterable[CheckCategories]",
+        supported_resources: "Iterable[str]",
         missing_attribute_result: CheckResult = CheckResult.PASSED,
     ) -> None:
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
@@ -44,6 +45,8 @@ class BaseResourceNegativeValueCheck(BaseResourceCheck):
             if get_referenced_vertices_in_value(value=value, aliases={}, resources_types=[]):
                 # we don't provide resources_types as we want to stay provider agnostic
                 return CheckResult.UNKNOWN
+            if value is None:
+                return self.missing_attribute_result
             if value in bad_values or ANY_VALUE in bad_values:
                 return CheckResult.FAILED
             else:

--- a/checkov/terraform/checks/resource/base_resource_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_value_check.py
@@ -65,6 +65,8 @@ class BaseResourceValueCheck(BaseResourceCheck):
             value = dpath.get(conf, inspected_key)
             if isinstance(value, list) and len(value) == 1:
                 value = value[0]
+            if value is None:
+                return self.missing_block_result
             if ANY_VALUE in expected_values and value is not None and (not isinstance(value, str) or value):
                 # Key is found on the configuration - if it accepts any value, the check is PASSED
                 return CheckResult.PASSED

--- a/tests/terraform/checks/resource/aws/example_EBSDefaultEncryption/main.tf
+++ b/tests/terraform/checks/resource/aws/example_EBSDefaultEncryption/main.tf
@@ -7,6 +7,10 @@ resource "aws_ebs_encryption_by_default" "enabled" {
 resource "aws_ebs_encryption_by_default" "default" {
 }
 
+resource "aws_ebs_encryption_by_default" "null" {
+  enabled = null
+}
+
 # failure
 
 resource "aws_ebs_encryption_by_default" "disabled" {

--- a/tests/terraform/checks/resource/aws/example_IAMPolicyAttachedToGroupOrRoles/iam.tf
+++ b/tests/terraform/checks/resource/aws/example_IAMPolicyAttachedToGroupOrRoles/iam.tf
@@ -1,0 +1,43 @@
+# pass
+
+resource "aws_iam_policy_attachment" "pass" {
+  name       = "example"
+  policy_arn = "aws_iam_policy.policy.arn"
+}
+
+resource "aws_iam_policy_attachment" "null" {
+  name       = "example"
+  policy_arn = "aws_iam_policy.policy.arn"
+
+  users = null
+}
+
+# fail
+
+resource "aws_iam_policy_attachment" "fail" {
+  name       = "example"
+  policy_arn = "aws_iam_policy.policy.arn"
+
+  users      = ["example"]
+}
+
+resource "aws_iam_user_policy" "fail" {
+  user   = "example"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "fail" {
+  user       = "example"
+  policy_arn = "aws_iam_policy.policy.arn"
+}

--- a/tests/terraform/checks/resource/aws/test_EBSDefaultEncryption.py
+++ b/tests/terraform/checks/resource/aws/test_EBSDefaultEncryption.py
@@ -1,23 +1,27 @@
 import os
 import unittest
+from pathlib import Path
 
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.EBSDefaultEncryption import check
 from checkov.terraform.runner import Runner
 
 
-class TestAppLoadBalancerTLS12(unittest.TestCase):
+class TestEBSDefaultEncryption(unittest.TestCase):
     def test(self):
-        runner = Runner()
-        current_dir = os.path.dirname(os.path.realpath(__file__))
+        # given
+        test_files_dir = Path(__file__).parent / "example_EBSDefaultEncryption"
 
-        test_files_dir = current_dir + "/example_EBSDefaultEncryption"
-        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
         summary = report.get_summary()
 
         passing_resources = {
             "aws_ebs_encryption_by_default.enabled",
             "aws_ebs_encryption_by_default.default",
+            "aws_ebs_encryption_by_default.null",
         }
         failing_resources = {
             "aws_ebs_encryption_by_default.disabled",
@@ -26,7 +30,7 @@ class TestAppLoadBalancerTLS12(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["passed"], 3)
         self.assertEqual(summary["failed"], 1)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)

--- a/tests/terraform/checks/resource/aws/test_IAMPolicyAttachedToGroupOrRoles.py
+++ b/tests/terraform/checks/resource/aws/test_IAMPolicyAttachedToGroupOrRoles.py
@@ -1,35 +1,43 @@
 import unittest
+from pathlib import Path
 
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.IAMPolicyAttachedToGroupOrRoles import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestIAMPolicyAttachedToGroupOrRoles(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_IAMPolicyAttachedToGroupOrRoles"
 
-    def test_failure(self):
-        resource_conf = {'user': ['${aws_iam_user.user.name}'], 'policy_arn': ['${aws_iam_policy.policy.arn}']}
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
 
-    def test_failure_2(self):
-        resource_conf = {'name': ['test'], 'user': ['${aws_iam_user.lb.name}'], 'policy': [
-            '{\n  "Version": "2012-10-17",\n  "Statement": [\n    {\n      "Action": [\n        "ec2:Describe*"\n      ],\n      "Effect": "Allow",'
-            '\n      "Resource": "*"\n    }\n  ]\n}']}
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        # then
+        summary = report.get_summary()
 
-    def test_failure_3(self):
-        conf = {'name': ['test-attachment'], 'users': [['${aws_iam_user.user.name}']], 'roles': [['${aws_iam_role.role.name}']],
-                'groups': [['${aws_iam_group.group.name}']], 'policy_arn': ['${aws_iam_policy.policy.arn}']}
-        scan_result = check.scan_resource_conf(conf=conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passing_resources = {
+            "aws_iam_policy_attachment.pass",
+            "aws_iam_policy_attachment.null",
+        }
+        failing_resources = {
+            "aws_iam_policy_attachment.fail",
+            "aws_iam_user_policy.fail",
+            "aws_iam_user_policy_attachment.fail",
+        }
 
-    def test_success(self):
-        conf = {'name': ['test-attachment'], 'users': [[]], 'roles': [['${aws_iam_role.role.name}']],
-                'groups': [['${aws_iam_group.group.name}']], 'policy_arn': ['${aws_iam_policy.policy.arn}']}
-        scan_result = check.scan_resource_conf(conf=conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Originally I wanted to migrate a check to  use `BaseResourceNegativeValueCheck`, but then I realized that the current `BaseResourceValueCheck` and `BaseResourceNegativeValueCheck` handle the usage of `null` values incorrectly, which is quite common in Terraform plans, but can also be used in normal template.