### PR TITLE
do not strip arrays of length 1 twice

### DIFF
--- a/checkov/common/graph/graph_builder/graph_components/blocks.py
+++ b/checkov/common/graph/graph_builder/graph_components/blocks.py
@@ -93,7 +93,7 @@ class Block:
             if isinstance(attribute_value, list) and len(attribute_value) == 1:
                 attribute_value = attribute_value[0]
             if isinstance(attribute_value, (list, dict)):
-                inner_attributes = self.get_inner_attributes(attribute_key, attribute_value)
+                inner_attributes = self.get_inner_attributes(attribute_key, attribute_value, False)
                 base_attributes.update(inner_attributes)
             if attribute_key == "self":
                 base_attributes["self_"] = attribute_value
@@ -168,6 +168,7 @@ class Block:
         cls,
         attribute_key: str,
         attribute_value: Union[str, List[str], Dict[str, Any]],
+        strip_list: bool = True  # used by subclass
     ) -> Dict[str, Any]:
         inner_attributes: Dict[str, Any] = {}
 

--- a/checkov/terraform/graph_builder/graph_components/blocks.py
+++ b/checkov/terraform/graph_builder/graph_components/blocks.py
@@ -104,8 +104,9 @@ class TerraformBlock(Block):
         cls,
         attribute_key: str,
         attribute_value: Union[str, List[str], Dict[str, Any]],
+        strip_list: bool = True
     ) -> Dict[str, Any]:
-        if isinstance(attribute_value, list) and len(attribute_value) == 1:
+        if strip_list and isinstance(attribute_value, list) and len(attribute_value) == 1:
             attribute_value = attribute_value[0]
 
         return super().get_inner_attributes(

--- a/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/WildcardWithin.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/WildcardWithin.yaml
@@ -1,0 +1,15 @@
+metadata:
+  id: "WildcardWithin"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "aws_xyz"
+  attribute: "arr.*"
+  operator: "within"
+  value:
+    - "allowed1"
+    - "allowed2"
+    - "allowed3"
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/test_solver.py
@@ -18,3 +18,12 @@ class TestWithinSolver(TestBaseSolver):
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
         self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_wildcard(self):
+        root_folder = '../../../resources/array_test'
+        check_id = 'WildcardWithin'
+        should_pass = ['aws_xyz.pass1', 'aws_xyz.pass2', 'aws_xyz.pass3']
+        # TODO fail1 needs to fail here, but for now we are just skipping the resource, because it's a larger discussion on how to handle wildcard matches.
+        should_fail = ['aws_xyz.fail2', 'aws_xyz.fail3']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)

--- a/tests/terraform/graph/resources/array_test/main.tf
+++ b/tests/terraform/graph/resources/array_test/main.tf
@@ -1,0 +1,39 @@
+resource "aws_xyz" "pass1" {
+  arr = [
+    "allowed1"
+  ]
+  a_string = "abc"
+}
+
+resource "aws_xyz" "pass2" {
+  arr = [
+    "allowed1",
+    "allowed3"
+  ]
+}
+
+resource "aws_xyz" "pass3" {
+  arr = [
+  ]
+}
+
+//resource "aws_xyz" "fail1" {
+//  arr = [
+//    "allowed1",
+//    "notallowed"
+//  ]
+//}
+
+resource "aws_xyz" "fail2" {
+  arr = [
+    "notallowed",
+    "alsonotallowed"
+  ]
+}
+
+resource "aws_xyz" "fail3" {
+  arr = [
+    "notallowed"
+  ]
+}
+


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes an issue where the following HCL:

`arr = ["abc"]`

does not get considered as an array for the purposes of graph attribute building. We want it to come away with two attributes:

`arr = ['abc']` and
`arr.0 = 'abc'`, but the `.#` keys do not get added like they do when the array is length 2+.

The test I added tests a specific type of policy case, but also implicitly tests this functionality. Before this change, the `pass1` resource would fail the test policy.