### PR TITLE
feat: add support for terraform AKS role_based_access_control_enabled

### DIFF
--- a/checkov/terraform/checks/resource/azure/AKSRbacEnabled.py
+++ b/checkov/terraform/checks/resource/azure/AKSRbacEnabled.py
@@ -1,17 +1,37 @@
-from checkov.common.models.enums import CheckCategories
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+import dpath.util
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
 
-class AKSRbacEnabled(BaseResourceValueCheck):
+class AKSRbacEnabled(BaseResourceCheck):
     def __init__(self):
         name = "Ensure RBAC is enabled on AKS clusters"
         id = "CKV_AZURE_5"
-        supported_resources = ['azurerm_kubernetes_cluster']
+        supported_resources = ["azurerm_kubernetes_cluster"]
         categories = [CheckCategories.KUBERNETES]
-        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+        super().__init__(
+            name=name,
+            id=id,
+            categories=categories,
+            supported_resources=supported_resources,
+        )
 
-    def get_inspected_key(self):
-        return 'role_based_access_control/[0]/enabled'
+    def scan_resource_conf(self, conf):
+        # azurerm < 2.99.0
+        inspected_key1 = "role_based_access_control/[0]/enabled"
+        # azurerm >= 2.99.0
+        inspected_key2 = "role_based_access_control_enabled"
+        rbac_enabled = False
+
+        if dpath.search(conf, inspected_key1) != {}:
+            rbac_enabled = dpath.get(conf, inspected_key1)[0]
+        elif dpath.search(conf, inspected_key2) != {}:
+            rbac_enabled = dpath.get(conf, inspected_key2)[0]
+
+        if rbac_enabled:
+            return CheckResult.PASSED
+
+        return CheckResult.FAILED
 
 
 check = AKSRbacEnabled()

--- a/checkov/terraform/checks/resource/azure/AKSRbacEnabled.py
+++ b/checkov/terraform/checks/resource/azure/AKSRbacEnabled.py
@@ -17,19 +17,14 @@ class AKSRbacEnabled(BaseResourceCheck):
         )
 
     def scan_resource_conf(self, conf):
-        # azurerm < 2.99.0
-        inspected_key1 = "role_based_access_control/[0]/enabled"
-        # azurerm >= 2.99.0
-        inspected_key2 = "role_based_access_control_enabled"
-        rbac_enabled = False
+        self.evaluated_keys = [
+            "role_based_access_control/[0]/enabled",  # azurerm < 2.99.0
+            "role_based_access_control_enabled",  # azurerm >= 2.99.0
+        ]
 
-        if dpath.search(conf, inspected_key1) != {}:
-            rbac_enabled = dpath.get(conf, inspected_key1)[0]
-        elif dpath.search(conf, inspected_key2) != {}:
-            rbac_enabled = dpath.get(conf, inspected_key2)[0]
-
-        if rbac_enabled:
-            return CheckResult.PASSED
+        for key in self.evaluated_keys:
+            if dpath.search(conf, key) and dpath.get(conf, key)[0]:
+                return CheckResult.PASSED
 
         return CheckResult.FAILED
 

--- a/tests/terraform/checks/resource/azure/test_AKSRbacEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_AKSRbacEnabled.py
@@ -5,37 +5,105 @@ from checkov.terraform.checks.resource.azure.AKSRbacEnabled import check
 
 
 class TestAKSRbacEnabled(unittest.TestCase):
-
+    # azurerm < 2.99.0
     def test_failure_false(self):
-        resource_conf = {'name': ['example-aks1'], 'location': ['${azurerm_resource_group.example.location}'],
-                         'resource_group_name': ['${azurerm_resource_group.example.name}'], 'dns_prefix': ['exampleaks1'],
-                         'default_node_pool': [{'name': ['default'], 'node_count': [1], 'vm_size': ['Standard_D2_v2']}],
-                         'identity': [{'type': ['SystemAssigned']}], 'agent_pool_profile': [{}], 'service_principal': [{}],
-                         'role_based_access_control': [{'enabled': [False]}], 'tags': [{'Environment': 'Production'}]}
+        resource_conf = {
+            "name": ["example-aks1"],
+            "location": ["${azurerm_resource_group.example.location}"],
+            "resource_group_name": ["${azurerm_resource_group.example.name}"],
+            "dns_prefix": ["exampleaks1"],
+            "default_node_pool": [
+                {"name": ["default"], "node_count": [1], "vm_size": ["Standard_D2_v2"]}
+            ],
+            "identity": [{"type": ["SystemAssigned"]}],
+            "agent_pool_profile": [{}],
+            "service_principal": [{}],
+            "role_based_access_control": [{"enabled": [False]}],
+            "tags": [{"Environment": "Production"}],
+        }
+
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    # azurerm >= 2.99.0
+    def test_failure_false_new_syntax(self):
+        resource_conf = {
+            "name": ["example-aks1"],
+            "location": ["${azurerm_resource_group.example.location}"],
+            "resource_group_name": ["${azurerm_resource_group.example.name}"],
+            "dns_prefix": ["exampleaks1"],
+            "default_node_pool": [
+                {"name": ["default"], "node_count": [1], "vm_size": ["Standard_D2_v2"]}
+            ],
+            "identity": [{"type": ["SystemAssigned"]}],
+            "agent_pool_profile": [{}],
+            "service_principal": [{}],
+            "role_based_access_control_enabled": [False],
+            "tags": [{"Environment": "Production"}],
+        }
 
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
     def test_failure_default(self):
