### PR TITLE
remove string cast of exception

### DIFF
--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -319,7 +319,7 @@ class Parser:
             result = _load_or_die_quietly(file, parsing_errors)
             # the exceptions type can un-pickleable
             for path, e in parsing_errors.items():
-                parsing_errors[path] = Exception(str(e))
+                parsing_errors[path] = e
 
             return (file.path, result), parsing_errors
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

No need to create a string here and then put it back into an exception. This resulted in a casting error of a `lark` parser exception.