### PR TITLE
fix SAM Globals issue with conditions

### DIFF
--- a/checkov/cloudformation/graph_builder/graph_components/blocks.py
+++ b/checkov/cloudformation/graph_builder/graph_components/blocks.py
@@ -28,11 +28,21 @@ class CloudformationBlock(Block):
         self.condition = condition
 
     def update_attribute(
-            self, attribute_key: str, attribute_value: Any, change_origin_id: int,
-            previous_breadcrumbs: List[BreadcrumbMetadata], attribute_at_dest: str
+        self, attribute_key: str,
+        attribute_value: Any,
+        change_origin_id: int,
+        previous_breadcrumbs: List[BreadcrumbMetadata],
+        attribute_at_dest: str,
+        transform_step: bool = False,
     ) -> None:
-        super().update_attribute(attribute_key, attribute_value, change_origin_id, previous_breadcrumbs,
-                                 attribute_at_dest)
+        super().update_attribute(
+            attribute_key=attribute_key,
+            attribute_value=attribute_value,
+            change_origin_id=change_origin_id,
+            previous_breadcrumbs=previous_breadcrumbs,
+            attribute_at_dest=attribute_at_dest,
+            transform_step=transform_step,
+        )
 
         attribute_key_parts = attribute_key.split(".")
         if attribute_key_parts:

--- a/checkov/cloudformation/graph_builder/local_graph.py
+++ b/checkov/cloudformation/graph_builder/local_graph.py
@@ -122,6 +122,7 @@ class CloudformationLocalGraph(LocalGraph):
                             attribute_value=value,
                             change_origin_id=index,
                             attribute_at_dest=property,
+                            transform_step=True,
                         )
                     elif isinstance(value, list):
                         self.update_vertex_attribute(
@@ -130,6 +131,7 @@ class CloudformationLocalGraph(LocalGraph):
                             attribute_value=[*vertex.attributes[property], *value],
                             change_origin_id=index,
                             attribute_at_dest=property,
+                            transform_step=True,
                         )
 
     def update_vertices_breadcrumbs(self) -> None:

--- a/checkov/common/graph/graph_builder/graph_components/blocks.py
+++ b/checkov/common/graph/graph_builder/graph_components/blocks.py
@@ -99,8 +99,13 @@ class Block:
         return attributes_dict.get(CustomAttributes.HASH, "")
 
     def update_attribute(
-            self, attribute_key: str, attribute_value: Any, change_origin_id: Optional[int],
-            previous_breadcrumbs: List[BreadcrumbMetadata], attribute_at_dest: Optional[str]
+        self,
+        attribute_key: str,
+        attribute_value: Any,
+        change_origin_id: Optional[int],
+        previous_breadcrumbs: List[BreadcrumbMetadata],
+        attribute_at_dest: Optional[str],
+        transform_step: bool = False,
     ) -> None:
         if self._should_add_previous_breadcrumbs(change_origin_id, previous_breadcrumbs, attribute_at_dest):
             previous_breadcrumbs.append(BreadcrumbMetadata(change_origin_id, attribute_at_dest))
@@ -120,6 +125,10 @@ class Block:
             key = join_trimmed_strings(char_to_join=".", str_lst=attribute_key_parts, num_to_trim=i)
             if key.find(".") > -1:
                 self.attributes[key] = attribute_value
+                end_key_part = attribute_key_parts[len(attribute_key_parts) - 1 - i]
+                if transform_step and end_key_part in ("1", "2"):
+                    # if condition logic during the transform step breaks the values
+                    return
                 attribute_value = {attribute_key_parts[len(attribute_key_parts) - 1 - i]: attribute_value}
                 if self._should_set_changed_attributes(change_origin_id, attribute_at_dest):
                     self.changed_attributes[key] = previous_breadcrumbs

--- a/checkov/common/graph/graph_builder/graph_components/blocks.py
+++ b/checkov/common/graph/graph_builder/graph_components/blocks.py
@@ -129,7 +129,7 @@ class Block:
                 if transform_step and end_key_part in ("1", "2"):
                     # if condition logic during the transform step breaks the values
                     return
-                attribute_value = {attribute_key_parts[len(attribute_key_parts) - 1 - i]: attribute_value}
+                attribute_value = {end_key_part: attribute_value}
                 if self._should_set_changed_attributes(change_origin_id, attribute_at_dest):
                     self.changed_attributes[key] = previous_breadcrumbs
 

