### PR TITLE
fix source_module assignment for multi module references

### DIFF
--- a/checkov/common/graph/graph_builder/graph_components/attribute_names.py
+++ b/checkov/common/graph/graph_builder/graph_components/attribute_names.py
@@ -18,6 +18,8 @@ class CustomAttributes:
     RESOURCE_TYPE = "resource_type"
     RESOURCE_ID = "resource_id"
     SOURCE_MODULE = "source_module_"
+    MODULE_DEPENDENCY = "module_dependency_"
+    MODULE_DEPENDENCY_NUM = "module_dependency_num_"
 
 
 def props(cls: Any) -> List[str]:

--- a/checkov/common/graph/graph_builder/graph_components/blocks.py
+++ b/checkov/common/graph/graph_builder/graph_components/blocks.py
@@ -64,8 +64,8 @@ class Block:
         self.get_origin_attributes(base_attributes)
 
         if hasattr(self, "module_dependency") and hasattr(self, "module_dependency_num"):
-            base_attributes["module_dependency_"] = self.module_dependency
-            base_attributes["module_dependency_num_"] = self.module_dependency_num
+            base_attributes[CustomAttributes.MODULE_DEPENDENCY] = self.module_dependency
+            base_attributes[CustomAttributes.MODULE_DEPENDENCY_NUM] = self.module_dependency_num
 
         if self.changed_attributes:
             # add changed attributes only for calculating the hash

--- a/checkov/common/graph/graph_builder/graph_components/blocks.py
+++ b/checkov/common/graph/graph_builder/graph_components/blocks.py
@@ -63,6 +63,10 @@ class Block:
         base_attributes = self.get_base_attributes()
         self.get_origin_attributes(base_attributes)
 
+        if hasattr(self, "module_dependency") and hasattr(self, "module_dependency_num"):
+            base_attributes["module_dependency_"] = self.module_dependency
+            base_attributes["module_dependency_num_"] = self.module_dependency_num
+
         if self.changed_attributes:
             # add changed attributes only for calculating the hash
             base_attributes["changed_attributes"] = sorted(self.changed_attributes.keys())

--- a/tests/terraform/graph/graph_builder/test_local_graph.py
+++ b/tests/terraform/graph/graph_builder/test_local_graph.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from unittest import TestCase
 
 from checkov.common.graph.db_connectors.networkx.networkx_db_connector import NetworkxConnector
@@ -166,13 +167,131 @@ class TestLocalGraph(TestCase):
         self.assertEqual(len(list(filter(lambda block: block.block_type == BlockType.MODULE and block.name == 'sub-module', module.blocks))), 1)
 
     def test_vertices_from_local_graph_module(self):
-        resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME, '../resources/modules/stacks'))
+        parent_dir = Path(TEST_DIRNAME).parent
+        resources_dir = str(parent_dir / "resources/modules/stacks")
         hcl_config_parser = Parser()
         module, _ = hcl_config_parser.parse_hcl_module(resources_dir, self.source)
         local_graph = TerraformLocalGraph(module)
         local_graph.build_graph(render_variables=True)
 
         self.assertEqual(12, len(local_graph.edges))
+
+        # check vertex breadcrumbs
+        bucket_vertex_1 = next(
+            vertex
+            for vertex in local_graph.vertices
+            if vertex.name == "aws_s3_bucket.inner_s3" and vertex.source_module == {4}
+        )
+        bucket_vertex_2 = next(
+            vertex
+            for vertex in local_graph.vertices
+            if vertex.name == "aws_s3_bucket.inner_s3" and vertex.source_module == {5}
+        )
+        bucket_vertex_3 = next(
+            vertex
+            for vertex in local_graph.vertices
+            if vertex.name == "aws_s3_bucket.inner_s3" and vertex.source_module == {6}
+        )
+        self.assertDictEqual(
+            {
+                "versioning.enabled": [
+                    {
+                        "type": "module",
+                        "name": "inner_module_call",
+                        "path": str(parent_dir / "resources/modules/s3_inner_modules/main.tf"),
+                        "module_connection": False,
+                    },
+                    {
+                        "type": "variable",
+                        "name": "versioning",
+                        "path": str(parent_dir / "resources/modules/s3_inner_modules/inner/variables.tf"),
+                        "module_connection": False,
+                    },
+                ],
+                "source_module_": [
+                    {
+                        "type": "module",
+                        "name": "sub-module",
+                        "path": str(parent_dir / "resources/modules/stacks/prod/main.tf"),
+                    },
+                    {
+                        "type": "module",
+                        "name": "s3",
+                        "path": str(parent_dir / "resources/modules/stacks/prod/sub-prod/main.tf"),
+                    },
+                    {
+                        "type": "module",
+                        "name": "inner_module_call",
+                        "path": str(parent_dir / "resources/modules/s3_inner_modules/main.tf"),
+                    },
+                ],
+            },
+            bucket_vertex_1.breadcrumbs,
+        )
+
+        self.assertDictEqual(
+            {
+                "versioning.enabled": [
+                    {
+                        "type": "module",
+                        "name": "inner_module_call",
+                        "path": str(parent_dir / "resources/modules/s3_inner_modules/main.tf"),
+                        "module_connection": False,
+                    },
+                    {
+                        "type": "variable",
+                        "name": "versioning",
+                        "path": str(parent_dir / "resources/modules/s3_inner_modules/inner/variables.tf"),
+                        "module_connection": False,
+                    },
+                ],
+                "source_module_": [
+                    {
+                        "type": "module",
+                        "name": "s3",
+                        "path": str(parent_dir / "resources/modules/stacks/stage/main.tf"),
+                    },
+                    {
+                        "type": "module",
+                        "name": "inner_module_call",
+                        "path": str(parent_dir / "resources/modules/s3_inner_modules/main.tf"),
+                    },
+                ],
+            },
+            bucket_vertex_2.breadcrumbs,
+        )
+
+        self.assertDictEqual(
+            {
+                "versioning.enabled": [
+                    {
+                        "type": "module",
+                        "name": "inner_module_call",
+                        "path": str(parent_dir / "resources/modules/s3_inner_modules/main.tf"),
+                        "module_connection": False,
+                    },
+                    {
+                        "type": "variable",
+                        "name": "versioning",
+                        "path": str(parent_dir / "resources/modules/s3_inner_modules/inner/variables.tf"),
+                        "module_connection": False,
+                    },
+                ],
+                "source_module_": [
+                    {
+                        "type": "module",
+                        "name": "s3",
+                        "path": str(parent_dir / "resources/modules/stacks/test/main.tf"),
+                    },
+                    {
+                        "type": "module",
+                        "name": "inner_module_call",
+                        "path": str(parent_dir / "resources/modules/s3_inner_modules/main.tf"),
+                    },
+                ],
+            },
+            bucket_vertex_3.breadcrumbs,
+        )
 
     def test_variables_same_name_different_modules(self):
         resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME, '../resources/modules/same_var_names'))


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Adjusted the `block_dirs_to_modules` creation to make `source_module` less ambiguous, optimally there should be only one reference now. 
