### PR TITLE
Trust openssl to be on PATH not hardcoded

### DIFF
--- a/admissioncontroller/setup.sh
+++ b/admissioncontroller/setup.sh
@@ -36,7 +36,7 @@ bcapikey=$2
 
 # Generate keys into a temporary directory.
 echo "Generating TLS certs ..."
-/usr/local/opt/openssl/bin/openssl req -x509 -sha256 -newkey rsa:2048 -keyout $certdir/webhook.key -out $certdir/webhook.crt -days 1024 -nodes -addext "subjectAltName = DNS.1:validate.$ns.svc"
+openssl req -x509 -sha256 -newkey rsa:2048 -keyout $certdir/webhook.key -out $certdir/webhook.crt -days 1024 -nodes -addext "subjectAltName = DNS.1:validate.$ns.svc"
 
 kubectl create secret generic admission-tls -n bridgecrew --type=Opaque --from-file=$certdir/webhook.key --from-file=$certdir/webhook.crt --dry-run=client -o yaml > $k8sdir/secret.yaml
 


### PR DESCRIPTION
Had issues in some environments where openssl was at a different path, we also use openssl without hard path later on via $(), so think this is acceptable! 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
