### PR TITLE
Added Oci security list checks

### DIFF
--- a/checkov/terraform/checks/resource/oci/SecurityListUnrestrictedIngress22.py
+++ b/checkov/terraform/checks/resource/oci/SecurityListUnrestrictedIngress22.py
@@ -5,7 +5,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 class SecurityListUnrestrictedIngress22(BaseResourceCheck):
     def __init__(self):
         name = "Ensure VCN inbound security lists allow all traffic on SSH port."
-        id = "CKV_OCI_17"  # TODO change id
+        id = "CKV_OCI_19"
         supported_resources = ['oci_core_security_list']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
@@ -15,9 +15,9 @@ class SecurityListUnrestrictedIngress22(BaseResourceCheck):
             self.evaluated_keys = ['ingress_security_rules']
             rules = conf.get("ingress_security_rules")
             for idx, rule in enumerate(rules):
-                if not "0.0.0.0/0" in rule['source'][0]:  # TODO to skip or fail?
+                if not "0.0.0.0/0" in rule['source'][0]:
                     self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]/source']
-                    return CheckResult.FAILED
+                    return CheckResult.SKIPPED
 
                 if not ((rule['protocol'][0] != '1' and (not 'udp_options' in rule) and (not 'tcp_options' in rule))
                         or (self.scan_protocol_conf(rule, 'tcp_options', idx) != CheckResult.FAILED

--- a/checkov/terraform/checks/resource/oci/SecurityListUnrestrictedIngress22.py
+++ b/checkov/terraform/checks/resource/oci/SecurityListUnrestrictedIngress22.py
@@ -1,0 +1,44 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class SecurityListUnrestrictedIngress22(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure VCN inbound security lists allow all traffic on SSH port."
+        id = "CKV_OCI_17"  # TODO change id
+        supported_resources = ['oci_core_security_list']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'ingress_security_rules' in conf:
+            self.evaluated_keys = ['ingress_security_rules']
+            rules = conf.get("ingress_security_rules")
+            for idx, rule in enumerate(rules):
+                if not "0.0.0.0/0" in rule['source'][0]:  # TODO to skip or fail?
+                    self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]/source']
+                    return CheckResult.FAILED
+
+                if not ((rule['protocol'][0] != '1' and (not 'udp_options' in rule) and (not 'tcp_options' in rule))
+                        or (self.scan_protocol_conf(rule, 'tcp_options', idx) != CheckResult.FAILED
+                            and self.scan_protocol_conf(rule, 'udp_options', idx) != CheckResult.FAILED)
+                        or rule['protocol'][0] == 'all'):
+                    self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]']
+                    return CheckResult.FAILED
+
+            return CheckResult.PASSED
+
+        return CheckResult.SKIPPED
+
+    def scan_protocol_conf(self, rule, protocol_name, idx):
+        """ scan udp/tcp_options configuration"""
+        if protocol_name in rule:
+            max_port = rule[protocol_name][0]['max'][0]
+            min_port = rule[protocol_name][0]['min'][0]
+            if min_port <= 22 and max_port >= 22:
+                return CheckResult.SKIPPED
+        self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]/protocol/[0]/{protocol_name}']
+        return CheckResult.FAILED
+
+
+check = SecurityListUnrestrictedIngress22()

