### PR TITLE
adjust provider tests and docs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,5 +68,9 @@ jobs:
     #   make bootstrap
     #   make release
 
+    - name: Retrieve IP
+      run: |
+        hostname -I
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/checkov/common/checks/base_check.py
+++ b/checkov/common/checks/base_check.py
@@ -16,8 +16,14 @@ class BaseCheck(metaclass=MultiSignatureMeta):
     supported_entities: "Iterable[str]" = ()
 
     def __init__(
-        self, name: str, id: str, categories: "Iterable[CheckCategories]", supported_entities: "Iterable[str]",
-            block_type: str, bc_id: Optional[str] = None, guideline: Optional[str] = None
+        self,
+        name: str,
+        id: str,
+        categories: "Iterable[CheckCategories]",
+        supported_entities: "Iterable[str]",
+        block_type: str,
+        bc_id: Optional[str] = None,
+        guideline: Optional[str] = None,
     ) -> None:
         self.name = name
         self.id = id

--- a/checkov/terraform/checks/provider/base_check.py
+++ b/checkov/terraform/checks/provider/base_check.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
-from typing import List, Dict, Any
+from collections.abc import Iterable
+from typing import List, Dict, Any, Optional
 
 from checkov.common.checks.base_check import BaseCheck
 from checkov.common.models.enums import CheckCategories, CheckResult
@@ -7,11 +8,21 @@ from checkov.terraform.checks.provider.registry import provider_registry
 
 
 class BaseProviderCheck(BaseCheck):
-    def __init__(self, name: str, id: str, categories: List[CheckCategories],
-                 supported_provider: List[str], guideline=None) -> None:
+    def __init__(
+        self,
+        name: str,
+        id: str,
+        categories: "Iterable[CheckCategories]",
+        supported_provider: "Iterable[str]",
+        guideline: Optional[str] = None
+    ) -> None:
         super().__init__(
-            name=name, id=id, categories=categories, supported_entities=supported_provider,
-            block_type="provider", guideline=guideline
+            name=name,
+            id=id,
+            categories=categories,
+            supported_entities=supported_provider,
+            block_type="provider",
+            guideline=guideline,
         )
         self.supported_provider = supported_provider
         provider_registry.register(self)

--- a/checkov/terraform/checks/provider/linode/__init__.py
+++ b/checkov/terraform/checks/provider/linode/__init__.py
@@ -1,5 +1,4 @@
-from os.path import dirname, basename, isfile, join
-import glob
+from pathlib import Path
 
-modules = glob.glob(join(dirname(__file__), "*.py"))
-__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith("__init__.py")]
+modules = Path(__file__).parent.glob("*.py")
+__all__ = [f.stem for f in modules if f.is_file() and not f.stem == "__init__"]

--- a/checkov/terraform/checks/provider/linode/credentials.py
+++ b/checkov/terraform/checks/provider/linode/credentials.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Pattern
 
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.provider.base_check import BaseProviderCheck
@@ -10,8 +10,8 @@ class LinodeCredentials(BaseProviderCheck):
     def __init__(self) -> None:
         name = "Ensure no hard coded Linode tokens exist in provider"
         id = "CKV_LIN_1"
-        supported_provider = ["linode"]
-        categories = [CheckCategories.SECRETS]
+        supported_provider = ("linode",)
+        categories = (CheckCategories.SECRETS,)
         super().__init__(name=name, id=id, categories=categories, supported_provider=supported_provider)
 
     def scan_provider_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
@@ -20,7 +20,7 @@ class LinodeCredentials(BaseProviderCheck):
         return CheckResult.PASSED
 
     @staticmethod
-    def secret_found(conf: Dict[str, List[Any]], field: str, pattern: str) -> bool:
+    def secret_found(conf: Dict[str, List[Any]], field: str, pattern: Pattern[str]) -> bool:
         if field in conf.keys():
             value = conf[field][0]
             if re.match(pattern, value) is not None:

