### PR TITLE
extend Azure NSG checks to handle ranges and prefixes

### DIFF
--- a/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
+++ b/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
@@ -1,59 +1,98 @@
+from typing import Union, List, Dict, Any
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
 from checkov.common.util.type_forcers import force_list
 import re
 
-INTERNET_ADDRESSES = ["*", "0.0.0.0", "<nw>/0", "/0", "internet", "any"] # nosec
-PORT_RANGE = re.compile(r'\d+-\d+')
+INTERNET_ADDRESSES = ("*", "0.0.0.0", "<nw>/0", "/0", "Internet", "any")  # nosec
+PORT_RANGE = re.compile(r"\d+-\d+")
 
 
 class NSGRulePortAccessRestricted(BaseResourceCheck):
-    def __init__(self, name, check_id, port):
-        supported_resources = ['azurerm_network_security_rule', 'azurerm_network_security_group']
-        categories = [CheckCategories.NETWORKING]
+    def __init__(self, name: str, check_id: str, port: int) -> None:
+        supported_resources = ("azurerm_network_security_rule", "azurerm_network_security_group")
+        categories = (CheckCategories.NETWORKING,)
         super().__init__(name=name, id=check_id, categories=categories, supported_resources=supported_resources)
         self.port = port
 
-    def is_port_in_range(self, conf):
-        ports = force_list(conf['destination_port_range'][0])
-        for range in ports:
+    def is_port_in_range(self, ports: Union[int, str, List[Union[int, str]]]) -> bool:
+        for range in force_list(ports):
             str_range = str(range)
             if re.match(PORT_RANGE, str_range):
-                start, end = int(range.split('-')[0]), int(range.split('-')[1])
+                start, end = int(range.split("-")[0]), int(range.split("-")[1])
                 if start <= self.port <= end:
                     return True
-            if str_range in [str(self.port), '*']:
+            if str_range in (str(self.port), "*"):
                 return True
         return False
 
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
         if "dynamic" in conf:
-            self.evaluated_keys = ['dynamic']
+            self.evaluated_keys = ["dynamic"]
             return CheckResult.UNKNOWN
 
         rule_confs = [conf]
-        evaluated_key_prefix = ''
-        if 'security_rule' in conf:
-            rule_confs = conf['security_rule']
-            self.evaluated_keys = ['security_rule']
-            evaluated_key_prefix = 'security_rule/'
+        evaluated_key_prefix = ""
+        if "security_rule" in conf:
+            rule_confs = conf["security_rule"]
+            self.evaluated_keys = ["security_rule"]
+            evaluated_key_prefix = "security_rule/"
 
         for rule_conf in rule_confs:
             if not isinstance(rule_conf, dict):
                 return CheckResult.UNKNOWN
-            if 'access' in rule_conf and rule_conf['access'][0].lower() == "allow" \
-                    and 'direction' in rule_conf and rule_conf['direction'][0].lower() == "inbound" \
-                    and 'protocol' in rule_conf and rule_conf['protocol'][0].lower() in ['tcp', '*'] \
-                    and 'destination_port_range' in rule_conf and self.is_port_in_range(rule_conf) \
-                    and 'source_address_prefix' in rule_conf \
-                    and rule_conf['source_address_prefix'][0].lower() in INTERNET_ADDRESSES:
-                evaluated_key_prefix = f'{evaluated_key_prefix}[{rule_confs.index(rule_conf)}]/' if \
-                    evaluated_key_prefix else ''
-                self.evaluated_keys = [f'{evaluated_key_prefix}access',
-                                       f'{evaluated_key_prefix}direction',
-                                       f'{evaluated_key_prefix}protocol',
-                                       f'{evaluated_key_prefix}destination_port_range',
-                                       f'{evaluated_key_prefix}source_address_prefix']
-                return CheckResult.FAILED
-        return CheckResult.PASSED
 
