### PR TITLE
prevent pointless destroy of Key materials

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleKMSPreventDestroy.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleKMSPreventDestroy.py
@@ -1,0 +1,23 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class GoogleKMSPreventDestroy(BaseResourceValueCheck):
+    def __init__(self):
+        # "From the Provider Documentation"
+        # CryptoKeys cannot be deleted from Google Cloud Platform.Destroying a Terraform - managed CryptoKey will remove
+        # it from state and delete all CryptoKeyVersions, rendering the key unusable, but will not delete the resource
+        # from the project.When Terraform destroys these keys, any data previously encrypted with these keys will be
+        # irrecoverable.For this reason, it is strongly recommended that you add lifecycle hooks to the resource to
+        # prevent accidental destruction.
+        name = "Ensure KMS keys are protected from deletion"
+        id = "CKV_GCP_82"
+        supported_resources = ['google_kms_crypto_key']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'lifecycle/[0]/prevent_destroy'
+
+
+check = GoogleKMSPreventDestroy()

--- a/tests/terraform/checks/resource/gcp/example_GoogleKMSPreventDestroy/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleKMSPreventDestroy/main.tf
@@ -1,0 +1,25 @@
+resource "google_kms_crypto_key" "pass" {
+  name            = "crypto-key-example"
+  key_ring        = google_kms_key_ring.keyring.id
+  rotation_period = "15552000s"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_kms_crypto_key" "fail" {
+  name            = "crypto-key-example"
+  key_ring        = google_kms_key_ring.keyring.id
+  rotation_period = "15552000s"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "google_kms_crypto_key" "fail2" {
+  name            = "crypto-key-example"
+  key_ring        = google_kms_key_ring.keyring.id
+  rotation_period = "15552000s"
+}

--- a/tests/terraform/checks/resource/gcp/test_GoogleKMSPreventDestroy.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleKMSPreventDestroy.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.gcp.GoogleKMSPreventDestroy import check
+from checkov.terraform.runner import Runner
+
+
+class TestGoogleKMSPreventDestroy(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_GoogleKMSPreventDestroy"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "google_kms_crypto_key.pass",
+        }
+
+        failing_resources = {
+            "google_kms_crypto_key.fail",
+            "google_kms_crypto_key.fail2",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
        # "From the Provider Documentation"
        # CryptoKeys cannot be deleted from Google Cloud Platform.Destroying a Terraform - managed CryptoKey will remove
        # it from state and delete all CryptoKeyVersions, rendering the key unusable, but will not delete the resource
        # from the project.When Terraform destroys these keys, any data previously encrypted with these keys will be
        # irrecoverable.For this reason, it is strongly recommended that you add lifecycle hooks to the resource to
        # prevent accidental destruction.
