### PR TITLE
move self attribute logic before inner attribute

### DIFF
--- a/checkov/common/graph/graph_builder/graph_components/blocks.py
+++ b/checkov/common/graph/graph_builder/graph_components/blocks.py
@@ -92,12 +92,13 @@ class Block:
             attribute_value = self.attributes[attribute_key]
             if isinstance(attribute_value, list) and len(attribute_value) == 1:
                 attribute_value = attribute_value[0]
-            if isinstance(attribute_value, (list, dict)):
-                inner_attributes = self.get_inner_attributes(attribute_key, attribute_value, False)
-                base_attributes.update(inner_attributes)
+            # needs to be checked before adding anything to 'base_attributes'
             if attribute_key == "self":
                 base_attributes["self_"] = attribute_value
                 continue
+            if isinstance(attribute_value, (list, dict)):
+                inner_attributes = self.get_inner_attributes(attribute_key, attribute_value, False)
+                base_attributes.update(inner_attributes)
             else:
                 base_attributes[attribute_key] = attribute_value
 

--- a/tests/cloudformation/graph/graph_builder/resources/sam/template.yaml
+++ b/tests/cloudformation/graph/graph_builder/resources/sam/template.yaml
@@ -1,6 +1,11 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 
+Mappings:
+  ServiceDiscovery:
+    self:
+      "name": 'amecard-cancel-api'
+
 Parameters:
   EnvironmentType:
     Type: String

--- a/tests/cloudformation/graph/graph_builder/test_local_graph.py
+++ b/tests/cloudformation/graph/graph_builder/test_local_graph.py
@@ -166,10 +166,11 @@ class TestLocalGraph(TestCase):
         local_graph = CloudformationLocalGraph(definitions)
         local_graph.build_graph(render_variables=False)
 
-        self.assertEqual(len(local_graph.vertices), 7)
+        self.assertEqual(len(local_graph.vertices), 8)
         self.assertEqual(len([v for v in local_graph.vertices if v.block_type == BlockType.GLOBALS]), 1)
         self.assertEqual(len([v for v in local_graph.vertices if v.block_type == BlockType.RESOURCE]), 3)
         self.assertEqual(len([v for v in local_graph.vertices if v.block_type == BlockType.OUTPUTS]), 1)
+        self.assertEqual(len([v for v in local_graph.vertices if v.block_type == BlockType.MAPPINGS]), 1)
 
         function_1_index = local_graph.vertices_block_name_map["resource"]["AWS::Serverless::Function.Function1"][0]
         function_2_index = local_graph.vertices_block_name_map["resource"]["AWS::Serverless::Function.Function2"][0]
@@ -225,6 +226,14 @@ class TestLocalGraph(TestCase):
         self.assertEqual("global-table", function_2_vertex.attributes["Environment"]["Variables"]["TABLE_NAME"])
         self.assertEqual(['sg-123', 'sg-456'], function_2_vertex.attributes["VpcConfig"]["SecurityGroupIds"])
         self.assertEqual(['subnet-123', 'subnet-456'], function_2_vertex.attributes["VpcConfig"]["SubnetIds"])
+
+        # check 'self' attribute is stored as 'self_'
+        mapping_index = local_graph.vertices_block_name_map["mappings"]["ServiceDiscovery"][0]
+        mapping_vertex = local_graph.vertices[mapping_index]
+
+        attribute_dict = mapping_vertex.get_attribute_dict()
+        self.assertNotIn("self", attribute_dict.keys())
+        self.assertIn("self_", attribute_dict.keys())
 
 
     def test_encryption_aws(self):


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

needed to move the block, because otherwise we will have an attribute named `self` in the `dict`, which results in an error in `networkx`
