### PR TITLE
Fix - Logging Init

### DIFF
--- a/checkov/logging_init.py
+++ b/checkov/logging_init.py
@@ -2,16 +2,15 @@ import logging
 import os
 
 
-def init() -> None:
-    LOG_LEVEL = os.environ.get('LOG_LEVEL', 'WARNING').upper()
-    logging.basicConfig(level=LOG_LEVEL)
-    log_formatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
-    root_logger = logging.getLogger()
-    stream_handler = root_logger.handlers[0]
-    stream_handler.setFormatter(log_formatter)
-    root_logger.setLevel(LOG_LEVEL)
-    logging.getLogger().setLevel(LOG_LEVEL)
-    logging.getLogger("urllib3").setLevel(logging.ERROR)
-    logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
-    logging.getLogger("urllib3.connectionpool").propagate = False
-    logging.getLogger("urllib3").propagate = False
+LOG_LEVEL = os.environ.get('LOG_LEVEL', 'WARNING').upper()
+logging.basicConfig(level=LOG_LEVEL)
+log_formatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
+root_logger = logging.getLogger()
+stream_handler = root_logger.handlers[0]
+stream_handler.setFormatter(log_formatter)
+root_logger.setLevel(LOG_LEVEL)
+logging.getLogger().setLevel(LOG_LEVEL)
+logging.getLogger("urllib3").setLevel(logging.ERROR)
+logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
+logging.getLogger("urllib3.connectionpool").propagate = False
+logging.getLogger("urllib3").propagate = False

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -15,7 +15,7 @@ from configargparse import ArgumentParser
 from configargparse import Namespace
 from urllib3.exceptions import MaxRetryError
 
-import checkov.logging_init # should be imported before the others to ensure correct logging setup
+import checkov.logging_init  # should be imported before the others to ensure correct logging setup
 from checkov.arm.runner import Runner as arm_runner
 from checkov.bitbucket.runner import Runner as bitbucket_configuration_runner
 from checkov.cloudformation.runner import Runner as cfn_runner

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -15,6 +15,7 @@ from configargparse import ArgumentParser
 from configargparse import Namespace
 from urllib3.exceptions import MaxRetryError
 
+import checkov.logging_init
 from checkov.arm.runner import Runner as arm_runner
 from checkov.bitbucket.runner import Runner as bitbucket_configuration_runner
 from checkov.cloudformation.runner import Runner as cfn_runner
@@ -43,7 +44,6 @@ from checkov.helm.runner import Runner as helm_runner
 from checkov.json_doc.runner import Runner as json_runner
 from checkov.kubernetes.runner import Runner as k8_runner
 from checkov.kustomize.runner import Runner as kustomize_runner
-from checkov.logging_init import init as logging_init
 from checkov.runner_filter import RunnerFilter
 from checkov.sca_image.runner import Runner as sca_image_runner
 from checkov.sca_package.runner import Runner as sca_package_runner
@@ -59,7 +59,6 @@ signal.signal(signal.SIGINT, lambda x, y: sys.exit(''))
 
 outer_registry = None
 
-logging_init()
 logger = logging.getLogger(__name__)
 checkov_runners = [value for attr, value in CheckType.__dict__.items() if not attr.startswith("__")]
 

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -15,7 +15,7 @@ from configargparse import ArgumentParser
 from configargparse import Namespace
 from urllib3.exceptions import MaxRetryError
 
-import checkov.logging_init
+import checkov.logging_init # should be imported before the others to ensure correct logging setup
 from checkov.arm.runner import Runner as arm_runner
 from checkov.bitbucket.runner import Runner as bitbucket_configuration_runner
 from checkov.cloudformation.runner import Runner as cfn_runner


### PR DESCRIPTION
Hey all, hope you're well!

Just looking at some issues to pick something up and found that there are some `INFO` logs leaking into CLI output by default.

I've found that this is due to how the logger is initialised and we need to ensure that it is done before anything else has an opportunity to run where we would like it to inherit the logging.

I am not an expert with any of this stuff so please guide me if you'd like another implementation to get the job done! For example, could import it as before and just run `init()` before some of the other imports.

## Value
Better User Experience with the cleaner CLI output and also users are less likely to raise an issue because they are being confused with DEBUG logs in the CLI output where they are not representing a functional problem - meaning less operational overhead.

## Details
**Before (default):**
```
INFO:root:Leveraging the IAM definition at /path/iam-definition.json
INFO:checkov.common.checks_infra.registry:Loading external checks from /path/graph_checks
INFO:checkov.common.checks_infra.registry:Searching through [] and ['SQLServerAuditingEnabled.yaml']
INFO:root:Resultant set of frameworks (removing skipped frameworks): all
```

**After (default):**
```
Nothing output!
```

**After (LOG_LEVEL=INFO):**
You can see the central logger is being used by how the output looks.
```
2022-03-28 12:35:59,363 [MainThread  ] [INFO ]  Leveraging the IAM definition at /path/iam-definition.json
2022-03-28 12:35:59,517 [MainThread  ] [INFO ]  Loading external checks from /path/graph_checks
2022-03-28 12:35:59,518 [MainThread  ] [INFO ]  Searching through [] and ['SQLServerAuditingEnabled.yaml']
2022-03-28 12:35:59,564 [MainThread  ] [INFO ]  Resultant set of frameworks (removing skipped frameworks): all
```

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
