### PR TITLE
add generic check for unrendered variable and update some checks to return UNKNOWN

### DIFF
--- a/checkov/terraform/checks/resource/aws/DBInstanceBackupRetentionPeriod.py
+++ b/checkov/terraform/checks/resource/aws/DBInstanceBackupRetentionPeriod.py
@@ -15,7 +15,10 @@ class DBInstanceBackupRetentionPeriod(BaseResourceCheck):
     def scan_resource_conf(self, conf):
         key = "backup_retention_period"
         if key in conf.keys():
-            period = force_int(conf[key][0])
+            period = conf[key][0]
+            if BaseResourceCheck.contains_unrendered_value(period):
+                return CheckResult.UNKNOWN
+            period = force_int(period)
             if period and 0 < period <= 35:
                 return CheckResult.PASSED
             return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/aws/DBInstanceBackupRetentionPeriod.py
+++ b/checkov/terraform/checks/resource/aws/DBInstanceBackupRetentionPeriod.py
@@ -16,7 +16,7 @@ class DBInstanceBackupRetentionPeriod(BaseResourceCheck):
         key = "backup_retention_period"
         if key in conf.keys():
             period = conf[key][0]
-            if BaseResourceCheck.contains_unrendered_value(period):
+            if self._is_variable_dependant(period):
                 return CheckResult.UNKNOWN
             period = force_int(period)
             if period and 0 < period <= 35:

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyExpiration.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyExpiration.py
@@ -28,7 +28,7 @@ class PasswordPolicyExpiration(BaseResourceValueCheck):
         key = 'max_password_age'
         if key in conf.keys():
             max_age = conf[key][0]
-            if BaseResourceCheck.contains_unrendered_value(max_age):
+            if self._is_variable_dependant(max_age):
                 return CheckResult.UNKNOWN
             max_age = force_int(max_age)
             if max_age and 0 < max_age <= 90:

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyExpiration.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyExpiration.py
@@ -1,4 +1,5 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.util.type_forcers import force_int
 
@@ -26,7 +27,10 @@ class PasswordPolicyExpiration(BaseResourceValueCheck):
         """
         key = 'max_password_age'
         if key in conf.keys():
-            max_age = force_int(conf[key][0])
+            max_age = conf[key][0]
+            if BaseResourceCheck.contains_unrendered_value(max_age):
+                return CheckResult.UNKNOWN
+            max_age = force_int(max_age)
             if max_age and 0 < max_age <= 90:
                 return CheckResult.PASSED
         return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyLength.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyLength.py
@@ -1,4 +1,5 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.util.type_forcers import force_int
 
@@ -26,7 +27,11 @@ class PasswordPolicyLength(BaseResourceValueCheck):
         """
         key = 'minimum_password_length'
         if key in conf.keys():
-            if not (force_int(conf[key][0]) and force_int(conf[key][0]) < 14):
+            length = conf[key][0]
+            if BaseResourceCheck.contains_unrendered_value(length):
+                return CheckResult.UNKNOWN
+            length = force_int(length)
+            if not (length and length < 14):
                 return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyLength.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyLength.py
@@ -28,7 +28,7 @@ class PasswordPolicyLength(BaseResourceValueCheck):
         key = 'minimum_password_length'
         if key in conf.keys():
             length = conf[key][0]
-            if BaseResourceCheck.contains_unrendered_value(length):
+            if self._is_variable_dependant(length):
                 return CheckResult.UNKNOWN
             length = force_int(length)
             if not (length and length < 14):

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyReuse.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyReuse.py
@@ -1,4 +1,5 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.util.type_forcers import force_int
 
