### PR TITLE
CKV2_GCP_9 - Ensure that Container Registry repositories are not anonymously or publicly accessible

### DIFF
--- a/checkov/terraform/checks/graph_checks/gcp/GCPContainerRegistryReposAreNotPubliclyAccessible.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPContainerRegistryReposAreNotPubliclyAccessible.yaml
@@ -1,0 +1,63 @@
+metadata:
+  id: "CKV2_GCP_9"
+  name: "Ensure that Container Registry repositories are not anonymously or publicly accessible"
+  category: "SECURITY"
+definition:
+  and:
+    - cond_type: filter
+      attribute: resource_type
+      value:
+        - google_container_registry
+      operator: within
+    - or:
+        - cond_type: connection
+          operator: not_exists
+          resource_types:
+            - google_container_registry
+          connected_resource_types:
+            - google_storage_bucket_iam_member
+        - and:
+            - cond_type: connection
+              operator: exists
+              resource_types:
+                - google_container_registry
+              connected_resource_types:
+                - google_storage_bucket_iam_member
+            - cond_type: attribute
+              attribute: member
+              operator: not_equals
+              value: "allAuthenticatedUsers"
+              resource_types:
+                - google_storage_bucket_iam_member
+            - cond_type: attribute
+              attribute: member
+              operator: not_equals
+              value: "allUsers"
+              resource_types:
+                - google_storage_bucket_iam_member
+    - or:
+        - cond_type: connection
+          operator: not_exists
+          resource_types:
+            - google_container_registry
+          connected_resource_types:
+            - google_storage_bucket_iam_binding
+        - and:
+            - cond_type: connection
+              operator: exists
+              resource_types:
+                - google_container_registry
+              connected_resource_types:
+                - google_storage_bucket_iam_binding
+            - cond_type: attribute
+              attribute: members
+              operator: not_contains
+              value: "allAuthenticatedUsers"
+              resource_types:
+                - google_storage_bucket_iam_binding
+            - cond_type: attribute
+              attribute: members
+              operator: not_contains
+              value: "allUsers"
+              resource_types:
+                - google_storage_bucket_iam_binding

--- a/tests/terraform/graph/checks/resources/GCPContainerRegistryReposAreNotPubliclyAccessible/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPContainerRegistryReposAreNotPubliclyAccessible/expected.yaml
@@ -1,0 +1,14 @@
+pass:
+  - "google_container_registry.pass1"
+  - "google_container_registry.pass2"
+  - "google_container_registry.pass3"
+  - "google_container_registry.pass4"
+fail:
+  - "google_container_registry.fail1"
+  - "google_container_registry.fail2"
+  - "google_container_registry.fail3"
+  - "google_container_registry.fail4"
+  - "google_container_registry.fail5"
+  - "google_container_registry.fail6"
+  - "google_container_registry.fail7"
+  - "google_container_registry.fail8"

