### PR TITLE
add terraform azure check AKSLocalAdminDisabled

### DIFF
--- a/checkov/terraform/checks/resource/azure/AKSLocalAdminDisabled.py
+++ b/checkov/terraform/checks/resource/azure/AKSLocalAdminDisabled.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class AKSLocalAdminDisabled(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure AKS local admin account is disabled"
+        id = "CKV_AZURE_141"
+        supported_resources = ['azurerm_kubernetes_cluster']
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "local_account_disabled"
+
+    def get_expected_value(self):
+        return True
+
+
+check = AKSLocalAdminDisabled()

--- a/tests/terraform/checks/resource/azure/example_AKSLocalAdminDisabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AKSLocalAdminDisabled/main.tf
@@ -1,0 +1,64 @@
+## SHOULD PASS: Explicitly disabled
+resource "azurerm_kubernetes_cluster" "ckv_unittest_pass" {
+    name                = "example-aks1"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+    local_account_disabled = true
+
+    default_node_pool {
+        name       = "default"
+        node_count = 1
+        vm_size    = "Standard_D2_v2"
+    }
+
+    identity {
+        type = "SystemAssigned"
+    }
+
+    tags = {
+        Environment = "Production"
+    }
+}
+
+## SHOULD FAIL: Default is enabled
+resource "azurerm_kubernetes_cluster" "ckv_unittest_fail" {
+    name                = "example-aks1"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+
+    default_node_pool {
+        name       = "default"
+        node_count = 1
+        vm_size    = "Standard_D2_v2"
+    }
+
+    identity {
+        type = "SystemAssigned"
+    }
+
+    tags = {
+        Environment = "Production"
+    }
+}
+
+## SHOULD FAIL: Explicitly enabled
+resource "azurerm_kubernetes_cluster" "ckv_unittest_fail_2" {
+    name                = "example-aks1"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+    local_account_disabled = false
+
+    default_node_pool {
+        name       = "default"
+        node_count = 1
+        vm_size    = "Standard_D2_v2"
+    }
+
+    identity {
+        type = "SystemAssigned"
+    }
+
+    tags = {
+        Environment = "Production"
+    }
+}

--- a/tests/terraform/checks/resource/azure/test_AKSLocalAdminDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_AKSLocalAdminDisabled.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.AKSLocalAdminDisabled import check
+
+
+class TestAKSLocalAdminDisabled(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AKSLocalAdminDisabled")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_kubernetes_cluster.ckv_unittest_pass'
+        }
+        failing_resources = {
+            'azurerm_kubernetes_cluster.ckv_unittest_fail',
+            'azurerm_kubernetes_cluster.ckv_unittest_fail_2',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Custom Policy id: CKV_AZURE_141
Custom Policy name: Ensure AKS local admin account is disabled
Custom Policy IaC type: terraform
Custom Policy type and provider: azurerm
IaC configuration documentation (If available): https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#local_account_disabled


Any additional information that would help other members to better understand the check: 
Per MS doc, "Even when enabling RBAC or Azure Active Directory integration, --admin access still exists, essentially as a non-auditable backdoor option." -- https://docs.microsoft.com/en-us/azure/aks/managed-aad#disable-local-accounts