### PR TITLE
Only validate api_server_authorized_ip_ranges if cluster is not private

### DIFF
--- a/checkov/terraform/checks/resource/azure/AKSApiServerAuthorizedIpRanges.py
+++ b/checkov/terraform/checks/resource/azure/AKSApiServerAuthorizedIpRanges.py
@@ -1,7 +1,7 @@
 from typing import List, Any
 
 from checkov.common.models.consts import ANY_VALUE
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
@@ -19,5 +19,11 @@ class AKSApiServerAuthorizedIpRanges(BaseResourceValueCheck):
     def get_expected_values(self) -> List[Any]:
         return [ANY_VALUE]
 
+    def scan_resource_conf(self, conf):
+        # can't be set for private cluster
+        private_cluster_enabled = conf.get('private_cluster_enabled',[False])[0]
+        if private_cluster_enabled:
+            return CheckResult.PASSED
+        return super().scan_resource_conf(conf)
 
 check = AKSApiServerAuthorizedIpRanges()

--- a/tests/terraform/checks/resource/azure/example_AKSApiServerAuthorizedIpRanges/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AKSApiServerAuthorizedIpRanges/main.tf
@@ -19,6 +19,25 @@ resource "azurerm_kubernetes_cluster" "enabled" {
   api_server_authorized_ip_ranges = ["192.168.0.0/16"]
 }
 
+resource "azurerm_kubernetes_cluster" "private" {
+  name                = "example"
+  location            = "azurerm_resource_group.example.location"
+  resource_group_name = "azurerm_resource_group.example.name"
+  dns_prefix          = "example"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  private_cluster_enabled = true
+}
+
 # fail
 
 resource "azurerm_kubernetes_cluster" "default" {

--- a/tests/terraform/checks/resource/azure/test_AKSApiServerAuthorizedIpRanges.py
+++ b/tests/terraform/checks/resource/azure/test_AKSApiServerAuthorizedIpRanges.py
@@ -19,6 +19,7 @@ class TestAKSApiServerAuthorizedIpRanges(unittest.TestCase):
 
         passing_resources = {
             "azurerm_kubernetes_cluster.enabled",
+            "azurerm_kubernetes_cluster.private"
         }
 
         failing_resources = {
@@ -29,7 +30,7 @@ class TestAKSApiServerAuthorizedIpRanges(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["passed"], 2)
         self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)


### PR DESCRIPTION
The api_server_authorized_ip_ranges can and should only be set if private_cluster_enabled is false. Azure won't allow setting the api_server_authorized_ip_ranges if the cluster is private.

*This is my first experience with writing a policy, any notes or approvements are welcome!*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
