### PR TITLE
fix computation of end line number

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -7,7 +7,7 @@ from concurrent import futures
 from json import JSONDecodeError
 from os import path
 from time import sleep
-from typing import Optional
+from typing import Optional, Dict
 
 import boto3
 import dpath.util
@@ -346,17 +346,17 @@ class BcPlatformIntegration(object):
             self.get_checkov_mapping_metadata()
         return self.guidelines
 
-    def get_id_mapping(self) -> dict:
+    def get_id_mapping(self) -> Dict[str, str]:
         if not self.bc_id_mapping:
             self.get_checkov_mapping_metadata()
         return self.bc_id_mapping
 
-    def get_ckv_to_bc_id_mapping(self) -> dict:
+    def get_ckv_to_bc_id_mapping(self) -> Dict[str, str]:
         if not self.ckv_to_bc_id_mapping:
             self.get_checkov_mapping_metadata()
         return self.ckv_to_bc_id_mapping
 
-    def get_checkov_mapping_metadata(self) -> Optional[dict]:
+    def get_checkov_mapping_metadata(self) -> None:
         if self.bc_skip_mapping is True:
             logging.debug("Skipped mapping API call")
             self.ckv_to_bc_id_mapping = {}

--- a/tests/terraform/context_parsers/test_base_parser.py
+++ b/tests/terraform/context_parsers/test_base_parser.py
@@ -4,28 +4,41 @@ import unittest
 from checkov.terraform.context_parsers.registry import parser_registry
 from tests.terraform.context_parsers.mock_context_parser import MockContextParser
 
-mock_tf_file = os.path.dirname(os.path.realpath(__file__)) + '/mock_tf_files/mock.tf'
-mock_definition = (mock_tf_file, {'mock': [
-    {
-        'mock_type': {
-            'mock_name': {
-                'value': [
-                    'mock_value']}}}
-]})
+mock_tf_file = os.path.dirname(os.path.realpath(__file__)) + "/mock_tf_files/mock.tf"
+mock_definition = (mock_tf_file, {"mock": [{"mock_type": {"mock_name": {"value": ["mock_value"]}}}]})
 
 
 class TestBaseParser(unittest.TestCase):
-
     def test_enrich_definition_block(self):
         mock_parser = MockContextParser()
         parser_registry.register(mock_parser)
         definition_context = parser_registry.enrich_definitions_context(mock_definition)
-        skipped_checks = definition_context[mock_tf_file]['mock']['mock_type']['mock_name'].get('skipped_checks')
+        skipped_checks = definition_context[mock_tf_file]["mock"]["mock_type"]["mock_name"].get("skipped_checks")
         self.assertIsNotNone(skipped_checks)
         self.assertEqual(len(skipped_checks), 3)
         # Ensure checkov IDs are mapped to BC IDs
-        self.assertEqual(skipped_checks[2]['id'], 'CKV_AWS_15')
+        self.assertEqual(skipped_checks[2]["id"], "CKV_AWS_15")
+
+    def test__compute_definition_end_line_with_multi_curly_brackets(self):
+        # given
+        mock_parser = MockContextParser()
+        mock_parser.filtered_lines = [
+            (1, '#data "aws_iam_policy_document" "null" {}'),
+            (3, 'resource "aws_subnet" "pub_sub" {'),
+            (4, "tags = merge({"),
+            (5, 'Name = "${var.network_name}-pub-sub-${element(var.azs, count.index)}"'),
+            (6, 'Tier = "public"'),
+            (7, '}, var.tags, var.add_eks_tags ? { "kubernetes.io/role/elb" : "1" } : {})'),
+            (8, "}"),
+        ]
+        mock_parser.filtered_line_numbers = [1, 3, 4, 5, 6, 7, 8]
+
+        # when
+        end_line_num = mock_parser._compute_definition_end_line(3)
+
+        # then
+        self.assertEqual(8, end_line_num)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #1146 

The issue was that we messed up the computation of the end line number of a resource, if a closing curly bracket is placed before an opening one, this can happen when the Terraform `merge()` function is used. This fix makes it slower, but I also extracted the computation of the `filtered_line_numbers` so it is only done once and this saves much more time, then the extra `count()` computation 💪 also improved some other smaller parts, which result in faster context parsing.
