### PR TITLE
Support nested rules for AbsSecurityListUnrestrictedIngress OCI check

### DIFF
--- a/checkov/terraform/checks/resource/oci/AbsSecurityListUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/oci/AbsSecurityListUnrestrictedIngress.py
@@ -17,14 +17,17 @@ class AbsSecurityListUnrestrictedIngress(BaseResourceCheck):
             rules = conf.get("ingress_security_rules", [])
 
             for idx, rule in enumerate(rules):
-                if "0.0.0.0/0" in rule['source'][0] \
-                        and (
-                        (rule['protocol'][0] != '1' and ('udp_options' not in rule) and ('tcp_options' not in rule))
-                        or self.scan_protocol_conf(rule, 'tcp_options', idx) != CheckResult.FAILED
-                        or self.scan_protocol_conf(rule, 'udp_options', idx) != CheckResult.FAILED
-                        or rule['protocol'][0] == 'all'):
-                    self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]']
-                    return CheckResult.FAILED
+                if not isinstance(rule, list):
+                    rule = [rule]
+                for sub_rule in rule:
+                    if "0.0.0.0/0" in sub_rule['source'][0] \
+                            and (
+                            (sub_rule['protocol'][0] != '1' and ('udp_options' not in sub_rule) and ('tcp_options' not in sub_rule))
+                            or self.scan_protocol_conf(sub_rule, 'tcp_options', idx) != CheckResult.FAILED
+                            or self.scan_protocol_conf(sub_rule, 'udp_options', idx) != CheckResult.FAILED
+                            or sub_rule['protocol'][0] == 'all'):
+                        self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]']
+                        return CheckResult.FAILED
 
             return CheckResult.PASSED
 

--- a/tests/terraform/checks/resource/kubernetes/example_TillerService/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_TillerService/main.tf
@@ -57,7 +57,7 @@ resource "kubernetes_service" "pass" {
   }
 }
 
-resource "kubernetes_service" "fail" {
+resource "kubernetes_service" "fail3" {
   metadata {
 
     labels = var.isNull == "not_null" ? {

--- a/tests/terraform/checks/resource/kubernetes/example_TillerService/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_TillerService/main.tf
@@ -57,7 +57,7 @@ resource "kubernetes_service" "pass" {
   }
 }
 
-resource "kubernetes_service" "fail3" {
+resource "kubernetes_service" "fail" {
   metadata {
 
     labels = var.isNull == "not_null" ? {

--- a/tests/terraform/checks/resource/oci/example_SecurityListUnrestrictedIngress22/main.tf
+++ b/tests/terraform/checks/resource/oci/example_SecurityListUnrestrictedIngress22/main.tf
@@ -136,3 +136,32 @@ resource "oci_core_security_list" "fail5" {
     compartment_id = "var.compartment_id"
     vcn_id = "oci_core_vcn.test_vcn.id"
 }
+
+resource "oci_core_security_list" "pass5" {
+  ingress_security_rules = [
+    {
+      protocol = "1"
+      source   = "${var.external_icmp_ingress}"
+
+      icmp_options {
+        "type" = 3
+        "code" = 4
+      }
+    },
+    {
+      protocol = "1"
+      source   = "${var.internal_icmp_ingress}"
+
+      icmp_options {
+        "type" = 3
+        "code" = 4
+      }
+    }
+  ]
+
+  provisioner "local-exec" {
+    command = "sleep 5"
+  }
+    compartment_id = ""
+    vcn_id         = ""
+}

--- a/tests/terraform/checks/resource/oci/test_SecurityListUnrestrictedIngress22.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityListUnrestrictedIngress22.py
@@ -15,12 +15,13 @@ class TestSecurityListUnrestrictedIngress22(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        passing_resources = {
+        expected_passing_resources = {
             "oci_core_security_list.pass0",
             "oci_core_security_list.pass1",
             "oci_core_security_list.pass4",
+            "oci_core_security_list.pass5",
         }
-        failing_resources = {
+        expected_failing_resources = {
             "oci_core_security_list.fail",
             "oci_core_security_list.fail1",
             "oci_core_security_list.fail2",
@@ -31,13 +32,13 @@ class TestSecurityListUnrestrictedIngress22(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 3)
-        self.assertEqual(summary["failed"], 5)
+        self.assertEqual(summary["passed"], len(expected_passing_resources))
+        self.assertEqual(summary["failed"], len(expected_failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 
-        self.assertEqual(passing_resources, passed_check_resources)
-        self.assertEqual(failing_resources, failed_check_resources)
+        self.assertEqual(expected_passing_resources, passed_check_resources)
+        self.assertEqual(expected_failing_resources, failed_check_resources)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Handle a case where the `ingress_security_rules` are parsed into double nested array.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
