### PR TITLE
Improve API error handling

### DIFF
--- a/checkov/common/bridgecrew/platform_errors.py
+++ b/checkov/common/bridgecrew/platform_errors.py
@@ -1,6 +1,6 @@
 class BridgecrewAuthError(Exception):
-    def __init__(self):
-        self.message = "Authorization error accessing Bridgecrew.cloud api. Please check bc-api-key"
+    def __init__(self, message="Authorization error accessing Bridgecrew.cloud api. Please check bc-api-key"):
+        self.message = message
 
     def __str__(self):
         return 'BCAuthError, {0} '.format(self.message)

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -198,7 +198,6 @@ class BcPlatformIntegration(object):
         if request.status == 403:
             raise BridgecrewAuthError()
         response = json.loads(request.data.decode("utf8"))
-        logging.debug(response)
         while ('Message' in response or 'message' in response):
             if 'Message' in response and response['Message'] == UNAUTHORIZED_MESSAGE:
                 raise BridgecrewAuthError()

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -18,7 +18,7 @@ from cachetools import cached, TTLCache
 from colorama import Style
 from termcolor import colored
 from tqdm import trange
-from urllib3.exceptions import HTTPError
+from urllib3.exceptions import HTTPError, MaxRetryError
 
 from checkov.common.bridgecrew.ci_variables import (
     BC_TO_BRANCH,
@@ -174,6 +174,10 @@ class BcPlatformIntegration(object):
                                               )
                 self.platform_integration_configured = True
                 self.use_s3_integration = True
+            except MaxRetryError as e:
+                logging.error(f"An SSL error occurred connecting to the platform. If you are on a VPN, please try "
+                              f"disabling it and re-running the command.\n{e}")
+                raise e
             except HTTPError as e:
                 logging.error(f"Failed to get customer assumed role\n{e}")
                 raise e

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import configargparse
 import argcomplete
+from urllib3.exceptions import MaxRetryError
 
 signal.signal(signal.SIGINT, lambda x, y: sys.exit(''))
 
@@ -154,6 +155,8 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
                                                         repo_branch=config.branch)
             platform_excluded_paths = bc_integration.get_excluded_paths() or []
             runner_filter.excluded_paths = runner_filter.excluded_paths + platform_excluded_paths
+        except MaxRetryError:
+            return
         except Exception:
             if bc_integration.prisma_url:
                 message = 'An error occurred setting up the Bridgecrew platform integration. Please check your API ' \

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -166,6 +166,7 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
                 logger.debug(message, exc_info=True)
             else:
                 logger.error(message)
+                logger.error('Please try setting the environment variable LOG_LEVEL=DEBUG and re-running the command, and provide the output to support')
             return
     else:
         logger.debug('No API key found. Scanning locally only.')


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Catches an issue that can occur if the backend config for assuming the S3 upload role fails, indicating an issue with the Bridgecrew backend itself.

The error message in the S3 role response is:
```
User: arn:aws:sts::___:assumed-role/bc-integrations-api-prod/bc-integrations-api-prod is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::___:role/upload-files-to-scanners-bucket-prod-___
```

This is not caught in the error handling, and results in an infinite loop.

This PR fixes that, and also adds a little extra logging to help catch it and instruct the user on next steps (for any auth error). And, while we're at it, it explicitly handles SSL errors.