### PR TITLE
Fix branch protection endpoint

### DIFF
--- a/checkov/github/dal.py
+++ b/checkov/github/dal.py
@@ -42,7 +42,7 @@ class Github(BaseVCSDAL):
     def get_branch_protection_rules(self):
         if self.current_branch and self.current_repository:
             branch_protection_rules = self._request(
-                endpoint="/repos/{}/branches/{}/protection".format(self.current_repository, self.current_branch))
+                endpoint="repos/{}/branches/{}/protection".format(self.current_repository, self.current_branch))
             return branch_protection_rules
         return None
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

There was a redundant `/` in the github api endpoint for branch protection and it always return 404