--- a/docs/6.Contribution/Contribute New Terraform Provider.md
+++ b/docs/6.Contribution/Contribute New Terraform Provider.md
@@ -21,32 +21,36 @@ First create a new folder `tests/terraform/checks/resource/linode/` and add `tes
 import unittest
 
 import hcl2
+
 from checkov.terraform.checks.resource.linode.authorized_keys import check
 from checkov.common.models.enums import CheckResult
 
 
-class Testauthorized_keys(unittest.TestCase):
-
+class TestAuthorizedKeys(unittest.TestCase):
     def test_success(self):
-        hcl_res = hcl2.loads("""
-        resource "linode_instance" "test" {
-        authorized_keys="1234355-12345-12-1213123"
-        }
-        """)
-        resource_conf = hcl_res['resource'][0]['linode_instance']['test']
+        hcl_res = hcl2.loads(
+            """
+            resource "linode_instance" "test" {
+                authorized_keys="1234355-12345-12-1213123"
+            }
+            """
+        )
+        resource_conf = hcl_res["resource"][0]["linode_instance"]["test"]
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
     def test_failure(self):
-        hcl_res = hcl2.loads("""
-        resource "linode_instance" "test" {
-        }
-        """)
-        resource_conf = hcl_res['resource'][0]['linode_instance']['test']
+        hcl_res = hcl2.loads(
+            """
+            resource "linode_instance" "test" {
+            }
+            """
+        )
+        resource_conf = hcl_res["resource"][0]["linode_instance"]["test"]
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 ```
 
@@ -57,34 +61,37 @@ Add a placeholder file at `tests/terraform/checks/resource/linode/__init__.py`
 Create the folder `checkov/checkov/terraform/checks/resource/linode` and add `authorized_keys.py`:
 
 ```python
-from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+from typing import Any
 
-class authorized_keys(BaseResourceCheck):
-    def __init__(self):
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+class AuthorizedKeys(BaseResourceValueCheck):
+    def __init__(self) -> None:
         name = "Ensure SSH key set in authorized_keys"
         id = "CKV_LIN_2"
-        supported_resources = ['linode_instance']
-        categories = [CheckCategories.GENERAL_SECURITY]
+        supported_resources = ("linode_instance",)
+        categories = (CheckCategories.GENERAL_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        if 'authorized_keys' in conf:
-            if conf['authorized_keys']:
-                return CheckResult.PASSED
-        return CheckResult.FAILED
+    def get_inspected_key(self) -> str:
+        return "authorized_keys"
+
+    def get_expected_value(self) -> Any:
+        return ANY_VALUE
 
 
-check = authorized_keys() 
+check = AuthorizedKeys() 
 ```
 
 And also add `checkov/terraform/checks/resource/linode/__init__.py`:
 
 ```python
-from os.path import dirname, basename, isfile, join
-import glob
-modules = glob.glob(join(dirname(__file__), "*.py"))
-__all__ = [ basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
+from pathlib import Path
+
+modules = Path(__file__).parent.glob("*.py")
+__all__ = [f.stem for f in modules if f.is_file() and not f.stem == "__init__"]
 ```
 
 ### Include Checks
@@ -93,10 +100,10 @@ In `checkov/terraform/checks/resource/__init__.py`, update include Linode resour
 This will ensure that this and any future Linode resource test are included in Checkov runs:
 
 ```python
-from checkov.terraform.checks.resource.gcp import *
-from checkov.terraform.checks.resource.azure import *
-from checkov.terraform.checks.resource.github import *
-from checkov.terraform.checks.resource.linode import * 
+from checkov.terraform.checks.resource.gcp import *  # noqa
+from checkov.terraform.checks.resource.azure import *  # noqa
+from checkov.terraform.checks.resource.github import *  # noqa
+from checkov.terraform.checks.resource.linode import *   # noqa
 ```
 
 ## Add New Provider Checks
@@ -110,24 +117,37 @@ Create the folder `tests/terraform/checks/provider/linode/` and `test_credential
 ```python
 import unittest
 
+import hcl2
+
 from checkov.terraform.checks.provider.linode.credentials import check
 from checkov.common.models.enums import CheckResult
 
 
 class TestCredentials(unittest.TestCase):
-
     def test_success(self):
