### PR TITLE
Support empty resource types for YAML queries

### DIFF
--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -10,6 +10,7 @@ from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
 from concurrent.futures import ThreadPoolExecutor
 
 from checkov.common.graph.graph_builder import CustomAttributes
+from checkov.common.graph.graph_builder.graph_components.block_types import BlockType
 
 WILDCARD_PATTERN = re.compile(r"(\S+[.][*][.]*)+")
 
@@ -29,7 +30,8 @@ class BaseAttributeSolver(BaseSolver):
         passed_vertices: List[Dict[str, Any]] = []
         failed_vertices: List[Dict[str, Any]] = []
         for _, data in graph_connector.nodes(data=True):
-            if data.get(CustomAttributes.RESOURCE_TYPE) in self.resource_types:
+            if (not self.resource_types or data.get(CustomAttributes.RESOURCE_TYPE) in self.resource_types) \
+                    and data.get(CustomAttributes.BLOCK_TYPE) == BlockType.RESOURCE:
                 jobs.append(executer.submit(self._process_node, data, passed_vertices, failed_vertices))
 
         concurrent.futures.wait(jobs)

--- a/tests/terraform/graph/checks_infra/attribute_solvers/exists_solver/TagEnvironmentExistsAll.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/exists_solver/TagEnvironmentExistsAll.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "TagEnvironmentExistsAll"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types: []
+  attribute: "tags.Environment"
+  operator: "exists"
+
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/exists_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/exists_solver/test_solver.py
@@ -27,3 +27,14 @@ class ExistsSolver(TestBaseSolver):
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
         self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_all_resources(self):
+        root_folder = '../../../resources/encryption_test'
+        check_id = "TagEnvironmentExistsAll"
+        should_pass = []
+        should_fail = ["aws_rds_cluster.rds_cluster_encrypted", "aws_rds_cluster.rds_cluster_unencrypted",
+                       "aws_s3_bucket.encrypted_bucket", "aws_s3_bucket.unencrypted_bucket",
+                       "aws_neptune_cluster.encrypted_neptune", "aws_neptune_cluster.unencrypted_neptune"]
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)


### PR DESCRIPTION
In case we have an empty list of resource types, we will apply attribute queries on all the `resource` vertices in the graph.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
