### PR TITLE
add tf azure ACRPublicNetworkAccessDisabled check

### DIFF
--- a/checkov/terraform/checks/resource/azure/ACRPublicNetworkAccessDisabled.py
+++ b/checkov/terraform/checks/resource/azure/ACRPublicNetworkAccessDisabled.py
@@ -1,0 +1,19 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+class ACRPublicNetworkAccessDisabled(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure ACR set to disable public networking"
+        id = "CKV_AZURE_139"
+        supported_resources = ['azurerm_container_registry']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "public_network_access_enabled"
+
+    def get_expected_value(self):
+        return False
+
+
+check = ACRPublicNetworkAccessDisabled()

--- a/tests/terraform/checks/resource/azure/example_ACRPublicNetworkAccessDisabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_ACRPublicNetworkAccessDisabled/main.tf
@@ -1,0 +1,23 @@
+## SHOULD PASS: Explicitly set to false
+resource "azurerm_container_registry" "ckv_unittest_pass" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+    public_network_access_enabled = false
+}
+
+
+## SHOULD FAIL: Explicitly set to true
+resource "azurerm_container_registry" "ckv_unittest_fail" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+    public_network_access_enabled = true    
+}
+
+## SHOULD FAIL: Not set, default is true
+resource "azurerm_container_registry" "ckv_unittest_fail_2" {
+    name                         = "containerRegistry1"
+    resource_group_name          = azurerm_resource_group.rg.name
+    location                     = azurerm_resource_group.rg.location
+}

--- a/tests/terraform/checks/resource/azure/test_ACRPublicNetworkAccessDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_ACRPublicNetworkAccessDisabled.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.ACRPublicNetworkAccessDisabled import check
+
+
+class TestACRPublicNetworkAccess(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_ACRPublicNetworkAccessDisabled")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_container_registry.ckv_unittest_pass'
+        }
+        failing_resources = {
+            'azurerm_container_registry.ckv_unittest_fail',
+            'azurerm_container_registry.ckv_unittest_fail_2',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Custom Policy id: CKV_AZURE_139
Custom Policy name: Ensure ACR set to disable public networking
Custom Policy IaC type: terraform
Custom Policy type and provider: azurerm
IaC configuration documentation (If available): 
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry#public_network_access_enabled

Any additional information that would help other members to better understand the check:
https://docs.microsoft.com/en-us/azure/container-registry/container-registry-access-selected-networks#disable-public-network-access