### PR TITLE
Add user agent to HTTP requests headers

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -131,8 +131,7 @@ class BcPlatformIntegration(object):
         if ca_certificate:
             os.environ['REQUESTS_CA_BUNDLE'] = ca_certificate
             try:
-                self.http = urllib3.ProxyManager(os.environ['https_proxy'], cert_reqs='REQUIRED',
-                                                 ca_certs=ca_certificate)
+                self.http = urllib3.ProxyManager(os.environ['https_proxy'], cert_reqs='REQUIRED', ca_certs=ca_certificate)
             except KeyError:
                 self.http = urllib3.PoolManager(cert_reqs='REQUIRED', ca_certs=ca_certificate)
         else:
@@ -208,8 +207,7 @@ class BcPlatformIntegration(object):
             if 'Message' in response and response['Message'] == UNAUTHORIZED_MESSAGE:
                 raise BridgecrewAuthError()
             if 'message' in response and ASSUME_ROLE_UNUATHORIZED_MESSAGE in response['message']:
-                raise BridgecrewAuthError(
-                    "Checkov got an unexpected authorization error that may not be due to your credentials. Please contact support.")
+                raise BridgecrewAuthError("Checkov got an unexpected authorization error that may not be due to your credentials. Please contact support.")
             if 'message' in response and "cannot be found" in response['message']:
                 self.loading_output("creating role")
                 request = self.http.request("POST", self.integrations_api_url, body=json.dumps({"repoId": repo_id}),
@@ -325,8 +323,7 @@ class BcPlatformIntegration(object):
                     logging.info(f"Finalize repository {self.repo_id} in bridgecrew's platform")
                 elif try_num < MAX_RETRIES and re.match('The integration ID .* in progress',
                                                         response.get('message', '')):
-                    logging.info(
-                        f"Failed to persist for repo {self.repo_id}, sleeping for {SLEEP_SECONDS} seconds before retrying")
+                    logging.info(f"Failed to persist for repo {self.repo_id}, sleeping for {SLEEP_SECONDS} seconds before retrying")
                     try_num += 1
                     sleep(SLEEP_SECONDS)
                 else:

--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -43,7 +43,7 @@ def get_version_headers(client, client_version):
 
 
 def get_user_agent_header():
-    return {'User-Agent': 'Mozilla/5.0 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36'}
+    return {'User-Agent': f'checkov/{checkov_version}'}
 
 
 def get_default_get_headers(client: SourceType, client_version: str):

--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -47,8 +47,8 @@ def get_user_agent_header():
 
 
 def get_default_get_headers(client: SourceType, client_version: str):
-    return merge_dicts(DEV_API_GET_HEADERS, get_version_headers(client.name, client_version))
+    return merge_dicts(DEV_API_GET_HEADERS, get_version_headers(client.name, client_version), get_user_agent_header())
 
 
 def get_default_post_headers(client: SourceType, client_version: str):
-    return merge_dicts(DEV_API_POST_HEADERS, get_version_headers(client.name, client_version))
+    return merge_dicts(DEV_API_POST_HEADERS, get_version_headers(client.name, client_version), get_user_agent_header())

--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -42,6 +42,10 @@ def get_version_headers(client, client_version):
     }
 
 
+def get_user_agent_header():
+    return {'User-Agent': 'Mozilla/5.0 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36'}
+
+
 def get_default_get_headers(client: SourceType, client_version: str):
     return merge_dicts(DEV_API_GET_HEADERS, get_version_headers(client.name, client_version))
 

--- a/checkov/common/vcs/base_vcs_dal.py
+++ b/checkov/common/vcs/base_vcs_dal.py
@@ -5,6 +5,9 @@ from abc import abstractmethod
 
 import urllib3
 
+from checkov.common.util.data_structures_utils import merge_dicts
+from checkov.common.util.http_utils import get_user_agent_header
+
 
 class BaseVCSDAL:
     def __init__(self):
@@ -63,8 +66,8 @@ class BaseVCSDAL:
 
     @abstractmethod
     def _headers(self):
-        return {"Accept": "application/vnd.github.v3+json",
-                "Authorization": "token {}".format(self.token)}
+        return merge_dicts({"Accept": "application/vnd.github.v3+json",
+                "Authorization": "token {}".format(self.token)}, get_user_agent_header())
 
     def _graphql_headers(self):
         return {


### PR DESCRIPTION
Extracted the `User-Agent` from the `SIGNUP_HEADER` and created a method in `http_utils` that retrieve this header.

Then we can merge existing headers with this `User-Agent` header.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