-        resource_conf = {'name': ['example-aks1'], 'location': ['${azurerm_resource_group.example.location}'],
-                         'resource_group_name': ['${azurerm_resource_group.example.name}'], 'dns_prefix': ['exampleaks1'],
-                         'default_node_pool': [{'name': ['default'], 'node_count': [1], 'vm_size': ['Standard_D2_v2']}],
-                         'identity': [{'type': ['SystemAssigned']}], 'agent_pool_profile': [{}], 'service_principal': [{}],
-                         'tags': [{'Environment': 'Production'}],
-                         'addon_profile': [{'oms_agent': [{'enabled': [True], 'log_analytics_workspace_id': ['']}]}]}
+        resource_conf = {
+            "name": ["example-aks1"],
+            "location": ["${azurerm_resource_group.example.location}"],
+            "resource_group_name": ["${azurerm_resource_group.example.name}"],
+            "dns_prefix": ["exampleaks1"],
+            "default_node_pool": [
+                {"name": ["default"], "node_count": [1], "vm_size": ["Standard_D2_v2"]}
+            ],
+            "identity": [{"type": ["SystemAssigned"]}],
+            "agent_pool_profile": [{}],
+            "service_principal": [{}],
+            "tags": [{"Environment": "Production"}],
+            "addon_profile": [
+                {"oms_agent": [{"enabled": [True], "log_analytics_workspace_id": [""]}]}
+            ],
+        }
 
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    # azurerm < 2.99.0
     def test_success(self):
-        resource_conf = {'name': ['example-aks1'], 'location': ['${azurerm_resource_group.example.location}'],
-                         'resource_group_name': ['${azurerm_resource_group.example.name}'], 'dns_prefix': ['exampleaks1'],
-                         'default_node_pool': [{'name': ['default'], 'node_count': [1], 'vm_size': ['Standard_D2_v2']}],
-                         'identity': [{'type': ['SystemAssigned']}], 'agent_pool_profile': [{}], 'service_principal': [{}],
-                         'role_based_access_control': [{'enabled': [True]}], 'tags': [{'Environment': 'Production'}]}
+        resource_conf = {
+            "name": ["example-aks1"],
+            "location": ["${azurerm_resource_group.example.location}"],
+            "resource_group_name": ["${azurerm_resource_group.example.name}"],
+            "dns_prefix": ["exampleaks1"],
+            "default_node_pool": [
+                {"name": ["default"], "node_count": [1], "vm_size": ["Standard_D2_v2"]}
+            ],
+            "identity": [{"type": ["SystemAssigned"]}],
+            "agent_pool_profile": [{}],
+            "service_principal": [{}],
+            "role_based_access_control": [{"enabled": [True]}],
+            "tags": [{"Environment": "Production"}],
+        }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    # azurerm >= 2.99.0
+    def test_success_new_syntax(self):
+        resource_conf = {
+            "name": ["example-aks1"],
+            "location": ["${azurerm_resource_group.example.location}"],
+            "resource_group_name": ["${azurerm_resource_group.example.name}"],
+            "dns_prefix": ["exampleaks1"],
+            "default_node_pool": [
+                {"name": ["default"], "node_count": [1], "vm_size": ["Standard_D2_v2"]}
+            ],
+            "identity": [{"type": ["SystemAssigned"]}],
+            "agent_pool_profile": [{}],
+            "service_principal": [{}],
+            "role_based_access_control_enabled": [True],
+            "tags": [{"Environment": "Production"}],
+        }
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Suggested change

Recently, azurerm [2.99.0](https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v2.99.0) was published, which, in preparation for 3.0, brought some syntax changes, one of which is listed below:
***
"Data Source: `azurerm_kubernetes_cluster` - deprecated the `role_based_access_control` block in favour of `azure_active_directory_role_based_access_control` and `role_based_access_control_enabled` properties (https://github.com/hashicorp/terraform-provider-azurerm/issues/15584)"
***

This PR adds support for `role_based_access_control_enabled`.

Closes #2649