### PR TITLE
CKV_GCP_94 - GCP Private dataflow job check

### DIFF
--- a/checkov/terraform/checks/resource/gcp/DataflowPrivateJob.py
+++ b/checkov/terraform/checks/resource/gcp/DataflowPrivateJob.py
@@ -1,0 +1,20 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class DataflowPrivateJob(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Dataflow jobs are private"
+        id = "CKV_GCP_94"
+        supported_resources = ['google_dataflow_job']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "ip_configuration"
+
+    # Possible values are "WORKER_IP_PUBLIC" or "WORKER_IP_PRIVATE"
+    def get_expected_value(self):
+        return "WORKER_IP_PRIVATE"
+
+check = DataflowPrivateJob()

--- a/tests/terraform/checks/resource/gcp/example_DataflowPrivateJob/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_DataflowPrivateJob/main.tf
@@ -1,0 +1,40 @@
+
+# Passes due to ip_configuration" existing and set to private
+resource "google_dataflow_job" "pass" {
+  name              = "my-pass-job"
+  template_gcs_path = "gs://my-bucket/templates/template_file"
+  temp_gcs_location = "gs://my-bucket/tmp_dir"
+  parameters = {
+    foo = "bar"
+    baz = "qux"
+  }
+
+  ip_configuration = "WORKER_IP_PRIVATE"
+}
+
+
+# Fails due to "ip_configuration" not existing
+# Dataflow jobs are public by default
+resource "google_dataflow_job" "fail1" {
+  name              = "my-pass-job"
+  template_gcs_path = "gs://my-bucket/templates/template_file"
+  temp_gcs_location = "gs://my-bucket/tmp_dir"
+  parameters = {
+    foo = "bar"
+    baz = "qux"
+  }
+
+}
+
+# Fails due to "ip_configuration" existing but set to public
+resource "google_dataflow_job" "fail2" {
+  name              = "my-pass-job"
+  template_gcs_path = "gs://my-bucket/templates/template_file"
+  temp_gcs_location = "gs://my-bucket/tmp_dir"
+  parameters = {
+    foo = "bar"
+    baz = "qux"
+  }
+
+  ip_configuration = "WORKER_IP_PUBLIC"
+}

--- a/tests/terraform/checks/resource/gcp/example_DataflowPrivateJob/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_DataflowPrivateJob/main.tf
@@ -16,7 +16,7 @@ resource "google_dataflow_job" "pass" {
 # Fails due to "ip_configuration" not existing
 # Dataflow jobs are public by default
 resource "google_dataflow_job" "fail1" {
-  name              = "my-pass-job"
+  name              = "my-fail-job1"
   template_gcs_path = "gs://my-bucket/templates/template_file"
   temp_gcs_location = "gs://my-bucket/tmp_dir"
   parameters = {
@@ -28,7 +28,7 @@ resource "google_dataflow_job" "fail1" {
 
 # Fails due to "ip_configuration" existing but set to public
 resource "google_dataflow_job" "fail2" {
-  name              = "my-pass-job"
+  name              = "my-fail-job2"
   template_gcs_path = "gs://my-bucket/templates/template_file"
   temp_gcs_location = "gs://my-bucket/tmp_dir"
   parameters = {

--- a/tests/terraform/checks/resource/gcp/test_DataflowPrivateJob.py
+++ b/tests/terraform/checks/resource/gcp/test_DataflowPrivateJob.py
@@ -1,0 +1,40 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.DataflowPrivateJob import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestDataflowPrivateJob(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_DataflowPrivateJob"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_dataflow_job.pass',
+        }
+        failing_resources = {
+            'google_dataflow_job.fail1',
+            'google_dataflow_job.fail2',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR adds a check for private dataflow jobs. By default Dataflow jobs in GCP are made public (aka the compute instances have public IPs.)

This check looks for 3 scenarios:

- If `ip_configuration` does not exist - Fail
- If `ip_configuration` exists but is set to `WORKER_IP_PUBLIC` - Fail
- If `ip_configuration`exists but is set to `WORKER_IP_PRIVATE` - PASS