### PR TITLE
Fix checks edge cases

### DIFF
--- a/checkov/kubernetes/checks/resource/base_container_check.py
+++ b/checkov/kubernetes/checks/resource/base_container_check.py
@@ -89,10 +89,10 @@ class BaseK8sContainerCheck(BaseK8Check):
 
         containers: List[Dict[str, Any]] = (
             spec.get("containers", []) if "containers" in self.supported_container_types else []
-        )
+        ) or []
         init_containers: List[Dict[str, Any]] = (
             spec.get("initContainers", []) if "initContainers" in self.supported_container_types else []
-        )
+        ) or []
 
         result = self._check_containers(
             evaluated_key_prefix=evaluated_key_prefix,

--- a/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
@@ -49,15 +49,20 @@ class AbsNACLUnrestrictedIngress(BaseResourceCheck):
         return CheckResult.UNKNOWN
 
     def check_rule(self, rule):
-        from_port = rule.get('from_port')
-        to_port = rule.get('to_port')
+        try:
+            from_port = int(rule.get('from_port', [None])[0])
+            to_port = int(rule.get('to_port', [None])[0])
+        except (TypeError, ValueError):
+            from_port = None
+            to_port = None
+
         if rule.get('cidr_block'):
             if rule.get('cidr_block') == ["0.0.0.0/0"]:
                 if rule.get('action') == ["allow"] or rule.get('rule_action') == ["allow"]:
                     protocol = rule.get('protocol')
                     if protocol and str(protocol[0]) == "-1":
                         return False
-                    if from_port and to_port and int(from_port[0]) <= self.port <= int(to_port[0]):
+                    if from_port and to_port and from_port <= self.port <= to_port:
                         return False
         if rule.get('ipv6_cidr_block'):
             if rule.get('ipv6_cidr_block') == ["::/0"]:
@@ -65,6 +70,6 @@ class AbsNACLUnrestrictedIngress(BaseResourceCheck):
                     protocol = rule.get('protocol')
                     if protocol and str(protocol[0]) == "-1":
                         return False
-                    if from_port and to_port and int(from_port[0]) <= self.port <= int(to_port[0]):
+                    if from_port and to_port and from_port <= self.port <= to_port:
                         return False
         return True

--- a/tests/kubernetes/checks/example_AllowedCapabilitiesSysAdmin/pod-FAILED2.yaml
+++ b/tests/kubernetes/checks/example_AllowedCapabilitiesSysAdmin/pod-FAILED2.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-demo-1
+spec:
+  containers:

--- a/tests/kubernetes/checks/test_AllowedCapabilitiesSysAdmin.py
+++ b/tests/kubernetes/checks/test_AllowedCapabilitiesSysAdmin.py
@@ -16,7 +16,7 @@ class TestAllowedCapabilitiesSysAdmin(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 1)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress3389/main.tf
+++ b/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress3389/main.tf
@@ -258,3 +258,16 @@ resource "aws_network_acl_rule" "public_ingress" {
   rule_action    = "allow"
   cidr_block     = "0.0.0.0/0"
 }
+
+
+resource "aws_network_acl_rule" "count_pass" {
+  count          = length(var.public_nacl_inbound_tcp_ports)
+  network_acl_id = "test_id"
+  rule_number    = count.index + 101
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = var.public_nacl_inbound_tcp_ports[count.index]
+  to_port        = var.public_nacl_inbound_tcp_ports[count.index]
+}

--- a/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress3389/variables.tf
+++ b/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress3389/variables.tf
@@ -1,0 +1,5 @@
+variable "public_nacl_inbound_tcp_ports" {
+  type        = list(string)
+  default     = ["80", "443", "22", "1194"]
+  description = "TCP Ports to allow inbound on public subnet via NACLs (this list cannot be empty)"
+}

--- a/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress3389.py
+++ b/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress3389.py
@@ -22,6 +22,7 @@ class TestNetworkACLUnrestrictedIngress3389(unittest.TestCase):
             "aws_network_acl.pass2",
             "aws_network_acl_rule.pass",
             "aws_network_acl_rule.pass2",
+            "aws_network_acl_rule.count_pass",
         }
         failing_resources = {
             "aws_network_acl.fail",
@@ -35,7 +36,7 @@ class TestNetworkACLUnrestrictedIngress3389(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 4)
+        self.assertEqual(summary["passed"], 5)
         self.assertEqual(summary["failed"], 6)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)


### PR DESCRIPTION
1. Support k8s yaml with no containers.
2. Support invalid ports (from un-rendered variables)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
