### PR TITLE
CKV_GCP_88 - Unrestricted mysql fw

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleComputeFirewallUnrestrictedIngress3306.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeFirewallUnrestrictedIngress3306.py
@@ -8,7 +8,7 @@ PORT = 3306
 class GoogleComputeFirewallUnrestrictedIngress3306(AbsGoogleComputeFirewallUnrestrictedIngress):
     def __init__(self):
         name = "Ensure Google compute firewall ingress does not allow unrestricted mysql access"
-        id = "CKV_GCP_87"
+        id = "CKV_GCP_88"
         supported_resources = ['google_compute_firewall']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources, port=PORT)

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeFirewallUnrestrictedIngress3306.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeFirewallUnrestrictedIngress3306.py
@@ -1,0 +1,17 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.gcp.AbsGoogleComputeFirewallUnrestrictedIngress import AbsGoogleComputeFirewallUnrestrictedIngress
+
+# standard mysql port
+PORT = 3306
+
+
+class GoogleComputeFirewallUnrestrictedIngress3306(AbsGoogleComputeFirewallUnrestrictedIngress):
+    def __init__(self):
+        name = "Ensure Google compute firewall ingress does not allow unrestricted mysql access"
+        id = "CKV_GCP_87"
+        supported_resources = ['google_compute_firewall']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources, port=PORT)
+
+
+check = GoogleComputeFirewallUnrestrictedIngress3306()

--- a/tests/terraform/checks/resource/gcp/example_GoogleComputeFirewallUnrestrictedIngress3306/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleComputeFirewallUnrestrictedIngress3306/main.tf
@@ -1,0 +1,100 @@
+#####################
+## PASS TEST CASES ##
+#####################
+
+# Passes b/c we are specifying a restricted CIDR
+resource "google_compute_firewall" "restricted" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3306"]
+  }
+
+  source_ranges = ["172.1.2.3/32"]
+}
+
+# Passes b/c it does not match port 3306 +
+# we are specifying a restricted CIDR
+resource "google_compute_firewall" "allow_different_int" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = [4624]
+  }
+
+  source_ranges = ["172.1.2.3/32"]
+}
+
+# Passes b/c the port is null and not 3306 +
+# we are specifying a restricted CIDR
+resource "google_compute_firewall" "allow_null" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = null
+  }
+
+  source_ranges = ["172.1.2.3/32"]
+  target_tags   = ["mysql"]
+}
+
+#####################
+## FAIL TEST CASES ##
+#####################
+
+
+# fails b/c of unrestricted CIDR
+# + port 3306 is in the range
+resource "google_compute_firewall" "allow_all" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+# Fails b/c of unrestricted CIDR + port 3306
+resource "google_compute_firewall" "allow_mysql_int" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = [3306]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+# Fails b/c of unrestricted CIDR + port 3306
+resource "google_compute_firewall" "allow_multiple" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["4000-65535", "3306"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+# unknown
+resource "google_compute_firewall" "allow_unknown" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow = "var.backends"
+
+  source_ranges = ["0.0.0.0/0"]
+}

--- a/tests/terraform/checks/resource/gcp/example_GoogleComputeFirewallUnrestrictedIngress3306/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleComputeFirewallUnrestrictedIngress3306/main.tf
@@ -49,8 +49,8 @@ resource "google_compute_firewall" "allow_null" {
 #####################
 
 
-# fails b/c of unrestricted CIDR
-# + port 3306 is in the range
+# fails b/c of unrestricted CIDR +
+# port 3306 is in the range
 resource "google_compute_firewall" "allow_all" {
   name    = "example"
   network = "google_compute_network.vpc.name"

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeFirewallUnrestrictedIngress3306.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeFirewallUnrestrictedIngress3306.py
@@ -1,0 +1,71 @@
+import unittest
+import hcl2
+
+from checkov.terraform.checks.resource.gcp.GoogleComputeFirewallUnrestrictedIngress3306 import check, PORT
+from checkov.common.models.enums import CheckResult
+
+
+class TestGoogleComputeFirewallUnrestrictedIngress3306(unittest.TestCase):
+
+    def test_failure(self):
+        resource_conf = {
+            'name': ['mysql-database-public'],
+            'network': ['${google_compute_network.mysql-network.name}'],
+            'allow': [
+                {
+                    'protocol': ['tcp'],
+                    'ports': [[str(PORT)]]
+                }
+            ],
+            'source_ranges': [['0.0.0.0/0']]
+            }
+
+        # This fails because we are allowing unrestricted mysql access
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_1(self):
+        resource_conf = {
+            'name': ['mysql-database-public'],
+            'network': ['${google_compute_network.mysql-network.name}'],
+            'allow': [
+                {
+                    'protocol': ['tcp'],
+                    'ports': [[str(PORT)]]
+                }
+            ],
+            'source_ranges': [['172.1.2.3/32']] # Non-public CIDR
+            }
+
+        # This passes b/c we specify a non-public CIDR/IP
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_2(self):
+        hcl_res = hcl2.loads(
+            """
+                resource "google_compute_firewall" "deny-all-egress" {
+                    name        = "deny-all-egress"
+                    description = "Prevent all egress traffic by default"
+
+                    network        = google_compute_network.vpc_network.name
+                    enable_logging = true
+
+                    priority           = 65534
+                    direction          = "EGRESS"
+                    destination_ranges = ["0.0.0.0/0"]
+                    deny { protocol = "all" }
+                }
+            """
+            )
+        resource_conf = hcl_res['resource'][0]['google_compute_firewall']['deny-all-egress']
+
+        # This passes b/c we always pass if "allow" is not found
+        # We tested "deny { protocol = "all" }" so there is no "allow" rule
+        # Check AbsGoogleComputeFirewallUnrestrictedIngress.py file for logic
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeFirewallUnrestrictedIngress3306.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeFirewallUnrestrictedIngress3306.py
@@ -34,7 +34,7 @@ class TestGoogleComputeFirewallUnrestrictedIngress3306(unittest.TestCase):
                     'ports': [[str(PORT)]]
                 }
             ],
