### PR TITLE
add tf azure check for ensuring ml cluster min nodes set to 0

### DIFF
--- a/checkov/terraform/checks/resource/azure/MLComputeClusterMinNodes.py
+++ b/checkov/terraform/checks/resource/azure/MLComputeClusterMinNodes.py
@@ -6,7 +6,7 @@ class MLComputeClusterMinNodes(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure Machine Learning Compute Cluster Minimum Nodes Set To 0"
         id = "CKV_AZURE_150"
-        supported_resources = ['machine_learning_compute_cluster']
+        supported_resources = ['azurerm_machine_learning_compute_cluster']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/azure/MLComputeClusterMinNodes.py
+++ b/checkov/terraform/checks/resource/azure/MLComputeClusterMinNodes.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class MLComputeClusterMinNodes(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Machine Learning Compute Cluster Minimum Nodes Set To 0"
+        id = "CKV_AZURE_150"
+        supported_resources = ['machine_learning_compute_cluster']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "scale_settings/[0]/min_node_count"
+
+    def get_expected_value(self):
+        return 0
+
+
+check = MLComputeClusterMinNodes()

--- a/tests/terraform/checks/resource/azure/example_MLComputeClusterMinNodes/main.tf
+++ b/tests/terraform/checks/resource/azure/example_MLComputeClusterMinNodes/main.tf
@@ -1,0 +1,31 @@
+## SHOULD PASS: Min nodes set to 0
+resource "machine_learning_compute_cluster" "ckv_unittest_pass" {
+    name                          = "example"
+    location                      = "West Europe"
+    vm_priority                   = "LowPriority"
+    vm_size                       = "Standard_DS2_v2"
+    machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+    subnet_resource_id            = azurerm_subnet.example.id
+
+    scale_settings {
+        min_node_count                       = 0
+        max_node_count                       = 1
+        scale_down_nodes_after_idle_duration = "PT30S" # 30 seconds
+    }
+}
+
+## SHOULD FAIL: Min nodes set to 1
+resource "machine_learning_compute_cluster" "ckv_unittest_fail" {
+    name                          = "example"
+    location                      = "West Europe"
+    vm_priority                   = "LowPriority"
+    vm_size                       = "Standard_DS2_v2"
+    machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+    subnet_resource_id            = azurerm_subnet.example.id
+
+    scale_settings {
+        min_node_count                       = 1
+        max_node_count                       = 2
+        scale_down_nodes_after_idle_duration = "PT30S" # 30 seconds
+    }
+}

--- a/tests/terraform/checks/resource/azure/example_MLComputeClusterMinNodes/main.tf
+++ b/tests/terraform/checks/resource/azure/example_MLComputeClusterMinNodes/main.tf
@@ -1,5 +1,5 @@
 ## SHOULD PASS: Min nodes set to 0
-resource "machine_learning_compute_cluster" "ckv_unittest_pass" {
+resource "azurerm_machine_learning_compute_cluster" "ckv_unittest_pass" {
     name                          = "example"
     location                      = "West Europe"
     vm_priority                   = "LowPriority"
@@ -15,7 +15,7 @@ resource "machine_learning_compute_cluster" "ckv_unittest_pass" {
 }
 
 ## SHOULD FAIL: Min nodes set to 1
-resource "machine_learning_compute_cluster" "ckv_unittest_fail" {
+resource "azurerm_machine_learning_compute_cluster" "ckv_unittest_fail" {
     name                          = "example"
     location                      = "West Europe"
     vm_priority                   = "LowPriority"

--- a/tests/terraform/checks/resource/azure/test_MLComputeClusterMinNodes.py
+++ b/tests/terraform/checks/resource/azure/test_MLComputeClusterMinNodes.py
@@ -18,10 +18,10 @@ class TestMLComputeClusterMinNodes(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            'machine_learning_compute_cluster.ckv_unittest_pass'
+            'azurerm_machine_learning_compute_cluster.ckv_unittest_pass'
         }
         failing_resources = {
-            'machine_learning_compute_cluster.ckv_unittest_fail',
+            'azurerm_machine_learning_compute_cluster.ckv_unittest_fail',
         }
         skipped_resources = {}
 

--- a/tests/terraform/checks/resource/azure/test_MLComputeClusterMinNodes.py
+++ b/tests/terraform/checks/resource/azure/test_MLComputeClusterMinNodes.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.MLComputeClusterMinNodes import check
+
+
+class TestMLComputeClusterMinNodes(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_MLComputeClusterMinNodes")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'machine_learning_compute_cluster.ckv_unittest_pass'
+        }
+        failing_resources = {
+            'machine_learning_compute_cluster.ckv_unittest_fail',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Custom Policy id - CKV_AZURE_150
Custom Policy name - "Ensure Machine Learning Compute Cluster Minimum Nodes Set To 0"
Custom Policy IaC type - terraform
Custom Policy type and provider - azurerm
IaC configuration documentation (If available) - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/machine_learning_compute_cluster#min_node_count

Any additional information that would help other members to better understand the check - https://docs.microsoft.com/en-us/azure/machine-learning/concept-vulnerability-management#compute-clusters
Per MS doc, if min nodes is set to 0 then not only is it a cost-saving configuration but it also allows the VMs in the cluster to get the latest VM images (with security patches).