### PR TITLE
bump bc-pyhton-hcl2 to 0.3.30

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -32,7 +32,7 @@ dlint = "*"
 #
 # REMINDER: Update "install_requires" deps on setup.py when changing
 #
-bc-python-hcl2 = ">=0.3.3"
+bc-python-hcl2 = ">=0.3.30"
 deep_merge = "*"
 tabulate = "*"
 colorama="*"

--- a/Pipfile
+++ b/Pipfile
@@ -32,7 +32,7 @@ dlint = "*"
 #
 # REMINDER: Update "install_requires" deps on setup.py when changing
 #
-bc-python-hcl2 = ">=0.3.21,<=0.3.28"
+bc-python-hcl2 = ">=0.3.3"
 deep_merge = "*"
 tabulate = "*"
 colorama="*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6d51aa0031d8b71216bf5333165e7ce73a4de7471a05469e774a074a7a2e7eaa"
+            "sha256": "a0b3f7c77272e3318815815c83f78777f70ed72ec40c9047fc5ca8056cf0a984"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -134,6 +134,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==4.0.2"
         },
+        "asynctest": {
+            "hashes": [
+                "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676",
+                "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==0.13.0"
+        },
         "attrs": {
             "hashes": [
                 "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
@@ -144,11 +152,11 @@
         },
         "bc-python-hcl2": {
             "hashes": [
-                "sha256:74e4b21d329b6bd9396617d075b835e5c0cb2ecdbd951fee631886de81f69c80",
-                "sha256:db2f14874cd049a7d05d56f0c14e6c6993975e62ef307c22b3b68091531ed38a"
+                "sha256:a5c1050d0166b43cc7c30d872c07fdaef3ab7fd1749d7e53f52a0f7d6a53a24a",
+                "sha256:c1f71320f29b30f6bbc695f3905b719f11b66511734f0df910fedfe33c07c5cb"
             ],
             "index": "pypi",
-            "version": "==0.3.28"
+            "version": "==0.3.30"
         },
         "beautifulsoup4": {
             "hashes": [
@@ -935,11 +943,12 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
-                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
+                "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
+                "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
+                "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
             ],
             "index": "pypi",
-            "version": "==4.1.1"
+            "version": "==3.10.0.2"
         },
         "update-checker": {
             "hashes": [
@@ -1161,6 +1170,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==4.0.2"
+        },
+        "asynctest": {
+            "hashes": [
+                "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676",
+                "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==0.13.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -1412,6 +1429,14 @@
             ],
             "markers": "python_version >= '3'",
             "version": "==3.3"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c",
+                "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"
+            ],
+            "index": "pypi",
+            "version": "==4.11.1"
         },
         "importlib-resources": {
             "hashes": [
@@ -1779,6 +1804,15 @@
                 "sha256:abd2d4857837482b1834b4817f0587678dcc531dbc9abe4cde4da28cef3f522c"
             ],
             "version": "==1.26.9"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
+                "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
+                "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
+            ],
+            "index": "pypi",
+            "version": "==3.10.0.2"
         },
         "urllib3": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         ]
     },
     install_requires=[
-        "bc-python-hcl2>=0.3.24,<=0.3.28",
+        "bc-python-hcl2>=0.3.3",
         "cloudsplaining>=0.4.1",
         "deep_merge",
         "tabulate",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         ]
     },
     install_requires=[
-        "bc-python-hcl2>=0.3.3",
+        "bc-python-hcl2>=0.3.30",
         "cloudsplaining>=0.4.1",
         "deep_merge",
         "tabulate",


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Bumping the parser package after reverting the changes in bc-python-hcl2 so the parser keeps wrapping attributes in lists (as it was before).