+            access = rule_conf.get("access")
+            direction = rule_conf.get("direction")
+            protocol = rule_conf.get("protocol")
+            destination_port_range = rule_conf.get("destination_port_range")
+            destination_port_ranges = rule_conf.get("destination_port_ranges")
+            source_address_prefix = rule_conf.get("source_address_prefix")
+            source_address_prefixes = rule_conf.get("source_address_prefixes")
+
+            if (
+                access
+                and access[0] == "Allow"
+                and direction
+                and direction[0] == "Inbound"
+                and protocol
+                and protocol[0] in ("Tcp", "*")
+                and (
+                    (
+                        destination_port_range
+                        and self.is_port_in_range(destination_port_range[0])  # fmt: skip
+                    )
+                    or (
+                        destination_port_ranges
+                        and destination_port_ranges[0]
+                        and any(self.is_port_in_range(range) for range in destination_port_ranges[0])
+                    )
+                )
+                and (
+                    (
+                        source_address_prefix
+                        and source_address_prefix[0] in INTERNET_ADDRESSES  # fmt: skip
+                    )
+                    or (
+                        source_address_prefixes
+                        and source_address_prefixes[0]
+                        and any(prefix in INTERNET_ADDRESSES for prefix in source_address_prefixes[0])
+                    )
+                )
+            ):
+                evaluated_key_prefix = (
+                    f"{evaluated_key_prefix}[{rule_confs.index(rule_conf)}]/" if evaluated_key_prefix else ""
+                )
+                self.evaluated_keys = [
+                    f"{evaluated_key_prefix}access",
+                    f"{evaluated_key_prefix}direction",
+                    f"{evaluated_key_prefix}protocol",
+                    f"{evaluated_key_prefix}destination_port_range",
+                    f"{evaluated_key_prefix}destination_port_ranges",
+                    f"{evaluated_key_prefix}source_address_prefix",
+                    f"{evaluated_key_prefix}source_address_prefixes",
+                ]
+                return CheckResult.FAILED
+
+        return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/azure/NSGRuleRDPAccessRestricted.py
+++ b/checkov/terraform/checks/resource/azure/NSGRuleRDPAccessRestricted.py
@@ -2,8 +2,12 @@ from checkov.terraform.checks.resource.azure.NSGRulePortAccessRestricted import 
 
 
 class NSGRuleRDPAccessRestricted(NSGRulePortAccessRestricted):
-    def __init__(self):
-        super().__init__(name="Ensure that RDP access is restricted from the internet", check_id="CKV_AZURE_9", port=3389)
+    def __init__(self) -> None:
+        super().__init__(
+            name="Ensure that RDP access is restricted from the internet",
+            check_id="CKV_AZURE_9",
+            port=3389,
+        )
 
 
 check = NSGRuleRDPAccessRestricted()

--- a/checkov/terraform/checks/resource/azure/NSGRuleSSHAccessRestricted.py
+++ b/checkov/terraform/checks/resource/azure/NSGRuleSSHAccessRestricted.py
@@ -2,8 +2,12 @@ from checkov.terraform.checks.resource.azure.NSGRulePortAccessRestricted import 
 
 
 class NSGRuleSSHAccessRestricted(NSGRulePortAccessRestricted):
-    def __init__(self):
-        super().__init__(name="Ensure that SSH access is restricted from the internet", check_id="CKV_AZURE_10", port=22)
+    def __init__(self) -> None:
+        super().__init__(
+            name="Ensure that SSH access is restricted from the internet",
+            check_id="CKV_AZURE_10",
+            port=22,
+        )
 
 
 check = NSGRuleSSHAccessRestricted()

--- a/checkov/terraform/checks/resource/azure/NSGRuleUDPAccessRestricted.py
+++ b/checkov/terraform/checks/resource/azure/NSGRuleUDPAccessRestricted.py
@@ -24,7 +24,7 @@ class NSGRuleUDPAccessRestricted(BaseResourceCheck):
                         and 'direction' in rule_conf and rule_conf['direction'][0].lower() == 'inbound' \
                         and 'access' in rule_conf and rule_conf['access'][0].lower() == 'allow' \
                         and 'source_address_prefix' in rule_conf \
