### PR TITLE
Kubernetes RootContainers validate runAsUser is an integer

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/RootContainers.py
+++ b/checkov/kubernetes/checks/resource/k8s/RootContainers.py
@@ -101,7 +101,7 @@ def check_runAsNonRoot(spec):
 def check_runAsUser(spec):
     if spec.get("securityContext"):
         if "runAsUser" in spec["securityContext"]:
-            if spec["securityContext"]["runAsUser"] > 0:
+            if isinstance(spec["securityContext"]["runAsUser"], int) and spec["securityContext"]["runAsUser"] > 0:
                 return "PASSED"
             else:
                 return "FAILED"

--- a/checkov/kubernetes/checks/resource/k8s/RootContainersHighUID.py
+++ b/checkov/kubernetes/checks/resource/k8s/RootContainersHighUID.py
@@ -87,7 +87,7 @@ check = RootContainersHighUID()
 def check_runAsUser(spec):
     if spec.get("securityContext"):
         if "runAsUser" in spec["securityContext"]:
-            if spec["securityContext"]["runAsUser"] >= 10000:
+            if isinstance(spec["securityContext"]["runAsUser"], int) and spec["securityContext"]["runAsUser"] >= 10000:
                 return "PASSED"
             else:
                 return "FAILED"

--- a/tests/kubernetes/checks/example_RootContainers/rootContainersFAILED.yaml
+++ b/tests/kubernetes/checks/example_RootContainers/rootContainersFAILED.yaml
@@ -55,3 +55,22 @@ spec:
     securityContext:
       runAsUser: 0
 
+---
+# runAsNonRoot not set, runAsUser is not an integer (FAILED)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod4
+spec:
+  securityContext:
+    runAsUser: username
+  containers:
+  - name: main
+    image: alpine
+    command: ["/bin/sleep", "999999"]
+  - name: main2
+    image: alpine
+    command: ["/bin/sleep", "999999"]
+    securityContext:
+      runAsUser: 0
+

--- a/tests/kubernetes/checks/example_RootContainersHighUID/rootContainersHighUIDFAILED.yaml
+++ b/tests/kubernetes/checks/example_RootContainersHighUID/rootContainersHighUIDFAILED.yaml
@@ -55,3 +55,19 @@ spec:
   - name: main2
     image: alpine
     command: ["/bin/sleep", "999999"]
+---
+# Pod runAsUser is not an integer (FAILED)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod4
+spec:
+  securityContext:
+    runAsUser: username
+  containers:
+  - name: main
+    image: alpine
+    command: ["/bin/sleep", "999999"]
+  - name: main2
+    image: alpine
+    command: ["/bin/sleep", "999999"]

--- a/tests/kubernetes/checks/test_RootContainers.py
+++ b/tests/kubernetes/checks/test_RootContainers.py
@@ -17,7 +17,7 @@ class TestRootContainers(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 5)
-        self.assertEqual(summary['failed'], 4)
+        self.assertEqual(summary['failed'], 5)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/kubernetes/checks/test_RootContainersHighUID.py
+++ b/tests/kubernetes/checks/test_RootContainersHighUID.py
@@ -17,7 +17,7 @@ class TestRootContainersHighUID(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 3)
-        self.assertEqual(summary['failed'], 4)
+        self.assertEqual(summary['failed'], 5)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
Validate that the runAsUser attribute is an integer before comparing it to a number.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
