### PR TITLE
Addition of new check to Ensure that Public Access is disabled for Ma…

### DIFF
--- a/checkov/terraform/checks/resource/azure/MLPublicAccess.py
+++ b/checkov/terraform/checks/resource/azure/MLPublicAccess.py
@@ -1,0 +1,27 @@
+from checkov.common.models.enums import CheckCategories
+from typing import List, Any
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+
+
+class MLPublicAccess(BaseResourceNegativeValueCheck):
+    def __init__(self):
+        # This is the full description of your check
+        description = "Ensure that Public Access is disabled for Machine Learning Workspace"
+
+        # This is the Unique ID for your check
+        id = "CKV_AZURE_144"
+
+        # These are the terraform objects supported by this check (ex: aws_iam_policy_document)
+        supported_resources = ['azurerm_machine_learning_workspace']
+
+        # Valid CheckCategories are defined in checkov/common/models/enums.py
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=description, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "public_network_access_enabled"
+
+    def get_forbidden_values(self) -> List[Any]:
+        return [True]
+
+check = MLPublicAccess()

--- a/tests/terraform/checks/resource/azure/example_MLPublicAccess/MLPublicAccess.tf
+++ b/tests/terraform/checks/resource/azure/example_MLPublicAccess/MLPublicAccess.tf
@@ -1,0 +1,58 @@
+## SHOULD PASS: Explicitly define parameter public_network_access_enabled to false
+resource "azurerm_machine_learning_workspace" "ckv_unittest_pass" {
+  name                          = "example-workspace"
+  location                      = azurerm_resource_group.example.location
+  resource_group_name           = azurerm_resource_group.example.name
+  application_insights_id       = azurerm_application_insights.example.id
+  key_vault_id                  = azurerm_key_vault.example.id
+  storage_account_id            = azurerm_storage_account.example.id
+  public_network_access_enabled = false
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  encryption {
+    key_vault_id = azurerm_key_vault.example.id
+    key_id       = azurerm_key_vault_key.example.id
+  }
+}
+
+## SHOULD PASS: Parameter public_network_access_enabled defaults to false
+resource "azurerm_machine_learning_workspace" "ckv_unittest_pass_2" {
+  name                          = "example-workspace"
+  location                      = azurerm_resource_group.example.location
+  resource_group_name           = azurerm_resource_group.example.name
+  application_insights_id       = azurerm_application_insights.example.id
+  key_vault_id                  = azurerm_key_vault.example.id
+  storage_account_id            = azurerm_storage_account.example.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  encryption {
+    key_vault_id = azurerm_key_vault.example.id
+    key_id       = azurerm_key_vault_key.example.id
+  }
+}
+
+## SHOULD FAIL: Explicitly define parameter public_network_access_enabled to true
+resource "azurerm_machine_learning_workspace" "ckv_unittest_fail" {
+  name                          = "example-workspace"
+  location                      = azurerm_resource_group.example.location
+  resource_group_name           = azurerm_resource_group.example.name
+  application_insights_id       = azurerm_application_insights.example.id
+  key_vault_id                  = azurerm_key_vault.example.id
+  storage_account_id            = azurerm_storage_account.example.id
+  public_network_access_enabled = true
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  encryption {
+    key_vault_id = azurerm_key_vault.example.id
+    key_id       = azurerm_key_vault_key.example.id
+  }
+}

--- a/tests/terraform/checks/resource/azure/test_MLPublicAccess.py
+++ b/tests/terraform/checks/resource/azure/test_MLPublicAccess.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.MLPublicAccess import check
+
+
+class TestMLPublicAccess(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_MLPublicAccess")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_machine_learning_workspace.ckv_unittest_pass',
+            'azurerm_machine_learning_workspace.ckv_unittest_pass_2'
+        }
+        failing_resources = {
+            'azurerm_machine_learning_workspace.ckv_unittest_fail',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…chine Learning Workspace

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Custom Policy id: CKV_AZURE_144
Custom Policy name: Ensure that Public Access is disabled for Machine Learning Workspace
Custom Policy IaC type: Terraform
Custom Policy type and provider: AzureRM
IaC configuration documentation (If available): https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/machine_learning_workspace#public_network_access_enabled

Any additional information that would help other members to better understand the check:
https://docs.microsoft.com/en-us/azure/machine-learning/how-to-configure-private-link
https://docs.microsoft.com/en-us/azure/machine-learning/how-to-secure-workspace-vnet

