### PR TITLE
fix broken output when provider block is a one-liner

### DIFF
--- a/checkov/common/graph/graph_builder/graph_components/blocks.py
+++ b/checkov/common/graph/graph_builder/graph_components/blocks.py
@@ -39,11 +39,10 @@ class Block:
 
     def _extract_inner_attributes(self) -> Dict[str, Any]:
         attributes_to_add = {}
-        for attribute_key in self.attributes:
-            attribute_value = self.attributes[attribute_key]
+        for attribute_key, attribute_value in self.attributes.items():
             if isinstance(attribute_value, dict) or (
-                    isinstance(attribute_value, list) and len(attribute_value) > 0 and isinstance(attribute_value[0],
-                                                                                                  dict)):
+                isinstance(attribute_value, list) and len(attribute_value) > 0 and isinstance(attribute_value[0], dict)
+            ):
                 inner_attributes = self.get_inner_attributes(
                     attribute_key=attribute_key,
                     attribute_value=attribute_value,

--- a/checkov/terraform/context_parsers/parsers/provider_context_parser.py
+++ b/checkov/terraform/context_parsers/parsers/provider_context_parser.py
@@ -19,9 +19,10 @@ class ProviderContextParser(BaseContextParser):
         # Ignore the alias as it is not part of the signature
         is_provider = super()._is_block_signature(line_num, line_tokens, entity_context_path[0:-1])
         if not is_provider or "=" in line_tokens or line_tokens[0] != "provider":
-            # The line provider = alias is not a provider block although it has the correct words
-            # Also skips comments that include words like provider and aws
-            return False
+            if not all(bracket in line_tokens for bracket in ("{", "}")):
+                # The line provider = alias is not a provider block although it has the correct words
+                # Also skips comments that include words like provider and aws
+                return False
 
         end_line = self._compute_definition_end_line(line_num)
         provider_type = entity_context_path[0]

--- a/checkov/terraform/graph_builder/graph_components/module.py
+++ b/checkov/terraform/graph_builder/graph_components/module.py
@@ -120,16 +120,17 @@ class Module:
 
     def _add_module(self, blocks: List[Dict[str, Dict[str, Any]]], path: str) -> None:
         for module_dict in blocks:
-            for name in module_dict:
-                module_block = TerraformBlock(
-                    block_type=BlockType.MODULE,
-                    name=name,
-                    config=module_dict,
-                    path=path,
-                    attributes=module_dict[name],
-                    source=self.source,
-                )
-                self._add_to_blocks(module_block)
+            for name, attributes in module_dict.items():
+                if isinstance(attributes, dict):
+                    module_block = TerraformBlock(
+                        block_type=BlockType.MODULE,
+                        name=name,
+                        config=module_dict,
+                        path=path,
+                        attributes=attributes,
+                        source=self.source,
+                    )
+                    self._add_to_blocks(module_block)
 
     def _add_resource(self, blocks: List[Dict[str, Dict[str, Any]]], path: str) -> None:
         for resource_dict in blocks:

--- a/tests/terraform/runner/resources/many_providers/main.tf
+++ b/tests/terraform/runner/resources/many_providers/main.tf
@@ -76,3 +76,5 @@ provider "aws" {
   region     = "us-west-2"
   alias      = "us-west-2"
 }
+
+provider "aws" { alias = "one-line" }

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -313,8 +313,13 @@ class TestRunnerValid(unittest.TestCase):
         runner = Runner()
         result = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
                             runner_filter=RunnerFilter(checks='CKV_AWS_41'))
-        self.assertEqual(len(result.passed_checks), 16)
+        self.assertEqual(len(result.passed_checks), 17)
         self.assertIn('aws.default', map(lambda record: record.resource, result.passed_checks))
+
+        # check if a one line provider is correctly processed
+        provider = next(check for check in result.passed_checks if check.resource == "aws.one-line")
+        self.assertIsNotNone(provider.file_line_range)
+
 
     def test_terraform_module_checks_are_performed(self):
         check_name = "TF_M_1"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

in case a provider is written as a one-liner `checkov` crashes when outputting the result.