--- a/checkov/common/graph/graph_builder/local_graph.py
+++ b/checkov/common/graph/graph_builder/local_graph.py
@@ -71,16 +71,17 @@ class LocalGraph:
         return self.vertices[index].get_attribute_dict(add_hash)
 
     def update_vertex_attribute(
-            self,
-            vertex_index: int,
-            attribute_key: str,
-            attribute_value: Any,
-            change_origin_id: int,
-            attribute_at_dest: Optional[Union[str, List[str]]],
+        self,
+        vertex_index: int,
+        attribute_key: str,
+        attribute_value: Any,
+        change_origin_id: int,
+        attribute_at_dest: Optional[Union[str, List[str]]],
+        transform_step: bool = False
     ) -> None:
         previous_breadcrumbs = []
         if attribute_at_dest:
             previous_breadcrumbs = self.vertices[change_origin_id].changed_attributes.get(attribute_at_dest, [])
         self.vertices[vertex_index].update_attribute(
-            attribute_key, attribute_value, change_origin_id, previous_breadcrumbs, attribute_at_dest
+            attribute_key, attribute_value, change_origin_id, previous_breadcrumbs, attribute_at_dest, transform_step
         )

--- a/tests/cloudformation/graph/graph_builder/resources/sam/template.yaml
+++ b/tests/cloudformation/graph/graph_builder/resources/sam/template.yaml
@@ -1,6 +1,13 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 
+Parameters:
+  EnvironmentType:
+    Type: String
+    AllowedValues:
+      - dev
+      - stage
+
 Globals:
   Function:
     Timeout: 5
@@ -9,6 +16,7 @@ Globals:
     Tracing: Active
     Environment:
       Variables:
+        QUEUE_URL: !If [ IsStageEnvironment, !Ref SomeQueue, unkown ]
         STAGE: Production
         TABLE_NAME: global-table
     VpcConfig:
@@ -18,6 +26,9 @@ Globals:
       SubnetIds:
         - subnet-123
         - subnet-456
+
+Conditions:
+  IsStageEnvironment: !Equals [ !Ref EnvironmentType, stage ]
 
 Resources:
   SomeQueue:

--- a/tests/cloudformation/graph/graph_builder/test_local_graph.py
+++ b/tests/cloudformation/graph/graph_builder/test_local_graph.py
@@ -164,7 +164,7 @@ class TestLocalGraph(TestCase):
         local_graph = CloudformationLocalGraph(definitions)
         local_graph.build_graph(render_variables=False)
 
-        self.assertEqual(len(local_graph.vertices), 5)
+        self.assertEqual(len(local_graph.vertices), 7)
         self.assertEqual(len([v for v in local_graph.vertices if v.block_type == BlockType.GLOBALS]), 1)
         self.assertEqual(len([v for v in local_graph.vertices if v.block_type == BlockType.RESOURCE]), 3)
         self.assertEqual(len([v for v in local_graph.vertices if v.block_type == BlockType.OUTPUTS]), 1)
@@ -180,6 +180,9 @@ class TestLocalGraph(TestCase):
             "Tracing",
             "Environment.Variables",
             "Environment.Variables.STAGE",
+            "Environment.Variables.QUEUE_URL",
+            "Environment.Variables.QUEUE_URL.Fn::If",
+            "Environment.Variables.QUEUE_URL.Fn::If.1.Ref",
             "VpcConfig.SecurityGroupIds",
             "VpcConfig.SubnetIds",
         ]
@@ -193,6 +196,9 @@ class TestLocalGraph(TestCase):
             "Environment.Variables",
             "Environment.Variables.STAGE",
             "Environment.Variables.TABLE_NAME",
+            "Environment.Variables.QUEUE_URL",
+            "Environment.Variables.QUEUE_URL.Fn::If",
+            "Environment.Variables.QUEUE_URL.Fn::If.1.Ref",
             "VpcConfig",
             "VpcConfig.SecurityGroupIds",
             "VpcConfig.SubnetIds",


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #2228

Added an extra flag `transform_step` to indicate that the attribute change resulted from a CloudFormation `Transform` and skip a recursive update, because this would result otherwise in transforming the values for an `if` condition.