### PR TITLE
Fix and/or order in SecurityGroupRuleDescription.py

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/SecurityGroupRuleDescription.py
+++ b/checkov/cloudformation/checks/resource/aws/SecurityGroupRuleDescription.py
@@ -25,7 +25,7 @@ class SecurityGroupRuleDescription(BaseResourceCheck):
                             return CheckResult.FAILED
                 if 'SecurityGroupEgress' in conf['Properties']:
                     for rule in conf['Properties']['SecurityGroupEgress']:
-                        if isinstance(rule, dict) and 'Description' not in rule.keys() or not rule['Description']:
+                        if isinstance(rule, dict) and ('Description' not in rule.keys() or not rule['Description']):
                             return CheckResult.FAILED
                 return CheckResult.PASSED
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Without the parenthesis, the `or` condition would still run even if `rule` is not a dict. This fixes it
