### PR TITLE
skip SLS sub resource if it is a file reference

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ECRPolicy.py
+++ b/checkov/cloudformation/checks/resource/aws/ECRPolicy.py
@@ -1,22 +1,25 @@
+from __future__ import annotations
+
 import json
 import logging
 import re
+from typing import Any
 
-from checkov.common.parsers.node import StrNode
-from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
-from checkov.serverless.parsers.parser import DEFAULT_VAR_PATTERN
+from checkov.common.models.consts import SLS_DEFAULT_VAR_PATTERN
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.common.parsers.node import StrNode
 
 
 class ECRPolicy(BaseResourceCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure ECR policy is not set to public"
         id = "CKV_AWS_32"
-        supported_resources = ['AWS::ECR::Repository']
-        categories = [CheckCategories.GENERAL_SECURITY]
+        supported_resources = ("AWS::ECR::Repository",)
+        categories = (CheckCategories.GENERAL_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:
         """
             Looks for public * policy for ecr repository:
             https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-repository.html
@@ -24,40 +27,43 @@ class ECRPolicy(BaseResourceCheck):
         :return: <CheckResult>
         """
         self.evaluated_keys = ["Properties/RepositoryPolicyText/Statement"]
-        policy_text = conf.get('Properties', {}).get('RepositoryPolicyText')
+        policy_text = conf.get("Properties", {}).get("RepositoryPolicyText")
         if not policy_text:
             return CheckResult.PASSED
-        if type(policy_text) in (str, StrNode):
+        if isinstance(policy_text, str):
             try:
                 policy_text = json.loads(str(policy_text))
             except json.decoder.JSONDecodeError as e:
-                if re.match(DEFAULT_VAR_PATTERN, str(policy_text)):
+                if re.match(SLS_DEFAULT_VAR_PATTERN, str(policy_text)):
                     # Case where the template is a sub-CFN configuration inside a serverless configuration,
                     # and the policy is a variable expression
                     logging.info(f"Encountered variable expression {str(policy_text)} in resource ${self.entity_path}")
                 else:
                     logging.error(
-                        f"Malformed policy configuration {str(policy_text)} of resource {self.entity_path}\n{e}")
+                        f"Malformed policy configuration {str(policy_text)} of resource {self.entity_path}\n{e}"
+                    )
                 return CheckResult.UNKNOWN
-        if 'Statement' in policy_text.keys():
-            for statement_index, statement in enumerate(policy_text['Statement']):
-                if 'Principal' in statement.keys():
-                    for principal_index, principal in enumerate(statement['Principal']):
+        if "Statement" in policy_text.keys():
+            for statement_index, statement in enumerate(policy_text["Statement"]):
+                if "Principal" in statement.keys():
+                    for principal_index, principal in enumerate(statement["Principal"]):
                         if principal == "*" and not self.check_for_constrained_condition(statement):
-                            self.evaluated_keys = [f"Properties/RepositoryPolicyText/Statement/[{statement_index}]/Principal/[{principal_index}]"]
+                            self.evaluated_keys = [
+                                f"Properties/RepositoryPolicyText/Statement/[{statement_index}]/Principal/[{principal_index}]"
+                            ]
                             return CheckResult.FAILED
         return CheckResult.PASSED
 
-    def check_for_constrained_condition(self, statement):
+    def check_for_constrained_condition(self, statement: dict[str, Any]) -> bool:
         """
         Checks to see if there is a constraint on a a wildcarded principal
         :param statement: statement from aws_repository_configuration
         :return: true if there is a constraint
         """
-        if 'Condition' in statement.keys():
-            condition = statement['Condition']
-            if 'ForAllValues:StringEquals' in condition.keys():
-                if 'aws:PrincipalOrgID' in condition['ForAllValues:StringEquals'].keys():
+        if "Condition" in statement.keys():
+            condition = statement["Condition"]
+            if "ForAllValues:StringEquals" in condition.keys():
+                if "aws:PrincipalOrgID" in condition["ForAllValues:StringEquals"].keys():
                     return True
         return False
 

--- a/checkov/common/models/consts.py
+++ b/checkov/common/models/consts.py
@@ -14,4 +14,5 @@ secret_key_pattern = re.compile("(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z
 linode_token_pattern = re.compile("(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{64}(?![A-Za-z0-9/+=])")  # nosec
 bridgecrew_token_pattern = re.compile(r"^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}\Z")  # nosec
 panos_api_key_pattern = re.compile(r"^LUFRPT1[a-zA-Z0-9]+==\Z")  # nosec
+SLS_DEFAULT_VAR_PATTERN = re.compile(r"\${([^{}]+?)}")
 YAML_COMMENT_MARK = '#'

--- a/checkov/serverless/parsers/parser.py
+++ b/checkov/serverless/parsers/parser.py
@@ -12,6 +12,7 @@ from yaml import YAMLError
 
 from checkov.cloudformation.parser import cfn_yaml
 from checkov.cloudformation.context_parser import ContextParser
+from checkov.common.models.consts import SLS_DEFAULT_VAR_PATTERN
 from checkov.common.parsers.node import DictNode, StrNode
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,6 @@ STACK_TAGS_TOKEN = 'stackTags'  # nosec
 TAGS_TOKEN = 'tags'  # nosec
 SUPPORTED_PROVIDERS = ['aws']
 
-DEFAULT_VAR_PATTERN = re.compile(r"\${([^{}]+?)}")
 QUOTED_WORD_SYNTAX = re.compile(r"(?:('|\").*?\1)")
 FILE_LOCATION_PATTERN = re.compile(r'^file\(([^?%*:|"<>]+?)\)')
 
@@ -101,7 +101,7 @@ Modifies the template data in-place to resolve variables.
         # Remove to prevent self-matching during processing
         del template["provider"]["variableSyntax"]
     else:
-        var_pattern = DEFAULT_VAR_PATTERN
+        var_pattern = SLS_DEFAULT_VAR_PATTERN
     compiled_var_pattern = re.compile(var_pattern)
 
     # Processing is done in a loop to deal with chained references and the like.

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -95,11 +95,12 @@ class Runner(BaseRunner):
 
             if CFN_RESOURCES_TOKEN in sls_file_data and isinstance(sls_file_data[CFN_RESOURCES_TOKEN], DictNode):
                 cf_sub_template = sls_file_data[CFN_RESOURCES_TOKEN]
-                if cf_sub_template.get("Resources"):
+                cf_sub_resources = cf_sub_template.get("Resources")
+                if cf_sub_resources and isinstance(cf_sub_resources, dict):
                     cf_context_parser = CfnContextParser(sls_file, cf_sub_template, definitions_raw[sls_file])
                     logging.debug(f"Template Dump for {sls_file}: {sls_file_data}")
                     cf_context_parser.evaluate_default_refs()
-                    for resource_name, resource in cf_sub_template['Resources'].items():
+                    for resource_name, resource in cf_sub_resources.items():
                         if not isinstance(resource, DictNode):
                             continue
                         cf_resource_id = cf_context_parser.extract_cf_resource_id(resource, resource_name)

--- a/tests/serverless/runner/resources/serverless.yaml
+++ b/tests/serverless/runner/resources/serverless.yaml
@@ -57,3 +57,6 @@ functions:
     fileSystemConfig:
       localMountPath: ${self:custom.localMountPath}
       arn: 'arn:aws:elasticfilesystem:${self:provider.region}:#{AWS::AccountId}:access-point/${self:custom.resources.efsAccessPoint}'
+
+resources:
+  Resources: ${file(./serverless.${opt:stage}.yml)}  # just shouldn't raise an exception


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

- added a bit of code to skip `file` reference in a resource block
```yaml
resources:
  Resources: ${file(./serverless.${opt:stage}.yml)} 
```
- also moved the `DEFAULT_VAR_PATTERN` to the `common` module, because I somehow had circular dependency