### PR TITLE
fix CKV_AWS_8

### DIFF
--- a/checkov/common/bridgecrew/vulnerability_scanning/integrations/docker_image_scanning.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/integrations/docker_image_scanning.py
@@ -63,7 +63,7 @@ class DockerImageScanningIntegration(TwistcliIntegration):
             "packages": self.get_packages_for_report(results_dict),
         }
         if bc_platform_integration.cicd_details:
-            payload["cicd_details"] = bc_platform_integration.cicd_details
+            payload["cicdDetails"] = bc_platform_integration.cicd_details
         return payload
 
     @staticmethod

--- a/checkov/terraform/checks/resource/aws/LaunchConfigurationEBSEncryption.py
+++ b/checkov/terraform/checks/resource/aws/LaunchConfigurationEBSEncryption.py
@@ -1,20 +1,21 @@
+from typing import Dict, List, Any
+
 from checkov.common.models.enums import CheckResult, CheckCategories
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
 
-class LaunchConfigurationEBSEncryption(BaseResourceValueCheck):
-    def __init__(self):
-        name = "Ensure all data stored in the Launch configuration or instance Elastic Blocks Store" \
-               " is securely encrypted"
+class LaunchConfigurationEBSEncryption(BaseResourceCheck):
+    def __init__(self) -> None:
+        name = (
+            "Ensure all data stored in the Launch configuration or instance Elastic Blocks Store "
+            "is securely encrypted"
+        )
         id = "CKV_AWS_8"
-        supported_resources = ['aws_launch_configuration', 'aws_instance']
-        categories = [CheckCategories.ENCRYPTION]
+        supported_resources = ("aws_launch_configuration", "aws_instance")
+        categories = (CheckCategories.ENCRYPTION,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return "*_block_device/[0]/encrypted"
-
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
         """
             Looks for encryption configuration at launch configuration:
             https://www.terraform.io/docs/providers/aws/r/launch_configuration.html or
@@ -26,19 +27,21 @@ class LaunchConfigurationEBSEncryption(BaseResourceValueCheck):
         #     # If present, the encrypted flag will be determined by the snapshot
         #     # Note: checkov does not know if snapshot is encrypted, so we default to PASSED
 
-        root = conf.get('root_block_device')
-        if not root:
+        self.evaluated_keys = ["root_block_device"]
+        root = conf.get("root_block_device")
+        if not root or not root[0]:
             # Issue 496 - TF will create unencrypted EBS root by default if whole root_block_device block is omitted.
             return CheckResult.FAILED
-        blocks = conf.get('ebs_block_device') or []
+        self.evaluated_keys.append("ebs_block_device")
+        blocks = conf.get("ebs_block_device") or []
 
         allblocks = root + blocks
 
         if not allblocks:
-            return CheckResult.Unknown
+            return CheckResult.UNKNOWN
 
         for block in allblocks:
-            if not block.get("encrypted") == [True]:
+            if isinstance(block, dict) and not block.get("encrypted") == [True]:
                 if not block.get("snapshot_id"):
                     return CheckResult.FAILED
         return CheckResult.PASSED

--- a/tests/common/bridgecrew/vulnerability_scanning/integrations/test_docker_image_scanning.py
+++ b/tests/common/bridgecrew/vulnerability_scanning/integrations/test_docker_image_scanning.py
@@ -73,7 +73,7 @@ async def test_report_results_with_cicd(mocker: MockerFixture, mock_bc_integrati
     bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
     report_url = get_report_url()
     cicd_details = {
-        "run_id": 123,
+        "runId": 123,
         "pr": "patch-1",
         "commit": "qwerty1234",
     }
@@ -96,7 +96,7 @@ async def test_report_results_with_cicd(mocker: MockerFixture, mock_bc_integrati
 
     # then
     assert result == 0
-    assert next(iter(m.requests.values()))[0].kwargs["json"]["cicd_details"] == cicd_details
+    assert next(iter(m.requests.values()))[0].kwargs["json"]["cicdDetails"] == cicd_details
 
 
 @pytest.mark.asyncio

--- a/tests/terraform/checks/resource/aws/example_LaunchConfigurationEBSEncryption/main.tf
+++ b/tests/terraform/checks/resource/aws/example_LaunchConfigurationEBSEncryption/main.tf
@@ -51,6 +51,34 @@ resource "aws_instance" "fail5" {
   key_name      = var.key_name
 }
 
+# empty array defaults
+
+variable "empty_list" {
+  default = []
+}
+
+resource "aws_instance" "fail_empty_root_list" {
+  image_id      = "ami-123"
+  instance_type = "t2.micro"
+
+  root_block_device = "${var.empty_list}"
+}
+
+resource "aws_instance" "fail_empty_ebs_list" {
+  image_id      = "ami-123"
+  instance_type = "t2.micro"
+
+  root_block_device = {
+    volume_type = "gp2"
+    volume_size = var.root_volume_size
+    encrypted   = true
+  }
+
+  ebs_block_device = "${var.empty_list}"
+}
+
+# pass
+
 resource "aws_instance" "pass" {
   ami           = var.ami_id
   instance_type = var.instance_type

--- a/tests/terraform/checks/resource/aws/test_LaunchConfigurationEBSEncryption.py
+++ b/tests/terraform/checks/resource/aws/test_LaunchConfigurationEBSEncryption.py
@@ -30,6 +30,8 @@ class TestLaunchConfigurationEBSEncryption(unittest.TestCase):
             "aws_instance.fail3",
             "aws_instance.fail4",
             "aws_instance.fail5",
+            "aws_instance.fail_empty_root_list",
+            "aws_instance.fail_empty_ebs_list",
             "aws_launch_configuration.fail",
         }
 
@@ -37,7 +39,7 @@ class TestLaunchConfigurationEBSEncryption(unittest.TestCase):
         failed_check_resources = {c.resource for c in report.failed_checks}
 
         self.assertEqual(summary["passed"], 5)
-        self.assertEqual(summary["failed"], 6)
+        self.assertEqual(summary["failed"], 8)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixed an issue in CKV_AWS_8, when using the old way of defining a block and it is empty by default