### PR TITLE
fixed non-string api keys

### DIFF
--- a/checkov/terraform/checks/provider/panos/credentials.py
+++ b/checkov/terraform/checks/provider/panos/credentials.py
@@ -25,7 +25,7 @@ class PanosCredentials(BaseProviderCheck):
     def secret_found(conf: Dict[str, List[Any]], field: str, pattern: str) -> bool:
         if field in conf.keys():
             value = conf[field][0]
-            if re.match(pattern, value) is not None:
+            if not isinstance(value, str) or re.match(pattern, value) is not None:
                 return True
         return False
 

--- a/tests/terraform/checks/provider/panos/resources/api_key/fail1.tf
+++ b/tests/terraform/checks/provider/panos/resources/api_key/fail1.tf
@@ -1,0 +1,3 @@
+provider "panos" {
+  api_key  = var.nested_var.apikey
+}

--- a/tests/terraform/checks/provider/panos/resources/api_key/fail2.tf
+++ b/tests/terraform/checks/provider/panos/resources/api_key/fail2.tf
@@ -1,0 +1,3 @@
+provider "panos" {
+  api_key  = "LUFRPT1yWFdyMFg5NlZxZ1ViU2ZhMTh6aGVEbDJ1UFU9ck9vc2tGcmlHV0tDbWRFa2cxcGUxSU8wMlVjaE9ReU0yYWN5SU1rL2pEOGhDcE50WEt5ABlHQWZoTm8xNG1SQQ=="
+}

--- a/tests/terraform/checks/provider/panos/resources/api_key/pass.tf
+++ b/tests/terraform/checks/provider/panos/resources/api_key/pass.tf
@@ -1,0 +1,3 @@
+provider "panos" {
+  api_key = ""
+}

--- a/tests/terraform/checks/provider/panos/resources/api_key/variables.tf
+++ b/tests/terraform/checks/provider/panos/resources/api_key/variables.tf
@@ -1,0 +1,5 @@
+variable "nested_var" {
+  default = {
+    apikey = ""
+  }
+}

--- a/tests/terraform/checks/provider/panos/test_credentials.py
+++ b/tests/terraform/checks/provider/panos/test_credentials.py
@@ -1,9 +1,12 @@
+import os
 import unittest
 
 import hcl2
 
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.provider.panos.credentials import check
 from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestCredentials(unittest.TestCase):
@@ -40,6 +43,35 @@ class TestCredentials(unittest.TestCase):
         provider_conf = hcl_res["provider"][0]["panos"]
         scan_result = check.scan_provider_conf(conf=provider_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_api_key(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/resources/api_key"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=["CKV_PAN_1"]))
+        summary = report.get_summary()
+
+        passing_resources_files = {
+            "/pass.tf",
+        }
+
+        failing_resources_files = {
+            "/fail1.tf",
+            "/fail2.tf"
+        }
+
+        passed_check_resources_files = set([c.file_path for c in report.passed_checks])
+        failing_check_resources_files = set([c.file_path for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources_files, passed_check_resources_files)
+        self.assertEqual(failing_resources_files, failing_check_resources_files)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/terraform/checks/provider/panos/test_credentials.py
+++ b/tests/terraform/checks/provider/panos/test_credentials.py
@@ -49,7 +49,7 @@ class TestCredentials(unittest.TestCase):
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
         test_files_dir = current_dir + "/resources/api_key"
-        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=["CKV_PAN_1"]))
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
         passing_resources_files = {


### PR DESCRIPTION
Handle non-string api_keys for terraform panos provider.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
