### PR TITLE
fix incorrect handling of empty lists in TF plan

### DIFF
--- a/checkov/terraform/checks/resource/azure/AKSApiServerAuthorizedIpRanges.py
+++ b/checkov/terraform/checks/resource/azure/AKSApiServerAuthorizedIpRanges.py
@@ -1,21 +1,23 @@
-from checkov.common.models.enums import CheckCategories
+from typing import List, Any
+
 from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
 class AKSApiServerAuthorizedIpRanges(BaseResourceValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure AKS has an API Server Authorized IP Ranges enabled"
         id = "CKV_AZURE_6"
-        supported_resources = ['azurerm_kubernetes_cluster']
-        categories = [CheckCategories.KUBERNETES]
+        supported_resources = ("azurerm_kubernetes_cluster",)
+        categories = (CheckCategories.KUBERNETES,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return 'api_server_authorized_ip_ranges/[0]'
+    def get_inspected_key(self) -> str:
+        return "api_server_authorized_ip_ranges/[0]"
 
-    def get_expected_value(self):
-        return ANY_VALUE
+    def get_expected_values(self) -> List[Any]:
+        return [ANY_VALUE]
 
 
 check = AKSApiServerAuthorizedIpRanges()

--- a/checkov/terraform/checks/resource/base_resource_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_value_check.py
@@ -65,7 +65,7 @@ class BaseResourceValueCheck(BaseResourceCheck):
             value = dpath.get(conf, inspected_key)
             if isinstance(value, list) and len(value) == 1:
                 value = value[0]
-            if value is None:
+            if value is None or (isinstance(value, list) and not value):
                 return self.missing_block_result
             if ANY_VALUE in expected_values and value is not None and (not isinstance(value, str) or value):
                 # Key is found on the configuration - if it accepts any value, the check is PASSED

--- a/checkov/terraform/checks/resource/gcp/GoogleSubnetworkLoggingEnabled.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleSubnetworkLoggingEnabled.py
@@ -1,20 +1,30 @@
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
-from checkov.common.models.enums import CheckCategories
+from typing import Any, List, Dict
+
 from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
 class GoogleSubnetworkLoggingEnabled(BaseResourceValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure that VPC Flow Logs is enabled for every subnet in a VPC Network"
         id = "CKV_GCP_26"
-        supported_resources = ['google_compute_subnetwork']
-        categories = [CheckCategories.LOGGING]
+        supported_resources = ("google_compute_subnetwork",)
+        categories = (CheckCategories.LOGGING,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return 'log_config'
+    def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
+        # flow logs can't be enabled for `INTERNAL_HTTPS_LOAD_BALANCER` subnetworks
+        purpose = conf.get("purpose")
+        if purpose and purpose[0] == "INTERNAL_HTTPS_LOAD_BALANCER":
+            return CheckResult.UNKNOWN
 
-    def get_expected_values(self):
+        return super().scan_resource_conf(conf)
+
+    def get_inspected_key(self) -> str:
+        return "log_config"
+
+    def get_expected_values(self) -> List[Any]:
         return [ANY_VALUE]
 
 

--- a/tests/terraform/checks/resource/azure/example_AKSApiServerAuthorizedIpRanges/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AKSApiServerAuthorizedIpRanges/main.tf
@@ -1,0 +1,58 @@
+# pass
+
+resource "azurerm_kubernetes_cluster" "enabled" {
+  name                = "example"
+  location            = "azurerm_resource_group.example.location"
+  resource_group_name = "azurerm_resource_group.example.name"
+  dns_prefix          = "example"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  api_server_authorized_ip_ranges = ["192.168.0.0/16"]
+}
+
+# fail
+
+resource "azurerm_kubernetes_cluster" "default" {
+  name                = "example"
+  location            = "azurerm_resource_group.example.location"
+  resource_group_name = "azurerm_resource_group.example.name"
+  dns_prefix          = "example"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster" "empty" {
+  name                = "example"
+  location            = "azurerm_resource_group.example.location"
+  resource_group_name = "azurerm_resource_group.example.name"
+  dns_prefix          = "example"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  api_server_authorized_ip_ranges = []
+}

--- a/tests/terraform/checks/resource/azure/test_AKSApiServerAuthorizedIpRanges.py
+++ b/tests/terraform/checks/resource/azure/test_AKSApiServerAuthorizedIpRanges.py
@@ -1,42 +1,42 @@
 import unittest
+from pathlib import Path
 
-from checkov.common.models.enums import CheckResult
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.azure.AKSApiServerAuthorizedIpRanges import check
+from checkov.terraform.runner import Runner
 
 
 class TestAKSApiServerAuthorizedIpRanges(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_AKSApiServerAuthorizedIpRanges"
 
-    def test_failure(self):
-        resource_conf = {'name': ['example-aks1'], 'location': ['${azurerm_resource_group.example.location}'],
-                         'resource_group_name': ['${azurerm_resource_group.example.name}'], 'dns_prefix': ['exampleaks1'],
-                         'default_node_pool': [{'name': ['default'], 'node_count': [1], 'vm_size': ['Standard_D2_v2']}],
-                         'identity': [{'type': ['SystemAssigned']}], 'agent_pool_profile': [{}], 'service_principal': [{}],
-                         'role_based_access_control': [{'enabled': [False]}], 'tags': [{'Environment': 'Production'}]}
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
 
-    def test_success(self):
-        resource_conf = {'name': ['example-aks1'], 'location': ['${azurerm_resource_group.example.location}'],
-                         'resource_group_name': ['${azurerm_resource_group.example.name}'], 'dns_prefix': ['exampleaks1'],
-                         'default_node_pool': [{'name': ['default'], 'node_count': [1], 'vm_size': ['Standard_D2_v2']}],
-                         'identity': [{'type': ['SystemAssigned']}], 'agent_pool_profile': [{}], 'service_principal': [{}],
-                         'api_server_authorized_ip_ranges': [['192.168.0.0/16']], 'tags': [{'Environment': 'Production'}],
-                         'addon_profile': [{'oms_agent': [{'enabled': [True], 'log_analytics_workspace_id': ['']}]}]}
+        # then
+        summary = report.get_summary()
 
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passing_resources = {
+            "azurerm_kubernetes_cluster.enabled",
+        }
 
-    def test_success2(self):
-        resource_conf = {'name': ['example-aks1'], 'location': ['${azurerm_resource_group.example.location}'],
-                         'resource_group_name': ['${azurerm_resource_group.example.name}'], 'dns_prefix': ['exampleaks1'],
-                         'default_node_pool': [{'name': ['default'], 'node_count': [1], 'vm_size': ['Standard_D2_v2']}],
-                         'identity': [{'type': ['SystemAssigned']}], 'agent_pool_profile': [{}], 'service_principal': [{}],
-                         'api_server_authorized_ip_ranges': [[]], 'role_based_access_control': [{'enabled': [True]}],
-                         'tags': [{'Environment': 'Production'}]}
+        failing_resources = {
+            "azurerm_kubernetes_cluster.default",
+            "azurerm_kubernetes_cluster.empty",
+        }
 
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/resource/gcp/example_GoogleSubnetworkLoggingEnabled/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleSubnetworkLoggingEnabled/main.tf
@@ -1,0 +1,32 @@
+# pass
+
+resource "google_compute_subnetwork" "enabled" {
+  name          = "example"
+  ip_cidr_range = "10.0.0.0/16"
+  network       = "google_compute_network.vpc.self_link"
+
+  log_config {
+    aggregation_interval = "INTERVAL_10_MIN"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}
+
+# fail
+
+resource "google_compute_subnetwork" "default" {
+  name          = "example"
+  ip_cidr_range = "10.0.0.0/16"
+  network       = "google_compute_network.vpc.id"
+}
+
+# unknown
+
+resource "google_compute_subnetwork" "internal_https_lb" {
+  name          = "example"
+  ip_cidr_range = "10.0.0.0/22"
+  network       = "google_compute_network.vpc.id"
+
+  purpose       = "INTERNAL_HTTPS_LOAD_BALANCER"
+  role          = "ACTIVE"
+}

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -163,7 +163,7 @@ class TestRunnerValid(unittest.TestCase):
         root_dir = current_dir + "/resources"
         runner = Runner()
         report = runner.run(
-            root_folder=root_dir, files=None, external_checks_dir=None, runner_filter=RunnerFilter(framework="all")
+            root_folder=root_dir, files=None, external_checks_dir=None, runner_filter=RunnerFilter(framework=["all"])
         )
         report_json = report.get_json()
         self.assertIsInstance(report_json, str)
@@ -172,8 +172,8 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.get_exit_code(soft_fail=False), 1)
         self.assertEqual(report.get_exit_code(soft_fail=True), 0)
 
-        self.assertGreaterEqual(report.get_summary()["failed"], 82)
-        self.assertGreaterEqual(report.get_summary()["passed"], 76)
+        self.assertGreaterEqual(report.get_summary()["failed"], 92)
+        self.assertGreaterEqual(report.get_summary()["passed"], 72)
 
         files_scanned = list(set(map(lambda rec: rec.file_path, report.failed_checks)))
         self.assertGreaterEqual(len(files_scanned), 6)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #1339

- adjusted the evaluation of empty lists to be a missing block, which is very typical in TF plan <- will result in much more checks to flag resources to be not complaint, had to adjust one TF plan test, which flagged 7 resources not being complaint against a check
- adjusted `CKV_GCP_26` to ignore `INTERNAL_HTTPS_LOAD_BALANCER` subnets
- adjusted `CKV_AZURE_6` tests to better syntax and one test was incorrect, because you can pass an empty list for `api_server_authorized_ip_ranges`, which is the same as removing the property