### PR TITLE
PAN-OS policy check for applications=any

### DIFF
--- a/checkov/terraform/checks/resource/panos/PolicyNoApplicationAny.py
+++ b/checkov/terraform/checks/resource/panos/PolicyNoApplicationAny.py
@@ -1,0 +1,48 @@
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+
+
+class PolicyNoApplicationAny(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure security rules do not have 'applications' set to 'any' "
+        id = "CKV_PAN_5"
+        supported_resources = ['panos_security_policy','panos_security_rule_group']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+    
+        # Check there is a rule defined in the resource
+        if 'rule' in conf:
+
+            # Report the area of evaluation
+            self.evaluated_keys = ['rule']
+
+            # Get all the rules defined in the resource
+            rules = conf.get('rule')
+
+            # Iterate over each rule
+            for secrule in rules:
+
+                # Check if applications is defined in the resource
+                if 'applications' in secrule:
+
+                    # If applications is defined, get the value
+                    apps = secrule.get('applications')
+                    
+                    # The value "any" is overly permissive and is therefore a fail. The value "any" can only appear on its on, "any" with any other values in the list is rejected by Terraform during apply stage
+                    if apps[0][0] == "any":
+                        return CheckResult.FAILED
+                    # Any non-any value is specifying an application, which is a pass
+                else:
+                    # If "applications" attribute is not defined, this is not valid and will fail during Terraform plan stage, and should therefore be a fail
+                    return CheckResult.FAILED
+            
+            # No "any" found for the "applications" attribute for any rules, therefore we have a pass
+            return CheckResult.PASSED
+
+        # If there's no rules we have nothing to check
+        return CheckResult.UNKNOWN
+
+
+check = PolicyNoApplicationAny()

--- a/tests/terraform/checks/resource/panos/example_PolicyNoApplicationAny/main.tf
+++ b/tests/terraform/checks/resource/panos/example_PolicyNoApplicationAny/main.tf
@@ -1,0 +1,228 @@
+# The "applications" attribute can be defined in either the panos_security_policy resource or the panos_security_rule_group resource.
+# Both resource types are covered by this check.
+
+# Note: Not explicitly setting the applications attribute when creating a rule is not valid, the applications attribute is mandatory and will fail Terraform validation at plan stage, so this is not covered in test cases
+
+# Note: Setting an applications list item of "any" alongside other applications is not valid, "any" must be used on it's own, and if used in a list alongside other application names and will fail Terraform validation at apply stage, so this is not covered in test cases
+
+# Application is set to any, which is a fail as it is overly permissive
+resource "panos_security_policy" "fail1" {
+    rule {
+        name = "my-bad-rule-fail1"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["any"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+}
+
+# Application is set to any, which is a fail as it is overly permissive
+resource "panos_security_rule_group" "fail2" {
+    rule {
+        name = "my-bad-rule-fail2"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["any"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+}
+
+# Application is set to non-any in the first rule, but any in the second rule, which is a fail as it is overly permissive
+resource "panos_security_policy" "fail3" {
+    rule {
+        name = "my-bad-fail3-rule1"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["web-browsing"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+    rule {
+        name = "my-bad-fail3-rule2"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["any"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+}
+
+# Application is set to non-any in the first rule, but any in the second rule, which is a fail as it is overly permissive
+resource "panos_security_rule_group" "fail4" {
+    rule {
+        name = "my-bad-fail4-rule1"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["web-browsing"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+    rule {
+        name = "my-bad-fail4-rule2"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["any"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+}
+
+# Application is set to a non-any value, which is a pass
+resource "panos_security_policy" "pass1" {
+    rule {
+        name = "my-good-rule-pass1"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["web-browsing"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+}
+
+# Application is set to a non-any value, which is a pass
+resource "panos_security_rule_group" "pass2" {
+    rule {
+        name = "my-good-rule-pass2"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["web-browsing"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+}
+
+# Application is set to a non-any value in both rules, which is a pass
+resource "panos_security_policy" "pass3" {
+    rule {
+        name = "my-good-pass3-rule1"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["web-browsing"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+    rule {
+        name = "my-good-pass3-rule2"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["web-browsing"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+}
+
+# Application is set to a non-any value in both rules, which is a pass
+resource "panos_security_rule_group" "pass4" {
+    rule {
+        name = "my-good-pass4-rule1"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["web-browsing"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+    rule {
+        name = "my-good-pass4-rule2"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["web-browsing"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+}
+
+# Application is set to multiple non-any values, which is a pass
+resource "panos_security_policy" "pass5" {
+    rule {
+        name = "my-good-rule-pass5"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+}
+
+# Application is set to multiple non-any values, which is a pass
+resource "panos_security_rule_group" "pass6" {
+    rule {
+        name = "my-good-rule-pass6"
+        source_zones = ["any"]
+        source_addresses = ["any"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["any"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+    }
+}

--- a/tests/terraform/checks/resource/panos/test_PolicyNoApplicationAny.py
+++ b/tests/terraform/checks/resource/panos/test_PolicyNoApplicationAny.py
@@ -1,0 +1,47 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.panos.PolicyNoApplicationAny import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class PolicyNoApplicationAny(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_PolicyNoApplicationAny"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'panos_security_policy.pass1',
+            'panos_security_rule_group.pass2',
+            'panos_security_policy.pass3',
+            'panos_security_rule_group.pass4',
+            'panos_security_policy.pass5',
+            'panos_security_rule_group.pass6',
+        }
+        failing_resources = {
+            'panos_security_policy.fail1',
+            'panos_security_rule_group.fail2',
+            'panos_security_policy.fail3',
+            'panos_security_rule_group.fail4',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 6)
+        self.assertEqual(summary['failed'], 4)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

A resource check for PAN-OS Terraform provider for security policy rules. This one ensures that 'applications' is not set to 'any' which is overly permissive. The 'applications' attribute can be set in two different resource types, both are covered by this check.