### PR TITLE
CKV_GCP_96 - Ensure that Dataproc clusters are not anonymously or publicly accessible

### DIFF
--- a/checkov/terraform/checks/resource/gcp/DataprocPrivateCluster.py
+++ b/checkov/terraform/checks/resource/gcp/DataprocPrivateCluster.py
@@ -1,0 +1,26 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from typing import List
+
+
+class DataprocPrivateCluster(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure that Dataproc clusters are not anonymously or publicly accessible"
+        id = "CKV_GCP_96"
+        supported_resources = ['google_dataproc_cluster_iam_member', 'google_dataproc_cluster_iam_binding']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        members = conf.get('members', [[]])[0]
+        members = members if isinstance(members, list) else []
+        member_conf = conf.get('member', []) + members
+        if not any(member in member_conf for member in ['allUsers', 'allAuthenticatedUsers']):
+            return CheckResult.PASSED
+        return CheckResult.FAILED
+
+    def get_evaluated_keys(self) -> List[str]:
+        return ['members', 'member']
+
+
+check = DataprocPrivateCluster()

--- a/tests/terraform/checks/resource/gcp/example_DataprocPrivateCluster/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_DataprocPrivateCluster/main.tf
@@ -1,0 +1,64 @@
+################
+## PASS TESTS ##
+################
+
+resource "google_dataproc_cluster_iam_binding" "pass1" {
+  cluster = "my-private-cluster-binding1"
+  role    = "roles/dataproc.serviceAgent"
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+resource "google_dataproc_cluster_iam_binding" "pass2" {
+  cluster = "my-private-cluster-binding2"
+  role    = "roles/dataproc.viewer"
+  members = [
+    "user:jason@example.com",
+  ]
+}
+
+resource "google_dataproc_cluster_iam_member" "pass1" {
+  cluster = "my-private-cluster-member1"
+  role    = "roles/dataproc.worker"
+  member  = "group:mygroup@example.com"
+}
+
+resource "google_dataproc_cluster_iam_member" "pass2" {
+  cluster = "my-private-cluster-member2"
+  role    = "roles/dataproc.editor"
+  member  = "domain:example.com"
+}
+
+
+################
+## FAIL TESTS ##
+################
+
+resource "google_dataproc_cluster_iam_binding" "fail1" {
+  cluster = "my-public-cluster-binding1"
+  role    = "roles/dataproc.hubAgent"
+  members = [
+    "allAuthenticatedUsers",
+  ]
+}
+
+resource "google_dataproc_cluster_iam_binding" "fail2" {
+  cluster = "my-public-cluster-binding2"
+  role    = "roles/dataproc.editor"
+  members = [
+    "allUsers",
+  ]
+}
+
+resource "google_dataproc_cluster_iam_member" "fail1" {
+  cluster = "my-public-cluster-member1"
+  role    = "roles/dataproc.admin"
+  member  = "allAuthenticatedUsers"
+}
+
+resource "google_dataproc_cluster_iam_member" "fail2" {
+  cluster = "my-public-cluster-member2"
+  role    = "roles/editor"
+  member  = "allUsers"
+}

--- a/tests/terraform/checks/resource/gcp/test_DataprocPrivateCluster.py
+++ b/tests/terraform/checks/resource/gcp/test_DataprocPrivateCluster.py
@@ -1,0 +1,46 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.DataprocPrivateCluster import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestDataprocPrivateCluster(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_DataprocPrivateCluster"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_dataproc_cluster_iam_binding.pass1',
+            'google_dataproc_cluster_iam_binding.pass2',
+            'google_dataproc_cluster_iam_member.pass1',
+            'google_dataproc_cluster_iam_member.pass2',
+
+        }
+        failing_resources = {
+            'google_dataproc_cluster_iam_binding.fail1',
+            'google_dataproc_cluster_iam_binding.fail2',
+            'google_dataproc_cluster_iam_member.fail1',
+            'google_dataproc_cluster_iam_member.fail2',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 4)
+        self.assertEqual(summary['failed'], 4)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR adds support for checking for public dataproc clusters. Dataproc clusters can be made public via IAM bindings.

This check can find 4 failure scenarios for two terraform resources `google_dataproc_cluster_iam_binding` and `google_dataproc_cluster_iam_binding`:

```
resource "google_dataproc_cluster_iam_binding" "fail1" {
  cluster = "my-public-cluster-binding1"
  role    = "roles/dataproc.hubAgent"
  members = [
    "allAuthenticatedUsers",
  ]
}

resource "google_dataproc_cluster_iam_binding" "fail2" {
  cluster = "my-public-cluster-binding2"
  role    = "roles/dataproc.editor"
  members = [
    "allUsers",
  ]
}

resource "google_dataproc_cluster_iam_member" "fail1" {
  cluster = "my-public-cluster-member1"
  role    = "roles/dataproc.admin"
  member  = "allAuthenticatedUsers"
}

resource "google_dataproc_cluster_iam_member" "fail2" {
  cluster = "my-public-cluster-member2"
  role    = "roles/editor"
  member  = "allUsers"
}
```