### PR TITLE
Update Runner.run method to make folder optional

### DIFF
--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -73,7 +73,7 @@ class Runner(BaseRunner):
 
     def run(
         self,
-        root_folder: str,
+        root_folder: Opiontal[str] = None,
         external_checks_dir: Optional[List[str]] = None,
         files: Optional[List[str]] = None,
         runner_filter: RunnerFilter = RunnerFilter(),


### PR DESCRIPTION
Right now, the test Runner class cannot be run on specific files, even though this is supported. This is because the `root_folder` is a required parameter, and because of this, the `files` parameter can never be used because of the `if/else` logic of the `run` method. This looks like an oversight because there is an explicit exception raised if _neither_ of these parameters are set, implying they should be optional.

This PR makes the `root_folder` parameter optional. It looks like this is handled differently in the various provider types (cloudformation, kubernetes, etc) so I wasn't sure what approach y'all would ideally want.


## Code Example 
```
        runner = Runner()
        current_dir = os.path.dirname(os.path.realpath(__file__))

        test_files_dir = os.path.join(current_dir, 'resources/terraform')
        report = runner.run(
            root_folder=test_files_dir,
            files = ['/path/to/file.tf'],  # completely ignored because `root_folder` takes precedence
            runner_filter=RunnerFilter(checks=[check.id]),
        )

```

## Ideal behavior
        runner = Runner()
        current_dir = os.path.dirname(os.path.realpath(__file__))

        test_files = os.path.join(current_dir, 'resources/terraform/file.tf')
        report = runner.run(
            files = test_files,  # Runner will now scan this specific file
            runner_filter=RunnerFilter(checks=[check.id]),
        )
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
