### PR TITLE
Fix get_expected_value for CloudFrontTLS12.py

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/CloudFrontTLS12.py
+++ b/checkov/cloudformation/checks/resource/aws/CloudFrontTLS12.py
@@ -1,20 +1,25 @@
-from checkov.common.models.enums import CheckCategories
+from typing import Any, List
+
 from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
 
 
 class CloudFrontTLS12(BaseResourceValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Verify CloudFront Distribution Viewer Certificate is using TLS v1.2"
         id = "CKV_AWS_174"
         supported_resources = ["AWS::CloudFront::Distribution"]
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
+    def get_inspected_key(self) -> str:
         return "Properties/DistributionConfig/ViewerCertificate/MinimumProtocolVersion"
 
-    def get_expected_values(self):
+    def get_expected_values(self) -> List[str]:
         return ['TLSv1.2_2018', 'TLSv1.2_2019', 'TLSv1.2_2021']
+
+    def get_expected_value(self) -> Any:
+        return 'TLSv1.2_2021'
 
 
 check = CloudFrontTLS12()

--- a/checkov/terraform/checks/resource/aws/CloudfrontTLS12.py
+++ b/checkov/terraform/checks/resource/aws/CloudfrontTLS12.py
@@ -18,5 +18,8 @@ class CloudFrontTLS12(BaseResourceValueCheck):
     def get_expected_values(self) -> List[Any]:
         return ["TLSv1.2_2018", "TLSv1.2_2019", "TLSv1.2_2021"]
 
+    def get_expected_value(self) -> Any:
+        return "TLSv1.2_2021"
+
 
 check = CloudFrontTLS12()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