@@ -26,7 +27,11 @@ class PasswordPolicyReuse(BaseResourceValueCheck):
         """
         key = 'password_reuse_prevention'
         if key in conf.keys():
-            if not (force_int(conf[key][0]) and force_int(conf[key][0]) < 24):
+            reuse = conf[key][0]
+            if BaseResourceCheck.contains_unrendered_value(reuse):
+                return CheckResult.UNKNOWN
+            reuse = force_int(reuse)
+            if not (reuse and reuse < 24):
                 return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/checkov/terraform/checks/resource/aws/PasswordPolicyReuse.py
+++ b/checkov/terraform/checks/resource/aws/PasswordPolicyReuse.py
@@ -28,7 +28,7 @@ class PasswordPolicyReuse(BaseResourceValueCheck):
         key = 'password_reuse_prevention'
         if key in conf.keys():
             reuse = conf[key][0]
-            if BaseResourceCheck.contains_unrendered_value(reuse):
+            if self._is_variable_dependant(reuse):
                 return CheckResult.UNKNOWN
             reuse = force_int(reuse)
             if not (reuse and reuse < 24):

--- a/checkov/terraform/checks/resource/base_resource_check.py
+++ b/checkov/terraform/checks/resource/base_resource_check.py
@@ -34,7 +34,7 @@ class BaseResourceCheck(BaseCheck):
         if not isinstance(value, str):
             return False
 
-        if value.startswith('var.') or value.startswith('local.') or value.startswith('module.'):
+        if value.startswith(('var.', 'local.', 'module.')):
             return True
 
         if "${" not in value:

--- a/checkov/terraform/checks/resource/base_resource_check.py
+++ b/checkov/terraform/checks/resource/base_resource_check.py
@@ -28,6 +28,18 @@ class BaseResourceCheck(BaseCheck):
         self.supported_resources = supported_resources
         resource_registry.register(self)
 
+    @staticmethod
+    def contains_unrendered_value(value):
+        if type(value) != str:
+            return False
+
+        if value.startswith('var.') or value.startswith('local.'):
+            return True
+        elif '${var.' in value or '${local.' in value:
+            return True
+
+        return False
+
     def scan_entity_conf(self, conf: Dict[str, List[Any]], entity_type: str) -> CheckResult:
         self.entity_type = entity_type
 

--- a/checkov/terraform/checks/resource/base_resource_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_value_check.py
@@ -36,17 +36,6 @@ class BaseResourceValueCheck(BaseResourceCheck):
         return [x for x in path.split("/") if not re.search(re.compile(r"^\[?\d+]?$"), x)]
 
     @staticmethod
-    def _is_variable_dependant(value: Any) -> bool:
-        if not isinstance(value, str):
-            return False
-        if "${" not in value:
-            return False
-
-        if find_var_blocks(value):
-            return True
-        return False
-
-    @staticmethod
     def _is_nesting_key(inspected_attributes: List[str], key: List[str]) -> bool:
         """
         Resolves whether a key is a subset of the inspected nesting attributes

