### PR TITLE
add tf azure check for ACR admin account disabled

### DIFF
--- a/checkov/terraform/checks/resource/azure/ACRAdminAccountDisabled.py
+++ b/checkov/terraform/checks/resource/azure/ACRAdminAccountDisabled.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class ACRAdminAccountDisabled(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure ACR admin account is disabled"
+        id = "CKV_AZURE_137"
+        supported_resources = ['azurerm_container_registry']
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        # default configuration disables admin account
+        if 'admin_enabled' in conf.keys() and conf['admin_enabled'][0] == True:
+            return CheckResult.FAILED
+
+        return CheckResult.PASSED
+
+
+check = ACRAdminAccountDisabled()

--- a/tests/terraform/checks/resource/azure/example_ACRAdminAccountDisabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_ACRAdminAccountDisabled/main.tf
@@ -1,0 +1,22 @@
+## SHOULD PASS: Explicit false
+resource "azurerm_container_registry" "ckv_unittest_pass" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+    admin_enabled                = false
+}
+
+## SHOULD PASS: Default false
+resource "azurerm_container_registry" "ckv_unittest_pass_2" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+}
+
+## SHOULD FAIL: Explicit true
+resource "azurerm_container_registry" "ckv_unittest_fail" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+    admin_enabled                = true
+}

--- a/tests/terraform/checks/resource/azure/test_ACRAdminAccountDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_ACRAdminAccountDisabled.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.ACRAdminAccountDisabled import check
+
+
+class TestACRAdminAccountDisabled(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_ACRAdminAccountDisabled")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_container_registry.ckv_unittest_pass',
+            'azurerm_container_registry.ckv_unittest_pass_2'
+        }
+        failing_resources = {
+            'azurerm_container_registry.ckv_unittest_fail'
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Custom Policy id: CKV_AZURE_137

Custom Policy name: Ensure ACR admin account is disabled

Custom Policy IaC type: Terraform

Custom Policy type and provider: AzureRM

IaC configuration documentation (If available): https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry#admin_enabled

Any additional information that would help other members to better understand the check:
By default the setting is disabled but can be explicitly enabled.  The security ramifications of enabling this are outlined in https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account