--- a/checkov/terraform/checks/resource/oci/SecurityListUnrestrictedIngress3389.py
+++ b/checkov/terraform/checks/resource/oci/SecurityListUnrestrictedIngress3389.py
@@ -1,0 +1,44 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class SecurityListUnrestrictedIngress3389(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure VCN inbound security lists allow all traffic on 3389 port."
+        id = "CKV_OCI_17"  # TODO change id
+        supported_resources = ['oci_core_security_list']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'ingress_security_rules' in conf:
+            self.evaluated_keys = ['ingress_security_rules']
+            rules = conf.get("ingress_security_rules")
+            for idx, rule in enumerate(rules):
+                if not "0.0.0.0/0" in rule['source'][0]:  # TODO to skip or fail?
+                    self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]/source']
+                    return CheckResult.FAILED
+
+                if not ((rule['protocol'][0] != '1' and (not 'udp_options' in rule) and (not 'tcp_options' in rule))
+                        or (self.scan_protocol_conf(rule, 'tcp_options', idx) != CheckResult.FAILED
+                        and self.scan_protocol_conf(rule, 'udp_options', idx) != CheckResult.FAILED)
+                        or rule['protocol'][0] == 'all'):
+                    self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]']
+                    return CheckResult.FAILED
+
+            return CheckResult.PASSED
+
+        return CheckResult.SKIPPED
+
+    def scan_protocol_conf(self, rule, protocol_name, idx):
+        """ scan udp/tcp_options configuration"""
+        if protocol_name in rule:
+            max_port = rule[protocol_name][0]['max'][0]
+            min_port = rule[protocol_name][0]['min'][0]
+            if min_port <= 3389 and max_port >= 3389:
+                return CheckResult.SKIPPED
+        self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]/protocol/[0]/{protocol_name}']
+        return CheckResult.FAILED
+
+
+check = SecurityListUnrestrictedIngress3389()

--- a/checkov/terraform/checks/resource/oci/SecurityListUnrestrictedIngress3389.py
+++ b/checkov/terraform/checks/resource/oci/SecurityListUnrestrictedIngress3389.py
@@ -5,7 +5,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 class SecurityListUnrestrictedIngress3389(BaseResourceCheck):
     def __init__(self):
         name = "Ensure VCN inbound security lists allow all traffic on 3389 port."
-        id = "CKV_OCI_17"  # TODO change id
+        id = "CKV_OCI_18"
         supported_resources = ['oci_core_security_list']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
@@ -15,13 +15,13 @@ class SecurityListUnrestrictedIngress3389(BaseResourceCheck):
             self.evaluated_keys = ['ingress_security_rules']
             rules = conf.get("ingress_security_rules")
             for idx, rule in enumerate(rules):
-                if not "0.0.0.0/0" in rule['source'][0]:  # TODO to skip or fail?
+                if not "0.0.0.0/0" in rule['source'][0]:
                     self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]/source']
-                    return CheckResult.FAILED
+                    return CheckResult.SKIPPED
 
                 if not ((rule['protocol'][0] != '1' and (not 'udp_options' in rule) and (not 'tcp_options' in rule))
                         or (self.scan_protocol_conf(rule, 'tcp_options', idx) != CheckResult.FAILED
-                        and self.scan_protocol_conf(rule, 'udp_options', idx) != CheckResult.FAILED)
+                            and self.scan_protocol_conf(rule, 'udp_options', idx) != CheckResult.FAILED)
                         or rule['protocol'][0] == 'all'):
                     self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]']
                     return CheckResult.FAILED

--- a/tests/terraform/checks/resource/oci/example_SecurityListUnrestrictedIngress22/main.tf
+++ b/tests/terraform/checks/resource/oci/example_SecurityListUnrestrictedIngress22/main.tf
@@ -123,7 +123,7 @@ resource "oci_core_security_list" "fail1" {
         source = "0.0.0.0/0"
     }
 }
