### PR TITLE
AZURE TF Check - CKV_AZURE_136

### DIFF
--- a/checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py
+++ b/checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py
@@ -4,7 +4,7 @@ from checkov.terraform.checks.resource.base_resource_value_check import BaseReso
 
 class PostgreSQLFlexiServerGeoBackupEnabled(BaseResourceValueCheck):
     def __init__(self):
-        name = "Ensure that PostgreSQL Flexi server enables geo-redundant backups"
+        name = "Ensure that PostgreSQL Flexible server enables geo-redundant backups"
         id = "CKV_AZURE_136"
         supported_resources = ['azurerm_postgresql_flexible_server']
         categories = [CheckCategories.BACKUP_AND_RECOVERY]

--- a/checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py
+++ b/checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py
@@ -5,7 +5,7 @@ from checkov.terraform.checks.resource.base_resource_value_check import BaseReso
 class PostgreSQLFlexiServerGeoBackupEnabled(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure that PostgreSQL Flexi server enables geo-redundant backups"
-        id = "CKV_AZURE_789"
+        id = "CKV_AZURE_136"
         supported_resources = ['azurerm_postgresql_flexible_server']
         categories = [CheckCategories.BACKUP_AND_RECOVERY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py
+++ b/checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py
@@ -1,0 +1,17 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class PostgreSQLFlexiServerGeoBackupEnabled(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure that PostgreSQL Flexi server enables geo-redundant backups"
+        id = "CKV_AZURE_789"
+        supported_resources = ['azurerm_postgresql_flexible_server']
+        categories = [CheckCategories.BACKUP_AND_RECOVERY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'geo_redundant_backup_enabled'
+
+
+check = PostgreSQLFlexiServerGeoBackupEnabled()

--- a/tests/terraform/checks/resource/azure/example_PostgreSQLFlexiServerGeoBackupEnabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_PostgreSQLFlexiServerGeoBackupEnabled/main.tf
@@ -1,0 +1,61 @@
+# pass
+
+resource "azurerm_postgresql_flexible_server" "pass" {
+  name                   = "example-psqlflexibleserver"
+  resource_group_name    = "azurerm_resource_group.example.name"
+  location               = "azurerm_resource_group.example.location"
+  version                = "12"
+  delegated_subnet_id    = "azurerm_subnet.example.id"
+  private_dns_zone_id    = "azurerm_private_dns_zone.example.id"
+  administrator_login    = "psqladmin"
+  administrator_password = "H@Sh1CoR3!"
+  zone                   = "1"
+
+  storage_mb                   = 32768
+  geo_redundant_backup_enabled = true
+
+  sku_name   = "GP_Standard_D4s_v3"
+  depends_on = ["azurerm_private_dns_zone_virtual_network_link.example"]
+
+}
+
+# fail
+
+resource "azurerm_postgresql_flexible_server" "fail1" {
+  name                   = "example-psqlflexibleserver"
+  resource_group_name    = "azurerm_resource_group.example.name"
+  location               = "azurerm_resource_group.example.location"
+  version                = "12"
+  delegated_subnet_id    = "azurerm_subnet.example.id"
+  private_dns_zone_id    = "azurerm_private_dns_zone.example.id"
+  administrator_login    = "psqladmin"
+  administrator_password = "H@Sh1CoR3!"
+  zone                   = "1"
+
+  storage_mb                   = 32768
+  geo_redundant_backup_enabled = false
+
+  sku_name   = "GP_Standard_D4s_v3"
+  depends_on = ["azurerm_private_dns_zone_virtual_network_link.example"]
+
+}
+
+resource "azurerm_postgresql_flexible_server" "fail2" {
+  name                   = "example-psqlflexibleserver"
+  resource_group_name    = "azurerm_resource_group.example.name"
+  location               = "azurerm_resource_group.example.location"
+  version                = "12"
+  delegated_subnet_id    = "azurerm_subnet.example.id"
+  private_dns_zone_id    = "azurerm_private_dns_zone.example.id"
+  administrator_login    = "psqladmin"
+  administrator_password = "H@Sh1CoR3!"
+  zone                   = "1"
+
+  storage_mb = 32768
+
+  sku_name   = "GP_Standard_D4s_v3"
+  depends_on = ["azurerm_private_dns_zone_virtual_network_link.example"]
+
+}
+
+

--- a/tests/terraform/checks/resource/azure/test_PostgreSQLFlexiServerGeoBackupEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_PostgreSQLFlexiServerGeoBackupEnabled.py
@@ -1,0 +1,87 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.azure.PostgreSQLFlexiServerGeoBackupEnabled import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestPostgressSQLGeoBackupEnabled(unittest.TestCase):
+
+    def test_failure_1(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_postgresql_flexible_server" "example" {
+              name                   = "example-psqlflexibleserver"
+              resource_group_name    = azurerm_resource_group.example.name
+              location               = azurerm_resource_group.example.location
+              version                = "12"
+              delegated_subnet_id    = azurerm_subnet.example.id
+              private_dns_zone_id    = azurerm_private_dns_zone.example.id
+              administrator_login    = "psqladmin"
+              administrator_password = "H@Sh1CoR3!"
+              zone                   = "1"
+            
+              storage_mb = 32768
+              geo_redundant_backup_enabled = false
+            
+              sku_name   = "GP_Standard_D4s_v3"
+              depends_on = [azurerm_private_dns_zone_virtual_network_link.example]
+            
+            }
+        """)
+        resource_conf = hcl_res['resource'][0]['azurerm_postgresql_flexible_server']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_2(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_postgresql_flexible_server" "example" {
+              name                   = "example-psqlflexibleserver"
+              resource_group_name    = azurerm_resource_group.example.name
+              location               = azurerm_resource_group.example.location
+              version                = "12"
+              delegated_subnet_id    = azurerm_subnet.example.id
+              private_dns_zone_id    = azurerm_private_dns_zone.example.id
+              administrator_login    = "psqladmin"
+              administrator_password = "H@Sh1CoR3!"
+              zone                   = "1"
+            
+              storage_mb = 32768
+            
+              sku_name   = "GP_Standard_D4s_v3"
+              depends_on = [azurerm_private_dns_zone_virtual_network_link.example]
+            
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_postgresql_flexible_server']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_postgresql_flexible_server" "example" {
+              name                   = "example-psqlflexibleserver"
+              resource_group_name    = azurerm_resource_group.example.name
+              location               = azurerm_resource_group.example.location
+              version                = "12"
+              delegated_subnet_id    = azurerm_subnet.example.id
+              private_dns_zone_id    = azurerm_private_dns_zone.example.id
+              administrator_login    = "psqladmin"
+              administrator_password = "H@Sh1CoR3!"
+              zone                   = "1"
+            
+              storage_mb = 32768
+              geo_redundant_backup_enabled = true
+            
+              sku_name   = "GP_Standard_D4s_v3"
+              depends_on = [azurerm_private_dns_zone_virtual_network_link.example]
+            
+            }
+                """)
+        resource_conf = hcl_res['resource'][0]['azurerm_postgresql_flexible_server']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/azure/test_PostgreSQLFlexiServerGeoBackupEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_PostgreSQLFlexiServerGeoBackupEnabled.py
@@ -1,86 +1,42 @@
 import unittest
+from pathlib import Path
 
-import hcl2
-
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.azure.PostgreSQLFlexiServerGeoBackupEnabled import check
-from checkov.common.models.enums import CheckResult
+from checkov.terraform.runner import Runner
 
 
 class TestPostgreSQLFlexiServerGeoBackupEnabled(unittest.TestCase):
 
-    def test_failure_1(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_postgresql_flexible_server" "example" {
-              name                   = "example-psqlflexibleserver"
-              resource_group_name    = azurerm_resource_group.example.name
-              location               = azurerm_resource_group.example.location
-              version                = "12"
-              delegated_subnet_id    = azurerm_subnet.example.id
-              private_dns_zone_id    = azurerm_private_dns_zone.example.id
-              administrator_login    = "psqladmin"
-              administrator_password = "H@Sh1CoR3!"
-              zone                   = "1"
-            
-              storage_mb = 32768
-              geo_redundant_backup_enabled = false
-            
-              sku_name   = "GP_Standard_D4s_v3"
-              depends_on = [azurerm_private_dns_zone_virtual_network_link.example]
-            
-            }
-        """)
-        resource_conf = hcl_res['resource'][0]['azurerm_postgresql_flexible_server']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_PostgreSQLFlexiServerGeoBackupEnabled"
 
-    def test_failure_2(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_postgresql_flexible_server" "example" {
-              name                   = "example-psqlflexibleserver"
-              resource_group_name    = azurerm_resource_group.example.name
-              location               = azurerm_resource_group.example.location
-              version                = "12"
-              delegated_subnet_id    = azurerm_subnet.example.id
-              private_dns_zone_id    = azurerm_private_dns_zone.example.id
-              administrator_login    = "psqladmin"
-              administrator_password = "H@Sh1CoR3!"
-              zone                   = "1"
-            
-              storage_mb = 32768
-            
-              sku_name   = "GP_Standard_D4s_v3"
-              depends_on = [azurerm_private_dns_zone_virtual_network_link.example]
-            
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_postgresql_flexible_server']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
 
-    def test_success(self):
-        hcl_res = hcl2.loads("""
-            resource "azurerm_postgresql_flexible_server" "example" {
-              name                   = "example-psqlflexibleserver"
-              resource_group_name    = azurerm_resource_group.example.name
-              location               = azurerm_resource_group.example.location
-              version                = "12"
-              delegated_subnet_id    = azurerm_subnet.example.id
-              private_dns_zone_id    = azurerm_private_dns_zone.example.id
-              administrator_login    = "psqladmin"
-              administrator_password = "H@Sh1CoR3!"
-              zone                   = "1"
-            
-              storage_mb = 32768
-              geo_redundant_backup_enabled = true
-            
-              sku_name   = "GP_Standard_D4s_v3"
-              depends_on = [azurerm_private_dns_zone_virtual_network_link.example]
-            
-            }
-                """)
-        resource_conf = hcl_res['resource'][0]['azurerm_postgresql_flexible_server']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "azurerm_postgresql_flexible_server.pass",
+        }
+        failing_resources = {
+            "azurerm_postgresql_flexible_server.fail1",
+            "azurerm_postgresql_flexible_server.fail2",
+
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
 if __name__ == '__main__':

--- a/tests/terraform/checks/resource/azure/test_PostgreSQLFlexiServerGeoBackupEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_PostgreSQLFlexiServerGeoBackupEnabled.py
@@ -6,7 +6,7 @@ from checkov.terraform.checks.resource.azure.PostgreSQLFlexiServerGeoBackupEnabl
 from checkov.common.models.enums import CheckResult
 
 
-class TestPostgressSQLGeoBackupEnabled(unittest.TestCase):
+class TestPostgreSQLFlexiServerGeoBackupEnabled(unittest.TestCase):
 
     def test_failure_1(self):
         hcl_res = hcl2.loads("""


### PR DESCRIPTION
Hello,

Implementing check for Azure PostgreSQL FlexiServer GeoBackup Enabled in terraform.

 Terraform Docs:
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server

Note:

If we have not pass the "geo_redundant_backup_enabled" argument in terraform then the check fails, as by default it will not provide backup facility.

If we have pass the "geo_redundant_backup_enabled" argument in terraform with value "false" in terraform template then the check fails, means we have turned off the backup facility.

If we have pass the "geo_redundant_backup_enabled" argument in terraform with value "true" in terraform template then the check passed, means we have turned on the backup facility.

License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.