-        provider_conf = {}
-
+        hcl_res = hcl2.loads(
+            """
+            provider "linode" {}
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["linode"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
     def test_failure(self):
-        provider_conf = {'token' :['AKIAIOSFODNN7EXAMPLE']}
+        hcl_res = hcl2.loads(
+            """
+            provider "linode" {
+                token = "c7680462065ee80d0fef2940784b1af6826f6e0b18586194c5f67c4b40fa7f09"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["linode"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()
 ```
 
@@ -139,27 +159,28 @@ Create a directory `checkov/terraform/checks/provider/linode` and add `credentia
 
 ```python
 import re
+from typing import Dict, List, Any, Pattern
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.provider.base_check import BaseProviderCheck
 from checkov.common.models.consts import linode_token_pattern
 
 
 class LinodeCredentials(BaseProviderCheck):
-
     def __init__(self):
         name = "Ensure no hard coded Linode tokens exist in provider"
         id = "CKV_LIN_1"
-        supported_provider = ['linode']
-        categories = [CheckCategories.SECRETS]
+        supported_provider = ("linode",)
+        categories = (CheckCategories.SECRETS,)
         super().__init__(name=name, id=id, categories=categories, supported_provider=supported_provider)
 
-    def scan_provider_conf(self, conf):
+    def scan_provider_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
         if self.secret_found(conf, "token", linode_token_pattern):
             return CheckResult.FAILED
         return CheckResult.PASSED
 
     @staticmethod
-    def secret_found(conf, field, pattern):
+    def secret_found(conf: Dict[str, List[Any]], field: str, pattern: Pattern[str]) -> bool:
         if field in conf.keys():
             value = conf[field][0]
             if re.match(pattern, value) is not None:
@@ -184,11 +205,10 @@ linode_token_pattern = re.compile("(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{64}(?![A-Za
 ```
 
 ```python
-from os.path import dirname, basename, isfile, join
-import glob
+from pathlib import Path
 
-modules = glob.glob(join(dirname(__file__), "*.py"))
-__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
+modules = Path(__file__).parent.glob("*.py")
+__all__ = [f.stem for f in modules if f.is_file() and not f.stem == "__init__"]
 ```
 
 ### Include the Provider Checks
@@ -196,8 +216,8 @@ __all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__
 Update `checkov/terraform/checks/provider/__init__.py` with `from checkov.terraform.checks.provider.linode import *`, making it:
 
 ```python
-from checkov.terraform.checks.provider.aws import *
-from checkov.terraform.checks.provider.linode import *
+from checkov.terraform.checks.provider.aws import *  # noqa
+from checkov.terraform.checks.provider.linode import *  # noqa
 ```
 
 So there you have it! Two new checks—one for your resource and a newly supported Terraform Provider.

--- a/tests/terraform/checks/provider/aws/test_credentials.py
+++ b/tests/terraform/checks/provider/aws/test_credentials.py
@@ -1,31 +1,74 @@
 import unittest
 
+import hcl2
+
 from checkov.terraform.checks.provider.aws.credentials import check
 from checkov.common.models.enums import CheckResult
 
 
 class TestCredentials(unittest.TestCase):
-
-    def test_success(self):
-        provider_conf = {'region': ['us-west-2']}
-
+    def test_success_empty(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "aws" {}
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["aws"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
-        provider_conf = {}
 
+    def test_success_region(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "aws" {
+                region = "us-west-2"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["aws"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-    def test_failure(self):
-        provider_conf = {'region': ['us-west-2'], 'access_key': ['AKIAIOSFODNN7EXAMPLE'], 'secret_key': ['wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY']}
-        scan_result = check.scan_provider_conf(conf=provider_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
-        provider_conf = {'region': ['us-west-2'], 'secret_key': ['wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY']}
-        scan_result = check.scan_provider_conf(conf=provider_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
-        provider_conf = {'region': ['us-west-2'], 'access_key': ['AKIAIOSFODNN7EXAMPLE']}
+    def test_failure_both_keys(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "aws" {
+                region     = "us-west-2"
+                access_key = "AKIAIOSFODNN7EXAMPLE"
+                secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["aws"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-if __name__ == '__main__':
+    def test_failure_access_key(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "aws" {
+                region     = "us-west-2"
+                access_key = "AKIAIOSFODNN7EXAMPLE"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["aws"]
+        scan_result = check.scan_provider_conf(conf=provider_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_secret_key(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "aws" {
+                region     = "us-west-2"
+                secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["aws"]
+        scan_result = check.scan_provider_conf(conf=provider_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/provider/bridgecrew/test_credentials.py
+++ b/tests/terraform/checks/provider/bridgecrew/test_credentials.py
@@ -1,21 +1,34 @@
 import unittest
 
+import hcl2
+
 from checkov.terraform.checks.provider.bridgecrew.credentials import check
 from checkov.common.models.enums import CheckResult
 
 
 class TestCredentials(unittest.TestCase):
-
     def test_success(self):
-        provider_conf = {}
-
+        hcl_res = hcl2.loads(
+            """
+            provider "bridgecrew" {}
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["bridgecrew"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
     def test_failure(self):
-        provider_conf = {'token' :['80e54890-f282-4595-ab3d-45f9bd874987']}
+        hcl_res = hcl2.loads(
+            """
+            provider "bridgecrew" {
+                token = "80e54890-f282-4595-ab3d-45f9bd874987"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["bridgecrew"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/provider/linode/test_credentials.py
+++ b/tests/terraform/checks/provider/linode/test_credentials.py
@@ -1,21 +1,34 @@
 import unittest
 
+import hcl2
+
 from checkov.terraform.checks.provider.linode.credentials import check
 from checkov.common.models.enums import CheckResult
 
 
 class TestCredentials(unittest.TestCase):
-
     def test_success(self):
-        provider_conf = {}
-
+        hcl_res = hcl2.loads(
+            """
+            provider "linode" {}
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["linode"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
     def test_failure(self):
-        provider_conf = {'token' :['c7680462065ee80d0fef2940784b1af6826f6e0b18586194c5f67c4b40fa7f09']}
+        hcl_res = hcl2.loads(
+            """
+            provider "linode" {
+                token = "c7680462065ee80d0fef2940784b1af6826f6e0b18586194c5f67c4b40fa7f09"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["linode"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/provider/oci/test_credentials.py
+++ b/tests/terraform/checks/provider/oci/test_credentials.py
@@ -1,21 +1,34 @@
 import unittest
 
+import hcl2
+
 from checkov.terraform.checks.provider.oci.credentials import check
 from checkov.common.models.enums import CheckResult
 
 
 class TestCredentials(unittest.TestCase):
-
     def test_success(self):
-        provider_conf = {}
-
+        hcl_res = hcl2.loads(
+            """
+            provider "panos" {}
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["panos"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
     def test_failure(self):
-        provider_conf = {'private_key_password' :['anystringwilldo']}
+        hcl_res = hcl2.loads(
+            """
+            provider "panos" {
+                private_key_password = "anystringwilldo"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["panos"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/provider/openstack/test_credentials.py
+++ b/tests/terraform/checks/provider/openstack/test_credentials.py
@@ -1,31 +1,77 @@
 import unittest
 
+import hcl2
+
 from checkov.terraform.checks.provider.openstack.credentials import check
 from checkov.common.models.enums import CheckResult
 
 
 class TestCredentials(unittest.TestCase):
-
-    def test_success(self):
-        provider_conf = {'region': ['RegionOne'], 'auth_url': ["http://myauthurl:5000/v2.0"]}
-
+    def test_success_empty(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "openstack" {}
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["openstack"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
-        provider_conf = {}
 
+    def test_success_region(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "openstack" {
+                auth_url = "http://myauthurl:5000/v2.0"
+                region   = "RegionOne"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["openstack"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-    def test_failure(self):
-        provider_conf = {'region': ['RegionOne'], 'auth_url': ["http://myauthurl:5000/v2.0"], 'password': ['Ahngak0fuokeexee5Quiu0oohayeiXie']}
-        scan_result = check.scan_provider_conf(conf=provider_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
-        provider_conf = {'region': ['RegionOne'], 'auth_url': ["http://myauthurl:5000/v2.0"], 'token': ['ifahghau4nun7eirahJ5baa8cichex7l']}
-        scan_result = check.scan_provider_conf(conf=provider_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
-        provider_conf = {'region': ['RegionOne'], 'auth_url': ["http://myauthurl:5000/v2.0"], 'application_credential_secret': ['mie8siw5ooTaed0AeQuepeiGhah9xaif']}
+    def test_failure_password(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "openstack" {
+                auth_url = "http://myauthurl:5000/v2.0"
+                region   = "RegionOne"
+                password = "Ahngak0fuokeexee5Quiu0oohayeiXie"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["openstack"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-        if __name__ == '__main__':
-            unittest.main()
+    def test_failure_token(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "openstack" {
+                auth_url = "http://myauthurl:5000/v2.0"
+                region   = "RegionOne"
+                token    = "ifahghau4nun7eirahJ5baa8cichex7l"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["openstack"]
+        scan_result = check.scan_provider_conf(conf=provider_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_app_secret(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "openstack" {
+                auth_url = "http://myauthurl:5000/v2.0"
+                region   = "RegionOne"
+                application_credential_secret = "mie8siw5ooTaed0AeQuepeiGhah9xaif"
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["openstack"]
+        scan_result = check.scan_provider_conf(conf=provider_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

When I checked PR #2135 I realized that our docs are quite old for adding a new Provider check, so I adjusted them and migrated all the provider tests to use the `hcl2` syntax.