### PR TITLE
fix NACL checks

### DIFF
--- a/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
@@ -48,11 +48,17 @@ class AbsNACLUnrestrictedIngress(BaseResourceCheck):
         if rule.get('cidr_block'):
             if rule.get('cidr_block') == ["0.0.0.0/0"]:
                 if rule.get('action') == ["allow"] or rule.get('rule_action') == ["allow"]:
+                    protocol = rule.get('protocol')
+                    if protocol and str(protocol[0]) == "-1":
+                        return False
                     if int(rule.get('from_port')[0]) <= self.port <= int(rule.get('to_port')[0]):
                         return False
         if rule.get('ipv6_cidr_block'):
             if rule.get('ipv6_cidr_block') == ["::/0"]:
                 if rule.get('action') == ["allow"] or rule.get('rule_action') == ["allow"]:
+                    protocol = rule.get('protocol')
+                    if protocol and str(protocol[0]) == "-1":
+                        return False
                     if int(rule.get('from_port')[0]) <= self.port <= int(rule.get('to_port')[0]):
                         return False
         return True

--- a/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress20/main.tf
+++ b/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress20/main.tf
@@ -246,3 +246,12 @@ resource "aws_network_acl_rule" "pass2" {
   to_port        = 25
 }
 
+# open all
+resource "aws_network_acl_rule" "public_ingress" {
+  network_acl_id = aws_network_acl.pass.id
+  rule_number    = 100
+  egress         = false
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+}

--- a/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress21/main.tf
+++ b/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress21/main.tf
@@ -254,3 +254,13 @@ resource "aws_network_acl_rule" "pass2" {
   from_port      = 5
   to_port        = 25
 }
+
+# open all
+resource "aws_network_acl_rule" "public_ingress" {
+  network_acl_id = aws_network_acl.pass.id
+  rule_number    = 100
+  egress         = false
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+}

--- a/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress22/main.tf
+++ b/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress22/main.tf
@@ -252,3 +252,13 @@ resource "aws_network_acl_rule" "pass2" {
   from_port      = 5
   to_port        = 25
 }
+
+# open all
+resource "aws_network_acl_rule" "public_ingress" {
+  network_acl_id = aws_network_acl.pass.id
+  rule_number    = 100
+  egress         = false
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+}

--- a/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress3389/main.tf
+++ b/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress3389/main.tf
@@ -248,3 +248,13 @@ resource "aws_vpc" "main" {
 provider "aws" {
   region="eu-west-2"
 }
+
+# open all
+resource "aws_network_acl_rule" "public_ingress" {
+  network_acl_id = aws_network_acl.pass.id
+  rule_number    = 100
+  egress         = false
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+}

--- a/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress20.py
+++ b/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress20.py
@@ -29,13 +29,14 @@ class TestNetworkACLUnrestrictedIngress20(unittest.TestCase):
             "aws_network_acl.fail3",
             "aws_network_acl_rule.fail",
             "aws_network_acl_rule.fail2",
+            "aws_network_acl_rule.public_ingress",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
         self.assertEqual(summary["passed"], 4)
-        self.assertEqual(summary["failed"], 5)
+        self.assertEqual(summary["failed"], 6)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress21.py
+++ b/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress21.py
@@ -29,13 +29,14 @@ class TestNetworkACLUnrestrictedIngress21(unittest.TestCase):
             "aws_network_acl.fail3",
             "aws_network_acl_rule.fail",
             "aws_network_acl_rule.fail2",
+            "aws_network_acl_rule.public_ingress",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
         self.assertEqual(summary["passed"], 4)
-        self.assertEqual(summary["failed"], 5)
+        self.assertEqual(summary["failed"], 6)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress22.py
+++ b/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress22.py
@@ -29,13 +29,14 @@ class TestNetworkACLUnrestrictedIngress22(unittest.TestCase):
             "aws_network_acl.fail3",
             "aws_network_acl_rule.fail",
             "aws_network_acl_rule.fail2",
+            "aws_network_acl_rule.public_ingress",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
         self.assertEqual(summary["passed"], 4)
-        self.assertEqual(summary["failed"], 5)
+        self.assertEqual(summary["failed"], 6)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress3389.py
+++ b/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress3389.py
@@ -29,13 +29,14 @@ class TestNetworkACLUnrestrictedIngress3389(unittest.TestCase):
             "aws_network_acl.fail3",
             "aws_network_acl_rule.fail",
             "aws_network_acl_rule.fail2",
+            "aws_network_acl_rule.public_ingress",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
         self.assertEqual(summary["passed"], 4)
-        self.assertEqual(summary["failed"], 5)
+        self.assertEqual(summary["failed"], 6)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #2542 

when `protocol` allows everything then from and to port don't need to be set.
