### PR TITLE
CKV_AZURE_80 - Update expected dotnet_framework_version to v6.0

### DIFF
--- a/checkov/terraform/checks/resource/azure/AppServiceDotnetFrameworkVersion.py
+++ b/checkov/terraform/checks/resource/azure/AppServiceDotnetFrameworkVersion.py
@@ -14,7 +14,7 @@ class AppServiceDotnetFrameworkVersion(BaseResourceValueCheck):
         return "site_config/0/dotnet_framework_version"
 
     def get_expected_value(self):
-        return "v5.0"
+        return "v6.0"
 
 
 check = AppServiceDotnetFrameworkVersion()

--- a/tests/terraform/checks/resource/azure/test_AppServiceDotnetFrameworkVersion.py
+++ b/tests/terraform/checks/resource/azure/test_AppServiceDotnetFrameworkVersion.py
@@ -17,7 +17,7 @@ class TestAppServiceDotnetFrameworkVersion(unittest.TestCase):
               app_service_plan_id = azurerm_app_service_plan.example.id
               https_only          = true
               site_config {
-                dotnet_framework_version = "v4.0"
+                dotnet_framework_version = "v5.0"
                 scm_type                 = "someValue"
                 }
               }
@@ -52,7 +52,7 @@ class TestAppServiceDotnetFrameworkVersion(unittest.TestCase):
               app_service_plan_id = azurerm_app_service_plan.example.id
               https_only          = true
               site_config {
-                dotnet_framework_version = "v5.0"
+                dotnet_framework_version = "v6.0"
                 scm_type                 = "someValue"
                 }
               }


### PR DESCRIPTION
Currently .NET 6.0 is the latest LTS version, therefore CKV_AZURE_80 should expect a dotnet_framework_version of v6.0.

Fixes #2209

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
