### PR TITLE
CKV_GCP_101 - Ensure that Artifact Registry repositories are not anonymously or publicly accessible

### DIFF
--- a/checkov/terraform/checks/resource/gcp/ArtifactRegistryPrivateRepo.py
+++ b/checkov/terraform/checks/resource/gcp/ArtifactRegistryPrivateRepo.py
@@ -1,0 +1,40 @@
+
+
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class ArtifactRegistryPrivateRepo(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure that Artifact Registry repositories are not anonymously or publicly accessible"
+        id = "CKV_GCP_101"
+        supported_resources = ['google_artifact_registry_repository_iam_member', 'google_artifact_registry_repository_iam_binding']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        public_principals = (
+            "allUsers",
+            "allAuthenticatedUsers"
+            )
+        # Depending on the terraform resource type -
+        # The member config is either a list or single principal
+        if self.entity_type == "google_artifact_registry_repository_iam_member":
+            # conf.get returns as a list
+            # so we create a string for comparison
+            member = conf.get("member")[0]
+            if member in public_principals:
+                return CheckResult.FAILED
+            else:
+                return CheckResult.PASSED
+        # iam_binding returns a list of principals
+        elif self.entity_type == "google_artifact_registry_repository_iam_binding":
+            # Since conf.get returns a list and iam_binding returns a list (nested list)
+            # we pull out the members list using the index 0
+            members_list = conf.get("members")[0]
+            if any(member in public_principals for member in members_list):
+                return CheckResult.FAILED
+            else:
+                return CheckResult.PASSED
+
+check = ArtifactRegistryPrivateRepo()

--- a/tests/terraform/checks/resource/gcp/example_ArtifactRegistryPrivateRepo/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_ArtifactRegistryPrivateRepo/main.tf
@@ -1,0 +1,114 @@
+################
+## PASS TESTS ##
+################
+
+resource "google_artifact_registry_repository_iam_binding" "pass1" {
+  provider = google-beta
+  location = google_artifact_registry_repository.my-repo.location
+  repository = google_artifact_registry_repository.my-repo.name
+  role = "roles/viewer"
+  members = [
+    "user:jane@example.com",
+    "group:mygroup@example.com",
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_binding" "pass2" {
+  provider = google-beta
+  location = google_artifact_registry_repository.my-repo.location
+  repository = google_artifact_registry_repository.my-repo.name
+  role = "roles/viewer"
+  members = [
+    "user:jason@example.com",
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_member" "pass1" {
+  provider = google-beta
+  location = google_artifact_registry_repository.my-repo.location
+  repository = google_artifact_registry_repository.my-repo.name
+  role = "roles/viewer"
+  member = "user:jane@example.com"
+}
+
+resource "google_artifact_registry_repository_iam_member" "pass2" {
+  provider = google-beta
+  location = google_artifact_registry_repository.my-repo.location
+  repository = google_artifact_registry_repository.my-repo.name
+  role = "roles/viewer"
+  member = "domain:example.com"
+}
+
+################
+## FAIL TESTS ##
+################
+
+resource "google_artifact_registry_repository_iam_binding" "fail1" {
+  provider = google-beta
+  location = google_artifact_registry_repository.my-repo.location
+  repository = google_artifact_registry_repository.my-repo.name
+  role = "roles/viewer"
+  members = [
+    "allAuthenticatedUsers",
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_binding" "fail2" {
+  provider = google-beta
+  location = google_artifact_registry_repository.my-repo.location
+  repository = google_artifact_registry_repository.my-repo.name
+  role = "roles/viewer"
+  members = [
+    "allUsers",
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_binding" "fail3" {
+  provider = google-beta
+  location = google_artifact_registry_repository.my-repo.location
+  repository = google_artifact_registry_repository.my-repo.name
+  role = "roles/viewer"
+  members = [
+    "allUsers",
+    "user:jason@example.com",
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_binding" "fail4" {
+  provider = google-beta
+  location = google_artifact_registry_repository.my-repo.location
+  repository = google_artifact_registry_repository.my-repo.name
+  role = "roles/viewer"
+  members = [
+    "user:jason@example.com",
+    "allAuthenticatedUsers",
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_binding" "fail5" {
+  provider = google-beta
+  location = google_artifact_registry_repository.my-repo.location
+  repository = google_artifact_registry_repository.my-repo.name
+  role = "roles/viewer"
+  members = [
+    "user:jason@example.com",
+    "allAuthenticatedUsers",
+    "domain:example.com",
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_member" "fail1" {
+  provider = google-beta
+  location = google_artifact_registry_repository.my-repo.location
+  repository = google_artifact_registry_repository.my-repo.name
+  role = "roles/viewer"
+  member  = "allAuthenticatedUsers"
+}
+
+resource "google_artifact_registry_repository_iam_member" "fail2" {
+  provider = google-beta
+  location = google_artifact_registry_repository.my-repo.location
+  repository = google_artifact_registry_repository.my-repo.name
+  role = "roles/viewer"
+  member  = "allUsers"
+}

--- a/tests/terraform/checks/resource/gcp/test_ArtifactRegistryPrivateRepo.py
+++ b/tests/terraform/checks/resource/gcp/test_ArtifactRegistryPrivateRepo.py
@@ -1,0 +1,49 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.ArtifactRegistryPrivateRepo import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class ArtifactRegistryPrivateRepo(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ArtifactRegistryPrivateRepo"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_artifact_registry_repository_iam_binding.pass1',
+            'google_artifact_registry_repository_iam_binding.pass2',
+            'google_artifact_registry_repository_iam_member.pass1',
+            'google_artifact_registry_repository_iam_member.pass2',
+
+        }
+        failing_resources = {
+            'google_artifact_registry_repository_iam_binding.fail1',
+            'google_artifact_registry_repository_iam_binding.fail2',
+            'google_artifact_registry_repository_iam_binding.fail3',
+            'google_artifact_registry_repository_iam_binding.fail4',
+            'google_artifact_registry_repository_iam_binding.fail5',
+            'google_artifact_registry_repository_iam_member.fail1',
+            'google_artifact_registry_repository_iam_member.fail2',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 4)
+        self.assertEqual(summary['failed'], 7)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR adds a new Checkov check for GCP:

`CKV_GCP_101 - Ensure that Artifact Registry repositories are not anonymously or publicly accessible`

Artifact Registry is the new/updated Google Container Registry service and it supports the ability to make repositories public which could expose user's sensitive data.