### PR TITLE
CKV_GCP_95 - Ensure Memorystore for Redis has AUTH enabled

### DIFF
--- a/checkov/terraform/checks/resource/gcp/MemorystoreForRedisAuthEnabled.py
+++ b/checkov/terraform/checks/resource/gcp/MemorystoreForRedisAuthEnabled.py
@@ -1,0 +1,20 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class MemorystoreForRedisAuthEnabled(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Memorystore for Redis has AUTH enabled"
+        id = "CKV_GCP_95"
+        supported_resources = ['google_redis_instance']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "auth_enabled"
+
+    # Accounts for if key is present but is set to False
+    def get_expected_value(self):
+        return True
+
+check = MemorystoreForRedisAuthEnabled()

--- a/tests/terraform/checks/resource/gcp/example_MemorystoreForRedisAuthEnabled/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_MemorystoreForRedisAuthEnabled/main.tf
@@ -1,0 +1,51 @@
+
+# Passes b/c we enabled AUTH
+resource "google_redis_instance" "pass" {
+  name           = "my-pass-instance"
+  memory_size_gb = 1
+  tier           = "STANDARD_HA"
+
+  location_id             = "us-central1-a"
+  alternative_location_id = "us-central1-f"
+  redis_version           = "REDIS_6_X"
+
+  labels = {
+    foo = "bar"
+  }
+
+  auth_enabled = true
+}
+
+# Fails b/c "auth_enabled" does not exist
+# AUTH is not enabled by default
+resource "google_redis_instance" "fail1" {
+  name           = "my-fail-instance1"
+  tier           = "STANDARD_HA"
+  memory_size_gb = 1
+
+  location_id             = "us-central1-a"
+  alternative_location_id = "us-central1-f"
+
+  redis_version = "REDIS_4_0"
+  display_name  = "I am insecure"
+
+  maintenance_policy {
+    weekly_maintenance_window {
+      day = "TUESDAY"
+      start_time {
+        hours   = 0
+        minutes = 30
+        seconds = 0
+        nanos   = 0
+      }
+    }
+  }
+}
+
+# Fails b/c we turn off AUTH
+resource "google_redis_instance" "fail2" {
+  name           = "my-fail-instance2"
+  memory_size_gb = 1
+
+  auth_enabled = false
+}

--- a/tests/terraform/checks/resource/gcp/test_MemorystoreForRedisAuthEnabled.py
+++ b/tests/terraform/checks/resource/gcp/test_MemorystoreForRedisAuthEnabled.py
@@ -1,0 +1,40 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.MemorystoreForRedisAuthEnabled import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestMemorystoreForRedisAuthEnabled(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_MemorystoreForRedisAuthEnabled"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_redis_instance.pass',
+        }
+        failing_resources = {
+            'google_redis_instance.fail1',
+            'google_redis_instance.fail2',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR adds a GCP terraform check for "Ensure Memorystore for Redis has AUTH enabled". The AUTH configuration for Memorystore for redis is not enabled by default, but when enabled, "incoming client connections must authenticate in order to connect". We generally recommend this feature be enabled to limit who/what can connect to redis databases.

This check accounts for 3 scenarios:

- If `auth_enabled` does not exist - FAIL
- If `auth_enabled` exists but is set to `false` - FAIL
- If `auth_enabled` exists but is set to `true` - PASS


You can read more about the AUTH feature [here](https://cloud.google.com/memorystore/docs/redis/auth-overview)