### PR TITLE
PAN-OS check for User-ID IncludeACL in Zones

### DIFF
--- a/checkov/terraform/checks/resource/panos/ZoneUserIDIncludeACL.py
+++ b/checkov/terraform/checks/resource/panos/ZoneUserIDIncludeACL.py
@@ -1,0 +1,50 @@
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+
+
+class ZoneUserIDIncludeACL(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure an Include ACL is defined for a Zone when User-ID is enabled"
+        id = "CKV_PAN_15"
+        supported_resources = ['panos_zone', 'panos_panorama_zone']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+
+        # Report the area of evaluation
+        self.evaluated_keys = ['include_acls']
+    
+        # Get User-ID status, boolean value
+        user_id_enabled = conf.get('enable_user_id')
+
+        # Check if User-ID is enabled in the zone
+        if user_id_enabled:
+
+            # Then check if an Include ACL is defined for User-ID
+            if 'include_acls' in conf:
+
+                # Get the Include ACL attribute
+                acls = conf.get('include_acls')[0]
+
+                # Cycle through each item in the Include ACL list
+                for acl in acls:
+
+                    # Check for empty strings
+                    if acl.strip() == "":
+                        
+                        # An empty string is no ACL, which is a fail
+                        return CheckResult.FAILED
+                
+                # No empty strings found in Include ACL definition, so this is a pass
+                return CheckResult.PASSED
+
+            else:
+                # No Include ACl for User-ID is a fail
+                return CheckResult.FAILED
+
+        # If User-ID is not enabled for the zone, the Include ACL check is not needed
+        else:
+            return CheckResult.PASSED
+
+check = ZoneUserIDIncludeACL()

--- a/tests/terraform/checks/resource/panos/example_ZoneUserIDIncludeACL/main.tf
+++ b/tests/terraform/checks/resource/panos/example_ZoneUserIDIncludeACL/main.tf
@@ -1,0 +1,83 @@
+# If User-ID is enabled for a zone (optional), an "include ACL" should be defined to provide scope for User-ID. This can be configured in "panos_zone" or "panos_panorama_zone" resources. Both resource types are covered by this check.
+
+# Passes
+
+# User-ID enabled, Include ACL defined, single entry in list
+resource "panos_zone" "pass1" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+    enable_user_id = true
+    include_acls = ["10.0.0.0./8"]
+}
+resource "panos_panorama_zone" "pass2" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+    enable_user_id = true
+    include_acls = ["10.0.0.0./8"]
+}
+
+# User-ID enabled, Include ACL defined, double entry in list
+resource "panos_zone" "pass3" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+    enable_user_id = true
+    include_acls = ["10.0.0.0./8", "192.168.0.0/16"]
+}
+resource "panos_panorama_zone" "pass4" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+    enable_user_id = true
+    include_acls = ["10.0.0.0./8", "192.168.0.0/16"]
+}
+
+# User-ID not enabled, Include ACL not required
+resource "panos_zone" "pass5" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+}
+resource "panos_panorama_zone" "pass6" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+}
+
+# Fails
+
+# User-ID enabled, Include ACL undefined
+resource "panos_zone" "fail1" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+    enable_user_id = true
+}
+resource "panos_panorama_zone" "fail2" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+    enable_user_id = true
+}
+
+# User-ID enabled, Include ACL defined, empty string in list
+resource "panos_zone" "fail3" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+    enable_user_id = true
+    include_acls = [""]
+}
+resource "panos_panorama_zone" "fail4" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+    enable_user_id = true
+    include_acls = [""]
+}
+
+# User-ID enabled, Include ACL defined, string of spaces in list
+resource "panos_zone" "fail5" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+    enable_user_id = true
+    include_acls = ["    "]
+}
+resource "panos_panorama_zone" "fail6" {
+    name = "new_zone"
+    zone_profile = "zone_protect_profile"
+    enable_user_id = true
+    include_acls = ["    "]
+}

--- a/tests/terraform/checks/resource/panos/test_ZoneUserIDIncludeACL.py
+++ b/tests/terraform/checks/resource/panos/test_ZoneUserIDIncludeACL.py
@@ -1,0 +1,49 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.panos.ZoneUserIDIncludeACL import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestZoneUserIDIncludeACL(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ZoneUserIDIncludeACL"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'panos_zone.pass1',
+            'panos_panorama_zone.pass2',
+            'panos_zone.pass3',
+            'panos_panorama_zone.pass4',
+            'panos_zone.pass5',
+            'panos_panorama_zone.pass6',
+        }
+        failing_resources = {
+            'panos_zone.fail1',
+            'panos_panorama_zone.fail2',
+            'panos_zone.fail3',
+            'panos_panorama_zone.fail4',
+            'panos_zone.fail5',
+            'panos_panorama_zone.fail6',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 6)
+        self.assertEqual(summary['failed'], 6)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Another check for PAN-OS. If User-ID is enabled for a zone (it is optional), an "include ACL" should be defined to provide the scope for source IP addresses used within User-ID. This can be configured in "panos_zone" or "panos_panorama_zone" resources. Both resource types are covered by this check.
