### PR TITLE
add tf azure check ACRAnonymousPullDisabled

### DIFF
--- a/checkov/terraform/checks/resource/azure/ACRAnonymousPullDisabled.py
+++ b/checkov/terraform/checks/resource/azure/ACRAnonymousPullDisabled.py
@@ -1,0 +1,22 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class ACRAnonymousPullDisabled(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensures that ACR disables anonymous pulling of images"
+        id = "CKV_AZURE_138"
+        supported_resources = ['azurerm_container_registry']
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        # anonymous_pull_enabled only applies to Standard and Premium skus, by default is set to false
+        if ('sku' in conf.keys() and conf['sku'][0] in ["Standard", "Premium"] 
+            and 'anonymous_pull_enabled' in conf.keys() and conf['anonymous_pull_enabled'][0] == True):
+                return CheckResult.FAILED
+
+        return CheckResult.PASSED
+
+
+check = ACRAnonymousPullDisabled()

--- a/tests/terraform/checks/resource/azure/example_ACRAnonymousPullDisabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_ACRAnonymousPullDisabled/main.tf
@@ -1,0 +1,59 @@
+## SHOULD PASS: Premium tier SKU, explicitly disabled
+resource "azurerm_container_registry" "ckv_unittest_pass_1" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+    sku                          = "Premium"
+    anonymous_pull_enabled       = false
+}
+
+## SHOULD PASS: Premium tier SKU, disabled by default
+resource "azurerm_container_registry" "ckv_unittest_pass_2" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+    sku                          = "Premium"
+}
+
+## SHOULD PASS: Standard tier SKU, disabled by default
+resource "azurerm_container_registry" "ckv_unittest_pass_3" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+    sku                          = "Standard"
+}
+
+## SHOULD PASS: Basic tier should be ignored, anonymous_pull_enabled not supported
+resource "azurerm_container_registry" "ckv_unittest_pass_4" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+    sku                          = "Basic"
+    anonymous_pull_enabled       = true
+}
+
+## SHOULD PASS: No explicit tier defined scenario should be ignored, as of azurerm v2.96.0 sku defaults to Classic which is unsupported
+resource "azurerm_container_registry" "ckv_unittest_pass_5" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+    anonymous_pull_enabled       = true
+}
+
+## SHOULD FAIL: Premium tier, explicitly enabled
+resource "azurerm_container_registry" "ckv_unittest_fail_1" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+    sku                          = "Premium"
+    anonymous_pull_enabled       = true
+}
+
+## SHOULD FAIL: Standard tier, explicitly enabled
+resource "azurerm_container_registry" "ckv_unittest_fail_2" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+    sku                          = "Standard"
+    anonymous_pull_enabled       = true
+}

--- a/tests/terraform/checks/resource/azure/test_ACRAnonymousPullDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_ACRAnonymousPullDisabled.py
@@ -1,0 +1,46 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.ACRAnonymousPullDisabled import check
+
+
+class TestACRAnonymousPullEnabled(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_ACRAnonymousPullDisabled")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_container_registry.ckv_unittest_pass_1',
+            'azurerm_container_registry.ckv_unittest_pass_2',
+            'azurerm_container_registry.ckv_unittest_pass_3',
+            'azurerm_container_registry.ckv_unittest_pass_4',
+            'azurerm_container_registry.ckv_unittest_pass_5'
+        }
+        failing_resources = {
+            'azurerm_container_registry.ckv_unittest_fail_1',
+            'azurerm_container_registry.ckv_unittest_fail_2'
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Custom Policy id: CKV_AZURE_138
Custom Policy name: "Ensures that ACR disables anonymous pulling of images"
Custom Policy IaC type: terraform
Custom Policy type and provider: azurerm
IaC configuration documentation (If available): 
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry#anonymous_pull_enabled


Any additional information that would help other members to better understand the check:
Microsoft documentation - https://docs.microsoft.com/en-us/azure/container-registry/anonymous-pull-access#about-anonymous-pull-access