### PR TITLE
revert setup-helm GH Action to v1 for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - uses: actions/setup-node@v2
-      - uses: azure/setup-helm@v2.0
+      - uses: azure/setup-helm@v1
       - uses: dschep/install-pipenv-action@v1
         with:
           # version 2021.11.5, 2021.11.5.post0 do not work

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - uses: actions/setup-node@v2
-      - uses: azure/setup-helm@v2.0
+      - uses: azure/setup-helm@v1
       - uses: imranismail/setup-kustomize@v1
         if: ${{ runner.os != 'windows' }}
       - uses: dschep/install-pipenv-action@v1
@@ -110,7 +110,7 @@ jobs:
         with:
           python-version: ${{ env.python-version }}
       - uses: actions/setup-node@v2
-      - uses: azure/setup-helm@v2.0
+      - uses: azure/setup-helm@v1
       - uses: imranismail/setup-kustomize@v1
       - uses: dschep/install-pipenv-action@v1
       - name: Build & install checkov package


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

MacOS builds are failing due to 403. https://github.com/Azure/setup-helm/issues/59
