### PR TITLE
Checkov breaks with nested modules

### DIFF
--- a/checkov/terraform/checks/resource/gcp/ArtifactRegistryPrivateRepo.py
+++ b/checkov/terraform/checks/resource/gcp/ArtifactRegistryPrivateRepo.py
@@ -22,19 +22,21 @@ class ArtifactRegistryPrivateRepo(BaseResourceCheck):
         if self.entity_type == "google_artifact_registry_repository_iam_member":
             # conf.get returns as a list
             # so we create a string for comparison
-            member = conf.get("member")[0]
-            if member in public_principals:
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+            if "member" in conf.keys():
+                member = conf.get("member")[0]
+                if member in public_principals:
+                    return CheckResult.FAILED
+                else:
+                    return CheckResult.PASSED
         # iam_binding returns a list of principals
         elif self.entity_type == "google_artifact_registry_repository_iam_binding":
             # Since conf.get returns a list and iam_binding returns a list (nested list)
             # we pull out the members list using the index 0
-            members_list = conf.get("members")[0]
-            if any(member in public_principals for member in members_list):
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+            if "members" in conf.keys():
+                members_list = conf.get("members")[0]
+                if any(member in public_principals for member in members_list):
+                    return CheckResult.FAILED
+                else:
+                    return CheckResult.PASSED
 
 check = ArtifactRegistryPrivateRepo()

--- a/checkov/terraform/checks/resource/gcp/BigQueryPrivateTable.py
+++ b/checkov/terraform/checks/resource/gcp/BigQueryPrivateTable.py
@@ -22,19 +22,21 @@ class BigQueryPrivateTable(BaseResourceCheck):
         if self.entity_type == "google_bigquery_table_iam_member":
             # conf.get returns as a list
             # so we create a string for comparison
-            member = conf.get("member")[0]
-            if member in public_principals:
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+            if "member" in conf.keys():
+                member = conf.get("member")[0]
+                if member in public_principals:
+                    return CheckResult.FAILED
+                else:
+                    return CheckResult.PASSED
         # iam_binding returns a list of principals
         elif self.entity_type == "google_bigquery_table_iam_binding":
             # Since conf.get returns a list and iam_binding returns a list (nested list)
             # we pull out the members list using the index 0
-            members_list = conf.get("members")[0]
-            if any(member in public_principals for member in members_list):
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+            if "members" in conf.keys():
+                members_list = conf.get("members")[0]
+                if any(member in public_principals for member in members_list):
+                    return CheckResult.FAILED
+                else:
+                    return CheckResult.PASSED
 
 check = BigQueryPrivateTable()

--- a/checkov/terraform/checks/resource/gcp/DataprocPrivateCluster.py
+++ b/checkov/terraform/checks/resource/gcp/DataprocPrivateCluster.py
@@ -21,19 +21,21 @@ class DataprocPrivateCluster(BaseResourceCheck):
         if self.entity_type == "google_dataproc_cluster_iam_member":
             # conf.get returns as a list
             # so we create a string for comparison
-            member = conf.get("member")[0]
-            if member in public_principals:
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+            if "member" in conf.keys():
+                member = conf.get("member")[0]
+                if member in public_principals:
+                    return CheckResult.FAILED
+                else:
+                    return CheckResult.PASSED
         # iam_binding returns a list of principals
         elif self.entity_type == "google_dataproc_cluster_iam_binding":
             # Since conf.get returns a list and iam_binding returns a list (nested list)
             # we pull out the members list using the index 0
-            members_list = conf.get("members")[0]
-            if any(member in public_principals for member in members_list):
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+            if "members" in conf.keys():
+                members_list = conf.get("members")[0]
+                if any(member in public_principals for member in members_list):
+                    return CheckResult.FAILED
+                else:
+                    return CheckResult.PASSED
 
 check = DataprocPrivateCluster()

--- a/checkov/terraform/checks/resource/gcp/GCPCloudRunPrivateService.py
+++ b/checkov/terraform/checks/resource/gcp/GCPCloudRunPrivateService.py
@@ -22,19 +22,21 @@ class GCPCloudRunPrivateService(BaseResourceCheck):
         if self.entity_type == "google_cloud_run_service_iam_member":
             # conf.get returns as a list
             # so we create a string for comparison
-            member = conf.get("member")[0]
-            if member in public_principals:
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+            if "member" in conf.keys():
+                member = conf.get("member")[0]
+                if member in public_principals:
+                    return CheckResult.FAILED
+                else:
+                    return CheckResult.PASSED
         # iam_binding returns a list of principals
         elif self.entity_type == "google_cloud_run_service_iam_binding":
             # Since conf.get returns a list and iam_binding returns a list (nested list)
             # we pull out the members list using the index 0
-            members_list = conf.get("members")[0]
-            if any(member in public_principals for member in members_list):
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+            if "members" in conf.keys():
+                members_list = conf.get("members")[0]
+                if any(member in public_principals for member in members_list):
+                    return CheckResult.FAILED
+                else:
+                    return CheckResult.PASSED
 
 check = GCPCloudRunPrivateService()

--- a/checkov/terraform/checks/resource/gcp/PubSubPrivateTopic.py
+++ b/checkov/terraform/checks/resource/gcp/PubSubPrivateTopic.py
@@ -22,19 +22,21 @@ class PubSubPrivateTopic(BaseResourceCheck):
         if self.entity_type == "google_pubsub_topic_iam_member":
             # conf.get returns as a list
             # so we create a string for comparison
-            member = conf.get("member")[0]
-            if member in public_principals:
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+            if "member" in conf.keys():
+                member = conf.get("member")[0]
+                if member in public_principals:
+                    return CheckResult.FAILED
+                else:
+                    return CheckResult.PASSED
         # iam_binding returns a list of principals
         elif self.entity_type == "google_pubsub_topic_iam_binding":
             # Since conf.get returns a list and iam_binding returns a list (nested list)
             # we pull out the members list using the index 0
-            members_list = conf.get("members")[0]
-            if any(member in public_principals for member in members_list):
-                return CheckResult.FAILED
-            else:
-                return CheckResult.PASSED
+            if "members" in conf.keys():
+                members_list = conf.get("members")[0]
+                if any(member in public_principals for member in members_list):
+                    return CheckResult.FAILED
+                else:
+                    return CheckResult.PASSED
 
 check = PubSubPrivateTopic()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Checkov will fail on some of the "check public" resource checks in GCP due to us not performing a safety check before diving into our evaluation logic. We ran into a specific scenario where nested modules broke some of checkov's checks due to:

```
TypeError: 'NoneType' object is not subscriptable
```

aka we were not checking to see if the key exists before assigning it to a variable. I didn't think this was possible since these resource keys are required, but there are scenarios where it could happen.