--- a/tests/terraform/checks/resource/aws/example_DBInstanceBackupRetentionPeriod/main.tf
+++ b/tests/terraform/checks/resource/aws/example_DBInstanceBackupRetentionPeriod/main.tf
@@ -29,3 +29,7 @@ resource "aws_db_instance" "fail2" {
 resource "aws_db_instance" "fail" {
   backup_retention_period = 36
 }
+
+resource "aws_db_instance" "unknown" {
+  backup_retention_period = var.backup_retention_period
+}

--- a/tests/terraform/checks/resource/aws/test_DBInstanceBackupRetentionPeriod.py
+++ b/tests/terraform/checks/resource/aws/test_DBInstanceBackupRetentionPeriod.py
@@ -34,8 +34,6 @@ class TestDBInstanceBackupRetentionPeriod(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        all_evaluated_resources = passed_check_resources.union(failed_check_resources)
-
         self.assertEqual(summary["passed"], 4)
         self.assertEqual(summary["failed"], 4)
         self.assertEqual(summary["skipped"], 0)
@@ -43,7 +41,7 @@ class TestDBInstanceBackupRetentionPeriod(unittest.TestCase):
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
-        self.assertEqual(len([r for r in all_evaluated_resources if r in unknown_resources]), 0)
+        self.assertEqual(len([r for r in report.resources if r in unknown_resources]), 0)
 
 
 if __name__ == "__main__":

--- a/tests/terraform/checks/resource/aws/test_DBInstanceBackupRetentionPeriod.py
+++ b/tests/terraform/checks/resource/aws/test_DBInstanceBackupRetentionPeriod.py
@@ -27,9 +27,14 @@ class TestDBInstanceBackupRetentionPeriod(unittest.TestCase):
             "aws_db_instance.fail",
             "aws_db_instance.fail2",
         }
+        unknown_resources = {
+            "aws_db_instance.unknown"
+        }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        all_evaluated_resources = passed_check_resources.union(failed_check_resources)
 
         self.assertEqual(summary["passed"], 4)
         self.assertEqual(summary["failed"], 4)
@@ -38,6 +43,7 @@ class TestDBInstanceBackupRetentionPeriod(unittest.TestCase):
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
+        self.assertEqual(len([r for r in all_evaluated_resources if r in unknown_resources]), 0)
 
 
 if __name__ == "__main__":

--- a/tests/terraform/checks/resource/aws/test_PasswordPolicyReuse.py
+++ b/tests/terraform/checks/resource/aws/test_PasswordPolicyReuse.py
@@ -47,7 +47,7 @@ class TestPasswordPolicyReuse(unittest.TestCase):
         conf = {'count': ['True ? 1 : 0}'], 'max_password_age': [0], 'minimum_password_length': [8], 'allow_users_to_change_password': [True], 'hard_expiry': [False], 'password_reuse_prevention': ['${var.password_reuse_prevention}'], 'require_lowercase_characters': [True], 'require_uppercase_characters': [True], 'require_numbers': [True], 'require_symbols': [True]}
 
         scan_result = check.scan_resource_conf(conf=conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
 
 
 if __name__ == '__main__':

--- a/tests/terraform/checks/test_base_resource_check.py
+++ b/tests/terraform/checks/test_base_resource_check.py
@@ -11,15 +11,15 @@ from checkov.runner_filter import RunnerFilter
 class TestWildcardEntities(unittest.TestCase):
 
     def test_contains_unrendered_variable(self):
-        self.assertTrue(BaseResourceCheck.contains_unrendered_value('var.xyz'))
-        self.assertTrue(BaseResourceCheck.contains_unrendered_value('local.xyz'))
-        self.assertTrue(BaseResourceCheck.contains_unrendered_value('${var.xyz}'))
-        self.assertTrue(BaseResourceCheck.contains_unrendered_value('${local.xyz}'))
+        self.assertTrue(BaseResourceCheck._is_variable_dependant('var.xyz'))
+        self.assertTrue(BaseResourceCheck._is_variable_dependant('local.xyz'))
+        self.assertTrue(BaseResourceCheck._is_variable_dependant('${var.xyz}'))
+        self.assertTrue(BaseResourceCheck._is_variable_dependant('${local.xyz}'))
 
-        self.assertFalse(BaseResourceCheck.contains_unrendered_value('xyz'))
-        self.assertFalse(BaseResourceCheck.contains_unrendered_value('123'))
-        self.assertFalse(BaseResourceCheck.contains_unrendered_value(123))
-        self.assertFalse(BaseResourceCheck.contains_unrendered_value(True))
+        self.assertFalse(BaseResourceCheck._is_variable_dependant('xyz'))
+        self.assertFalse(BaseResourceCheck._is_variable_dependant('123'))
+        self.assertFalse(BaseResourceCheck._is_variable_dependant(123))
+        self.assertFalse(BaseResourceCheck._is_variable_dependant(True))
 
 
 if __name__ == '__main__':

--- a/tests/terraform/checks/test_base_resource_check.py
+++ b/tests/terraform/checks/test_base_resource_check.py
@@ -13,8 +13,10 @@ class TestWildcardEntities(unittest.TestCase):
     def test_contains_unrendered_variable(self):
         self.assertTrue(BaseResourceCheck._is_variable_dependant('var.xyz'))
         self.assertTrue(BaseResourceCheck._is_variable_dependant('local.xyz'))
+        self.assertTrue(BaseResourceCheck._is_variable_dependant('module.xyz'))
         self.assertTrue(BaseResourceCheck._is_variable_dependant('${var.xyz}'))
         self.assertTrue(BaseResourceCheck._is_variable_dependant('${local.xyz}'))
+        self.assertTrue(BaseResourceCheck._is_variable_dependant('${module.xyz}'))
 
         self.assertFalse(BaseResourceCheck._is_variable_dependant('xyz'))
         self.assertFalse(BaseResourceCheck._is_variable_dependant('123'))

--- a/tests/terraform/checks/test_base_resource_check.py
+++ b/tests/terraform/checks/test_base_resource_check.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.terraform.checks.resource.registry import resource_registry as registry
+from checkov.terraform.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestWildcardEntities(unittest.TestCase):
+
+    def test_contains_unrendered_variable(self):
+        self.assertTrue(BaseResourceCheck.contains_unrendered_value('var.xyz'))
+        self.assertTrue(BaseResourceCheck.contains_unrendered_value('local.xyz'))
+        self.assertTrue(BaseResourceCheck.contains_unrendered_value('${var.xyz}'))
+        self.assertTrue(BaseResourceCheck.contains_unrendered_value('${local.xyz}'))
+
+        self.assertFalse(BaseResourceCheck.contains_unrendered_value('xyz'))
+        self.assertFalse(BaseResourceCheck.contains_unrendered_value('123'))
+        self.assertFalse(BaseResourceCheck.contains_unrendered_value(123))
+        self.assertFalse(BaseResourceCheck.contains_unrendered_value(True))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -1123,7 +1123,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='terraform',
                                                        checks=checks_allow_list, skip_checks=skip_checks))
 
-        self.assertEqual(len(report.passed_checks), 1)
+        self.assertEqual(len(report.passed_checks), 7)
         self.assertEqual(len(report.failed_checks), 1)
 
     def test_resource_values_do_exist(self):
@@ -1139,7 +1139,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='terraform',
                                                        checks=checks_allow_list, skip_checks=skip_checks))
 
-        self.assertEqual(len(report.passed_checks), 3)
+        self.assertEqual(len(report.passed_checks), 5)
         self.assertEqual(len(report.failed_checks), 3)
 
     def test_resource_negative_values_dont_exist(self):


### PR DESCRIPTION
A lot of checks return failures if they encounter an unrendered variable. This also means that our fix engine suggests fixes for them (e.g., change `enabled = var.versioning` to `enabled = true`), which is rarely actually correct.

This PR puts some basic logic in place to check for obvious cases of unrendered variables, and updates some checks to use it. This will be the basis for future more comprehensive changes, and is based on specific feedback from one user who raised it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
