### PR TITLE
add check AKSNodePublicIpDisabled

### DIFF
--- a/checkov/terraform/checks/resource/azure/AKSNodePublicIpDisabled.py
+++ b/checkov/terraform/checks/resource/azure/AKSNodePublicIpDisabled.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+from typing import List, Any
+
+
+class AKSNodePublicIpDisabled(BaseResourceNegativeValueCheck):
+    def __init__(self):
+        name = "Ensure AKS cluster nodes do not have public IP addresses"
+        id = "CKV_AZURE_143"
+        supported_resources = ['azurerm_kubernetes_cluster']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "default_node_pool/[0]/enable_node_public_ip"
+
+    def get_forbidden_values(self) -> List[Any]:
+        return [True]
+
+
+check = AKSNodePublicIpDisabled()

--- a/tests/terraform/checks/resource/azure/example_AKSNodePublicIpDisabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AKSNodePublicIpDisabled/main.tf
@@ -1,0 +1,45 @@
+## SHOULD PASS: Default is false
+resource "azurerm_kubernetes_cluster" "ckv_unittest_pass" {
+    name                = "example-aks1"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+    dns_prefix          = "exampleaks1"
+
+    default_node_pool {
+        name       = "default"
+        node_count = 1
+        vm_size    = "Standard_D2_v2"
+    }
+
+    identity {
+        type = "SystemAssigned"
+    }
+
+    tags = {
+        Environment = "Production"
+    }
+}
+
+
+## SHOULD FAIL: Explicitly set to true
+resource "azurerm_kubernetes_cluster" "ckv_unittest_fail" {
+        name                = "example-aks1"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+    dns_prefix          = "exampleaks1"
+
+    default_node_pool {
+        name       = "default"
+        node_count = 1
+        vm_size    = "Standard_D2_v2"
+        enable_node_public_ip = true
+    }
+
+    identity {
+        type = "SystemAssigned"
+    }
+
+    tags = {
+        Environment = "Production"
+    }
+}

--- a/tests/terraform/checks/resource/azure/test_AKSNodePublicIpDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_AKSNodePublicIpDisabled.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.AKSNodePublicIpDisabled import check
+
+
+class TestAKSNodePublicIpDisabled(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AKSNodePublicIpDisabled")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_kubernetes_cluster.ckv_unittest_pass'
+        }
+        failing_resources = {
+            'azurerm_kubernetes_cluster.ckv_unittest_fail',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Custom Policy id. CKV_AZURE_143
Custom Policy name. Ensure AKS cluster nodes do not have public IP addresses
Custom Policy IaC type. terraform
Custom Policy type and provider. azurerm
IaC configuration documentation (If available). https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#enable_node_public_ip

Any additional information that would help other members to better understand the check.
https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools