### PR TITLE
Increase K8s job's memory

### DIFF
--- a/kubernetes/checkov-job.yaml
+++ b/kubernetes/checkov-job.yaml
@@ -185,10 +185,10 @@ spec:
           imagePullPolicy: Always
           resources:
             requests:
-              memory: "128Mi"
+              memory: "256Mi"
               cpu: "500m"
             limits:
-              memory: "128Mi"
+              memory: "256Mi"
               cpu: "500m"
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
The current values used by the Kubernetes Job causes `OOMKilled` error. Doubling the size request and limit memory avoids it.
