### PR TITLE
add tests covering Prisma integrations

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -22,6 +22,7 @@ class SuppressionsIntegration(BaseIntegrationFeature):
         # bcorgname_provider_timestamp (ex: companyxyz_aws_1234567891011)
         # the provider may be lower or upper depending on where the policy was created
         self.custom_policy_id_regex = re.compile(r'^[a-zA-Z0-9]+_[a-zA-Z]+_\d{13}$')
+        self.repo_name_regex = None
 
     def is_valid(self):
         return self.bc_integration.is_integration_configured() and not self.bc_integration.skip_suppressions \
@@ -29,6 +30,7 @@ class SuppressionsIntegration(BaseIntegrationFeature):
 
     def pre_scan(self):
         try:
+            self._init_repo_regex()
             suppressions = sorted(self._get_suppressions_from_platform(), key=lambda s: s['checkovPolicyId'])
             # group and map by policy ID
             self.suppressions = {policy_id: list(sup) for policy_id, sup in groupby(suppressions, key=lambda s: s['checkovPolicyId'])}
@@ -151,7 +153,10 @@ class SuppressionsIntegration(BaseIntegrationFeature):
 
     def _repo_matches(self, repo_name):
         # matches xyz_org/repo or org/repo (where xyz is the BC org name and the CLI repo prefix from the platform)
-        return re.match(re.compile(f'^(\\w+_)?{self.bc_integration.repo_id}$'), repo_name) is not None
+        return self.repo_name_regex.match(repo_name) is not None
+
+    def _init_repo_regex(self):
+        self.repo_name_regex = re.compile(f'^([a-zA-Z0-9]+_)?{self.bc_integration.repo_id}$')
 
 
 integration = SuppressionsIntegration(bc_integration)

--- a/tests/common/integration_features/test_suppressions_integration.py
+++ b/tests/common/integration_features/test_suppressions_integration.py
@@ -77,6 +77,7 @@ class TestSuppressionsIntegration(unittest.TestCase):
         }
 
         suppressions_integration = SuppressionsIntegration(instance)
+        suppressions_integration._init_repo_regex()
 
         suppression = {
             "suppressionType": "Accounts",
@@ -198,6 +199,7 @@ class TestSuppressionsIntegration(unittest.TestCase):
         instance = BcPlatformIntegration()
 
         suppressions_integration = SuppressionsIntegration(instance)
+        suppressions_integration._init_repo_regex()
 
         suppression = {
             "suppressionType": "Policy",
@@ -225,6 +227,7 @@ class TestSuppressionsIntegration(unittest.TestCase):
         instance = BcPlatformIntegration()
         instance.repo_id = 'org/repo'
         suppressions_integration = SuppressionsIntegration(instance)
+        suppressions_integration._init_repo_regex()
         suppression = {
             "suppressionType": "Accounts",
             "policyId": "BC_AWS_S3_13",
@@ -251,6 +254,7 @@ class TestSuppressionsIntegration(unittest.TestCase):
         instance = BcPlatformIntegration()
         instance.repo_id = 'org/repo'
         suppressions_integration = SuppressionsIntegration(instance)
+        suppressions_integration._init_repo_regex()
         suppression = {
             "suppressionType": "Accounts",
             "policyId": "BC_AWS_S3_13",
@@ -277,6 +281,7 @@ class TestSuppressionsIntegration(unittest.TestCase):
         instance = BcPlatformIntegration()
         instance.repo_id = 'org/repo'
         suppressions_integration = SuppressionsIntegration(instance)
+        suppressions_integration._init_repo_regex()
         suppression = {
             "suppressionType": "Resources",
             "policyId": "BC_AWS_S3_13",
@@ -317,6 +322,7 @@ class TestSuppressionsIntegration(unittest.TestCase):
         instance = BcPlatformIntegration()
         instance.repo_id = 'org/repo'
         suppressions_integration = SuppressionsIntegration(instance)
+        suppressions_integration._init_repo_regex()
         suppression = {
             "suppressionType": "Resources",
             "policyId": "BC_AWS_S3_13",
@@ -356,6 +362,7 @@ class TestSuppressionsIntegration(unittest.TestCase):
     def test_tag_suppression(self):
         instance = BcPlatformIntegration()
         suppressions_integration = SuppressionsIntegration(instance)
+        suppressions_integration._init_repo_regex()
         suppression = {
             "suppressionType": "Tags",
             "policyId": "BC_AWS_S3_16",

--- a/tests/common/integration_features/test_suppressions_integration.py
+++ b/tests/common/integration_features/test_suppressions_integration.py
@@ -30,7 +30,6 @@ class TestSuppressionsIntegration(unittest.TestCase):
         suppressions_integration.integration_feature_failures = True
         self.assertFalse(suppressions_integration.is_valid())
 
-
     def test_policy_id_regex(self):
         suppressions_integration = SuppressionsIntegration(BcPlatformIntegration())
 
@@ -39,7 +38,8 @@ class TestSuppressionsIntegration(unittest.TestCase):
             'bcORrg_aws_1234567891011',
             'bcORrg_AWS_1234567891011',
             'bcorg12_aws_1234567891011',
-            'bcorgabcdefgh_azure_1234567891011'
+            'bcorgabcdefgh_azure_1234567891011',
+            '0123456_azure_1234567891011'
         ]
 
         non_matching_ids = [
@@ -55,6 +55,19 @@ class TestSuppressionsIntegration(unittest.TestCase):
 
         for id in non_matching_ids:
             self.assertIsNone(suppressions_integration.custom_policy_id_regex.match(id))
+
+    def test_repo_match(self):
+        integration = BcPlatformIntegration()
+        integration.repo_id = 'org/repo'
+        suppressions_integration = SuppressionsIntegration(integration)
+        suppressions_integration._init_repo_regex()
+
+        self.assertTrue(suppressions_integration._repo_matches('org/repo'))
+        self.assertTrue(suppressions_integration._repo_matches('xyz_org/repo'))
+        self.assertTrue(suppressions_integration._repo_matches('80001234_org/repo'))
+        self.assertFalse(suppressions_integration._repo_matches('org/repo1'))
+        self.assertFalse(suppressions_integration._repo_matches('xyz_org/repo1'))
+        self.assertFalse(suppressions_integration._repo_matches('80001234_org/repo1'))
 
     def test_suppression_valid(self):
         instance = BcPlatformIntegration()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I became worried that our logic for matching --repo-id with platform suppressions did not properly account for Prisma org names (all numeric). There is no issue, but I added some tests to cover it and did a small refactor so that we do not recompile a regex repeatedly.