### PR TITLE
consolidate url setup

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -400,7 +400,7 @@ class BcPlatformIntegration(object):
 
     def get_customer_run_config(self) -> None:
         if self.skip_download is True:
-            logging.debug("Skipping getting run config")
+            logging.debug("Skipping customer run config API call")
             return
 
         if not self.bc_api_key or not self.is_integration_configured():
@@ -412,27 +412,25 @@ class BcPlatformIntegration(object):
             if not self.http:
                 self.setup_http_manager()
             request = self.http.request("GET", self.platform_run_config_url, headers=headers)
-
             self.customer_run_config_response = json.loads(request.data.decode("utf8"))
-
             logging.debug("Got customer run config from Bridgecrew BE")
         except Exception as e:
-            logging.warning(f"Failed to get the guidelines from {self.guidelines_api_url}, error:\n{e}")
+            logging.warning(f"Failed to get the customer run config from {self.platform_run_config_url}, error:\n{e}")
 
     def get_public_run_config(self) -> None:
         if self.skip_download is True:
-            logging.debug("Skipping ID mapping and guidelines API call")
+            logging.debug("Skipping checkov mapping and guidelines API call")
             return
 
-        headers = {}
         try:
+            headers = {}
             if not self.http:
                 self.setup_http_manager()
             request = self.http.request("GET", self.guidelines_api_url, headers=headers)
             self.public_metadata_response = json.loads(request.data.decode("utf8"))
-            logging.debug("Got checkov mappings from Bridgecrew BE")
+            logging.debug("Got checkov mappings and guidelines from Bridgecrew BE")
         except Exception as e:
-            logging.warning(f"Failed to get the guidelines from {self.guidelines_api_url}, error:\n{e}")
+            logging.warning(f"Failed to get the checkov mappings and guidelines from {self.guidelines_api_url}, error:\n{e}")
 
     def onboarding(self):
         if not self.bc_api_key:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -383,7 +383,7 @@ def add_parser_args(parser: ArgumentParser) -> None:
                         action='append',
                         default=None)
     parser.add('--bc-api-key', env_var='BC_API_KEY', sanitize=True,
-               help='Bridgecrew API key or Prisma access key / secret (see --prisma-api-url)')
+               help='Bridgecrew API key or Prisma Cloud Access Key (see --prisma-api-url)')
     parser.add('--prisma-api-url', env_var='PRISMA_API_URL', default=None,
                help='The Prisma Cloud API URL (see: https://prisma.pan.dev/api/cloud/api-urls). '
                     'Requires --bc-api-key to be a Prisma Cloud Access Key in the following format: <access_key_id>::<secret_key>')


### PR DESCRIPTION
Prior to this pull request:
    
API URLs were setup in both `__init__()` and `setup_bridgecrew_credentials()`
(as `setup_bridgecrew_credentials()` is where/when parameters are first available)
This introduced the potential for a URL to be setup in one but not the other.

Specifically, `guidelines_api_url` was recently overlooked in `setup_bridgecrew_credentials()`,
resulting in `Failed to get the guidelines from` warnings when using Prisma Cloud Code Security.

With this pull request:
    
`setup_api_urls()` consolidates url setup (aka dry)
`self.bc_api_url` is used to store the default api url for the Bridgecrew platform

This pull request also updates the cli help with a consistent reference for "Prisma Cloud Access Keys".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.