### PR TITLE
Persist external modules file with to bridgecrew integration

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -7,7 +7,7 @@ from concurrent import futures
 from json import JSONDecodeError
 from os import path
 from time import sleep
-from typing import Dict
+from typing import Dict, Optional, List
 
 import boto3
 import dpath.util
@@ -227,7 +227,7 @@ class BcPlatformIntegration(object):
         """
         return self.platform_integration_configured
 
-    def persist_repository(self, root_dir, files=None, excluded_paths=None):
+    def persist_repository(self, root_dir, files=None, excluded_paths=None, included_paths: Optional[List[str]] = None):
         """
         Persist the repository found on root_dir path to Bridgecrew's platform. If --file flag is used, only files
         that are specified will be persisted.
@@ -250,7 +250,7 @@ class BcPlatformIntegration(object):
             for root_path, d_names, f_names in os.walk(root_dir):
                 # self.excluded_paths only contains the config fetched from the platform.
                 # but here we expect the list from runner_registry as well (which includes self.excluded_paths).
-                filter_ignored_paths(root_path, d_names, excluded_paths)
+                filter_ignored_paths(root_path, d_names, excluded_paths, included_paths=included_paths)
                 filter_ignored_paths(root_path, f_names, excluded_paths)
                 for file_path in f_names:
                     _, file_extension = os.path.splitext(file_path)

--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -77,7 +77,7 @@ class BaseRunner(ABC):
         return checks_results
 
 
-def filter_ignored_paths(root_dir: str, names: List[Union[str, os.DirEntry]], excluded_paths: Optional[List[str]]) -> None:
+def filter_ignored_paths(root_dir: str, names: List[Union[str, os.DirEntry]], excluded_paths: Optional[List[str]], included_paths: Optional[List[str]] = None) -> None:
     # we need to handle legacy logic, where directories to skip could be specified using the env var (default value above)
     # or a directory starting with '.'; these look only at directory basenames, not relative paths.
     #
@@ -97,11 +97,12 @@ def filter_ignored_paths(root_dir: str, names: List[Union[str, os.DirEntry]], ex
 
     # first handle the legacy logic - this will also remove files starting with '.' but that's probably fine
     # mostly this will just remove those problematic directories hardcoded above.
+    included_paths = included_paths or []
     for entry in list(names):
         path = entry if type(entry) == str else entry.name
         if path in ignored_directories:
             safe_remove(names, entry)
-        if path.startswith(".") and IGNORE_HIDDEN_DIRECTORY_ENV:
+        if path.startswith(".") and IGNORE_HIDDEN_DIRECTORY_ENV and path not in included_paths:
             safe_remove(names, entry)
 
     # now apply the new logic

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -225,7 +225,7 @@ def run(banner=checkov_banner, argv=sys.argv[1:]):
             if baseline:
                 baseline.compare_and_reduce_reports(scan_reports)
             if bc_integration.is_integration_configured():
-                bc_integration.persist_repository(root_folder, excluded_paths=runner_filter.excluded_paths)
+                bc_integration.persist_repository(root_folder, excluded_paths=runner_filter.excluded_paths, included_paths=[config.external_modules_download_path])
                 bc_integration.persist_scan_results(scan_reports)
                 url = bc_integration.commit_repository(config.branch)
 


### PR DESCRIPTION
Enabled persisting external modules using an optional param `included_paths` for the `filter_ignored_paths` method, and add the external modules dir to it when persisting the repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
