### PR TITLE
adjust CICD details output to use camelCase

### DIFF
--- a/checkov/common/bridgecrew/vulnerability_scanning/integrations/docker_image_scanning.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/integrations/docker_image_scanning.py
@@ -59,7 +59,7 @@ class DockerImageScanningIntegration(TwistcliIntegration):
             "vulnerabilities": vulnerabilities,
         }
         if bc_integration.cicd_details:
-            payload["cicd_details"] = bc_integration.cicd_details
+            payload["cicdDetails"] = bc_integration.cicd_details
         return payload
 
 

--- a/checkov/common/bridgecrew/vulnerability_scanning/integrations/package_scanning.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/integrations/package_scanning.py
@@ -53,7 +53,7 @@ class PackageScanningIntegration(TwistcliIntegration):
             "packages": packages,
         }
         if bc_platform_integration.cicd_details:
-            payload["cicd_details"] = bc_platform_integration.cicd_details
+            payload["cicdDetails"] = bc_platform_integration.cicd_details
         return payload
 
 

--- a/tests/common/bridgecrew/vulnerability_scanning/integrations/test_package_scanning.py
+++ b/tests/common/bridgecrew/vulnerability_scanning/integrations/test_package_scanning.py
@@ -73,7 +73,7 @@ async def test_report_results_with_cicd(mocker: MockerFixture, mock_bc_integrati
     bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
     report_url = get_report_url()
     cicd_details = {
-        "run_id": 123,
+        "runId": 123,
         "pr": "patch-1",
         "commit": "qwerty1234",
     }
@@ -94,7 +94,7 @@ async def test_report_results_with_cicd(mocker: MockerFixture, mock_bc_integrati
 
     # then
     assert result == 0
-    assert next(iter(m.requests.values()))[0].kwargs["json"]["cicd_details"] == cicd_details
+    assert next(iter(m.requests.values()))[0].kwargs["json"]["cicdDetails"] == cicd_details
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Streamlined the SCA output to use camelCase for the CICD block