### PR TITLE
Add tf plan ref

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -3,6 +3,7 @@ import itertools
 import json
 import sys
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import List, Dict, Union, Any, Optional, Set
 
@@ -57,7 +58,7 @@ class Report:
         self.parsing_errors: List[str] = []
         self.resources: Set[str] = set()
 
-    def add_parsing_errors(self, errors: List[str]) -> None:
+    def add_parsing_errors(self, errors: "Iterable[str]") -> None:
         for file in errors:
             self.add_parsing_error(file)
 

--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -1,8 +1,8 @@
 import itertools
 from typing import Optional, Tuple, Dict, List, Any
 
-from checkov.terraform.context_parsers.tf_plan import parse
 from checkov.common.parsers.node import DictNode, ListNode
+from checkov.terraform.context_parsers.tf_plan import parse
 
 simple_types = (str, int, float, bool)
 
@@ -64,10 +64,16 @@ def _hclify(obj: DictNode, conf: Optional[DictNode] = None, parent_key: Optional
             else:
                 ret_dict[key] = [child_dict]
     if conf and isinstance(conf, dict):
+        found_ref = False
         for conf_key in conf.keys() - obj.keys():
             ref = next((x for x in conf[conf_key].get("references", []) if not x.startswith(("var.", "local."))), None)
             if ref:
                 ret_dict[conf_key] = [ref]
+                found_ref = True
+        if not found_ref:
+            for value in conf.values():
+                if isinstance(value, dict) and "references" in value.keys():
+                    ret_dict["references_"] = value["references"]
 
     return ret_dict
 

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from typing import Optional, List
 
 from checkov.common.checks_infra.registry import get_graph_checks_registry
 from checkov.common.graph.graph_builder.graph_components.attribute_names import CustomAttributes
@@ -27,8 +28,14 @@ class Runner(TerraformRunner):
         'resource': resource_registry,
     }
 
-    def run(self, root_folder=None, external_checks_dir=None, files=None, runner_filter=RunnerFilter(),
-            collect_skip_comments=True):
+    def run(
+        self,
+        root_folder: Optional[str] = None,
+        external_checks_dir: Optional[List[str]] = None,
+        files: Optional[List[str]] = None,
+        runner_filter: RunnerFilter = RunnerFilter(),
+        collect_skip_comments: bool = True
+    ) -> Report:
         report = Report(self.check_type)
         self.tf_definitions = {}
         parsing_errors = {}
@@ -68,7 +75,7 @@ class Runner(TerraformRunner):
                 else:
                     logging.debug(f'Failed to load {file} as is not a .json file, skipping')
 
-        report.add_parsing_errors(list(parsing_errors.keys()))
+        report.add_parsing_errors(parsing_errors.keys())
 
         if self.tf_definitions:
             graph = self.graph_manager.build_graph_from_definitions(self.tf_definitions, render_variables=False)

--- a/tests/terraform/runner/resources/plan_with_resource_reference/tfplan_graph.json
+++ b/tests/terraform/runner/resources/plan_with_resource_reference/tfplan_graph.json
@@ -1,0 +1,196 @@
+{
+  "format_version": "0.2",
+  "terraform_version": "1.0.11",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_s3_bucket.example",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "example",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "arn": "arn:aws:s3:::example",
+            "bucket": "example",
+            "bucket_domain_name": "example.s3.amazonaws.com",
+            "bucket_regional_domain_name": "example.s3.amazonaws.com",
+            "id": "example",
+            "object_lock_configuration": [
+              {
+                "object_lock_enabled": "Enabled",
+                "rule": [
+                  {
+                    "default_retention": [
+                      {
+                        "days": 7,
+                        "mode": "COMPLIANCE",
+                        "years": 0
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ]
+          },
+          "sensitive_values": {
+            "object_lock_configuration": [
+              {
+                "rule": [
+                  {
+                    "default_retention": [
+                      {}
+                    ]
+                  }
+                ]
+              }
+            ],
+            "replication_configuration": [],
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {}
+                    ]
+                  }
+                ]
+              }
+            ],
+            "versioning": [
+              {}
+            ]
+          }
+        },
+        {
+          "address": "aws_s3_bucket_public_access_block.example",
+          "mode": "managed",
+          "type": "aws_s3_bucket_public_access_block",
+          "name": "example",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "bucket": "example",
+            "id": "example",
+            "ignore_public_acls": true,
+            "restrict_public_buckets": true
+          },
+          "sensitive_values": {}
+        }
+      ]
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "version_constraint": "~> 3.50.0"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_s3_bucket.example",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "example",
+          "provider_config_key": "aws",
+          "expressions": {
+            "acl": {
+              "constant_value": "log-delivery-write"
+            },
+            "bucket": {
+              "constant_value": "example"
+            },
+            "object_lock_configuration": [
+              {
+                "object_lock_enabled": {
+                  "constant_value": "Enabled"
+                },
+                "rule": [
+                  {
+                    "default_retention": [
+                      {
+                        "days": {
+                          "constant_value": 7
+                        },
+                        "mode": {
+                          "constant_value": "COMPLIANCE"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "sse_algorithm": {
+                          "references": [
+                            "var.s3_defaults.sse_algorithm",
+                            "var.s3_defaults"
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_s3_bucket_public_access_block.example",
+          "mode": "managed",
+          "type": "aws_s3_bucket_public_access_block",
+          "name": "example",
+          "provider_config_key": "aws",
+          "expressions": {
+            "block_public_acls": {
+              "constant_value": true
+            },
+            "block_public_policy": {
+              "constant_value": true
+            },
+            "bucket": {
+              "references": [
+                "aws_s3_bucket.example.id",
+                "aws_s3_bucket.example"
+              ]
+            },
+            "ignore_public_acls": {
+              "constant_value": true
+            },
+            "restrict_public_buckets": {
+              "constant_value": true
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -316,6 +316,25 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.get_summary()["failed"], 0)
         self.assertEqual(report.get_summary()["passed"], 1)
 
+    def test_runner_with_resource_reference_graph_check(self):
+        # given
+        valid_plan_path = Path(__file__).parent / "resources/plan_with_resource_reference/tfplan_graph.json"
+        allowed_checks = ["CKV2_AWS_6"]
+
+        # when
+        report = Runner().run(
+            root_folder=None,
+            files=[str(valid_plan_path)],
+            external_checks_dir=None,
+            runner_filter=RunnerFilter(framework=["terraform_plan"], checks=allowed_checks),
+        )
+
+        # then
+        summary = report.get_summary()
+
+        self.assertEqual(summary["failed"], 0)
+        self.assertEqual(summary["passed"], 1)
+
     def test_runner_skip_graph_when_no_plan_exists(self):
         # given
         tf_file_path = Path(__file__).parent / "resource/example/example.tf"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #2327

I added an extra attribute for the references, which are only available in a TF plan. This is then leveraged for the graph checks to make the connection. The previous approach only added missing attributes and now it will add a reference if available.