### PR TITLE
fix skips of wildcard checks when another skip is present

### DIFF
--- a/checkov/dockerfile/base_registry.py
+++ b/checkov/dockerfile/base_registry.py
@@ -24,6 +24,7 @@ class Registry(BaseCheckRegistry):
                                            skip_info)
 
         for check in self.wildcard_checks["*"]:
+            skip_info = {}
             if skipped_checks:
                 if check.id in [x['id'] for x in skipped_checks]:
                     skip_info = [x for x in skipped_checks if x['id'] == check.id][0]

--- a/tests/dockerfile/resources/wildcard_skip/Dockerfile
+++ b/tests/dockerfile/resources/wildcard_skip/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.10-alpine
+#checkov:skip=CKV_DOCKER_1: I like port 22
+EXPOSE 22

--- a/tests/dockerfile/test_runner.py
+++ b/tests/dockerfile/test_runner.py
@@ -85,6 +85,16 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.passed_checks, [])
         report.print_console()
 
+    def test_skip_wildcard_check(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/resources/wildcard_skip"
+        runner = Runner()
+        report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework=['dockerfile']))
+        self.assertEqual(len(report.skipped_checks), 1)
+        self.assertGreaterEqual(len(report.passed_checks), 1)
+        self.assertGreaterEqual(len(report.failed_checks), 2)
+
     def test_wrong_check_imports(self):
         wrong_imports = ["arm", "cloudformation", "helm", "kubernetes", "serverless", "terraform"]
         check_imports = []


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes an issue where a skip applied to one line would also skip "wildcard" or checks that look for missing instructions. Example:

```
>> cat Dockerfile
#checkov:skip=CKV_DOCKER_1: I like port 22
EXPOSE 22

>> ckv -f Dockerfile


       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By bridgecrew.io | version: 2.0.704
Update available 2.0.704 -> 2.0.707
Run pip3 install -U checkov to update


dockerfile scan results:

Passed checks: 0, Failed checks: 0, Skipped checks: 3

Check: CKV_DOCKER_1: "Ensure port 22 is not exposed"
	SKIPPED for resource: Dockerfile.
	Suppress comment:  I like port 22
	File: Dockerfile:1-2
	Guide: https://docs.bridgecrew.io/docs/ensure-port-22-is-not-exposed

Check: CKV_DOCKER_2: "Ensure that HEALTHCHECK instructions have been added to container images"
	SKIPPED for resource: Dockerfile.
	Suppress comment:  I like port 22
	File: Dockerfile:1-2
	Guide: https://docs.bridgecrew.io/docs/ensure-that-healthcheck-instructions-have-been-added-to-container-images

Check: CKV_DOCKER_3: "Ensure that a user for the container has been created"
	SKIPPED for resource: Dockerfile.
	Suppress comment:  I like port 22
	File: Dockerfile:1-2
	Guide: https://docs.bridgecrew.io/docs/ensure-that-a-user-for-the-container-has-been-created
```