### PR TITLE
PC-policy-team-build-once || AWS RDS retention policy should be greater than or equal to 7 days

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/AWSRDSBackupRetentionPeriodGreaterThanOrEqualto7Days.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/AWSRDSBackupRetentionPeriodGreaterThanOrEqualto7Days.yaml
@@ -1,0 +1,20 @@
+metadata:
+  name: "AWS RDS retention policy should be greater than or equal to 7 days"
+  guidelines: "RDS Retention Policies for Backups are an important part of your DR/BCP strategy. Recovering data from catastrophic failures, malicious attacks, or corruption often requires a several day window of potentially good backup material to leverage. As such, the best practice is to ensure your RDS clusters are retaining at least 7 days of backups, if not more (up to a maximum of 35)."
+  category: "storage"
+  severity: "medium"
+scope:
+  provider: "aws"
+definition:
+    or:
+      - cond_type: "attribute"
+        resource_types:
+        - "aws_db_instance"
+        attribute: "backup_retention_period"
+        operator: "not_exists"
+      - cond_type: "attribute"
+        resource_types:
+        - "aws_db_instance"
+        attribute: "backup_retention_period"
+        operator: "greater_than_or_equal"
+        value: "7"

--- a/tests/terraform/graph/checks/resources/AWSRDSBackupRetentionPeriodGreaterThanOrEqualto7Days/expected.yaml
+++ b/tests/terraform/graph/checks/resources/AWSRDSBackupRetentionPeriodGreaterThanOrEqualto7Days/expected.yaml
@@ -1,0 +1,5 @@
+pass:
+  - "aws_db_instance.aws_db_instance_ok"
+  - "aws_db_instance.aws_db_instance_default_ok"
+fail:
+  - "aws_db_instance.aws_db_instance_not_ok"

--- a/tests/terraform/graph/checks/resources/AWSRDSBackupRetentionPeriodGreaterThanOrEqualto7Days/main.tf
+++ b/tests/terraform/graph/checks/resources/AWSRDSBackupRetentionPeriodGreaterThanOrEqualto7Days/main.tf
@@ -1,0 +1,38 @@
+resource "aws_db_instance" "aws_db_instance_ok" {
+  allocated_storage       = 10
+  engine                  = "mysql"
+  engine_version          = "5.7"
+  instance_class          = "db.t3.micro"
+  name                    = "mydb"
+  username                = "foo"
+  password                = "foobarbaz"
+  parameter_group_name    = "default.mysql5.7"
+  skip_final_snapshot     = true
+  backup_retention_period = 8
+}
+
+#Default BackUp Retention is 7 Days
+resource "aws_db_instance" "aws_db_instance_default_ok" {
+  allocated_storage       = 10
+  engine                  = "mysql"
+  engine_version          = "5.7"
+  instance_class          = "db.t3.micro"
+  name                    = "mydb"
+  username                = "foo"
+  password                = "foobarbaz"
+  parameter_group_name    = "default.mysql5.7"
+  skip_final_snapshot     = true
+}
+
+resource "aws_db_instance" "aws_db_instance_not_ok" {
+  allocated_storage       = 10
+  engine                  = "mysql"
+  engine_version          = "5.7"
+  instance_class          = "db.t3.micro"
+  name                    = "mydb"
+  username                = "foo"
+  password                = "foobarbaz"
+  parameter_group_name    = "default.mysql5.7"
+  skip_final_snapshot     = true
+  backup_retention_period = 1
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -200,6 +200,9 @@ class TestYamlPolicies(unittest.TestCase):
     def test_SQLServerAuditingRetention90Days(self):
         self.go("SQLServerAuditingRetention90Days")
 
+    def test_AWSRDSBackupRetentionPeriodGreaterThanorEqualto7Days(self):
+        self.go("AWSRDSBackupRetentionPeriodGreaterThanorEqualto7Days")
+
     def test_registry_load(self):
         registry = Registry(parser=NXGraphCheckParser(), checks_dir=str(
             Path(__file__).parent.parent.parent.parent.parent / "checkov" / "terraform" / "checks" / "graph_checks"))


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

**PC Policy ID** - bf55f5c1-d05d-4e2a-bd39-560f7900be88

**Compliance Standard** - APRA (CPS 234) Information Security-CPS234-23, APRA (CPS 234) Information Security-CPS234-27, APRA (CPS 234) Information Security-CPS234-34, Brazilian Data Protection Law (LGPD)-Article 16, Brazilian Data Protection Law (LGPD)-Article 40, CyberSecurity Law of the People's Republic of China-Article 34, Cybersecurity Maturity Model Certification (CMMC) v.1.02-AU.2.042, HITRUST v.9.4.2-Control Reference:06.c, HITRUST v.9.4.2-Control Reference:06.d, MAS TRM 2021-8.4.2, MLPS 2.0-8.1.10.6, Marcos Soares test standard-Article 16, Marcos Soares test standard-Article 40, NIST 800-53 Rev 5-Audit Record Retention, NIST 800-53 Rev4-DM-2, NIST CSF-PR.MA-1, NIST SP 800-171 Revision 2-3.7.1, NIST SP 800-172-3.1.1e, PCI DSS v3.2.1-3.1, PIPEDA-4.5.2, Risk Management in Technology (RMiT)-10.3, Tags including NIST 800-53 Rev 5-Audit Record Retention

**Remediation Steps:**

Configure RDS backup retention policy to at least 7 days.
1. Go to the AWS console RDS dashboard.
2. In the navigation pane, choose Instances.
3. Select the database instance you wish to configure.
4. Click on  'Modify'.
5. Scroll down to Additional Configuration and set the retention period to at least 7 days under 'Backup retention period'.
6. Click Continue.
7. Under 'Scheduling of modifications' choose 'When to apply modifications'
8. On the confirmation page, Review the changes and Click on 'Modify DB Instance' to save your changes.