### PR TITLE
Fix types comparison in AbsNACLUnrestrictedIngress check

### DIFF
--- a/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
@@ -48,11 +48,11 @@ class AbsNACLUnrestrictedIngress(BaseResourceCheck):
         if rule.get('cidr_block'):
             if rule.get('cidr_block') == ["0.0.0.0/0"]:
                 if rule.get('action') == ["allow"] or rule.get('rule_action') == ["allow"]:
-                    if rule.get('from_port')[0] <= self.port <= rule.get('to_port')[0]:
+                    if int(rule.get('from_port')[0]) <= self.port <= int(rule.get('to_port')[0]):
                         return False
         if rule.get('ipv6_cidr_block'):
             if rule.get('ipv6_cidr_block') == ["::/0"]:
                 if rule.get('action') == ["allow"] or rule.get('rule_action') == ["allow"]:
-                    if rule.get('from_port')[0] <= self.port <= rule.get('to_port')[0]:
+                    if int(rule.get('from_port')[0]) <= self.port <= int(rule.get('to_port')[0]):
                         return False
         return True

--- a/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress3389/main.tf
+++ b/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress3389/main.tf
@@ -34,8 +34,8 @@ resource "aws_network_acl" "fail" {
       rule_no    = 110
       action     = "allow"
       cidr_block = "0.0.0.0/0"
-      from_port  = 3389
-      to_port    = 3389
+      from_port  = "3389"
+      to_port    = "3389"
     }
 
 


### PR DESCRIPTION
Support the case when ports are written as strings instead of integers, which causes exception when trying to compare the port ranges.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
