### PR TITLE
Update COMMENT_REGEX to collect non-numerical Check IDs

### DIFF
--- a/checkov/common/comment/enum.py
+++ b/checkov/common/comment/enum.py
@@ -1,3 +1,3 @@
 import re
 
-COMMENT_REGEX = re.compile(r'(checkov:skip=|bridgecrew:skip=) *([A-Z_\d]+)(:[^\n]+)?')
+COMMENT_REGEX = re.compile(r'(checkov:skip=|bridgecrew:skip=) *([a-zA-Z\d_]+)(:[^\n]+)?')


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes https://github.com/bridgecrewio/checkov/issues/1941

This edit chances the regex group to match on lower case as well as the other characters/numbers. The screenshot below shows the new regex and how it groups both traditional and non-numerical Check IDs correctly.

![image](https://user-images.githubusercontent.com/17982571/148298483-247202fe-43f5-40bf-8c88-5f72ee8d3194.png)
