### PR TITLE
GoogleComputeExternalIP - This check looked for the wrong place

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleComputeExternalIP.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeExternalIP.py
@@ -13,7 +13,7 @@ class GoogleComputeExternalIP(BaseResourceNegativeValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        if 'source_instance_template' in conf.keys() and 'network_config' not in conf.keys():
+        if 'source_instance_template' in conf.keys() and 'network_interface' not in conf.keys():
             # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
             # and the access_config block is not present, then this check cannot PASS, since we don't know what the
             # underlying source template looks like.

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeExternalIP.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeExternalIP.py
@@ -15,8 +15,8 @@ class GoogleComputeExternalIP(BaseResourceNegativeValueCheck):
     def scan_resource_conf(self, conf) -> CheckResult:
         if 'source_instance_template' in conf.keys() and 'network_interface' not in conf.keys():
             # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
-            # and the access_config block is not present, then this check cannot PASS, since we don't know what the
-            # underlying source template looks like.
+            # and the networks _interface block is not present, then this check cannot PASS,
+            # since we don't know what the underlying source template looks like.
             return CheckResult.UNKNOWN
         else:
             # in all other cases, pass/fail the check if block-project-ssh-keys is true/false or not present.

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeExternalIP.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeExternalIP.py
@@ -13,7 +13,7 @@ class GoogleComputeExternalIP(BaseResourceNegativeValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        if 'source_instance_template' in conf.keys() and 'access_config' not in conf.keys():
+        if 'source_instance_template' in conf.keys() and 'network_config' not in conf.keys():
             # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
             # and the access_config block is not present, then this check cannot PASS, since we don't know what the
             # underlying source template looks like.
@@ -23,7 +23,7 @@ class GoogleComputeExternalIP(BaseResourceNegativeValueCheck):
             return super().scan_resource_conf(conf)
 
     def get_inspected_key(self):
-        return 'access_config'
+        return 'network_interface/[0]/access_config'
 
     def get_forbidden_values(self):
         return [ANY_VALUE]

--- a/tests/terraform/checks/resource/gcp/example_GoogleComputeExternalIP/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleComputeExternalIP/main.tf
@@ -1,0 +1,59 @@
+
+resource "google_compute_instance" "fail" {
+  name         = "test"
+  machine_type = "n1-standard-1"
+  zone         = "us-central1-a"
+  boot_disk {
+    auto_delete = true
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+    }
+  }
+}
+
+
+resource "google_compute_instance_template" "fail" {
+  name         = "test"
+  machine_type = "n1-standard-1"
+
+  disk {}
+  network_interface {
+    network = "default"
+    access_config {
+
+    }
+  }
+}
+
+
+resource "google_compute_instance_from_template" "fail" {
+  name                     = "test"
+  source_instance_template = google_compute_instance_template.pass.id
+}
+
+resource "google_compute_instance" "pass" {
+  name         = "test"
+  machine_type = "n1-standard-1"
+  zone         = "us-central1-a"
+  boot_disk {
+    auto_delete = true
+  }
+  network_interface {
+
+  }
+}
+
+resource "google_compute_instance_template" "pass" {
+  name         = "test"
+  machine_type = "n1-standard-1"
+  disk {}
+}
+
+resource "google_compute_instance_from_template" "unknown" {
+  name                     = "test"
+  source_instance_template = google_compute_instance_template.pass.id
+}
+

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeExternalIP.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeExternalIP.py
@@ -1,95 +1,40 @@
 import unittest
-
-import hcl2
+import os
 
 from checkov.terraform.checks.resource.gcp.GoogleComputeExternalIP import check
-from checkov.common.models.enums import CheckResult
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
 
 
 class TestGoogleComputeExternalIP(unittest.TestCase):
 
-    def test_failure(self):
-        hcl_res = hcl2.loads("""
-            resource "google_compute_instance" "default" {
-              name         = "test"
-              machine_type = "n1-standard-1"
-              zone         = "us-central1-a"
-              boot_disk {}
-              access_config {
-                network_tier = "STANDARD"
-                }
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['google_compute_instance']['default']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
 
-    def test_failure_1(self):
-        hcl_res = hcl2.loads("""
-            resource "google_compute_instance_template" "default" {
-              name         = "test"
-              machine_type = "n1-standard-1"
-              zone         = "us-central1-a"
-              boot_disk {}
-              access_config {
-                network_tier = "STANDARD"
-                }
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        test_files_dir = current_dir + "/example_GoogleComputeExternalIP"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
 
-    def test_failure_2(self):
-        hcl_res = hcl2.loads("""
-            resource "google_compute_instance_from_template" "default" {
-              name         = "test"
-              source_instance_template = google_compute_instance_template.default.id
-              access_config {
-                network_tier = "STANDARD"
-                }
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        passing_resources = {
+            'google_compute_instance.pass',
+            'google_compute_instance_template.pass'
+        }
+        failing_resources = {
+            'google_compute_instance.fail',
+            'google_compute_instance_template.fail',
+        }
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-            resource "google_compute_instance" "default" {
-              name         = "test"
-              machine_type = "n1-standard-1"
-              zone         = "us-central1-a"
-              boot_disk {}
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['google_compute_instance']['default']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
 
-    def test_success_1(self):
-        hcl_res = hcl2.loads("""
-            resource "google_compute_instance_template" "default" {
-              name         = "test"
-              machine_type = "n1-standard-1"
-              zone         = "us-central1-a"
-              boot_disk {}
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['google_compute_instance_template']['default']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
 
-    def test_unknown(self):
-        hcl_res = hcl2.loads("""
-            resource "google_compute_instance_from_template" "default" {
-              name         = "test"
-              source_instance_template = google_compute_instance_template.default.id
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['google_compute_instance_from_template']['default']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Access_config lies inside a network_config block, it may have worked like this at one time- it doesnt now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
