### PR TITLE
Ensure Machine Learning Compute Cluster Local Authentication is disabled

### DIFF
--- a/checkov/terraform/checks/resource/azure/MLCCLADisabled.py
+++ b/checkov/terraform/checks/resource/azure/MLCCLADisabled.py
@@ -1,0 +1,26 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class MLCCLADisabled(BaseResourceValueCheck):
+    def __init__(self):
+        # This is the full description of your check
+        description = "Ensure Machine Learning Compute Cluster Local Authentication is disabled"
+
+        # This is the Unique ID for your check
+        id = "CKV_AZURE_142"
+
+        # These are the terraform objects supported by this check (ex: aws_iam_policy_document)
+        supported_resources = ['azurerm_machine_learning_compute_cluster']
+
+        # Valid CheckCategories are defined in checkov/common/models/enums.py
+        categories = [CheckCategories.IAM]
+        super().__init__(name=description, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "local_auth_enabled"
+
+    def get_expected_value(self):
+        return False
+
+check = MLCCLADisabled()

--- a/tests/terraform/checks/resource/azure/example_MLCCLADisabled/MLCCLADisabled.tf
+++ b/tests/terraform/checks/resource/azure/example_MLCCLADisabled/MLCCLADisabled.tf
@@ -1,0 +1,58 @@
+## SHOULD PASS: Explicitly define parameter local_auth_enabled to false
+resource "azurerm_machine_learning_compute_cluster" "ckv_unittest_pass" {
+  name                          = "example"
+  location                      = "West Europe"
+  vm_priority                   = "LowPriority"
+  vm_size                       = "Standard_DS2_v2"
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+  local_auth_enabled            = false
+
+  scale_settings {
+    min_node_count                       = 0
+    max_node_count                       = 1
+    scale_down_nodes_after_idle_duration = "PT30S" # 30 seconds
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+## SHOULD FAIL: Explicitly define parameter local_auth_enabled to true
+resource "azurerm_machine_learning_compute_cluster" "ckv_unittest_fail" {
+  name                          = "example"
+  location                      = "West Europe"
+  vm_priority                   = "LowPriority"
+  vm_size                       = "Standard_DS2_v2"
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+  local_auth_enabled            = true
+
+  scale_settings {
+    min_node_count                       = 0
+    max_node_count                       = 1
+    scale_down_nodes_after_idle_duration = "PT30S" # 30 seconds
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+## SHOULD FAIL: Do not explicitly assign value to local_auth_enabled parameter as default value is true
+resource "azurerm_machine_learning_compute_cluster" "ckv_unittest_fail_2" {
+  name                          = "example"
+  location                      = "West Europe"
+  vm_priority                   = "LowPriority"
+  vm_size                       = "Standard_DS2_v2"
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+
+  scale_settings {
+    min_node_count                       = 0
+    max_node_count                       = 1
+    scale_down_nodes_after_idle_duration = "PT30S" # 30 seconds
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}

--- a/tests/terraform/checks/resource/azure/test_MLCCLADisabled.py
+++ b/tests/terraform/checks/resource/azure/test_MLCCLADisabled.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.MLCCLADisabled import check
+
+
+class TestMLCCLADisabled(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_MLCCLADisabled")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_machine_learning_compute_cluster.ckv_unittest_pass'
+        }
+        failing_resources = {
+            'azurerm_machine_learning_compute_cluster.ckv_unittest_fail',
+            'azurerm_machine_learning_compute_cluster.ckv_unittest_fail_2'
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Custom Policy ID: CKV_AZURE_142
Custom Policy name: Ensure Machine Learning Compute Cluster Local Authentication is disabled
Custom Policy IaC type: Terraform
Custom Policy type and provider: AzureRM
IaC configuration documentation (If available): https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/machine_learning_compute_cluster#local_auth_enabled
Sample Terraform configuration file: N/A
Any additional information that would help other members to better understand the check: 
https://docs.microsoft.com/en-us/azure/machine-learning/how-to-setup-authentication
https://docs.microsoft.com/en-us/azure/machine-learning/how-to-create-attach-compute-cluster