### PR TITLE
Update output description

### DIFF
--- a/checkov/main.py
+++ b/checkov/main.py
@@ -302,7 +302,7 @@ def add_parser_args(parser):
     parser.add('-l', '--list', help='List checks', action='store_true')
     parser.add('-o', '--output', action='append', choices=OUTPUT_CHOICES,
                default=None,
-               help='Report output format. Can be repeated')
+               help='Report output format. Add multiple outputs by using the flag multiple times (-o sarif -o cli)')
     parser.add('--output-bc-ids', action='store_true',
                help='Print Bridgecrew platform IDs (BC...) instead of Checkov IDs (CKV...), if the check exists in the platform')
     parser.add('--no-guide', action='store_true',

--- a/docs/2.Basics/CLI Command Reference.md
+++ b/docs/2.Basics/CLI Command Reference.md
@@ -18,7 +18,7 @@ nav_order: 2
 | `--external-checks-dir EXTERNAL_CHECKS_DIR` | Directory for custom checks to be loaded. Can be repeated. |
 | `--external-checks-git EXTERNAL_CHECKS_GIT` | Github url of external checks to be added. \n you can specify a subdirectory after a double-slash //. \n cannot be used together with --external-checks-dir' |
 | `-l`, `--list` | List checks. |
-| `-o [{cli,cyclonedx,json,junitxml,github_failed_only,sarif}]`, `--output [{cli,cyclonedx,json,junitxml,github_failed_only,sarif}]` | Report output format. |
+| `-o {cli,cyclonedx,json,junitxml,github_failed_only,sarif}`, `--output {cli,cyclonedx,json,junitxml,github_failed_only,sarif}` | Report output format. Add multiple outputs by using the flag multiple times (`-o sarif -o cli`) |
 | `--output-bc-ids` | Print Bridgecrew platform IDs (BC...) instead of Checkov IDs (CKV...), if the check exists in the platform |
 | `--no-guide` | Do not fetch Bridgecrew platform IDs and guidelines for the checkov output report. Note: this prevents Bridgecrew platform check IDs from being used anywhere in the CLI. |
 | `--quiet` | Display only failed checks in CLI output. | [View Scan Results](doc:scan-use-cases#section-view-scan-results) |


### PR DESCRIPTION
The [] brackets by the output implied you could do a list of outputs (-o [sarif,cli]), but the real way to have multiple outputs is multiple flags (-o sarif -o cli)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
