### PR TITLE
add extra info to the report and add flag to enable package.json scan

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -7,7 +7,7 @@ from concurrent import futures
 from json import JSONDecodeError
 from os import path
 from time import sleep
-from typing import Optional, Dict
+from typing import Dict
 
 import boto3
 import dpath.util
@@ -97,6 +97,7 @@ class BcPlatformIntegration(object):
         self.http = None
         self.excluded_paths = []
         self.bc_skip_mapping = False
+        self.cicd_details = {}
 
     @staticmethod
     def is_bc_token(token: str) -> bool:

--- a/checkov/common/bridgecrew/vulnerability_scanning/integrations/docker_image_scanning.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/integrations/docker_image_scanning.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Dict, Any
 from datetime import datetime, timedelta
 
-from checkov.common.bridgecrew.platform_integration import bc_integration, BcPlatformIntegration
+from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.bridgecrew.vulnerability_scanning.integrations.twistcli import TwistcliIntegration
 from checkov.common.util.str_utils import removeprefix
 
@@ -58,6 +58,8 @@ class DockerImageScanningIntegration(TwistcliIntegration):
             "sourceType": bc_integration.bc_source.name,
             "vulnerabilities": vulnerabilities,
         }
+        if bc_integration.cicd_details:
+            payload["cicd_details"] = bc_integration.cicd_details
         return payload
 
 

--- a/checkov/common/bridgecrew/vulnerability_scanning/integrations/package_scanning.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/integrations/package_scanning.py
@@ -52,6 +52,8 @@ class PackageScanningIntegration(TwistcliIntegration):
             "vulnerabilities": vulnerabilities,
             "packages": packages,
         }
+        if bc_platform_integration.cicd_details:
+            payload["cicd_details"] = bc_platform_integration.cicd_details
         return payload
 
 

