### PR TITLE
adjust module dep number assignment

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -147,8 +147,9 @@ class TerraformLocalGraph(LocalGraph):
                             dest_module_version=module_version
                         )
                         if dest_module_path == dir_name:
-                            module_dependency_num = self.module.module_address_map[(module_vertex.path, module_vertex.name)]
-                            block_dirs_to_modules[(dir_name, path_to_module_str)].setdefault(module_dependency_num, set()).add(module_index)
+                            module_dependency_num = self.module.module_address_map.get((module_vertex.path, module_vertex.name))
+                            if module_dependency_num:
+                                block_dirs_to_modules[(dir_name, path_to_module_str)].setdefault(module_dependency_num, set()).add(module_index)
 
         for vertex in self.vertices:
             # match the right module vertex according to the vertex path directory


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #2288

This somehow happens, when a relative recursive path is used for a module and also other external modules are used, which were not downloaded. Had to debug it via the good old way of adding `print` statements into the installed lib 🙈 😄 that's why I didn't add any test.