### PR TITLE
Missing "Test" in unit test

### DIFF
--- a/tests/terraform/checks/resource/gcp/test_ArtifactRegistryPrivateRepo.py
+++ b/tests/terraform/checks/resource/gcp/test_ArtifactRegistryPrivateRepo.py
@@ -6,7 +6,7 @@ from checkov.runner_filter import RunnerFilter
 from checkov.terraform.runner import Runner
 
 
-class ArtifactRegistryPrivateRepo(unittest.TestCase):
+class TestArtifactRegistryPrivateRepo(unittest.TestCase):
 
     def test(self):
         runner = Runner()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Looks like I missed the word `Test` in the unit test class. It doesn't affect the tests passing but it's more of a stylistic thing. 