### PR TITLE
PAN-OS resource check for IPsec protocols

### DIFF
--- a/checkov/terraform/checks/resource/panos/NetworkIPsecProtocols.py
+++ b/checkov/terraform/checks/resource/panos/NetworkIPsecProtocols.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+
+
+class NetworkIPsecProtocols(BaseResourceNegativeValueCheck):
+    def __init__(self):
+        name = "Ensure IPsec profiles do not specify use of insecure protocols"
+        id = "CKV_PAN_13"
+        supported_resources = ['panos_ipsec_crypto_profile', 'panos_panorama_ipsec_crypto_profile']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'protocol'
+
+    def get_forbidden_values(self):
+        return ['ah']
+
+
+check = NetworkIPsecProtocols()

--- a/tests/terraform/checks/resource/panos/example_NetworkIPsecProtocols/main.tf
+++ b/tests/terraform/checks/resource/panos/example_NetworkIPsecProtocols/main.tf
@@ -1,0 +1,79 @@
+# The "protocol" attribute can be used in either the panos_ipsec_crypto_profile or the panos_panorama_ipsec_crypto_profile resource.
+# Both resource types are covered by this check.
+
+# Fails
+
+# Setting the protocol attribute to "ah" uses Authentication Header, which only provides connection authentication and not confidentiality, and is therefore a fail, we only want to see ESP in use
+resource "panos_ipsec_crypto_profile" "fail1" {
+    name = "fail1"
+    authentications = ["sha384", "sha256"]
+    encryptions = ["aes-256-gcm"]
+    dh_group = "group14"
+    lifetime_type = "hours"
+    lifetime_value = 4
+    lifesize_type = "mb"
+    lifesize_value = 1
+    protocol = "ah"
+}
+# Setting the protocol attribute to "ah" uses Authentication Header, which only provides connection authentication and not confidentiality, and is therefore a fail, we only want to see ESP in use
+resource "panos_panorama_ipsec_crypto_profile" "fail2" {
+    name = "fail2"
+    authentications = ["sha384", "sha256"]
+    encryptions = ["aes-256-gcm"]
+    dh_group = "group14"
+    lifetime_type = "hours"
+    lifetime_value = 4
+    lifesize_type = "mb"
+    lifesize_value = 1
+    protocol = "ah"
+}
+
+# Passes
+
+# Setting the protocol attribute to "esp" uses Encapsulating Security Payload, which provides connection authentication and confidentiality, and is therefore a pass
+resource "panos_ipsec_crypto_profile" "pass1" {
+    name = "pass1"
+    authentications = ["sha384", "sha256"]
+    encryptions = ["aes-256-gcm"]
+    dh_group = "group14"
+    lifetime_type = "hours"
+    lifetime_value = 4
+    lifesize_type = "mb"
+    lifesize_value = 1
+    protocol = "esp"
+}
+# Setting the protocol attribute to "esp" uses Encapsulating Security Payload, which provides connection authentication and confidentiality, and is therefore a pass
+resource "panos_panorama_ipsec_crypto_profile" "pass2" {
+    name = "pass2"
+    authentications = ["sha384", "sha256"]
+    encryptions = ["aes-256-gcm"]
+    dh_group = "group14"
+    lifetime_type = "hours"
+    lifetime_value = 4
+    lifesize_type = "mb"
+    lifesize_value = 1
+    protocol = "esp"
+}
+
+# Not explicitly setting the protocol attribute when creating an IPsec profile leads to the default setting of "esp", using Encapsulating Security Payload, which provides connection authentication and confidentiality, and is therefore a pass
+resource "panos_ipsec_crypto_profile" "pass3" {
+    name = "pass3"
+    authentications = ["sha384", "sha256"]
+    encryptions = ["aes-256-gcm"]
+    dh_group = "group14"
+    lifetime_type = "hours"
+    lifetime_value = 4
+    lifesize_type = "mb"
+    lifesize_value = 1
+}
+# Not explicitly setting the protocol attribute when creating an IPsec profile leads to the default setting of "esp", using Encapsulating Security Payload, which provides connection authentication and confidentiality, and is therefore a pass
+resource "panos_panorama_ipsec_crypto_profile" "pass4" {
+    name = "pass4"
+    authentications = ["sha384", "sha256"]
+    encryptions = ["aes-256-gcm"]
+    dh_group = "group14"
+    lifetime_type = "hours"
+    lifetime_value = 4
+    lifesize_type = "mb"
+    lifesize_value = 1
+}

--- a/tests/terraform/checks/resource/panos/test_NetworkIPsecProtocols.py
+++ b/tests/terraform/checks/resource/panos/test_NetworkIPsecProtocols.py
@@ -1,0 +1,43 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.panos.NetworkIPsecProtocols import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestNetworkIPsecProtocols(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_NetworkIPsecProtocols"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'panos_ipsec_crypto_profile.pass1',
+            'panos_panorama_ipsec_crypto_profile.pass2',
+            'panos_ipsec_crypto_profile.pass3',
+            'panos_panorama_ipsec_crypto_profile.pass4',
+        }
+        failing_resources = {
+            'panos_ipsec_crypto_profile.fail1',
+            'panos_panorama_ipsec_crypto_profile.fail2',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 4)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

A resource check for PAN-OS Terraform provider to ensure use of secure protocols for IPsec VPNs. It can be configured in two different resource types, both are covered by this check.