### PR TITLE
Fix CKV_AWS_149 for terraform_plan

### DIFF
--- a/checkov/terraform/checks/resource/aws/SecretManagerSecretEncrypted.py
+++ b/checkov/terraform/checks/resource/aws/SecretManagerSecretEncrypted.py
@@ -17,7 +17,7 @@ class SecretManagerSecretEncrypted(BaseResourceCheck):
     def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
         aws_kms_alias = 'aws/'
         kms_key_id = force_list(conf.get('kms_key_id', []))
-        if not kms_key_id:
+        if not kms_key_id or not kms_key_id[0]:
             return CheckResult.FAILED
         else:
             return CheckResult.FAILED if aws_kms_alias in kms_key_id[0] else CheckResult.PASSED

--- a/tests/terraform/checks/resource/aws/example_SecretManagerSecretEncrypted/tfplan.json
+++ b/tests/terraform/checks/resource/aws/example_SecretManagerSecretEncrypted/tfplan.json
@@ -1,0 +1,119 @@
+{
+    "format_version": "0.2",
+    "terraform_version": "1.0.11",
+    "planned_values":
+    {
+        "root_module":
+        {
+            "resources":
+            [
+                {
+                    "address": "aws_secretsmanager_secret.not_specified",
+                    "mode": "managed",
+                    "type": "aws_secretsmanager_secret",
+                    "name": "not_specified",
+                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                    "schema_version": 0,
+                    "values":
+                    {
+                        "description": null,
+                        "force_overwrite_replica_secret": false,
+                        "kms_key_id": null,
+                        "name": "the-site-secret",
+                        "recovery_window_in_days": 30,
+                        "tags": null
+                    },
+                    "sensitive_values":
+                    {
+                        "replica":
+                        [],
+                        "rotation_rules":
+                        [],
+                        "tags_all":
+                        {}
+                    }
+                }
+            ]
+        }
+    },
+    "resource_changes":
+    [
+        {
+            "address": "aws_secretsmanager_secret.not_specified",
+            "mode": "managed",
+            "type": "aws_secretsmanager_secret",
+            "name": "not_specified",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "change":
+            {
+                "actions":
+                [
+                    "create"
+                ],
+                "before": null,
+                "after":
+                {
+                    "description": null,
+                    "force_overwrite_replica_secret": false,
+                    "kms_key_id": null,
+                    "name": "the-site-secret",
+                    "recovery_window_in_days": 30,
+                    "tags": null
+                },
+                "after_unknown":
+                {
+                    "arn": true,
+                    "id": true,
+                    "name_prefix": true,
+                    "policy": true,
+                    "replica": true,
+                    "rotation_enabled": true,
+                    "rotation_lambda_arn": true,
+                    "rotation_rules": true,
+                    "tags_all": true
+                },
+                "before_sensitive": false,
+                "after_sensitive":
+                {
+                    "replica":
+                    [],
+                    "rotation_rules":
+                    [],
+                    "tags_all":
+                    {}
+                }
+            }
+        }
+    ],
+    "configuration":
+    {
+        "provider_config":
+        {
+            "aws":
+            {
+                "name": "aws"
+            }
+        },
+        "root_module":
+        {
+            "resources":
+            [
+                {
+                    "address": "aws_secretsmanager_secret.not_specified",
+                    "mode": "managed",
+                    "type": "aws_secretsmanager_secret",
+                    "name": "not_specified",
+                    "provider_config_key": "aws",
+                    "expressions":
+                    {
+                        "name":
+                        {
+                            "constant_value": "the-site-secret"
+                        }
+                    },
+                    "schema_version": 0
+                }
+            ]
+        }
+    }
+}

--- a/tests/terraform/checks/resource/aws/test_SecretManagerSecretEncrypted.py
+++ b/tests/terraform/checks/resource/aws/test_SecretManagerSecretEncrypted.py
@@ -4,6 +4,7 @@ import unittest
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.SecretManagerSecretEncrypted import check
 from checkov.terraform.runner import Runner
+from checkov.terraform.plan_runner import Runner as PlanRunner
 
 
 class TestSecretManagerSecretEncrypted(unittest.TestCase):
@@ -33,6 +34,27 @@ class TestSecretManagerSecretEncrypted(unittest.TestCase):
         self.assertEqual(summary["parsing_errors"], 0)
 
         self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+    def test_terraform_plan(self):
+        runner = PlanRunner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_path = current_dir + "/example_SecretManagerSecretEncrypted/tfplan.json"
+        report = runner.run(files=[test_files_path], runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        failing_resources = {
+            "aws_secretsmanager_secret.not_specified",
+        }
+
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 0)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
         self.assertEqual(failing_resources, failed_check_resources)
 
 


### PR DESCRIPTION
Fixes issue https://github.com/bridgecrewio/checkov/issues/2238
When creating a plan file with a `aws_secretsmanager_secret` resource that does not specify `kms_key_id`, the run would get an execption.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