-                        and rule_conf['source_address_prefix'][0].lower() in INTERNET_ADDRESSES:
+                        and rule_conf['source_address_prefix'][0] in INTERNET_ADDRESSES:
                     evaluated_key_prefix = f'{evaluated_key_prefix}[{rule_confs.index(rule_conf)}]/' if \
                         evaluated_key_prefix else ''
                     self.evaluated_keys = [f'{evaluated_key_prefix}protocol',

--- a/tests/terraform/checks/resource/azure/example_NSGRuleRDPAccessRestricted/main.tf
+++ b/tests/terraform/checks/resource/azure/example_NSGRuleRDPAccessRestricted/main.tf
@@ -1,0 +1,131 @@
+# pass
+
+resource "azurerm_network_security_rule" "https" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = 443
+  source_address_prefix  = "Internet"
+}
+
+resource "azurerm_network_security_rule" "rdp_restricted_prefixes" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = 3389
+  source_address_prefixes = [
+    "123.123.123.123/32",
+    "10.0.0.0/16"
+  ]
+}
+
+resource "azurerm_network_security_group" "rdp_restricted" {
+  name                = "example"
+  location            = "azurerm_resource_group.example.location"
+  resource_group_name = "azurerm_resource_group.example.name"
+
+  security_rule {
+    name      = "example"
+    access    = "Allow"
+    direction = "Inbound"
+    priority  = 100
+    protocol  = "Tcp"
+
+    destination_port_range = 3389
+    source_address_prefix  = "10.0.0.0/16"
+  }
+}
+
+# fail
+
+resource "azurerm_network_security_rule" "rdp" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range  = 3389
+  source_address_prefix   = "*"
+  destination_port_ranges = null
+  source_address_prefixes = null
+}
+
+resource "azurerm_network_security_rule" "all" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = "*"
+  source_address_prefix  = "Internet"
+}
+
+resource "azurerm_network_security_rule" "range" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = "3000-4000"
+  source_address_prefix  = "Internet"
+}
+
+resource "azurerm_network_security_rule" "ranges_prefixes" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range  = null
+  source_address_prefix   = null
+  destination_port_ranges = [
+    3389,
+    443
+  ]
+  source_address_prefixes = [
+    "Internet",
+    "10.0.0.0/16"
+  ]
+}
+
+resource "azurerm_network_security_group" "ranges" {
+  name                = "example"
+  location            = "azurerm_resource_group.example.location"
+  resource_group_name = "azurerm_resource_group.example.name"
+
+  security_rule {
+    name      = "example"
+    access    = "Allow"
+    direction = "Inbound"
+    priority  = 100
+    protocol  = "Tcp"
+
+    destination_port_ranges = [
+      "3000-4000",
+      "8000-9000"
+    ]
+    source_address_prefix  = "*"
+  }
+}

--- a/tests/terraform/checks/resource/azure/example_NSGRuleSSHAccessRestricted/main.tf
+++ b/tests/terraform/checks/resource/azure/example_NSGRuleSSHAccessRestricted/main.tf
@@ -1,0 +1,131 @@
+# pass
+
+resource "azurerm_network_security_rule" "https" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = 443
+  source_address_prefix  = "Internet"
+}
+
+resource "azurerm_network_security_rule" "ssh_restricted_prefixes" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = 22
+  source_address_prefixes = [
+    "123.123.123.123/32",
+    "10.0.0.0/16"
+  ]
+}
+
+resource "azurerm_network_security_group" "ssh_restricted" {
+  name                = "example"
+  location            = "azurerm_resource_group.example.location"
+  resource_group_name = "azurerm_resource_group.example.name"
+
+  security_rule {
+    name      = "example"
+    access    = "Allow"
+    direction = "Inbound"
+    priority  = 100
+    protocol  = "Tcp"
+
+    destination_port_range = 22
+    source_address_prefix  = "10.0.0.0/16"
+  }
+}
+
+# fail
+
+resource "azurerm_network_security_rule" "ssh" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range  = 22
+  source_address_prefix   = "*"
+  destination_port_ranges = null
+  source_address_prefixes = null
+}
+
+resource "azurerm_network_security_rule" "all" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = "*"
+  source_address_prefix  = "Internet"
+}
+
+resource "azurerm_network_security_rule" "range" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = "10-100"
+  source_address_prefix  = "Internet"
+}
+
+resource "azurerm_network_security_rule" "ranges_prefixes" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range  = null
+  source_address_prefix   = null
+  destination_port_ranges = [
+    22,
+    443
+  ]
+  source_address_prefixes = [
+    "Internet",
+    "10.0.0.0/16"
+  ]
+}
+
+resource "azurerm_network_security_group" "ranges" {
+  name                = "example"
+  location            = "azurerm_resource_group.example.location"
+  resource_group_name = "azurerm_resource_group.example.name"
+
+  security_rule {
+    name      = "example"
+    access    = "Allow"
+    direction = "Inbound"
+    priority  = 100
+    protocol  = "Tcp"
+
+    destination_port_ranges = [
+      "10-100",
+      "8000-9000"
+    ]
+    source_address_prefix  = "*"
+  }
+}

--- a/tests/terraform/checks/resource/azure/test_NSGRuleRDPAccessRestricted.py
+++ b/tests/terraform/checks/resource/azure/test_NSGRuleRDPAccessRestricted.py
@@ -1,97 +1,46 @@
 import unittest
+from pathlib import Path
 
