### PR TITLE
Remove ownerReferences filter from scan

### DIFF
--- a/checkov/kubernetes/graph_builder/local_graph.py
+++ b/checkov/kubernetes/graph_builder/local_graph.py
@@ -26,7 +26,7 @@ class KubernetesLocalGraph(LocalGraph):
                 resource_type = resource.get('kind')
                 metadata = resource.get('metadata') or {}
                 # TODO: add support for generateName
-                if is_invalid_k8_definition(resource) or metadata.get("ownerReferences") or not metadata.get('name'):
+                if is_invalid_k8_definition(resource) or not metadata.get('name'):
                     logging.info(f"failed to create a vertex in file {file_path}")
                     file_conf.remove(resource)
                     continue

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s 
 RUN groupadd -g 12000 -r checkov && useradd -u 12000 --no-log-init -r -g checkov checkov
 RUN mkdir /data && mkdir /app && mkdir /home/checkov
 RUN chown checkov:checkov /data /app /home/checkov
-RUN curl -L -o /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64 \
+RUN curl -L -o /usr/bin/yq https://github.com/bridgecrewio/yq/releases/download/v4.16.2/yq_linux_amd64 \
     && chmod +x /usr/bin/yq
 
 COPY kubernetes/run_checkov.sh /app

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -12,6 +12,8 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s 
 RUN groupadd -g 12000 -r checkov && useradd -u 12000 --no-log-init -r -g checkov checkov
 RUN mkdir /data && mkdir /app && mkdir /home/checkov
 RUN chown checkov:checkov /data /app /home/checkov
+RUN curl -L -o /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64 \
+    && chmod +x /usr/bin/yq
 
 COPY kubernetes/run_checkov.sh /app
 WORKDIR /app

--- a/kubernetes/run_checkov.sh
+++ b/kubernetes/run_checkov.sh
@@ -30,7 +30,7 @@ statefulsets"
 
 for resource in $RESOURCES;
 do
-  kubectl get $resource --all-namespaces -oyaml > /data/runtime.${resource}.yaml
+  kubectl get $resource --all-namespaces -oyaml | yq eval 'del(.items[] | select(.metadata.ownerReferences)) ' -  > /data/runtime.${resource}.yaml
 done
 
 if [ -f /etc/checkov/apikey ]; then


### PR DESCRIPTION
From what I can gather the ownerReferences filter was there only (needs double checking) for the cronjob implementation of checkov.   I've submitted a different PR to this one to locally remove k8s objects with this metadata as part of the job as opposed to being baked into checkov.  

The positive by-product of removing this filter will be that the new checkov admission controller can then properly scan child components during a UPDATE of k8s resources.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
