### PR TITLE
Fix non-dict labels in TillerService

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/TillerService.py
+++ b/checkov/terraform/checks/resource/kubernetes/TillerService.py
@@ -17,7 +17,8 @@ class TillerService(BaseResourceCheck):
         if "metadata" in conf and isinstance(conf["metadata"], list):
             metadata = conf.get("metadata")[0]
 
-            if metadata.get("labels") and isinstance(metadata.get("labels"), list):
+            if metadata.get("labels") and isinstance(metadata.get("labels"), list) \
+                    and isinstance(metadata.get("labels")[0], dict):
                 labels = metadata.get("labels")[0]
                 self.evaluated_keys = ["metadata/[0]/labels"]
                 if labels.get("app") == "helm":

--- a/tests/terraform/checks/resource/kubernetes/example_TillerService/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_TillerService/main.tf
@@ -56,3 +56,15 @@ resource "kubernetes_service" "pass" {
     type = "LoadBalancer"
   }
 }
+
+resource "kubernetes_service" "fail3" {
+  metadata {
+
+    labels = var.isNull == "not_null" ? {
+      app="helm"
+      name="tiller"
+    } : null
+
+  }
+  spec {}
+}


### PR DESCRIPTION
Handle the case where the labels are not dictionary, to avoid throwing exceptions
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