--- a/checkov/sca_package/output.py
+++ b/checkov/sca_package/output.py
@@ -1,6 +1,7 @@
 import asyncio
 import itertools
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -349,9 +350,9 @@ def create_package_overview_table_part(
 
 
 async def _report_results_to_bridgecrew_async(
-        scan_results: List[Dict[str, Any]],
-        bc_integration: BcPlatformIntegration,
-        bc_api_key: str
+    scan_results: "Iterable[Dict[str, Any]]",
+    bc_integration: BcPlatformIntegration,
+    bc_api_key: str
 ) -> "Sequence[int]":
     package_scanning_int = PackageScanningIntegration()
     args = [
@@ -374,7 +375,7 @@ async def _report_results_to_bridgecrew_async(
 
 
 def report_results_to_bridgecrew(
-    scan_results: List[Dict[str, Any]],
+    scan_results: "Iterable[Dict[str, Any]]",
     bc_integration: BcPlatformIntegration,
     bc_api_key: str
 ) -> "Sequence[int]":

--- a/checkov/sca_package/runner.py
+++ b/checkov/sca_package/runner.py
@@ -25,6 +25,7 @@ class Runner(BaseRunner):
         root_folder: Union[str, Path],
         files: Optional[List[str]] = None,
         runner_filter: RunnerFilter = RunnerFilter(),
+        exclude_package_json: bool = True,
     ) -> "Optional[Sequence[Dict[str, Any]]]":
 
         if not strtobool(os.getenv("ENABLE_SCA_PACKAGE_SCAN", "False")):
@@ -50,6 +51,7 @@ class Runner(BaseRunner):
             root_path=self._code_repo_path,
             files=files,
             excluded_paths=excluded_paths,
+            exclude_package_json=exclude_package_json
         )
         if not input_output_paths:
             # no packages found
@@ -112,7 +114,7 @@ class Runner(BaseRunner):
         return report
 
     def find_scannable_files(
-        self, root_path: Path, files: Optional[List[str]], excluded_paths: Set[str]
+        self, root_path: Path, files: Optional[List[str]], excluded_paths: Set[str], exclude_package_json: bool = True
     ) -> Set[Tuple[Path, Path]]:
         input_paths = {
             file_path
@@ -120,10 +122,13 @@ class Runner(BaseRunner):
             if file_path.name in SUPPORTED_PACKAGE_FILES and not any(p in file_path.parts for p in excluded_paths)
         }
 
-        # filter out package.json, if package-lock.json exists
-        package_lock_parent_paths = {
-            file_path.parent for file_path in input_paths if file_path.name == "package-lock.json"
-        }
+        package_lock_parent_paths = set()
+        if exclude_package_json:
+            # filter out package.json, if package-lock.json exists
+            package_lock_parent_paths = {
+                file_path.parent for file_path in input_paths if file_path.name == "package-lock.json"
+            }
+
         input_output_paths = {
             (file_path, file_path.parent / f"{file_path.stem}_result.json")
             for file_path in input_paths

--- a/tests/common/bridgecrew/vulnerability_scanning/conftest.py
+++ b/tests/common/bridgecrew/vulnerability_scanning/conftest.py
@@ -3,11 +3,12 @@ from typing import Dict, Any
 import pytest
 
 from checkov.common.bridgecrew.bc_source import SourceType
-from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration, bc_integration
+from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
 
 
 @pytest.fixture()
 def mock_bc_integration() -> BcPlatformIntegration:
+    bc_integration = BcPlatformIntegration()
     bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
     bc_integration.setup_bridgecrew_credentials(
         repo_id="bridgecrewio/checkov",

--- a/tests/common/bridgecrew/vulnerability_scanning/integrations/test_package_scanning.py
+++ b/tests/common/bridgecrew/vulnerability_scanning/integrations/test_package_scanning.py
@@ -68,6 +68,36 @@ async def test_report_results(mocker: MockerFixture, mock_bc_integration, scan_r
 
 
 @pytest.mark.asyncio
+async def test_report_results_with_cicd(mocker: MockerFixture, mock_bc_integration, scan_result):
+    # given
+    bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
+    report_url = get_report_url()
+    cicd_details = {
+        "run_id": 123,
+        "pr": "patch-1",
+        "commit": "qwerty1234",
+    }
+
+    mock_bc_integration.cicd_details = cicd_details
+    mocker.patch.dict(os.environ, {"BC_ROOT_DIR": "app"})
+
+    # when
+    with aioresponses() as m:
+        m.post(report_url, status=200)
+
+        result = await package_scanning_integration.report_results_async(
+            twistcli_scan_result=scan_result,
+            bc_platform_integration=mock_bc_integration,
+            bc_api_key=bc_api_key,
+            file_path=Path("app/requirements.txt"),
+        )
+
+    # then
+    assert result == 0
+    assert next(iter(m.requests.values()))[0].kwargs["json"]["cicd_details"] == cicd_details
+
+
+@pytest.mark.asyncio
 async def test_report_results_fail(mocker: MockerFixture, mock_bc_integration, scan_result):
     # given
     bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"

--- a/tests/sca_package/test_runner.py
+++ b/tests/sca_package/test_runner.py
@@ -169,3 +169,23 @@ def test_find_scannable_files():
         (EXAMPLES_DIR / "package-lock.json", EXAMPLES_DIR / "package-lock_result.json"),
         (EXAMPLES_DIR / "requirements.txt", EXAMPLES_DIR / "requirements_result.json"),
     }
+
+
+def test_find_scannable_files_with_package_json():
+    # when
+    input_output_paths = Runner().find_scannable_files(
+        root_path=EXAMPLES_DIR,
+        files=[],
+        excluded_paths=set(),
+        exclude_package_json=False,
+    )
+
+    # then
+    assert len(input_output_paths) == 4
+
+    assert input_output_paths == {
+        (EXAMPLES_DIR / "go.sum", EXAMPLES_DIR / "go_result.json"),
+        (EXAMPLES_DIR / "package.json", EXAMPLES_DIR / "package_result.json"),
+        (EXAMPLES_DIR / "package-lock.json", EXAMPLES_DIR / "package-lock_result.json"),
+        (EXAMPLES_DIR / "requirements.txt", EXAMPLES_DIR / "requirements_result.json"),
+    }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

- add extra info to the SCA report
- add flag to enable scanning of `package.json` even, if the lock file exists