### PR TITLE
explicitly check TLS types

### DIFF
--- a/checkov/terraform/checks/resource/azure/StorageAccountMinimumTlsVersion.py
+++ b/checkov/terraform/checks/resource/azure/StorageAccountMinimumTlsVersion.py
@@ -18,10 +18,9 @@ class StorageAccountMinimumTlsVersion(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if 'min_tls_version' not in conf or \
-                conf['min_tls_version'][0] == 'TLS1_0' or conf['min_tls_version'][0] == 'TLS1_1':
-            return CheckResult.FAILED
-        return CheckResult.PASSED
+        if 'min_tls_version' in conf and conf['min_tls_version'][0] in ['TLS1_2', 'TLS1_3']:
+            return CheckResult.PASSED
+        return CheckResult.FAILED
 
     def get_evaluated_keys(self) -> List[str]:
         return ['min_tls_version']


### PR DESCRIPTION
A user reported an issue that this check was giving a false negative (i.e., passing) when they had a var with a default value of `null`, i.e.:

```
variable "tls" {
  type = string
  default = null
}

resource "azurerm_storage_account" "example" {
  min_tls_version = var.tls
}
```

This is because our variable rendering logic does not handle default values of `null`, so the `scan_resource_conf` method was getting `min_tls_version = 'var.tls'` and passing the check. This is a quick fix for that issue while we work on the actual variable rendering issue.

Note that there was a UT checking for TLS 1.3 as a future proofing thing, so I just added that in here for good measure even though it's not supported yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
