### PR TITLE
CKV_AWS_92 : Update Failed Status

### DIFF
--- a/checkov/terraform/checks/resource/aws/ELBAccessLogs.py
+++ b/checkov/terraform/checks/resource/aws/ELBAccessLogs.py
@@ -16,7 +16,7 @@ class ELBAccessLogs(BaseResourceCheck):
         if 'access_logs' not in conf:
             return CheckResult.FAILED
         if 'enabled' not in conf['access_logs'][0]:
-            return CheckResult.PASSED
+            return CheckResult.FAILED
         if conf['access_logs'][0]['enabled'] == [True]:
             return CheckResult.PASSED
         return CheckResult.FAILED


### PR DESCRIPTION
In case , 'enabled' is not found ['access_logs'][0], the status should be FAILED instead of PASSED.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
