### PR TITLE
CKV_GCP_103 - Ensure Dataproc Clusters do not have public IPs

### DIFF
--- a/checkov/terraform/checks/resource/gcp/DataprocPublicIpCluster.py
+++ b/checkov/terraform/checks/resource/gcp/DataprocPublicIpCluster.py
@@ -13,8 +13,4 @@ class DataprocPublicIpCluster(BaseResourceValueCheck):
     def get_inspected_key(self):
         return 'cluster_config/[0]/gce_cluster_config/[0]/internal_ip_only'
 
-    # Accounts for if key is present but is set to False
-    def get_expected_value(self):
-        return True
-
 check = DataprocPublicIpCluster()

--- a/checkov/terraform/checks/resource/gcp/DataprocPublicIpCluster.py
+++ b/checkov/terraform/checks/resource/gcp/DataprocPublicIpCluster.py
@@ -1,0 +1,20 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class DataprocPublicIpCluster(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Dataproc Clusters do not have public IPs"
+        id = "CKV_GCP_103"
+        supported_resources = ['google_dataproc_cluster']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'cluster_config/[0]/gce_cluster_config/[0]/internal_ip_only'
+
+    # Accounts for if key is present but is set to False
+    def get_expected_value(self):
+        return True
+
+check = DataprocPublicIpCluster()

--- a/tests/terraform/checks/resource/gcp/example_DataprocPublicIpCluster/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_DataprocPublicIpCluster/main.tf
@@ -1,0 +1,62 @@
+
+resource "google_dataproc_cluster" "pass1" {
+  name   = "my-pass-cluster"
+  region = "us-central1"
+
+  cluster_config {
+    gce_cluster_config {
+      zone = "us-central1-a"
+      # no public IPs
+      internal_ip_only = true
+    }
+
+    master_config {
+      accelerators {
+        accelerator_type  = "nvidia-tesla-k80"
+        accelerator_count = "1"
+      }
+    }
+  }
+}
+
+
+resource "google_dataproc_cluster" "fail1" {
+  name   = "my-fail1-cluster"
+  region = "us-central1"
+
+  cluster_config {
+    gce_cluster_config {
+      zone = "us-central1-a"
+      # "internal_ip_only" does not exist
+      # and the default is public IPs
+    }
+
+    master_config {
+      accelerators {
+        accelerator_type  = "nvidia-tesla-k80"
+        accelerator_count = "1"
+      }
+    }
+  }
+}
+
+resource "google_dataproc_cluster" "fail2" {
+  name   = "my-fail2-cluster"
+  region = "us-central1"
+
+  cluster_config {
+    gce_cluster_config {
+      zone = "us-central1-a"
+      # "internal_ip_only" exists but it is set to false
+      # public IPs are assigned
+      internal_ip_only = false
+    }
+
+    master_config {
+      accelerators {
+        accelerator_type  = "nvidia-tesla-k80"
+        accelerator_count = "1"
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/gcp/test_DataprocPublicIpCluster.py
+++ b/tests/terraform/checks/resource/gcp/test_DataprocPublicIpCluster.py
@@ -1,0 +1,40 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.DataprocPublicIpCluster import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestDataprocPublicIpCluster(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_DataprocPublicIpCluster"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_dataproc_cluster.pass1',
+        }
+        failing_resources = {
+            'google_dataproc_cluster.fail1',
+            'google_dataproc_cluster.fail2',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR adds a new Checkov check for Public IP Dataproc clusters. By default Dataproc clusters have public IPs.