### PR TITLE
let CKV2_AWS_28 pass when nlb or gateway lb

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/ALBProtectedByWAF.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/ALBProtectedByWAF.yaml
@@ -32,5 +32,12 @@ definition:
         - aws_lb
         - aws_alb
         operator: equals
-       
-        
+      - cond_type: attribute
+        resource_types:
+        - aws_lb
+        - aws_alb
+        attribute: load_balancer_type
+        operator: within
+        value:
+          - network
+          - gateway

--- a/tests/terraform/graph/checks/resources/ALBProtectedByWAF/expected.yaml
+++ b/tests/terraform/graph/checks/resources/ALBProtectedByWAF/expected.yaml
@@ -3,6 +3,8 @@ pass:
   - "aws_lb.lb_good_2"
   - "aws_lb.ignore"
   - "aws_alb.alb_good_1"
+  - "aws_lb.network"
+  - "aws_lb.gateway"
 fail:
   - "aws_lb.lb_bad_1"
   - "aws_lb.lb_bad_2"

--- a/tests/terraform/graph/checks/resources/ALBProtectedByWAF/main.tf
+++ b/tests/terraform/graph/checks/resources/ALBProtectedByWAF/main.tf
@@ -43,3 +43,21 @@ resource "aws_lb" "lb_bad_2" {
 resource "aws_alb" "alb_bad_1" {
   internal=false
 }
+
+// NLB or Gateway LB can't have a WAF associated
+
+resource "aws_lb" "network" {
+  internal           = false
+  load_balancer_type = "network"
+  name               = "nlb"
+  subnets            = var.public_subnet_ids
+}
+
+resource "aws_lb" "gateway" {
+  load_balancer_type = "gateway"
+  name               = "glb"
+
+  subnet_mapping {
+    subnet_id = var.subnet_id
+  }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #2326 

NLBs and Gateway LBs can't have a WAF associated with.