### PR TITLE
Fix AbsNACLUnrestrictedIngress check

### DIFF
--- a/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
@@ -50,7 +50,7 @@ class AbsNACLUnrestrictedIngress(BaseResourceCheck):
 
     def check_rule(self, rule):
         from_port = rule.get('from_port')
-        to_port = rule.get('from_port')
+        to_port = rule.get('to_port')
         if rule.get('cidr_block'):
             if rule.get('cidr_block') == ["0.0.0.0/0"]:
                 if rule.get('action') == ["allow"] or rule.get('rule_action') == ["allow"]:

--- a/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
@@ -32,8 +32,12 @@ class AbsNACLUnrestrictedIngress(BaseResourceCheck):
         if conf.get("ingress"):
             ingress = conf.get("ingress")
             for rule in ingress:
-                if not self.check_rule(rule):
-                    return CheckResult.FAILED
+                rule_lst = rule
+                if not isinstance(rule_lst, list):
+                    rule_lst = [rule_lst]
+                for sub_rule in rule_lst:
+                    if not self.check_rule(sub_rule):
+                        return CheckResult.FAILED
             return CheckResult.PASSED
         # maybe its an network_acl_rule
         if conf.get("network_acl_id"):

--- a/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
@@ -41,7 +41,7 @@ class AbsNACLUnrestrictedIngress(BaseResourceCheck):
             return CheckResult.PASSED
         # maybe its an network_acl_rule
         if conf.get("network_acl_id"):
-            if not conf.get("egress")[0]:
+            if not conf.get("egress") or not conf.get("egress")[0]:
                 if not self.check_rule(conf):
                     return CheckResult.FAILED
             return CheckResult.PASSED
@@ -49,13 +49,15 @@ class AbsNACLUnrestrictedIngress(BaseResourceCheck):
         return CheckResult.UNKNOWN
 
     def check_rule(self, rule):
+        from_port = rule.get('from_port')
+        to_port = rule.get('from_port')
         if rule.get('cidr_block'):
             if rule.get('cidr_block') == ["0.0.0.0/0"]:
                 if rule.get('action') == ["allow"] or rule.get('rule_action') == ["allow"]:
                     protocol = rule.get('protocol')
                     if protocol and str(protocol[0]) == "-1":
                         return False
-                    if int(rule.get('from_port')[0]) <= self.port <= int(rule.get('to_port')[0]):
+                    if from_port and to_port and int(from_port[0]) <= self.port <= int(to_port[0]):
                         return False
         if rule.get('ipv6_cidr_block'):
             if rule.get('ipv6_cidr_block') == ["::/0"]:
@@ -63,6 +65,6 @@ class AbsNACLUnrestrictedIngress(BaseResourceCheck):
                     protocol = rule.get('protocol')
                     if protocol and str(protocol[0]) == "-1":
                         return False
-                    if int(rule.get('from_port')[0]) <= self.port <= int(rule.get('to_port')[0]):
+                    if from_port and to_port and int(from_port[0]) <= self.port <= int(to_port[0]):
                         return False
         return True

--- a/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress3389/main.tf
+++ b/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress3389/main.tf
@@ -92,22 +92,22 @@ resource "aws_network_acl" "pass" {
       to_port    = 443
     }
 
-  ingress {
+  ingress =[{
       protocol   = "tcp"
       rule_no    = 100
       action     = "allow"
       cidr_block = "10.0.0.0/32"
       from_port  = 22
       to_port    = 22
-    }
-    ingress {
+    },
+    {
       protocol   = "tcp"
       rule_no    = 110
       action     = "allow"
       cidr_block = "10.0.0.0/32"
       from_port  = 3389
       to_port    = 3389
-    }
+    }]
 
 
   tags = {


### PR DESCRIPTION
Handled cases where input for AbsNACLUnrestrictedIngress check can be different - 
1. No ports exist
2. ingress is an array.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