-resource "oci_core_security_list" "fail2" {
+resource "oci_core_security_list" "skip" {
     compartment_id = "var.compartment_id"
     vcn_id = "oci_core_vcn.test_vcn.id"
 

--- a/tests/terraform/checks/resource/oci/example_SecurityListUnrestrictedIngress22/main.tf
+++ b/tests/terraform/checks/resource/oci/example_SecurityListUnrestrictedIngress22/main.tf
@@ -1,0 +1,134 @@
+resource "oci_core_security_list" "pass" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "var.security_list_ingress_security_rules_protocol"
+        source = "0.0.0.0/0"
+
+        tcp_options {
+            max = 22
+            min = 22
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_tcp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_tcp_options_source_port_range_min"
+            }
+        }
+        udp_options {
+            max = 900
+            min = 7
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_udp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_udp_options_source_port_range_min"
+            }
+        }
+    }
+}
+
+resource "oci_core_security_list" "fail" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "var.security_list_ingress_security_rules_protocol"
+        source = "0.0.0.0/0"
+
+        tcp_options {
+            max = 25
+            min = 25
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_tcp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_tcp_options_source_port_range_min"
+            }
+        }
+        udp_options {
+            max = 22
+            min = 22
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_udp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_udp_options_source_port_range_min"
+            }
+        }
+    }
+}
+
+resource "oci_core_security_list" "fail0" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "var.security_list_ingress_security_rules_protocol"
+        source = "0.0.0.0/0"
+
+        tcp_options {
+            max = 25
+            min = 25
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_tcp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_tcp_options_source_port_range_min"
+            }
+        }
+        udp_options {
+            max = 21
+            min = 20
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_udp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_udp_options_source_port_range_min"
+            }
+        }
+    }
+}
+
+resource "oci_core_security_list" "pass2" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "var.security_list_ingress_security_rules_protocol"
+        source = "0.0.0.0/0"
+
+        tcp_options {
+            max = 22
+            min = 21
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_tcp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_tcp_options_source_port_range_min"
+            }
+        }
+        udp_options {
+            max = 23
+            min = 20
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_udp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_udp_options_source_port_range_min"
+            }
+        }
+    }
+}
+resource "oci_core_security_list" "pass3" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "all"
+        source = "0.0.0.0/0"
+    }
+}
+resource "oci_core_security_list" "fail1" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "1"
+        source = "0.0.0.0/0"
+    }
+}
+resource "oci_core_security_list" "fail2" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "all"
+        source = "0.0.0.1/0"
+    }
+}

--- a/tests/terraform/checks/resource/oci/example_SecurityListUnrestrictedIngress3389/main.tf
+++ b/tests/terraform/checks/resource/oci/example_SecurityListUnrestrictedIngress3389/main.tf
@@ -123,7 +123,7 @@ resource "oci_core_security_list" "fail1" {
         source = "0.0.0.0/0"
     }
 }
-resource "oci_core_security_list" "fail2" {
+resource "oci_core_security_list" "skip" {
     compartment_id = "var.compartment_id"
     vcn_id = "oci_core_vcn.test_vcn.id"
 

--- a/tests/terraform/checks/resource/oci/example_SecurityListUnrestrictedIngress3389/main.tf
+++ b/tests/terraform/checks/resource/oci/example_SecurityListUnrestrictedIngress3389/main.tf
@@ -1,0 +1,134 @@
+resource "oci_core_security_list" "pass" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "var.security_list_ingress_security_rules_protocol"
+        source = "0.0.0.0/0"
+
+        tcp_options {
+            max = 3389
+            min = 3389
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_tcp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_tcp_options_source_port_range_min"
+            }
+        }
+        udp_options {
+            max = 4000
+            min = 3388
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_udp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_udp_options_source_port_range_min"
+            }
+        }
+    }
+}
+
+resource "oci_core_security_list" "fail" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "var.security_list_ingress_security_rules_protocol"
+        source = "0.0.0.0/0"
+
+        tcp_options {
+            max = 25
+            min = 25
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_tcp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_tcp_options_source_port_range_min"
+            }
+        }
+        udp_options {
+            max = 3389
+            min = 3389
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_udp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_udp_options_source_port_range_min"
+            }
+        }
+    }
+}
+
+resource "oci_core_security_list" "fail0" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "var.security_list_ingress_security_rules_protocol"
+        source = "0.0.0.0/0"
+
+        tcp_options {
+            max = 4000
+            min = 3390
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_tcp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_tcp_options_source_port_range_min"
+            }
+        }
+        udp_options {
+            max = 21
+            min = 20
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_udp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_udp_options_source_port_range_min"
+            }
+        }
+    }
+}
+
+resource "oci_core_security_list" "pass2" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "var.security_list_ingress_security_rules_protocol"
+        source = "0.0.0.0/0"
+
+        tcp_options {
+            max = 3389
+            min = 3388
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_tcp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_tcp_options_source_port_range_min"
+            }
+        }
+        udp_options {
+            max = 3390
+            min = 3386
+            source_port_range {
+                max = "var.security_list_ingress_security_rules_udp_options_source_port_range_max"
+                min = "var.security_list_ingress_security_rules_udp_options_source_port_range_min"
+            }
+        }
+    }
+}
+resource "oci_core_security_list" "pass3" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "all"
+        source = "0.0.0.0/0"
+    }
+}
+resource "oci_core_security_list" "fail1" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "1"
+        source = "0.0.0.0/0"
+    }
+}
+resource "oci_core_security_list" "fail2" {
+    compartment_id = "var.compartment_id"
+    vcn_id = "oci_core_vcn.test_vcn.id"
+
+    ingress_security_rules {
+        protocol = "all"
+        source = "0.0.0.1/0"
+    }
+}

