### PR TITLE
Fix bugs in cfn variable rendering and ECRPolicy check

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ECRPolicy.py
+++ b/checkov/cloudformation/checks/resource/aws/ECRPolicy.py
@@ -25,26 +25,27 @@ class ECRPolicy(BaseResourceCheck):
         """
         self.evaluated_keys = ["Properties/RepositoryPolicyText/Statement"]
         policy_text = conf.get('Properties', {}).get('RepositoryPolicyText')
-        if policy_text:
-            if type(policy_text) in (str, StrNode):
-                try:
-                    policy_text = json.loads(str(policy_text))
-                except json.decoder.JSONDecodeError as e:
-                    if re.match(DEFAULT_VAR_PATTERN, str(policy_text)):
-                        # Case where the template is a sub-CFN configuration inside a serverless configuration,
-                        # and the policy is a variable expression
-                        logging.info(f"Encountered variable expression {str(policy_text)} in resource ${self.entity_path}")
-                    else:
-                        logging.error(
-                            f"Malformed policy configuration {str(policy_text)} of resource {self.entity_path}\n{e}")
-                    return CheckResult.UNKNOWN
-            if 'Statement' in policy_text.keys():
-                for statement_index, statement in enumerate(policy_text['Statement']):
-                    if 'Principal' in statement.keys():
-                        for principal_index, principal in enumerate(statement['Principal']):
-                            if principal == "*" and not self.check_for_constrained_condition(statement):
-                                self.evaluated_keys = [f"Properties/RepositoryPolicyText/Statement/[{statement_index}]/Principal/[{principal_index}]"]
-                                return CheckResult.FAILED
+        if not policy_text:
+            return CheckResult.PASSED
+        if type(policy_text) in (str, StrNode):
+            try:
+                policy_text = json.loads(str(policy_text))
+            except json.decoder.JSONDecodeError as e:
+                if re.match(DEFAULT_VAR_PATTERN, str(policy_text)):
+                    # Case where the template is a sub-CFN configuration inside a serverless configuration,
+                    # and the policy is a variable expression
+                    logging.info(f"Encountered variable expression {str(policy_text)} in resource ${self.entity_path}")
+                else:
+                    logging.error(
+                        f"Malformed policy configuration {str(policy_text)} of resource {self.entity_path}\n{e}")
+                return CheckResult.UNKNOWN
+        if 'Statement' in policy_text.keys():
+            for statement_index, statement in enumerate(policy_text['Statement']):
+                if 'Principal' in statement.keys():
+                    for principal_index, principal in enumerate(statement['Principal']):
+                        if principal == "*" and not self.check_for_constrained_condition(statement):
+                            self.evaluated_keys = [f"Properties/RepositoryPolicyText/Statement/[{statement_index}]/Principal/[{principal_index}]"]
+                            return CheckResult.FAILED
         return CheckResult.PASSED
 
     def check_for_constrained_condition(self, statement):

--- a/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
@@ -126,6 +126,9 @@ class CloudformationVariableRenderer(VariableRenderer):
             return None
         if isinstance(values_list, str):
             values_list = values_list.split(', ')
+        for value in values_list:
+            if not isinstance(value, str):
+                return None
         if isinstance(delimiter, str) and isinstance(values_list, list):
             for curr_value in values_list:
                 if isinstance(curr_value, dict):


### PR DESCRIPTION
cfn variable rendering - check that all the values from the `values_list` are string before using them in `join` and getting exceptions.
ECRPolicy check - fix edge-case of properties are from NoneType and then `AttributeError` are thrown for getting the `properties.keys`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
