### PR TITLE
fix metadata mapping for custom policies

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
@@ -68,7 +68,7 @@ class FixesIntegration(BaseIntegrationFeature):
 
         errors = list(map(lambda c: {
             'resourceId': c.resource,
-            'policyId': metadata_integration.get_bc_id(c.check_id),
+            'policyId': metadata_integration.get_bc_id(c.check_id) or c.check_id,
             'startLine': c.file_line_range[0],
             'endLine': c.file_line_range[1]
         }, failed_checks))

--- a/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
@@ -94,6 +94,7 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
 
     def _handle_customer_run_config(self, run_config):
         self.check_metadata = run_config['policyMetadata']
+        self.bc_to_ckv_id_mapping = {pol['id']: ckv_id for (ckv_id, pol) in self.check_metadata.items()}
 
         # Custom policies are returned in run_config['customPolicies'] rather than run_config['policyMetadata'].
         if 'customPolicies' in run_config:
@@ -102,8 +103,6 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
                     self.check_metadata[custom_policy['id']] = {
                         'guideline': custom_policy['guideline']
                     }
-
-        self.bc_to_ckv_id_mapping = {pol['id']: ckv_id for (ckv_id, pol) in self.check_metadata.items()}
 
 
 integration = PolicyMetadataIntegration(bc_integration)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes an issue where custom policy IDs were getting sent to the fixes API as None, resulting in an error