### PR TITLE
check if redirect block is a dict

### DIFF
--- a/checkov/terraform/checks/resource/aws/AppLoadBalancerTLS12.py
+++ b/checkov/terraform/checks/resource/aws/AppLoadBalancerTLS12.py
@@ -1,14 +1,16 @@
+from typing import Dict, List, Any
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.common.util.type_forcers import force_list
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
 
 class AppLoadBalancerTLS12(BaseResourceCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure that load balancer is using TLS 1.2"
         id = "CKV_AWS_103"
-        supported_resources = ["aws_lb_listener", "aws_alb_listener"]
-        categories = [CheckCategories.GENERAL_SECURITY]
+        supported_resources = ("aws_lb_listener", "aws_alb_listener")
+        categories = (CheckCategories.GENERAL_SECURITY,)
         super().__init__(
             name=name,
             id=id,
@@ -16,7 +18,7 @@ class AppLoadBalancerTLS12(BaseResourceCheck):
             supported_resources=supported_resources,
         )
 
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
         key = "protocol"
         self.evaluated_keys = [key]
         if key in conf.keys():
@@ -34,7 +36,7 @@ class AppLoadBalancerTLS12(BaseResourceCheck):
             for idx_action, action in enumerate(conf.get("default_action", [])):
                 redirects = action.get("redirect", [])
                 for idx_redirect, redirect in enumerate(force_list(redirects)):
-                    if redirect.get("protocol", []) == ["HTTPS"]:
+                    if isinstance(redirect, dict) and redirect.get("protocol", []) == ["HTTPS"]:
                         redirect_index = f"[{idx_redirect}]/" if isinstance(redirects, list) else ""
                         self.evaluated_keys.append(f'default_action/[{idx_action}]/redirect/{redirect_index}protocol')
                         return CheckResult.PASSED

--- a/tests/terraform/checks/resource/aws/example_AppLoadBalancerTLS12/main.tf
+++ b/tests/terraform/checks/resource/aws/example_AppLoadBalancerTLS12/main.tf
@@ -139,3 +139,18 @@ resource "aws_alb_listener" "tls_fs_1_1" {
     target_group_arn = var.aws_lb_target_group_arn
   }
 }
+
+# mimicking a Terraform plan output by using an empty block
+
+resource "aws_lb_listener" "cognito" {
+  load_balancer_arn = var.aws_lb_arn
+  protocol          = "HTTP"
+  port              = "80"
+
+  default_action {
+    type = "authenticate-cognito"
+
+    redirect {
+    }
+  }
+}

--- a/tests/terraform/checks/resource/aws/test_AppLoadBalancerTLS12.py
+++ b/tests/terraform/checks/resource/aws/test_AppLoadBalancerTLS12.py
@@ -31,13 +31,14 @@ class TestAppLoadBalancerTLS12(unittest.TestCase):
             "aws_lb_listener.https_2016",
             "aws_lb_listener.tls_fs_1_1",
             "aws_alb_listener.tls_fs_1_1",
+            "aws_lb_listener.cognito",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
         self.assertEqual(summary["passed"], 7)
-        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["failed"], 5)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #2441 this can happen when using the Terraform plan runner, so I I mimicked it by adding an empty `redirect` block.