### PR TITLE
display guidelines for custom policies

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
@@ -94,6 +94,15 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
 
     def _handle_customer_run_config(self, run_config):
         self.check_metadata = run_config['policyMetadata']
+
+        # Custom policies are returned in run_config['customPolicies'] rather than run_config['policyMetadata'].
+        if 'customPolicies' in run_config:
+            for custom_policy in run_config['customPolicies']:
+                if 'guideline' in custom_policy:
+                    self.check_metadata[custom_policy['id']] = {
+                        'guideline': custom_policy['guideline']
+                    }
+
         self.bc_to_ckv_id_mapping = {pol['id']: ckv_id for (ckv_id, pol) in self.check_metadata.items()}
 
 


### PR DESCRIPTION
In `_handle_customer_run_config()`, custom policies are stored in `run_config['customPolicies']` instead of in `run_config['policyMetadata']`.

This PR adds guidelines for custom policies to `self.check_metadata` in the same way that `_handle_public_metadata()` adds guidelines to `self.check_metadata` resulting in those guidelines being displayed in the output of the `checkov` command.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Addresses: https://github.com/bridgecrewio/checkov/issues/2433