### PR TITLE
handle boolean values in graph equals check

### DIFF
--- a/checkov/common/checks_infra/solvers/attribute_solvers/equals_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/equals_attribute_solver.py
@@ -12,4 +12,10 @@ class EqualsAttributeSolver(BaseAttributeSolver):
                          attribute=attribute, value=value)
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
-        return str(vertex.get(attribute)) == str(self.value)
+        attr_val = vertex.get(attribute)
+        if type(attr_val) == bool or type(self.value) == bool:
+            # handle cases like str(False) == "false"
+            # generally self.value will be a string, but could be a bool if the policy was created straight from json
+            return str(attr_val).lower() == str(self.value).lower()
+        else:
+            return str(attr_val) == str(self.value)

--- a/tests/common/integration_features/test_custom_policies_integration.py
+++ b/tests/common/integration_features/test_custom_policies_integration.py
@@ -192,7 +192,7 @@ class TestCustomPoliciesIntegration(unittest.TestCase):
 
         report = cfn_runner.run(root_folder=test_files_dir,
                                 runner_filter=RunnerFilter(checks=['kpande_AWS_1635187541652']))
-        self.assertEqual(len([r for r in report.failed_checks if r.check_id == 'kpande_AWS_1635187541652']), 6)
+        self.assertEqual(len([r for r in report.failed_checks if r.check_id == 'kpande_AWS_1635187541652']), 2)
         self.assertEqual(len([r for r in report.failed_checks if r.check_id == 'kpande_AWS_1635180094606']), 0)
 
         report = cfn_runner.run(root_folder=test_files_dir,
@@ -203,7 +203,7 @@ class TestCustomPoliciesIntegration(unittest.TestCase):
         report = cfn_runner.run(root_folder=test_files_dir,
                                 runner_filter=RunnerFilter(skip_checks=['kpande_AWS_1635180094606']))
         self.assertEqual(len([r for r in report.failed_checks if r.check_id == 'kpande_AWS_1635180094606']), 0)
-        self.assertEqual(len([r for r in report.failed_checks if r.check_id == 'kpande_AWS_1635187541652']), 6)
+        self.assertEqual(len([r for r in report.failed_checks if r.check_id == 'kpande_AWS_1635187541652']), 2)
 
     def test_pre_scan_with_cloned_checks(self):
         instance = BcPlatformIntegration()

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/BooleanString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/BooleanString.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "BooleanString"
+scope:
+  provider: "Azure"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "azurerm_storage_account"
+  attribute: "allow_blob_public_access"
+  operator: "equals"
+  value: "true"
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/test_solver.py
@@ -28,3 +28,13 @@ class TestEqualsSolver(TestBaseSolver):
 
         super(TestEqualsSolver, self).run_test(root_folder=root_folder, expected_results=expected_results,
                                                check_id=check_id)
+
+    def test_equals_solver_boolean(self):
+        root_folder = '../../../resources/boolean_test'
+        check_id = "BooleanString"
+        should_pass = ['azurerm_storage_account.fail1', 'azurerm_storage_account.fail2', 'azurerm_storage_account.fail3']
+        should_fail = ['azurerm_storage_account.pass1', 'azurerm_storage_account.pass2']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        super(TestEqualsSolver, self).run_test(root_folder=root_folder, expected_results=expected_results,
+                                               check_id=check_id)

--- a/tests/terraform/graph/resources/boolean_test/main.tf
+++ b/tests/terraform/graph/resources/boolean_test/main.tf
@@ -1,0 +1,19 @@
+resource "azurerm_storage_account" "fail1" {
+  allow_blob_public_access = true
+}
+
+resource "azurerm_storage_account" "fail2" {
+  allow_blob_public_access = "true"
+}
+
+resource "azurerm_storage_account" "fail3" {
+
+}
+
+resource "azurerm_storage_account" "pass1" {
+  allow_blob_public_access = false
+}
+
+resource "azurerm_storage_account" "pass2" {
+  allow_blob_public_access = "false"
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes an issue where custom policies with a condition like `== "false"` would fail against a Terraform attribute like `= false` due to case sensitivity in Python booleans.