### PR TITLE
Docs update, small reordering change

### DIFF
--- a/docs/6.Contribution/Contribute New Terraform Provider.md
+++ b/docs/6.Contribution/Contribute New Terraform Provider.md
@@ -192,6 +192,14 @@ check = LinodeCredentials()
 ```
 
 And also `checkov/terraform/checks/provider/linode/__init__.py`
+
+```python
+from pathlib import Path
+
+modules = Path(__file__).parent.glob("*.py")
+__all__ = [f.stem for f in modules if f.is_file() and not f.stem == "__init__"]
+```
+
 Update the security constants `checkov/common/models/consts.py` with the new pattern.
 
 ```python
@@ -202,13 +210,6 @@ DOCKER_IMAGE_REGEX = re.compile(r'(?:[^\s\/]+/)?([^\s:]+):?([^\s]*)')
 access_key_pattern = re.compile(r"(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])") # nosec
 secret_key_pattern = re.compile("(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])") # nosec
 linode_token_pattern = re.compile("(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{64}(?![A-Za-z0-9/+=])") # nosec
-```
-
-```python
-from pathlib import Path
-
-modules = Path(__file__).parent.glob("*.py")
-__all__ = [f.stem for f in modules if f.is_file() and not f.stem == "__init__"]
 ```
 
 ### Include the Provider Checks


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Whilst using the documentation, I thought it would be easier for future contributors if the example code blocks were directly adjacent to their descriptions, so this change just reorders the code blocks and brings the provider init next to its description, leaving the consts code block next to its description.

Before:
![Screenshot 2022-01-04 at 12 47 26](https://user-images.githubusercontent.com/6574404/148061408-d8e5862d-6335-49ef-9dcc-9a55ab85afd6.png)


After:
![Screenshot 2022-01-04 at 12 47 10](https://user-images.githubusercontent.com/6574404/148061419-ff9bee1c-e1db-4a30-b3f4-cfc766239a25.png)
