### PR TITLE
remove pipenv version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,6 @@ jobs:
       - uses: actions/setup-node@v2
       - uses: azure/setup-helm@v1
       - uses: dschep/install-pipenv-action@v1
-        with:
-          # version 2021.11.5, 2021.11.5.post0 do not work
-          version: 2021.5.29
       - uses: imranismail/setup-kustomize@v1
         if: ${{ runner.os != 'windows' }}
       - name: Build & install checkov package
@@ -67,9 +64,6 @@ jobs:
         with:
           python-version: 3.7
       - uses: dschep/install-pipenv-action@v1
-        with:
-          # version 2021.11.5, 2021.11.5.post0 do not work
-          version: 2021.5.29
       - name: Clone Terragoat - vulnerable terraform
         run: git clone https://github.com/bridgecrewio/terragoat
       - name: Build & install checkov package
@@ -97,8 +91,6 @@ jobs:
         with:
           python-version: 3.7
       - uses: dschep/install-pipenv-action@v1
-        with:
-          version: 2021.5.29
       - name: Install dependencies
         run: |
           pipenv --python 3.7
@@ -126,8 +118,6 @@ jobs:
         with:
           python-version: 3.7
       - uses: dschep/install-pipenv-action@v1
-        with:
-          version: 2021.5.29
       - name: Install dependencies
         run: |
           pipenv --python 3.7
@@ -209,9 +199,6 @@ jobs:
         with:
           python-version: 3.7
       - uses: dschep/install-pipenv-action@v1
-        with:
-          # version 2021.11.5, 2021.11.5.post0 do not work
-          version: 2021.5.29
       - name: Install dependencies
         run: |
           pipenv --python 3.7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,9 @@ jobs:
           python-version: ${{ matrix.python }}
       - uses: actions/setup-node@v2
       - uses: azure/setup-helm@v1
-      - uses: dschep/install-pipenv-action@v1
+      - name: Install pipenv
+        run: |
+          python -m pip install --no-cache-dir --upgrade pipenv
       - uses: imranismail/setup-kustomize@v1
         if: ${{ runner.os != 'windows' }}
       - name: Build & install checkov package
@@ -63,7 +65,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - uses: dschep/install-pipenv-action@v1
+      - name: Install pipenv
+        run: |
+          python -m pip install --no-cache-dir --upgrade pipenv
       - name: Clone Terragoat - vulnerable terraform
         run: git clone https://github.com/bridgecrewio/terragoat
       - name: Build & install checkov package
@@ -90,7 +94,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - uses: dschep/install-pipenv-action@v1
+      - name: Install pipenv
+        run: |
+          python -m pip install --no-cache-dir --upgrade pipenv
       - name: Install dependencies
         run: |
           pipenv --python 3.7
@@ -117,7 +123,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - uses: dschep/install-pipenv-action@v1
+      - name: Install pipenv
+        run: |
+          python -m pip install --no-cache-dir --upgrade pipenv
       - name: Install dependencies
         run: |
           pipenv --python 3.7
@@ -198,7 +206,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - uses: dschep/install-pipenv-action@v1
+      - name: Install pipenv
+        run: |
+          python -m pip install --no-cache-dir --upgrade pipenv
       - name: Install dependencies
         run: |
           pipenv --python 3.7

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -21,7 +21,9 @@ jobs:
         with:
           python-version: 3.7
       - uses: imranismail/setup-kustomize@v1
-      - uses: dschep/install-pipenv-action@v1
+      - name: Install pipenv
+        run: |
+          python -m pip install --no-cache-dir --upgrade pipenv
       - name: Install dependencies
         run: |
           pipenv --python 3.7

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,8 +22,6 @@ jobs:
           python-version: 3.7
       - uses: imranismail/setup-kustomize@v1
       - uses: dschep/install-pipenv-action@v1
-        with:
-          version: 2021.5.29
       - name: Install dependencies
         run: |
           pipenv --python 3.7

--- a/.github/workflows/pipenv-update.yml
+++ b/.github/workflows/pipenv-update.yml
@@ -20,7 +20,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - uses: dschep/install-pipenv-action@v1
+      - name: Install pipenv
+        run: |
+          python -m pip install --no-cache-dir --upgrade pipenv
       - run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"

--- a/.github/workflows/pipenv-update.yml
+++ b/.github/workflows/pipenv-update.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           python-version: 3.7
       - uses: dschep/install-pipenv-action@v1
-        with:
-          # version 2021.11.5, 2021.11.5.post0 do not work
-          version: 2021.5.29
       - run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -41,9 +41,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - uses: dschep/install-pipenv-action@v1
-        with:
-          # version 2021.11.5, 2021.11.5.post0 do not work
-          version: 2021.5.29
       - name: Install dependencies
         run: |
           pipenv --python ${{ matrix.python }}
@@ -72,9 +69,6 @@ jobs:
       - uses: imranismail/setup-kustomize@v1
         if: ${{ runner.os != 'windows' }}
       - uses: dschep/install-pipenv-action@v1
-        with:
-          # version 2021.11.5, 2021.11.5.post0 do not work
-          version: 2021.5.29
       - name: Build & install checkov package
         run: |
           pipenv --python ${{ matrix.python }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -40,7 +40,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - uses: dschep/install-pipenv-action@v1
+      - name: Install pipenv
+        run: |
+          python -m pip install --no-cache-dir --upgrade pipenv
       - name: Install dependencies
         run: |
           pipenv --python ${{ matrix.python }}
@@ -68,7 +70,9 @@ jobs:
       - uses: azure/setup-helm@v1
       - uses: imranismail/setup-kustomize@v1
         if: ${{ runner.os != 'windows' }}
-      - uses: dschep/install-pipenv-action@v1
+      - name: Install pipenv
+        run: |
+          python -m pip install --no-cache-dir --upgrade pipenv
       - name: Build & install checkov package
         run: |
           pipenv --python ${{ matrix.python }}
@@ -106,7 +110,9 @@ jobs:
       - uses: actions/setup-node@v2
       - uses: azure/setup-helm@v1
       - uses: imranismail/setup-kustomize@v1
-      - uses: dschep/install-pipenv-action@v1
+      - name: Install pipenv
+        run: |
+          python -m pip install --no-cache-dir --upgrade pipenv
       - name: Build & install checkov package
         run: |
           pipenv --python ${{ env.python-version }}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

replace the outdated pipenv action by just installing it manually, looks like that installing `pipenv` changed with new Win Server version 2022. Other actions in the marketplace are doing the same, so I don't see any need to use them at the moment.