--- a/tests/terraform/graph/checks/resources/GCPContainerRegistryReposAreNotPubliclyAccessible/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPContainerRegistryReposAreNotPubliclyAccessible/main.tf
@@ -1,0 +1,156 @@
+resource "google_container_registry" "pass1" {
+  project  = "my-project"
+  location = "EU"
+}
+
+resource "google_storage_bucket_iam_member" "pass1_member" {
+  bucket = google_container_registry.pass1.id
+  role = "roles/storage.objectViewer"
+  member = "user:jason@example.com"
+}
+
+resource "google_container_registry" "pass2" {
+  project  = "my-project"
+  location = "EU"
+}
+
+resource "google_storage_bucket_iam_member" "pass2_member" {
+  bucket = google_container_registry.pass2.id
+  role = "roles/storage.objectViewer"
+  member = "group:my-group@example.com"
+}
+
+resource "google_container_registry" "pass3" {
+  project  = "my-project"
+  location = "US"
+}
+
+resource "google_storage_bucket_iam_binding" "pass3_binding" {
+  bucket = google_container_registry.pass3.id
+  role = "roles/storage.admin"
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+resource "google_container_registry" "pass4" {
+  project  = "my-project"
+  location = "US"
+}
+
+resource "google_storage_bucket_iam_binding" "pass4_binding" {
+  bucket = google_container_registry.pass4.id
+  role = "roles/storage.admin"
+  members = [
+    "user:jane@example.com",
+    "domain:example.com",
+    "group:my-group@example.com",
+  ]
+}
+
+resource "google_container_registry" "fail1" {
+  project  = "my-project"
+  location = "EU"
+}
+
+resource "google_storage_bucket_iam_member" "fail1_member" {
+  bucket = google_container_registry.fail1.id
+  role = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+resource "google_container_registry" "fail2" {
+  project  = "my-project"
+  location = "EU"
+}
+
+resource "google_storage_bucket_iam_member" "fail2_member" {
+  bucket = google_container_registry.fail2.id
+  role = "roles/storage.objectViewer"
+  member = "allAuthenticatedUsers"
+}
+
+resource "google_container_registry" "fail3" {
+  project  = "my-project"
+  location = "EU"
+}
+
+resource "google_storage_bucket_iam_binding" "fail3_binding" {
+  bucket = google_container_registry.fail3.id
+  role = "roles/storage.admin"
+  members = [
+    "allUsers",
+  ]
+}
+
+resource "google_container_registry" "fail4" {
+  project  = "my-project"
+  location = "EU"
+}
+
+resource "google_storage_bucket_iam_binding" "fail4_binding" {
+  bucket = google_container_registry.fail4.id
+  role = "roles/storage.admin"
+  members = [
+    "allAuthenticatedUsers",
+  ]
+}
+
+resource "google_container_registry" "fail5" {
+  project  = "my-project"
+  location = "EU"
+}
+
+resource "google_storage_bucket_iam_binding" "fail5_binding" {
+  bucket = google_container_registry.fail5.id
+  role = "roles/storage.admin"
+  members = [
+    "allAuthenticatedUsers",
+    "group:my-group@example.com"
+  ]
+}
+
+resource "google_container_registry" "fail6" {
+  project  = "my-project"
+  location = "EU"
+}
+
+resource "google_storage_bucket_iam_binding" "fail6_binding" {
+  bucket = google_container_registry.fail6.id
+  role = "roles/storage.admin"
+  members = [
+    "group:my-group@example.com",
+    "allUsers",
+    "user:jason@example.com",
+  ]
+}
+
+resource "google_container_registry" "fail7" {
+  project  = "my-project"
+  location = "EU"
+}
+
+resource "google_storage_bucket_iam_binding" "fail7_binding" {
+  bucket = google_container_registry.fail7.id
+  role = "roles/storage.admin"
+  members = [
+    "allUsers",
+    "group:my-group@example.com",
+    "user:jason@example.com",
+  ]
+}
+
+resource "google_container_registry" "fail8" {
+  project  = "my-project"
+  location = "EU"
+}
+
+resource "google_storage_bucket_iam_binding" "fail8_binding" {
+  bucket = google_container_registry.fail8.id
+  role = "roles/storage.admin"
+  members = [
+    "group:my-group@example.com",
+    "user:jason@example.com",
+    "allAuthenticatedUsers",
+  ]
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -213,6 +213,9 @@ class TestYamlPolicies(unittest.TestCase):
     def test_GCPKMSKeyRingsAreNotPubliclyAccessible(self):
         self.go("GCPKMSKeyRingsAreNotPubliclyAccessible")
 
+    def test_GCPContainerRegistryReposAreNotPubliclyAccessible(self):
+        self.go("GCPContainerRegistryReposAreNotPubliclyAccessible")
+
     def test_registry_load(self):
         registry = Registry(parser=NXGraphCheckParser(), checks_dir=str(
             Path(__file__).parent.parent.parent.parent.parent / "checkov" / "terraform" / "checks" / "graph_checks"))


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR is a new graph check for GCP [Container Registry repositories](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_registry).

This is a good scenario for a graph check in checkov. Container registry terraform resources themselves only support two keys `location` and `project`. The way to make them public is via a GCS bucket IAM resource like `google_storage_bucket_iam_member`, but if we only check for that resource, it would technically be a GCS public bucket check.

I think it's important to keep them separate so that the remediation guidance walks through the risks of public container registries. With a graph check, we can specifically hit the public repo check if `google_container_registry` AND `google_storage_bucket_iam_member` OR `google_storage_bucket_iam_binding` exist.

Let me know what you think. Happy to adjust however needed.

Thanks!