### PR TITLE
Missing Job from CKV_K8S_31

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/Seccomp.py
+++ b/checkov/kubernetes/checks/resource/k8s/Seccomp.py
@@ -27,7 +27,7 @@ class Seccomp(BaseK8Check):
                 return CheckResult.PASSED if security_profile == 'RuntimeDefault' else CheckResult.FAILED
             if "metadata" in conf:
                 metadata = conf["metadata"]
-        if conf['kind'] == 'Deployment' or conf['kind'] == 'StatefulSet' or conf['kind'] == 'Job':
+        if conf['kind'] in ['Deployment', 'StatefulSet', 'DaemonSet', 'Job', 'ReplicaSet']:
             security_profile = find_in_dict(conf, 'spec/template/spec/securityContext/seccompProfile/type')
             if security_profile:
                 return CheckResult.PASSED if security_profile == 'RuntimeDefault' else CheckResult.FAILED

--- a/checkov/kubernetes/checks/resource/k8s/Seccomp.py
+++ b/checkov/kubernetes/checks/resource/k8s/Seccomp.py
@@ -27,7 +27,7 @@ class Seccomp(BaseK8Check):
                 return CheckResult.PASSED if security_profile == 'RuntimeDefault' else CheckResult.FAILED
             if "metadata" in conf:
                 metadata = conf["metadata"]
-        if conf['kind'] == 'Deployment' or conf['kind'] == 'StatefulSet':
+        if conf['kind'] == 'Deployment' or conf['kind'] == 'StatefulSet' or conf['kind'] == 'Job':
             security_profile = find_in_dict(conf, 'spec/template/spec/securityContext/seccompProfile/type')
             if security_profile:
                 return CheckResult.PASSED if security_profile == 'RuntimeDefault' else CheckResult.FAILED


### PR DESCRIPTION
RIght now, if the block:
```
securityContext:
  seccompProfile:
    type:RunTimeDefault
```
is added to a Job, and checkov runs against this job, it will still report CKV_K8S_31 as FAILED.

In this file it is obvious that if instead, we add the annotation `seccomp.security.alpha.kubernetes.io/pod`, then checkov will not report CKV_K8S_31 as FAILED. However, this annotation is deprecated as per Kubernetes documentation: https://kubernetes.io/docs/tutorials/security/seccomp/#create-a-pod-with-a-seccomp-profile-for-syscall-auditing

So, since Job follows the spec order of Deployment, I have added it next to Deployment and StatefulSet. I have also added DaemonSet and ReplicaSet.

