### PR TITLE
PAN-OS resource check for log forwarding profiles

### DIFF
--- a/checkov/terraform/checks/resource/panos/PolicyLogForwarding.py
+++ b/checkov/terraform/checks/resource/panos/PolicyLogForwarding.py
@@ -1,0 +1,46 @@
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+
+
+class PolicyLogForwarding(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure a Log Forwarding Profile is selected for each security policy rule"
+        id = "CKV_PAN_9"
+        supported_resources = ['panos_security_policy','panos_security_rule_group']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+    
+        # Check there is a rule defined in the resource
+        if 'rule' in conf:
+
+            # Report the area of evaluation
+            self.evaluated_keys = ['rule']
+
+            # Get all the rules defined in the resource
+            rules = conf.get('rule')
+
+            # Iterate over each rule
+            for secrule in rules:
+
+                # Check if a log_setting is defined in the rule
+                if 'log_setting' in secrule:
+
+                    # If a log_setting is defined, get the value
+                    desc = secrule.get('log_setting')
+
+                    if desc[0].strip() == "":
+                        # An empty string is no log_setting, which is a fail
+                        return CheckResult.FAILED
+                else:
+                    # If a log_setting attribute is not explicitly set, this is a fail
+                    return CheckResult.FAILED
+            
+            # If no fails have been found, this is a pass
+            return CheckResult.PASSED
+
+        # If there's no rules we have nothing to check
+        return CheckResult.UNKNOWN
+
+check = PolicyLogForwarding()

--- a/tests/terraform/checks/resource/panos/example_PolicyLogForwarding/main.tf
+++ b/tests/terraform/checks/resource/panos/example_PolicyLogForwarding/main.tf
@@ -1,0 +1,360 @@
+# The Log Forwarding Profile attribute "log_setting" be used in either the panos_security_policy resource or the panos_security_rule_group resource.
+# Both resource types are covered by this check.
+
+# Fails
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, therefore absence of the log_setting attribute is therefore a fail
+resource "panos_security_policy" "fail1" {
+    rule {
+        name = "my-bad-rule-fail1"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, therefore absence of the log_setting attribute is therefore a fail
+resource "panos_security_rule_group" "fail2" {
+    rule {
+        name = "my-bad-rule-fail2"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, therefore any empty log_setting attribute is a fail
+resource "panos_security_policy" "fail3" {
+    rule {
+        name = "my-bad-rule-fail3"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = ""
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, therefore any empty log_setting attribute is a fail
+resource "panos_security_rule_group" "fail4" {
+    rule {
+        name = "my-bad-rule-fail4"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = ""
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, therefore any empty log_setting attribute is a fail (2nd rule)
+resource "panos_security_policy" "fail5" {
+    rule {
+        name = "my-good-rule-fail5"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "my-log-fwd-profile"
+    }
+    rule {
+        name = "my-bad-rule-fail5"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = ""
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, therefore any empty log_setting attribute is a fail (2nd rule)
+resource "panos_security_rule_group" "fail6" {
+    rule {
+        name = "my-good-rule-fail6"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "my-log-fwd-profile"
+    }
+    rule {
+        name = "my-bad-rule-fail6"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = ""
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, therefore absence of the log_setting attribute is therefore a fail (2nd rule)
+resource "panos_security_policy" "fail7" {
+    rule {
+        name = "my-good-rule-fail7"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "my-log-fwd-profile"
+    }
+    rule {
+        name = "my-bad-rule-fail7"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, therefore absence of the log_setting attribute is therefore a fail (2nd rule)
+resource "panos_security_rule_group" "fail8" {
+    rule {
+        name = "my-good-rule-fail8"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "my-log-fwd-profile"
+    }
+    rule {
+        name = "my-bad-rule-fail8"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, therefore any empty log_setting attribute is a fail (even strings of spaces) 
+resource "panos_security_policy" "fail9" {
+    rule {
+        name = "my-bad-rule-fail9"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "  "
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, therefore any empty log_setting attribute is a fail (even strings of spaces)
+resource "panos_security_rule_group" "fail10" {
+    rule {
+        name = "my-bad-rule-fail10"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "  "
+    }
+}
+
+
+# Passes
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server
+resource "panos_security_policy" "pass1" {
+    rule {
+        name = "my-good-rule-pass1"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "my-log-fwd-profile"
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server
+resource "panos_security_rule_group" "pass2" {
+    rule {
+        name = "my-good-rule-pass2"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "my-log-fwd-profile"
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, test block with 2 passing rules 
+resource "panos_security_policy" "pass3" {
+    rule {
+        name = "my-good-rule-pass3-1"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "my-log-fwd-profile"
+    }
+    rule {
+        name = "my-good-rule-pass3-2"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "my-log-fwd-profile"
+    }
+}
+
+# Security rules should should have a log_setting populated to ensure logs are sent to Panorama and/or a logging server, test block with 2 passing rules
+resource "panos_security_rule_group" "pass4" {
+    rule {
+        name = "my-good-rule-pass4-1"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "my-log-fwd-profile"
+    }
+    rule {
+        name = "my-good-rule-pass4-2"
+        source_zones = ["any"]
+        source_addresses = ["10.10.10.10/32"]
+        source_users = ["any"]
+        hip_profiles = ["any"]
+        destination_zones = ["any"]
+        destination_addresses = ["8.8.8.8/32"]
+        applications = ["web-browsing","ssl"]
+        categories = ["any"]
+        services = ["any"]
+        action = "allow"
+        description = "This rule is for..."
+        log_setting = "my-log-fwd-profile"
+    }
+}

--- a/tests/terraform/checks/resource/panos/test_PolicyLogForwarding.py
+++ b/tests/terraform/checks/resource/panos/test_PolicyLogForwarding.py
@@ -1,0 +1,51 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.panos.PolicyLogForwarding import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestPolicyLogForwarding(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_PolicyLogForwarding"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'panos_security_policy.pass1',
+            'panos_security_rule_group.pass2',
+            'panos_security_policy.pass3',
+            'panos_security_rule_group.pass4',
+        }
+        failing_resources = {
+            'panos_security_policy.fail1',
+            'panos_security_rule_group.fail2',
+            'panos_security_policy.fail3',
+            'panos_security_rule_group.fail4',
+            'panos_security_policy.fail5',
+            'panos_security_rule_group.fail6',
+            'panos_security_policy.fail7',
+            'panos_security_rule_group.fail8',
+            'panos_security_policy.fail9',
+            'panos_security_rule_group.fail10',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 4)
+        self.assertEqual(summary['failed'], 10)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

A resource check for PAN-OS Terraform provider for security policy rules. This one ensures that security policy rules have a log forwarding profile enabled, such that logs are collected at Panorama and/or an external logging server. Log forwarding can be set in two different resource types, both are covered by this check.