-import hcl2
-
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.azure.NSGRuleRDPAccessRestricted import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestNSGRuleRDPAccessRestricted(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_NSGRuleRDPAccessRestricted"
 
-    def test_failure(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_network_security_rule" "example" {
-              name                        = "test123"
-              priority                    = 100
-              direction                   = "Inbound"
-              access                      = "Allow"
-              protocol                    = "TCP"
-              source_port_range           = "*"
-              destination_port_range      = ["3380-3390", "22"]
-              source_address_prefix       = "*"
-              destination_address_prefix  = "*"
-              resource_group_name         = azurerm_resource_group.example.name
-              network_security_group_name = azurerm_network_security_group.example.name
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_network_security_rule']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
 
-    def test_failure_case_insensitive(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_network_security_rule" "example" {
-              name                        = "test123"
-              priority                    = 100
-              direction                   = "inbound"
-              access                      = "allow"
-              protocol                    = "Tcp"
-              source_port_range           = "*"
-              destination_port_range      = ["3380-3390", "22"]
-              source_address_prefix       = "Internet"
-              destination_address_prefix  = "*"
-              resource_group_name         = azurerm_resource_group.example.name
-              network_security_group_name = azurerm_network_security_group.example.name
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_network_security_rule']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        # then
+        summary = report.get_summary()
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-                    resource "azurerm_network_security_rule" "example" {
-                      name                        = "test123"
-                      priority                    = 100
-                      direction                   = "Inbound"
-                      access                      = "Deny"
-                      protocol                    = "TCP"
-                      source_port_range           = "*"
-                      destination_port_range      = ["3389"]
-                      source_address_prefix       = "*"
-                      destination_address_prefix  = "*"
-                      resource_group_name         = azurerm_resource_group.example.name
-                      network_security_group_name = azurerm_network_security_group.example.name
-                    }
-                        """)
-        resource_conf = hcl_res['resource'][0]['azurerm_network_security_rule']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
-
-    def test_failure2(self):
-        hcl_res = hcl2.loads("""
-        resource "azurerm_network_security_group" "tfer--Second-002D-nsg" {
-          location            = "eastus"
-          name                = "Second-nsg"
-          resource_group_name = "Ariel"
-        
-          security_rule {
-            access                     = "Allow"
-            destination_address_prefix = "*"
-            destination_port_range     = "3389"
-            direction                  = "Inbound"
-            name                       = "RDP"
-            priority                   = "300"
-            protocol                   = "*"
-            source_address_prefix      = "*"
-            source_port_range          = "*"
-          }
+        passing_resources = {
+            "azurerm_network_security_rule.https",
+            "azurerm_network_security_rule.rdp_restricted_prefixes",
+            "azurerm_network_security_group.rdp_restricted",
         }
-        """)
-        resource_conf = hcl_res['resource'][0]['azurerm_network_security_group']['tfer--Second-002D-nsg']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        failing_resources = {
+            "azurerm_network_security_rule.all",
+            "azurerm_network_security_rule.range",
+            "azurerm_network_security_rule.ranges_prefixes",
+            "azurerm_network_security_rule.rdp",
+            "azurerm_network_security_group.ranges",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["failed"], 5)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/resource/azure/test_NSGRuleSSHAccessRestricted.py
+++ b/tests/terraform/checks/resource/azure/test_NSGRuleSSHAccessRestricted.py
@@ -1,85 +1,46 @@
 import unittest
+from pathlib import Path
 
-import hcl2
-
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.azure.NSGRuleSSHAccessRestricted import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestNSGRuleSSHAccessRestricted(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_NSGRuleSSHAccessRestricted"
 
-    def test_failure(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_network_security_rule" "example" {
-              name                        = "test123"
-              priority                    = 100
-              direction                   = "Inbound"
-              access                      = "Allow"
-              protocol                    = "TCP"
-              source_port_range           = "*"
-              destination_port_range      = "22"
-              source_address_prefix       = "*"
-              destination_address_prefix  = "*"
-              resource_group_name         = azurerm_resource_group.example.name
-              network_security_group_name = azurerm_network_security_group.example.name
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_network_security_rule']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-                    resource "azurerm_network_security_rule" "example" {
-                      name                        = "test123"
-                      priority                    = 100
-                      direction                   = "Inbound"
-                      access                      = "Deny"
-                      protocol                    = "TCP"
-                      source_port_range           = "*"
-                      destination_port_range      = ["22"]
-                      source_address_prefix       = "*"
-                      destination_address_prefix  = "*"
-                      resource_group_name         = azurerm_resource_group.example.name
-                      network_security_group_name = azurerm_network_security_group.example.name
-                    }
-                        """)
-        resource_conf = hcl_res['resource'][0]['azurerm_network_security_rule']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        # then
+        summary = report.get_summary()
 
-    def test_unknown(self):
-        hcl_res = hcl2.loads("""
-resource "azurerm_network_security_group" "mynsg" {
-    name = var.nsg_name
-    resource_group_name = azurerm_resource_group.rg.name
-    location = var.location
+        passing_resources = {
+            "azurerm_network_security_rule.https",
+            "azurerm_network_security_rule.ssh_restricted_prefixes",
+            "azurerm_network_security_group.ssh_restricted",
+        }
+        failing_resources = {
+            "azurerm_network_security_rule.all",
+            "azurerm_network_security_rule.range",
+            "azurerm_network_security_rule.ranges_prefixes",
+            "azurerm_network_security_rule.ssh",
+            "azurerm_network_security_group.ranges",
+        }
 
-    security_rule = [for rule in var.security_rules : {
-        name = rule.name
-        priority = rule.priority
-        source_address_prefix = lookup(rule, "source_address_prefixes", []) == [] ? lookup(rule, "source_address_prefix", var.nsg_default_source_address_prefix) : ""
-        source_address_prefixes = lookup(rule, "source_address_prefixes", [])
-        access = lookup(rule, "access", var.nsg_default_access)
-        destination_port_range = lookup(rule, "destination_port_ranges", []) == [] ? lookup(rule, "destination_port_range", var.nsg_default_destination_port_range) : ""
-        destination_port_ranges = lookup(rule, "destination_port_ranges", [])
-        direction = lookup(rule, "direction", var.nsg_default_direction)
-        protocol = lookup(rule, "protocol", var.nsg_default_protocol)
-        source_port_range = lookup(rule, "source_port_range", var.nsg_default_source_port_range)
-        description = ""
-        destination_address_prefix = "*"
-        destination_address_prefixes = []
-        destination_application_security_group_ids = []
-        source_application_security_group_ids = []
-        source_port_ranges = []
-    }]
-}
-        """)
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
 
-        resource_conf = hcl_res['resource'][0]['azurerm_network_security_group']['mynsg']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["failed"], 5)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/resource/azure/test_NSGRuleUDPAccessRestricted.py
+++ b/tests/terraform/checks/resource/azure/test_NSGRuleUDPAccessRestricted.py
@@ -135,7 +135,7 @@ class TestNSGRuleUDPAccessRestricted(unittest.TestCase):
                 protocol                   = "Udp"
                 source_port_range          = "*"
                 destination_port_range     = "*"
-                source_address_prefix      = "internet"
+                source_address_prefix      = "Internet"
                 destination_address_prefix = "*"
               }
 
@@ -314,7 +314,7 @@ class TestNSGRuleUDPAccessRestricted(unittest.TestCase):
                 protocol                   = "Udp"
                 source_port_range          = "*"
                 destination_port_range     = "*"
-                source_address_prefix      = "internet"
+                source_address_prefix      = "Internet"
                 destination_address_prefix = "*"
             }
                 """)

--- a/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/expected.yaml
+++ b/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/expected.yaml
@@ -5,7 +5,7 @@ pass:
   - "aws_route53_record.pass4"
   - "aws_route53_record.pass5"
   - "aws_route53_record.legacy-tf"
-  
+  - "aws_route53_record.pass_eb"
 fail:
   - "aws_route53_record.fail"
 ignore:

--- a/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
+++ b/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
@@ -197,3 +197,22 @@ resource "aws_route53_record" "legacy-tf" {
 }
 
 resource "aws_instance" "brochureworker" {}
+
+# ElasticBeanstalk
+
+resource "aws_route53_record" "pass_eb" {
+  zone_id = data.aws_route53_zone.dns_zone.zone_id
+  name    = var.sub_domain
+  type    = "A"
+
+  alias {
+    name                   =  aws_elastic_beanstalk_environment.pass_eb.cname
+    zone_id                =  data.aws_elastic_beanstalk_hosted_zone.current.id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_elastic_beanstalk_environment" "pass_eb" {
+  application = aws_elastic_beanstalk_application.example.name
+  name        = "example"
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #2211

I had to extend the `if` clause to differentiate between `destination_port_range` vs `destination_port_ranges` and `source_address_prefix` vs `source_address_prefixes`. You can only set either one of it.

Also changed the tests to the better syntax and added a ElasticBeanstalk test, because I tested something and this wasn't tested before.