### PR TITLE
CKV_GCP_89 - Public vertex ai notebook check

### DIFF
--- a/checkov/terraform/checks/resource/gcp/VertexAIPrivateInstance.py
+++ b/checkov/terraform/checks/resource/gcp/VertexAIPrivateInstance.py
@@ -1,0 +1,20 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class VertexAIPrivateInstance(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Vertex AI instances are private"
+        id = "CKV_GCP_89"
+        supported_resources = ['google_notebooks_instance']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'no_public_ip'
+
+    # Accounts for if key is present but is set to False
+    def get_expected_value(self):
+        return True
+
+check = VertexAIPrivateInstance()

--- a/tests/terraform/checks/resource/gcp/example_VertexAIPrivateInstance/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_VertexAIPrivateInstance/main.tf
@@ -1,0 +1,39 @@
+
+resource "google_notebooks_instance" "pass1" {
+  name = "pass1-instance"
+  location = "us-west1-a"
+  machine_type = "e2-medium"
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+
+  # This configures a private Vertex AI instance
+  no_public_ip = true
+}
+
+
+resource "google_notebooks_instance" "fail1" {
+  name = "fail1-instance"
+  location = "us-west1-a"
+  machine_type = "e2-medium"
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+
+  # This configures a public Vertex AI instance
+  no_public_ip = false
+}
+
+# This configures a public Vertex AI instance
+# b/c there is no "no_public_ip" setting configured
+resource "google_notebooks_instance" "fail2" {
+  name = "fail2-instance"
+  location = "us-west1-a"
+  machine_type = "e2-medium"
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+}

--- a/tests/terraform/checks/resource/gcp/test_VertexAIPrivateInstance.py
+++ b/tests/terraform/checks/resource/gcp/test_VertexAIPrivateInstance.py
@@ -1,0 +1,40 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.VertexAIPrivateInstance import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestVertexAIPrivateInstance(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_VertexAIPrivateInstance"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_notebooks_instance.pass1',
+        }
+        failing_resources = {
+            'google_notebooks_instance.fail1',
+            'google_notebooks_instance.fail2',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR adds a new GCP check for public Vertex AI instances. These instances are the underlining compute that powers the notebooks and are __by default public__. 

The check logic and tests accounts for three scenarios:

- If the `no_public_ip` setting does not exist - Fail
- If the `no_public_ip` setting exists but is set to `false` - Fail
- If the `no_public_ip` setting exists and is set to `true` - Pass