### PR TITLE
Panos zone protection

### DIFF
--- a/checkov/terraform/checks/resource/panos/ZoneProtectionProfile.py
+++ b/checkov/terraform/checks/resource/panos/ZoneProtectionProfile.py
@@ -1,0 +1,38 @@
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+
+
+class ZoneProtectionProfile(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure a Zone Protection Profile is defined within Security Zones"
+        id = "CKV_PAN_14"
+        supported_resources = ['panos_zone', 'panos_zone_entry', 'panos_panorama_zone']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+
+        # Report the area of evaluation
+        self.evaluated_keys = ['zone_profile']
+    
+        # Check there is a Zone Protection Profile defined in the resource
+        if 'zone_profile' in conf:
+
+            # Get the Zone Protection Profile
+            profile_definition = conf.get('zone_profile')
+
+            # There can only be one "zone_profile" or Terraform fails at the "plan" stage
+            if profile_definition[0].strip() == "":
+                
+                # An empty string is no Zone Protection Profile, which is a fail
+                return CheckResult.FAILED
+            
+            else:
+                
+                # A non-empty string is a Zone Protection Profile being used, which is a pass
+                return CheckResult.PASSED
+
+        # If the "zone_profile" attribute is not defined, there is no Zone Protection Profile for this zone, which is a fail
+        return CheckResult.FAILED
+
+check = ZoneProtectionProfile()

--- a/tests/terraform/checks/resource/panos/example_ZoneProtectionProfile/main.tf
+++ b/tests/terraform/checks/resource/panos/example_ZoneProtectionProfile/main.tf
@@ -1,20 +1,16 @@
-# The "zone_profile" attributes can be defined in either the "panos_zone", "panos_zone_entry" or "panos_panorama_zone" resources.
-# All three resource types are covered by this check.
+# The "zone_profile" attributes can be defined in either the "panos_zone" or "panos_panorama_zone" resources.
+# All these resource types are covered by this check.
 
 # Passes
 
 # Zones should should have a "zone_profile" populated to protect against provide extended protection against IP floods, reconnaissance, packet based attacks, etc
 resource "panos_zone" "pass1" {
     name = "new_zone"
-    zone_profile = "a_zone_protection_profile"
+    zone_profile = "zone_protect_profile"
 }
-resource "panos_zone_entry" "pass2" {
-    name = "new_zone_entry"
-    zone_profile = "a_zone_protection_profile"
-}
-resource "panos_panorama_zone" "pass3" {
+resource "panos_panorama_zone" "pass2" {
     name = "new_zone_panorama"
-    zone_profile = "a_zone_protection_profile"
+    zone_profile = "zone_protect_profile"
 }
 
 # Fails
@@ -23,37 +19,26 @@ resource "panos_panorama_zone" "pass3" {
 resource "panos_zone" "fail1" {
     name = "new_zone"
 }
-resource "panos_zone_entry" "fail2" {
-    name = "new_zone_entry"
-}
-resource "panos_panorama_zone" "fail3" {
+resource "panos_panorama_zone" "fail2" {
     name = "new_zone_panorama"
 }
 
 # Zones should should have a "zone_profile" populated to protect against provide extended protection against IP floods, reconnaissance, packet based attacks, etc - empty string "zone_profile" attributes are a fail
-resource "panos_zone" "fail4" {
+resource "panos_zone" "fail3" {
     name = "new_zone"
     zone_profile = ""
 }
-resource "panos_zone_entry" "fail5" {
-    name = "new_zone_entry"
-    zone_profile = ""
-}
-resource "panos_panorama_zone" "fail6" {
+resource "panos_panorama_zone" "fail4" {
     name = "new_zone_panorama"
     zone_profile = ""
 }
 
 # Zones should should have a "zone_profile" populated to protect against provide extended protection against IP floods, reconnaissance, packet based attacks, etc - strings of space characters for "zone_profile" attributes are a fail
-resource "panos_zone" "fail7" {
+resource "panos_zone" "fail5" {
     name = "new_zone"
     zone_profile = "   "
 }
-resource "panos_zone_entry" "fail8" {
-    name = "new_zone_entry"
-    zone_profile = "   "
-}
-resource "panos_panorama_zone" "fail9" {
+resource "panos_panorama_zone" "fail6" {
     name = "new_zone_panorama"
     zone_profile = "   "
 }

--- a/tests/terraform/checks/resource/panos/example_ZoneProtectionProfile/main.tf
+++ b/tests/terraform/checks/resource/panos/example_ZoneProtectionProfile/main.tf
@@ -1,0 +1,59 @@
+# The "zone_profile" attributes can be defined in either the "panos_zone", "panos_zone_entry" or "panos_panorama_zone" resources.
+# All three resource types are covered by this check.
+
+# Passes
+
+# Zones should should have a "zone_profile" populated to protect against provide extended protection against IP floods, reconnaissance, packet based attacks, etc
+resource "panos_zone" "pass1" {
+    name = "new_zone"
+    zone_profile = "a_zone_protection_profile"
+}
+resource "panos_zone_entry" "pass2" {
+    name = "new_zone_entry"
+    zone_profile = "a_zone_protection_profile"
+}
+resource "panos_panorama_zone" "pass3" {
+    name = "new_zone_panorama"
+    zone_profile = "a_zone_protection_profile"
+}
+
+# Fails
+
+# Zones should should have a "zone_profile" populated to protect against provide extended protection against IP floods, reconnaissance, packet based attacks, etc - lack of "zone_profile" attribute is a fail
+resource "panos_zone" "fail1" {
+    name = "new_zone"
+}
+resource "panos_zone_entry" "fail2" {
+    name = "new_zone_entry"
+}
+resource "panos_panorama_zone" "fail3" {
+    name = "new_zone_panorama"
+}
+
+# Zones should should have a "zone_profile" populated to protect against provide extended protection against IP floods, reconnaissance, packet based attacks, etc - empty string "zone_profile" attributes are a fail
+resource "panos_zone" "fail4" {
+    name = "new_zone"
+    zone_profile = ""
+}
+resource "panos_zone_entry" "fail5" {
+    name = "new_zone_entry"
+    zone_profile = ""
+}
+resource "panos_panorama_zone" "fail6" {
+    name = "new_zone_panorama"
+    zone_profile = ""
+}
+
+# Zones should should have a "zone_profile" populated to protect against provide extended protection against IP floods, reconnaissance, packet based attacks, etc - strings of space characters for "zone_profile" attributes are a fail
+resource "panos_zone" "fail7" {
+    name = "new_zone"
+    zone_profile = "   "
+}
+resource "panos_zone_entry" "fail8" {
+    name = "new_zone_entry"
+    zone_profile = "   "
+}
+resource "panos_panorama_zone" "fail9" {
+    name = "new_zone_panorama"
+    zone_profile = "   "
+}

--- a/tests/terraform/checks/resource/panos/test_ZoneProtectionProfile.py
+++ b/tests/terraform/checks/resource/panos/test_ZoneProtectionProfile.py
@@ -18,26 +18,22 @@ class TestZoneProtectionProfile(unittest.TestCase):
 
         passing_resources = {
             'panos_zone.pass1',
-            'panos_zone_entry.pass2',
-            'panos_panorama_zone.pass3',
+            'panos_panorama_zone.pass2',
         }
         failing_resources = {
             'panos_zone.fail1',
-            'panos_zone_entry.fail2',
-            'panos_panorama_zone.fail3',
-            'panos_zone.fail4',
-            'panos_zone_entry.fail5',
+            'panos_panorama_zone.fail2',
+            'panos_zone.fail3',
+            'panos_panorama_zone.fail4',
+            'panos_zone.fail5',
             'panos_panorama_zone.fail6',
-            'panos_zone.fail7',
-            'panos_zone_entry.fail8',
-            'panos_panorama_zone.fail9',
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary['passed'], 3)
-        self.assertEqual(summary['failed'], 9)
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 6)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/terraform/checks/resource/panos/test_ZoneProtectionProfile.py
+++ b/tests/terraform/checks/resource/panos/test_ZoneProtectionProfile.py
@@ -1,0 +1,49 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.panos.ZoneProtectionProfile import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestZoneProtectionProfile(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ZoneProtectionProfile"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'panos_zone.pass1',
+            'panos_zone_entry.pass2',
+            'panos_panorama_zone.pass3',
+        }
+        failing_resources = {
+            'panos_zone.fail1',
+            'panos_zone_entry.fail2',
+            'panos_panorama_zone.fail3',
+            'panos_zone.fail4',
+            'panos_zone_entry.fail5',
+            'panos_panorama_zone.fail6',
+            'panos_zone.fail7',
+            'panos_zone_entry.fail8',
+            'panos_panorama_zone.fail9',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 3)
+        self.assertEqual(summary['failed'], 9)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

A resource check for PAN-OS Terraform provider to ensure Zone Protection Profiles are configured for each zone. This can be configured in two different resource types, both are covered by this check.