### PR TITLE
Modify severity of problemMatcher

### DIFF
--- a/github_action_resources/checkov-problem-matcher-softfail.json
+++ b/github_action_resources/checkov-problem-matcher-softfail.json
@@ -16,7 +16,7 @@
           "line": 2
         }
       ],
-      "severity": "warning"
+      "severity": "error"
     }
   ]
 }


### PR DESCRIPTION
When having a failed check, modify the severity from warning to error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