-            'source_ranges': [['172.1.2.3/32']] # Non-public CIDR
+            'source_ranges': [['172.1.2.3/32']]  # Non-public CIDR
             }
 
         # This passes b/c we specify a non-public CIDR/IP

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeFirewallUnrestrictedIngress3306.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeFirewallUnrestrictedIngress3306.py
@@ -1,71 +1,46 @@
 import unittest
-import hcl2
+from pathlib import Path
 
-from checkov.terraform.checks.resource.gcp.GoogleComputeFirewallUnrestrictedIngress3306 import check, PORT
-from checkov.common.models.enums import CheckResult
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.gcp.GoogleComputeFirewallUnrestrictedIngress3306 import check
+from checkov.terraform.runner import Runner
 
 
 class TestGoogleComputeFirewallUnrestrictedIngress3306(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_GoogleComputeFirewallUnrestrictedIngress3306"
 
-    def test_failure(self):
-        resource_conf = {
-            'name': ['mysql-database-public'],
-            'network': ['${google_compute_network.mysql-network.name}'],
-            'allow': [
-                {
-                    'protocol': ['tcp'],
-                    'ports': [[str(PORT)]]
-                }
-            ],
-            'source_ranges': [['0.0.0.0/0']]
-            }
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
 
-        # This fails because we are allowing unrestricted mysql access
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        # then
+        summary = report.get_summary()
 
-    def test_success_1(self):
-        resource_conf = {
-            'name': ['mysql-database-public'],
-            'network': ['${google_compute_network.mysql-network.name}'],
-            'allow': [
-                {
-                    'protocol': ['tcp'],
-                    'ports': [[str(PORT)]]
-                }
-            ],
-            'source_ranges': [['172.1.2.3/32']]  # Non-public CIDR
-            }
+        passing_resources = {
+            "google_compute_firewall.restricted",
+            "google_compute_firewall.allow_different_int",
+            "google_compute_firewall.allow_null",
+        }
 
-        # This passes b/c we specify a non-public CIDR/IP
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        failing_resources = {
+            "google_compute_firewall.allow_multiple",
+            "google_compute_firewall.allow_mysql_int",
+            "google_compute_firewall.allow_all",
+        }
 
-    def test_success_2(self):
-        hcl_res = hcl2.loads(
-            """
-                resource "google_compute_firewall" "deny-all-egress" {
-                    name        = "deny-all-egress"
-                    description = "Prevent all egress traffic by default"
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
 
-                    network        = google_compute_network.vpc_network.name
-                    enable_logging = true
+        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+        self.assertEqual(summary["resource_count"], 7)  # 1 unknown
 
-                    priority           = 65534
-                    direction          = "EGRESS"
-                    destination_ranges = ["0.0.0.0/0"]
-                    deny { protocol = "all" }
-                }
-            """
-            )
-        resource_conf = hcl_res['resource'][0]['google_compute_firewall']['deny-all-egress']
-
-        # This passes b/c we always pass if "allow" is not found
-        # We tested "deny { protocol = "all" }" so there is no "allow" rule
-        # Check AbsGoogleComputeFirewallUnrestrictedIngress.py file for logic
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


This PR adds a new GCP terraform check for unrestricted mysql firewall rules. Basically, any firewall rule with an `allow` block that has `"0.0.0.0/0"` in its `source_ranges`. 

For ingress rules, one of `source_ranges`, `source_tags` or `source_service_accounts` is required per the tf [docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall#source_ranges). 

The only tests that failed locally are unrelated to this PR:

```
=============================== short test summary info =========================================
FAILED tests/kustomize/test_runner.py::TestRunnerValid::test_record_relative_path_with_direct_oberlay - TypeError: decoding to str: need a bytes-like object, FileNotFoundError found
FAILED tests/kustomize/test_runner.py::TestRunnerValid::test_record_relative_path_with_direct_prod2_oberlay - TypeError: decoding to str: need a bytes-like object, FileNotFoundError found
FAILED tests/kustomize/test_runner.py::TestRunnerValid::test_record_relative_path_with_relative_dir - TypeError: decoding to str: need a bytes-like object, FileNotFoundError found
```
