### PR TITLE
Fix colored example

### DIFF
--- a/docs/4.Integrations/GitLab CI.md
+++ b/docs/4.Integrations/GitLab CI.md
@@ -95,11 +95,6 @@ checkov:
     # Use `script` to emulate `tty` for colored output.
     - script -q -c 'checkov -d . ; echo $? > CKVEXIT'
     - exit $(cat CKVEXIT)
-  artifacts:
-    reports:
-      junit: "checkov.test.xml"
-    paths:
-      - "checkov.test.xml"
 ```
 
 See the [GitLab CI documentation](https://docs.gitlab.com/ee/ci/) for additional information.


### PR DESCRIPTION
The colored example does not generate a junit xml file. Uploading the artifact will fail for this pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