--- a/tests/terraform/checks/resource/oci/test_SecurityListUnrestrictedIngress22.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityListUnrestrictedIngress22.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.oci.SecurityListUnrestrictedIngress22 import check
+from checkov.terraform.runner import Runner
+
+
+class TestSecurityListUnrestrictedIngress22(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_SecurityListUnrestrictedIngress22"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "oci_core_security_list.pass",
+            "oci_core_security_list.pass2",
+            "oci_core_security_list.pass3",
+        }
+        failing_resources = {
+            "oci_core_security_list.fail",
+            "oci_core_security_list.fail0",
+            "oci_core_security_list.fail1",
+            "oci_core_security_list.fail2",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/oci/test_SecurityListUnrestrictedIngress22.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityListUnrestrictedIngress22.py
@@ -24,15 +24,14 @@ class TestSecurityListUnrestrictedIngress22(unittest.TestCase):
             "oci_core_security_list.fail",
             "oci_core_security_list.fail0",
             "oci_core_security_list.fail1",
-            "oci_core_security_list.fail2",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
         self.assertEqual(summary["passed"], 3)
-        self.assertEqual(summary["failed"], 4)
-        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 1)
         self.assertEqual(summary["parsing_errors"], 0)
 
         self.assertEqual(passing_resources, passed_check_resources)

--- a/tests/terraform/checks/resource/oci/test_SecurityListUnrestrictedIngress3389.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityListUnrestrictedIngress3389.py
@@ -24,7 +24,6 @@ class TestSecurityListUnrestrictedIngress3389(unittest.TestCase):
             "oci_core_security_list.fail",
             "oci_core_security_list.fail0",
             "oci_core_security_list.fail1",
-            "oci_core_security_list.fail2",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
@@ -32,7 +31,7 @@ class TestSecurityListUnrestrictedIngress3389(unittest.TestCase):
 
         self.assertEqual(summary["passed"], 3)
         self.assertEqual(summary["failed"], 3)
-        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["skipped"], 1)
         self.assertEqual(summary["parsing_errors"], 0)
 
         self.assertEqual(passing_resources, passed_check_resources)

--- a/tests/terraform/checks/resource/oci/test_SecurityListUnrestrictedIngress3389.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityListUnrestrictedIngress3389.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.oci.SecurityListUnrestrictedIngress3389 import check
+from checkov.terraform.runner import Runner
+
+
+class TestSecurityListUnrestrictedIngress3389(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_SecurityListUnrestrictedIngress3389"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "oci_core_security_list.pass",
+            "oci_core_security_list.pass2",
+            "oci_core_security_list.pass3",
+        }
+        failing_resources = {
+            "oci_core_security_list.fail",
+            "oci_core_security_list.fail0",
+            "oci_core_security_list.fail1",
+            "oci_core_security_list.fail2",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Added security list checks, that allow unrestricted ingress access to port 3389 and 22
Resolves #1975, resolves #1974 
