### PR TITLE
Fix Route53 filter to include aws_alb as well

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/Route53ARecordAttachedResource.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/Route53ARecordAttachedResource.yaml
@@ -36,6 +36,7 @@ definition:
               - aws_eip
               - aws_elb
               - aws_lb
+              - aws_alb
               - aws_route53_record
               - aws_s3_bucket
               - aws_api_gateway_domain_name

--- a/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/expected.yaml
+++ b/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/expected.yaml
@@ -7,6 +7,7 @@ pass:
   - "aws_route53_record.legacy-tf"
   - "aws_route53_record.pass_eb"
   - "aws_route53_record.pass_apiv2"
+  - "aws_route53_record.pass_alb"
 fail:
   - "aws_route53_record.fail"
 ignore:

--- a/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
+++ b/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
@@ -97,14 +97,22 @@ resource "aws_route53_record" "pass4" {
   }
 }
 
+resource "aws_alb" "example" {
+  name               = "example"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.lb_sg.id]
+  subnets            = [for subnet in aws_subnet.public : subnet.id]
+}
+
 resource "aws_route53_record" "pass_alb" {
   zone_id = data.aws_route53_zone.example.zone_id
   name    = "example"
   type    = "A"
 
   alias {
-    name                   = data.aws_alb.example.dns_name
-    zone_id                = data.aws_alb.example.zone_id
+    name                   = aws_alb.example.dns_name
+    zone_id                = aws_alb.example.zone_id
     evaluate_target_health = true
   }
 }

--- a/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
+++ b/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
@@ -97,6 +97,18 @@ resource "aws_route53_record" "pass4" {
   }
 }
 
+resource "aws_route53_record" "pass_alb" {
+  zone_id = data.aws_route53_zone.example.zone_id
+  name    = "example"
+  type    = "A"
+
+  alias {
+    name                   = data.aws_alb.example.dns_name
+    zone_id                = data.aws_alb.example.zone_id
+    evaluate_target_health = true
+  }
+}
+
 resource "aws_route53_record" "pass5" {
   zone_id = data.aws_route53_zone.selected.zone_id
   name    = var.fqdn


### PR DESCRIPTION
Currently, the filter only checks for aws_lb and aws_elb. But aws_alb is a correct resource name as well as it's an alias for aws_lb

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
