### PR TITLE
[Kustomize Support] Correct incorrect codepath bug for certain bases

### DIFF
--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -152,7 +152,7 @@ class Runner(BaseRunner):
                 if 'bases' in fileContent:
                     metadata['referenced_bases'] = fileContent['bases']
 
-            elif 'bases' in fileContent.get:
+            elif 'bases' in fileContent:
                 logging.debug(f"Kustomization contains bases: section. Likley an overlay/env. {parseKustomizationData}/kustomization.yaml")
                 metadata['type'] =  "overlay"
                 metadata['referenced_bases'] = fileContent['bases']


### PR DESCRIPTION
Small change to correct a bug in base vs overlay handling in the Kustomize framework.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
