### PR TITLE
correct the environment variable used to specify a custom CA certificate bundle

### DIFF
--- a/checkov/main.py
+++ b/checkov/main.py
@@ -375,7 +375,7 @@ def add_parser_args(parser):
                help="evaluate the values of variables and locals",
                default=True)
     parser.add('-ca', '--ca-certificate',
-               help='custom CA (bundle) file', default=None, env_var='CA_CERTIFICATE')
+               help='Custom CA certificate (bundle) file', default=None, env_var='BC_CA_BUNDLE')
     parser.add('--repo-root-for-plan-enrichment',
                help='Directory containing the hcl code used to generate a given plan file. Use with -f.',
                dest="repo_root_for_plan_enrichment", action='append')

--- a/docs/2.Basics/CLI Command Reference.md
+++ b/docs/2.Basics/CLI Command Reference.md
@@ -40,7 +40,7 @@ nav_order: 2
 | `--var-file VAR_FILE` | Variable files to load in addition to the default files (see https://www.terraform.io/docs/language/values/variables.html#variable-definitions-tfvars-files).Currently only supported for source Terraform (.tf file), and Helm chart scans.Requires using --directory, not --file. | 
 | `--external-modules-download-path EXTERNAL_MODULES_DOWNLOAD_PATH` | set the path for the download external terraform modules [env var: EXTERNAL_MODULES_DIR] | 
 | `--evaluate-variables EVALUATE_VARIABLES` | evaluate the values of variables and locals | 
-| `-ca CA_CERTIFICATE`, `--ca-certificate CA_CERTIFICATE` | custom CA (bundle) file [env var: CA_CERTIFICATE] | 
+| `-ca CA_CERTIFICATE`, `--ca-certificate CA_CERTIFICATE` | Custom CA certificate (bundle) file [env var: BC_CA_BUNDLE] |
 | `--repo-root-for-plan-enrichment REPO_ROOT_FOR_PLAN_ENRICHMENT` | Directory containing the hcl code used to generate a given plan file. Use with -f. | 
 | `--config-file CONFIG_FILE` | path to the Checkov configuration YAML file | 
 | `--create-config CREATE_CONFIG` | takes the current command line args and writes them out to a config file at the given path


### PR DESCRIPTION
Correct the environment variable used to specify a custom CA certificate bundle.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
