### PR TITLE
PAN-OS resource check for http in mgmt profile

### DIFF
--- a/checkov/terraform/checks/resource/__init__.py
+++ b/checkov/terraform/checks/resource/__init__.py
@@ -5,4 +5,5 @@ from checkov.terraform.checks.resource.github import *
 from checkov.terraform.checks.resource.linode import *
 from checkov.terraform.checks.resource.oci import *
 from checkov.terraform.checks.resource.openstack import *
+from checkov.terraform.checks.resource.panos import *
 from checkov.terraform.checks.resource.digitalocean import *

--- a/checkov/terraform/checks/resource/panos/InterfaceMgmtProfileNoHTTP.py
+++ b/checkov/terraform/checks/resource/panos/InterfaceMgmtProfileNoHTTP.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+
+
+class InterfaceMgmtProfileNoHTTP(BaseResourceNegativeValueCheck):
+    def __init__(self):
+        name = "Ensure plain-text management HTTP is not enabled for an Interface Management Profile"
+        id = "CKV_PAN_2"
+        supported_resources = ['panos_management_profile']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'http'
+
+    def get_forbidden_values(self):
+        return [True]
+
+
+check = InterfaceMgmtProfileNoHTTP()

--- a/checkov/terraform/checks/resource/panos/__init__.py
+++ b/checkov/terraform/checks/resource/panos/__init__.py
@@ -1,0 +1,5 @@
+from os.path import dirname, basename, isfile, join
+import glob
+
+modules = glob.glob(join(dirname(__file__), "*.py"))
+__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith("__init__.py")]

--- a/tests/terraform/checks/resource/panos/example_InterfaceMgmtProfileNoHTTP/main.tf
+++ b/tests/terraform/checks/resource/panos/example_InterfaceMgmtProfileNoHTTP/main.tf
@@ -1,0 +1,16 @@
+# Setting the http attribute to true turns on HTTP for management, and is therefore a fail, we only want to see HTTPS in use
+resource "panos_management_profile" "fail" {
+    name = "my-mgmt-profile"
+    http = true
+}
+
+# Setting the http attribute to false leaves HTTP disabled for management, and is therefore a pass
+resource "panos_management_profile" "pass1" {
+    name = "my-mgmt-profile"
+    http = false
+}
+
+# Not explicitly setting the http attribute when creating a mgmt profile leads to the default setting of false, which leaves HTTP disabled for management, and is therefore a pass
+resource "panos_management_profile" "pass2" {
+    name = "my-mgmt-profile"
+}

--- a/tests/terraform/checks/resource/panos/test_InterfaceMgmtProfileNoHTTP.py
+++ b/tests/terraform/checks/resource/panos/test_InterfaceMgmtProfileNoHTTP.py
@@ -1,0 +1,40 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.panos.InterfaceMgmtProfileNoHTTP import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestInterfaceMgmtProfileNoHTTP(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_InterfaceMgmtProfileNoHTTP"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'panos_management_profile.pass1',
+            'panos_management_profile.pass2',
+        }
+        failing_resources = {
+            'panos_management_profile.fail',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

First resource check for PAN-OS Terraform provider. Ensures that plain-text HTTP is not enabled for managing PAN-OS firewalls, we only want to see HTTPS being used for firewall management.