### PR TITLE
Allow references to aws_lightsail_instance resources in CKV2_AWS_23

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/Route53ARecordAttachedResource.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/Route53ARecordAttachedResource.yaml
@@ -52,5 +52,6 @@ definition:
               - aws_cloudfront_distribution
               - aws_db_instance
               - aws_apigatewayv2_domain_name
+              - aws_lightsail_instance
            operator: exists
            attribute: networking


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This fixes a false positive with CKV2_AWS_23 where it fails when you reference a `aws_lightsail_instance` resource.