### PR TITLE
To eliminate child duplicates on scan locally

### DIFF
--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -12,6 +12,8 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s 
 RUN groupadd -g 12000 -r checkov && useradd -u 12000 --no-log-init -r -g checkov checkov
 RUN mkdir /data && mkdir /app && mkdir /home/checkov
 RUN chown checkov:checkov /data /app /home/checkov
+RUN curl -L -o /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64 \
+    && chmod +x /usr/bin/yq
 
 COPY kubernetes/run_checkov.sh /app
 WORKDIR /app

--- a/kubernetes/run_checkov.sh
+++ b/kubernetes/run_checkov.sh
@@ -30,7 +30,7 @@ statefulsets"
 
 for resource in $RESOURCES;
 do
-  kubectl get $resource --all-namespaces -oyaml > /data/runtime.${resource}.yaml
+  kubectl get $resource --all-namespaces -oyaml | yq eval 'del(.items[] | select(.metadata.ownerReferences)) ' -  > /data/runtime.${resource}.yaml
 done
 
 if [ -f /etc/checkov/apikey ]; then


### PR DESCRIPTION
Previously the job/cronjob for checkov extracted all resources and relied on checkov to filter out child duplicates in resources based on "ownerReferences" in the yaml.  Now it installs yq (in the Dockerfile) and uses it to filter our child resources locally.  The result should align with previous behaviour so should be compatible with previous runs when users upgrade.  Tested on my local cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
