### PR TITLE
bump hcl2 version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -33,7 +33,7 @@ dlint = "*"
 #
 # REMINDER: Update "install_requires" deps on setup.py when changing
 #
-bc-python-hcl2 = "==0.3.30"
+bc-python-hcl2 = "==0.3.33"
 deep_merge = "*"
 tabulate = "*"
 colorama="*"
@@ -49,7 +49,7 @@ update_checker = "*"
 semantic_version = "*"
 packaging = "*"
 cloudsplaining = ">=0.4.3"
-networkx = "*"
+networkx = "<2.7"
 dockerfile-parse ="*"
 docker = "*"
 configargparse = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c98df5a3c0bd33cb4e25619a3c4b591fecce95fc1e9cdc443573d6346927d01d"
+            "sha256": "d6ca7b11b19c470e1315c15020364d5f5a38840ca988124cec21609f65ea1d96"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -144,11 +144,11 @@
         },
         "bc-python-hcl2": {
             "hashes": [
-                "sha256:a5c1050d0166b43cc7c30d872c07fdaef3ab7fd1749d7e53f52a0f7d6a53a24a",
-                "sha256:c1f71320f29b30f6bbc695f3905b719f11b66511734f0df910fedfe33c07c5cb"
+                "sha256:a736cf67b950fc481f19fb30944263b2df4b64db1da382bbe3bac4a0771fb324",
+                "sha256:b5db30f607fae15187f6d456818659ab714d6b907924d84dde4eb0507ad4e736"
             ],
             "index": "pypi",
-            "version": "==0.3.30"
+            "version": "==0.3.33"
         },
         "beautifulsoup4": {
             "hashes": [
@@ -160,19 +160,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:9b6903fe9cc92d2f6111db28675263f1ab45adbcf1483025c82a304ce7790b71",
-                "sha256:f2ce641957c1782e382548ced4a447189e45851bbe58c1f6752ff2b661527de7"
+                "sha256:bf5f6a8997ed11a66280ace67cc25ec31c28525940da91d309c3976a9955d4cf",
+                "sha256:f2cecf5d176f398a39bfde0008df83c03f2142b2be5eabe32bf104961df68810"
             ],
             "index": "pypi",
-            "version": "==1.21.8"
+            "version": "==1.21.11"
         },
         "botocore": {
             "hashes": [
-                "sha256:9fbc5c57b31850c51c87abc3e166ed4e0f343665bec4e1a0ff814fbc9704642c",
-                "sha256:a5431d806dc75fb1844463d921759fcd8d387674443af8d7fd0867f296b02759"
+                "sha256:2af93de704f3122878a3233e7cf5de0b02f6c4c9fa993ca853b583f597bb1c38",
+                "sha256:b29c2b5906d7f70782634bb8713c77e39f23aafc994bb2f7dccbeb2b36712adc"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.24.8"
+            "version": "==1.24.11"
         },
         "cached-property": {
             "hashes": [
@@ -272,7 +272,7 @@
                 "sha256:9653a2297357335d7325a1827e71ac1245d91c97d959346a7decabd4a52d5354",
                 "sha256:a6e924f3c46b657feb5b72679f7e930f8e5b224b766ab35c91ae4019b4e0615e"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==0.5.3"
         },
         "cloudsplaining": {
@@ -453,11 +453,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c",
-                "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"
+                "sha256:b36ffa925fe3139b2f6ff11d6925ffd4fa7bc47870165e3ac260ac7b4f91e6ac",
+                "sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735"
             ],
             "index": "pypi",
-            "version": "==4.11.1"
+            "version": "==4.11.2"
         },
         "jinja2": {
             "hashes": [
@@ -499,11 +499,12 @@
             "index": "pypi",
             "version": "==1.9"
         },
-        "lark-parser": {
+        "lark": {
             "hashes": [
-                "sha256:42f367612a1bbc4cf9d8c8eb1b209d8a9b397d55af75620c9e6f53e502235996"
+                "sha256:7a8d0c07d663da9391d7faee1bf1d7df4998c47ca43a593cbef5c7566acd057a",
+                "sha256:c1ab213fc5e2d273fe2d91da218ccc8b5b92d065b17faa5e743499cb16594b7d"
             ],
-            "version": "==0.10.1"
+            "version": "==1.1.2"
         },
         "markdown": {
             "hashes": [
@@ -884,11 +885,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c",
-                "sha256:d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d"
+                "sha256:1d9835ede8e394bb8c9dcbffbca02d717217113adc679236873eeaac5bc0b3cd",
+                "sha256:e643e071046f17139dea55b880dc9b33822ce21613b4a4f5ea57f202833dbc29"
             ],
             "index": "pypi",
-            "version": "==4.62.3"
+            "version": "==4.63.0"
         },
         "types-setuptools": {
             "hashes": [
@@ -925,7 +926,7 @@
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
                 "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.8"
         },
         "wcwidth": {
@@ -1151,11 +1152,11 @@
         },
         "bandit": {
             "hashes": [
-                "sha256:6d11adea0214a43813887bfe71a377b5a9955e4c826c8ffd341b494e3ab25260",
-                "sha256:e20402cadfd126d85b68ed4c8862959663c8c372dbbb1fca8f8e2c9f55a067ec"
+                "sha256:3ce9b4e6a4f7f41aa966c9543e635dd35e52a793a47e746f0c55c7ecfc69d7e8",
+                "sha256:58772ca951bf1129dda8a280d351547de832720bf7b5c29fac3103927980b8a6"
             ],
             "index": "pypi",
-            "version": "==1.7.2"
+            "version": "==1.7.3"
         },
         "certifi": {
             "hashes": [
@@ -1754,17 +1755,17 @@
         },
         "types-urllib3": {
             "hashes": [
-                "sha256:4a54f6274ab1c80968115634a55fb9341a699492b95e32104a7c513db9fe02e9",
-                "sha256:abd2d4857837482b1834b4817f0587678dcc531dbc9abe4cde4da28cef3f522c"
+                "sha256:a26898f530e6c3f43f25b907f2b884486868ffd56a9faa94cbf9b3eb6e165d6a",
+                "sha256:d755278d5ecd7a7a6479a190e54230f241f1a99c19b81518b756b19dc69e518c"
             ],
-            "version": "==1.26.9"
+            "version": "==1.26.10"
         },
         "urllib3": {
             "hashes": [
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
                 "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.8"
         },
         "urllib3-mock": {

--- a/checkov/arm/checks/resource/NSGRulePortAccessRestricted.py
+++ b/checkov/arm/checks/resource/NSGRulePortAccessRestricted.py
@@ -33,10 +33,10 @@ class NSGRulePortAccessRestricted(BaseResourceCheck):
     def scan_resource_conf(self, conf: Dict[str, Any]) -> CheckResult:
         if "properties" in conf:
             securityRules = []
-            if "type" in conf and conf["type"] == "Microsoft.Network/networkSecurityGroups":
+            if self.entity_type == "Microsoft.Network/networkSecurityGroups":
                 if "securityRules" in conf["properties"]:
                     securityRules.extend(conf["properties"]["securityRules"])
-            if "type" in conf and conf["type"] == "Microsoft.Network/networkSecurityGroups/securityRules":
+            if self.entity_type == "Microsoft.Network/networkSecurityGroups/securityRules":
                 securityRules.append(conf)
 
             for rule in securityRules:

--- a/checkov/common/checks/base_check_registry.py
+++ b/checkov/common/checks/base_check_registry.py
@@ -5,13 +5,11 @@ import logging
 import os
 import sys
 from abc import abstractmethod
+from collections import defaultdict
 from itertools import chain
 from typing import Generator, Tuple, Dict, List, Optional, Any
 
 from checkov.common.checks.base_check import BaseCheck
-
-from collections import defaultdict
-
 from checkov.common.typing import _SkippedCheck
 from checkov.runner_filter import RunnerFilter
 

--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -98,14 +98,14 @@ class Record:
 
         return f"/{'/'.join(repo_file_path.parts[1:])}"
 
-    def set_guideline(self, guideline):
+    def set_guideline(self, guideline: Optional[str]) -> None:
         self.guideline = guideline
 
     @staticmethod
-    def _trim_special_chars(expression):
+    def _trim_special_chars(expression: str) -> str:
         return "".join(re.findall(re.compile(r"[^ ${\}]+"), expression))
 
-    def _is_expression_in_code_lines(self, expression):
+    def _is_expression_in_code_lines(self, expression: str) -> bool:
         stripped_expression = self._trim_special_chars(expression)
         return any(stripped_expression in self._trim_special_chars(line) for (_, line) in self.code_block)
 

--- a/tests/terraform/graph/variable_rendering/expected_data.py
+++ b/tests/terraform/graph/variable_rendering/expected_data.py
@@ -31,7 +31,7 @@ expected_eks = {
             "version": ["1.19"],
             "vpc_config": {
                 "security_group_ids": ["aws_security_group.master.id"],
-                "subnet_ids": "Tree('full_splat_expr_term', ['aws_subnet.eks', 'id'])"
+                "subnet_ids": "aws_subnet.eks[*].id"
             },
         }
     }

--- a/tests/terraform/parser/test_hcl2_load_assumptions.py
+++ b/tests/terraform/parser/test_hcl2_load_assumptions.py
@@ -50,7 +50,7 @@ class TestHCL2LoadAssumptions(unittest.TestCase):
         expect = {
             "locals": [
                 {
-                    "a_string": ["${merge(local.foo,,{'a': 'b'},)}"]
+                    "a_string": ["${merge(local.foo,{'a': 'b'})}"]
                 }
             ]
         }
@@ -297,6 +297,6 @@ class TestHCL2LoadAssumptions(unittest.TestCase):
     def test_splat_expression(self):
         tf = 'instances = flatten(aws_instance.ubuntu[*].id)'
         expect = {
-            'instances': ["${flatten(Tree('full_splat_expr_term', ['aws_instance.ubuntu', 'id']))}"]
+            'instances': ["${flatten(aws_instance.ubuntu[*].id)}"]
         }
         self.go(tf, expect)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

- bumped the `hcl2` version to latest one and adjusted some tests, the new output looks better I would say 😄 
- I also limited the `networkx` version, so the newest release won't be picked up, because they officially don't support Python 3.7 anymore
- some other minor adjustments, which I stumbled upon