### PR TITLE
CKV_GCP_102 - Ensure that GCP Cloud Run services are not anonymously or publicly accessible

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GCPCloudRunPrivateService.py
+++ b/checkov/terraform/checks/resource/gcp/GCPCloudRunPrivateService.py
@@ -1,0 +1,40 @@
+
+
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class GCPCloudRunPrivateService(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure that GCP Cloud Run services are not anonymously or publicly accessible"
+        id = "CKV_GCP_102"
+        supported_resources = ['google_cloud_run_service_iam_member', 'google_cloud_run_service_iam_binding']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        public_principals = (
+            "allUsers",
+            "allAuthenticatedUsers"
+            )
+        # Depending on the terraform resource type -
+        # The member config is either a list or single principal
+        if self.entity_type == "google_cloud_run_service_iam_member":
+            # conf.get returns as a list
+            # so we create a string for comparison
+            member = conf.get("member")[0]
+            if member in public_principals:
+                return CheckResult.FAILED
+            else:
+                return CheckResult.PASSED
+        # iam_binding returns a list of principals
+        elif self.entity_type == "google_cloud_run_service_iam_binding":
+            # Since conf.get returns a list and iam_binding returns a list (nested list)
+            # we pull out the members list using the index 0
+            members_list = conf.get("members")[0]
+            if any(member in public_principals for member in members_list):
+                return CheckResult.FAILED
+            else:
+                return CheckResult.PASSED
+
+check = GCPCloudRunPrivateService()

--- a/tests/terraform/checks/resource/gcp/example_GCPCloudRunPrivateService/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GCPCloudRunPrivateService/main.tf
@@ -1,0 +1,103 @@
+################
+## PASS TESTS ##
+################
+
+resource "google_cloud_run_service_iam_binding" "pass1" {
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/viewer"
+  members = [
+    "user:jane@example.com",
+    "group:mygroup@example.com",
+  ]
+}
+
+resource "google_cloud_run_service_iam_binding" "pass2" {
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/viewer"
+  members = [
+    "user:jason@example.com",
+  ]
+}
+
+resource "google_cloud_run_service_iam_member" "pass1" {
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/viewer"
+  member = "user:jane@example.com"
+}
+
+resource "google_cloud_run_service_iam_member" "pass2" {
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/viewer"
+  member = "domain:example.com"
+}
+
+################
+## FAIL TESTS ##
+################
+
+resource "google_cloud_run_service_iam_binding" "fail1" {
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/viewer"
+  members = [
+    "allAuthenticatedUsers",
+  ]
+}
+
+resource "google_cloud_run_service_iam_binding" "fail2" {
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/viewer"
+  members = [
+    "allUsers",
+  ]
+}
+
+resource "google_cloud_run_service_iam_binding" "fail3" {
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/viewer"
+  members = [
+    "allUsers",
+    "user:jason@example.com",
+  ]
+}
+
+resource "google_cloud_run_service_iam_binding" "fail4" {
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/viewer"
+  members = [
+    "user:jason@example.com",
+    "allAuthenticatedUsers",
+  ]
+}
+
+resource "google_cloud_run_service_iam_binding" "fail5" {
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/viewer"
+  members = [
+    "user:jason@example.com",
+    "allAuthenticatedUsers",
+    "domain:example.com",
+  ]
+}
+
+resource "google_cloud_run_service_iam_member" "fail1" {
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/viewer"
+  member  = "allAuthenticatedUsers"
+}
+
+resource "google_cloud_run_service_iam_member" "fail2" {
+  location = google_cloud_run_service.default.location
+  service = google_cloud_run_service.default.name
+  role = "roles/viewer"
+  member  = "allUsers"
+}

--- a/tests/terraform/checks/resource/gcp/test_GCPCloudRunPrivateService.py
+++ b/tests/terraform/checks/resource/gcp/test_GCPCloudRunPrivateService.py
@@ -1,0 +1,49 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.GCPCloudRunPrivateService import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestGCPCloudRunPrivateService(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_GCPCloudRunPrivateService"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_cloud_run_service_iam_binding.pass1',
+            'google_cloud_run_service_iam_binding.pass2',
+            'google_cloud_run_service_iam_member.pass1',
+            'google_cloud_run_service_iam_member.pass2',
+
+        }
+        failing_resources = {
+            'google_cloud_run_service_iam_binding.fail1',
+            'google_cloud_run_service_iam_binding.fail2',
+            'google_cloud_run_service_iam_binding.fail3',
+            'google_cloud_run_service_iam_binding.fail4',
+            'google_cloud_run_service_iam_binding.fail5',
+            'google_cloud_run_service_iam_member.fail1',
+            'google_cloud_run_service_iam_member.fail2',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 4)
+        self.assertEqual(summary['failed'], 7)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR adds a new checkov check for public Cloud Run services. Ideally Cloud Run services would not be exposed for unauthenticated access and instead a loud balancer would be used.