### PR TITLE
Exclude raw HELM templates from Kubernetes runner

### DIFF
--- a/checkov/kubernetes/parser/k8_yaml.py
+++ b/checkov/kubernetes/parser/k8_yaml.py
@@ -29,6 +29,9 @@ def load(filename: Path) -> Tuple[List[Dict[str, Any]], List[Tuple[int, str]]]:
     if not all(key in content for key in ("apiVersion", "kind")):
         return [{}], []
 
+    if '{{' in content:
+        return [{}], []
+
     file_lines = [(idx + 1, line) for idx, line in enumerate(content.splitlines(keepends=True))]
 
     template = loads(content)

--- a/tests/kubernetes/parser/examples/yaml/helm.yaml
+++ b/tests/kubernetes/parser/examples/yaml/helm.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  redis-password: {{ include "redis.password" . | b64enc | quote }}
+{{- end -}}

--- a/tests/kubernetes/parser/examples/yaml/helm2.yaml
+++ b/tests/kubernetes/parser/examples/yaml/helm2.yaml
@@ -1,0 +1,8 @@
+---
+layout: null
+---
+{% helm %}
+datastore: kubernetes
+network: something
+vxlan: true
+{% endhelm %}

--- a/tests/kubernetes/parser/test_k8_yaml.py
+++ b/tests/kubernetes/parser/test_k8_yaml.py
@@ -1,30 +1,59 @@
+import unittest
 from pathlib import Path
 
 from checkov.kubernetes.parser.k8_yaml import load
 
+
 EXAMPLES_DIR = Path(__file__).parent / "examples"
+class TestScannerRegistry(unittest.TestCase):
 
-def test_load_pod():
-    # given
-    file_path = EXAMPLES_DIR / "yaml/busybox.yaml"
+    def test_load_pod(self):
+        # given
+        file_path = EXAMPLES_DIR / "yaml/busybox.yaml"
 
-    # when
-    template, file_lines = load(file_path)
+        # when
+        template, file_lines = load(file_path)
 
-    # then
-    assert len(template) == 1
-    assert template[0]["apiVersion"] == "v1"
-    assert template[0]["kind"] == "Pod"
-    assert len(file_lines) == 28
+        # then
+        assert len(template) == 1
+        assert template[0]["apiVersion"] == "v1"
+        assert template[0]["kind"] == "Pod"
+        assert len(file_lines) == 28
 
 
-def test_load_not_k8s_file():
-    # given
-    file_path = EXAMPLES_DIR / "yaml/normal.yaml"
+    def test_load_not_k8s_file(self):
+        # given
+        file_path = EXAMPLES_DIR / "yaml/normal.yaml"
 
-    # when
-    template, file_lines = load(file_path)
+        # when
+        template, file_lines = load(file_path)
 
-    # then
-    assert template == [{}]
-    assert file_lines == []
+        # then
+        assert template == [{}]
+        assert file_lines == []
+
+
+    def test_load_helm_template_file(self):
+        # given
+        file_path = EXAMPLES_DIR / "yaml/helm.yaml"
+
+        # when
+        template, file_lines = load(file_path)
+
+        # then
+        assert template == [{}]
+        assert file_lines == []
+
+    def test_load_helm_vars_file(self):
+        # given
+        file_path = EXAMPLES_DIR / "yaml/helm2.yaml"
+
+        # when
+        template, file_lines = load(file_path)
+
+        # then
+        assert template == [{}]
+        assert file_lines == []
+        
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Prevents HELM template files which have not gone through the HELM runner being picked up directly by the kubernetes runner.

Previously this would cause the kubernetes runner to fail at a yaml.loads due to {{- HELM variable/markup syntax within the files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
