### PR TITLE
Feature/platform only policies

### DIFF
--- a/admissioncontroller/k8s/deployment.yaml
+++ b/admissioncontroller/k8s/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             drop:
               - ALL
               - NET_RAW
-        image: bridgecrew/whorf@sha256:7fb639f267e6d11f81c8ccc6375eb677f45d21da1802bc0e449b8c2e1133f26c
+        image: bridgecrew/whorf@sha256:4c8103fda786e5289fd44b46b3f97b3d7d30b4543633a919413ecf1a608b1255
         resources:
           limits:
             cpu: "1"

--- a/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
@@ -33,15 +33,19 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
 
             all_checks = BaseCheckRegistry.get_all_registered_checks()
 
-            graph_registry = get_graph_checks_registry("terraform")
-            graph_registry.load_checks()
+            registries = ['terraform', 'cloudformation', 'kubernetes', 'bicep', 'terraform_plan']
+
+            for r in registries:
+                registry = get_graph_checks_registry(r)
+                registry.load_checks()
+                all_checks += registry.checks
 
             use_prisma_metadata = self.bc_integration.is_prisma_integration()
 
             if use_prisma_metadata:
                 self.severity_key = 'pcSeverity'
 
-            for check in all_checks + graph_registry.checks:
+            for check in all_checks:
                 checkov_id = check.id
                 metadata = self.get_policy_metadata(checkov_id)
                 if metadata:

--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -88,6 +88,7 @@ class NXGraphCheckParser(BaseGraphCheckParser):
         policy_definition = raw_check.get("definition", {})
         check = self._parse_raw_check(policy_definition, kwargs.get("resources_types"))
         check.id = raw_check.get("metadata", {}).get("id", "")
+        check.bc_id = raw_check.get("metadata", {}).get("id", "")
         check.name = raw_check.get("metadata", {}).get("name", "")
         check.category = raw_check.get("metadata", {}).get("category", "")
         solver = self.get_check_solver(check)

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -128,7 +128,7 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
         config.var_file = [os.path.abspath(f) for f in config.var_file]
 
     runner_filter = RunnerFilter(framework=config.framework, skip_framework=config.skip_framework, checks=config.check,
-                                 skip_checks=config.skip_check,
+                                 skip_checks=config.skip_check, include_all_checkov_policies=config.include_all_checkov_policies,
                                  download_external_modules=convert_str_to_bool(config.download_external_modules),
                                  external_modules_download_path=config.external_modules_download_path,
                                  evaluate_variables=convert_str_to_bool(config.evaluate_variables),
@@ -203,6 +203,7 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
             return None
     else:
         logger.debug('No API key found. Scanning locally only.')
+        config.include_all_checkov_policies = True
 
     if config.check and config.skip_check:
         if any(item in runner_filter.checks for item in runner_filter.skip_checks):
@@ -337,6 +338,13 @@ def add_parser_args(parser: ArgumentParser) -> None:
                help='Name for output file. The first selected output via output flag will be saved to the file (default output is cli)')
     parser.add('--output-bc-ids', action='store_true',
                help='Print Bridgecrew platform IDs (BC...) instead of Checkov IDs (CKV...), if the check exists in the platform')
+    parser.add('--include-all-checkov-policies', action='store_true',
+               help='When running with an API key, the Checkov will omit any policies that do not exist '
+                    'in the Bridgecrew or Prisma Cloud platform, except for local custom policies loaded with the '
+                    '--external-check flags. Use this key to include policies that only exist in Checkov in the scan. '
+                    'Note that this will make the local CLI results different from the results you see in the '
+                    'platform. Has no effect if you are not using an API key. Use the --check option to explicitly '
+                    'include checks by ID even if they are not in the platform, without using this flag.')
     parser.add('--quiet', action='store_true',
                default=False,
                help='in case of CLI output, display only failed checks')
@@ -363,7 +371,9 @@ def add_parser_args(parser: ArgumentParser) -> None:
                     '--skip-check. If it is, priority is given to checks explicitly listed by ID or wildcard over '
                     'checks listed by severity. For example, if you use --check CKV_123 and --skip-check LOW, then '
                     'CKV_123 will run even if it is a LOW severity. In the case of a tie (e.g., --check MEDIUM and '
-                    '--skip-check HIGH for a medium severity check), then the check will be skipped.',
+                    '--skip-check HIGH for a medium severity check), then the check will be skipped. If you use a '
+                    'check ID here along with an API key, and the check is not part of the BC / PC platform, then the '
+                    'check will still be run (see --include-all-checkov-policies for more info).',
                action='append', default=None,
                env_var='CKV_CHECK')
     parser.add('--skip-check',
@@ -495,6 +505,15 @@ def normalize_config(config: Namespace) -> None:
     if config.skip_policy_download:
         logger.warning('--skip-policy-download is deprecated and will be removed in a future release. Use --skip-download instead')
         config.skip_download = True
+
+    if config.bc_api_key and not config.include_all_checkov_policies:
+        # info because we expect this to be the standard usage
+        logger.info('You are using an API key and did not set the --include-all-checkov-policies flag, so policies '
+                    'that only exist in Checkov, and not the BC / PC platform, will be skipped.')
+    elif not config.bc_api_key and not config.include_all_checkov_policies:
+        # makes it easier to pick out policies later if we can just always rely on this flag without other context
+        logger.debug('No API key present; setting include_all_checkov_policies to True')
+        config.include_all_checkov_policies = True
 
 
 if __name__ == '__main__':

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -18,19 +18,20 @@ class RunnerFilter(object):
     __EXTERNAL_CHECK_IDS: Set[str] = set()
 
     def __init__(
-        self,
-        framework: Optional[List[str]] = None,
-        checks: Union[str, List[str], None] = None,
-        skip_checks: Union[str, List[str], None] = None,
-        download_external_modules: bool = False,
-        external_modules_download_path: str = DEFAULT_EXTERNAL_MODULES_DIR,
-        evaluate_variables: bool = True,
-        runners: Optional[List[str]] = None,
-        skip_framework: Optional[List[str]] = None,
-        excluded_paths: Optional[List[str]] = None,
-        all_external: bool = False,
-        var_files: Optional[List[str]] = None,
-        skip_cve_package: Optional[List[str]] = None
+            self,
+            framework: Optional[List[str]] = None,
+            checks: Union[str, List[str], None] = None,
+            skip_checks: Union[str, List[str], None] = None,
+            include_all_checkov_policies: bool = True,
+            download_external_modules: bool = False,
+            external_modules_download_path: str = DEFAULT_EXTERNAL_MODULES_DIR,
+            evaluate_variables: bool = True,
+            runners: Optional[List[str]] = None,
+            skip_framework: Optional[List[str]] = None,
+            excluded_paths: Optional[List[str]] = None,
+            all_external: bool = False,
+            var_files: Optional[List[str]] = None,
+            skip_cve_package: Optional[List[str]] = None
     ) -> None:
 
         checks = convert_csv_string_arg_to_list(checks)
@@ -58,6 +59,8 @@ class RunnerFilter(object):
             else:
                 self.skip_checks.append(val)
 
+        self.include_all_checkov_policies = include_all_checkov_policies
+
         self.framework: "Iterable[str]" = framework if framework else ["all"]
         if skip_framework:
             if "all" in self.framework:
@@ -77,7 +80,6 @@ class RunnerFilter(object):
         self.var_files = var_files
         self.skip_cve_package = skip_cve_package
 
-
     def should_run_check(self,
                          check: Optional[BaseCheck] = None,
                          check_id: Optional[str] = None,
@@ -95,8 +97,14 @@ class RunnerFilter(object):
         implicit_run = not self.checks and not self.check_threshold
         is_external = RunnerFilter.is_external_check(check_id)
 
-        # True if this check is present in the allow list, or if there is no allow list - this is not necessarily the return value
-        should_run_check = run_severity or explicit_run or implicit_run or (is_external and self.all_external)
+        # True if this check is present in the allow list, or if there is no allow list
+        # this is not necessarily the return value (need to apply other filters)
+        should_run_check = (
+                run_severity or
+                explicit_run or
+                implicit_run or
+                (is_external and self.all_external)
+        )
 
         if not should_run_check:
             return False
@@ -104,7 +112,11 @@ class RunnerFilter(object):
         skip_severity = severity and self.skip_check_threshold and severity.level <= self.skip_check_threshold.level
         explicit_skip = self.skip_checks and self.check_matches(check_id, bc_check_id, self.skip_checks)
 
-        should_skip_check = skip_severity or explicit_skip
+        should_skip_check = (
+                skip_severity or
+                explicit_skip or
+                (not bc_check_id and not self.include_all_checkov_policies and not is_external and not explicit_run)
+        )
 
         if should_skip_check:
             return False
@@ -117,7 +129,9 @@ class RunnerFilter(object):
     def check_matches(check_id: str,
                       bc_check_id: Optional[str],
                       pattern_list: List[str]) -> bool:
-        return any((fnmatch.fnmatch(check_id, pattern) or (bc_check_id and fnmatch.fnmatch(bc_check_id, pattern))) for pattern in pattern_list)
+        return any(
+            (fnmatch.fnmatch(check_id, pattern) or (bc_check_id and fnmatch.fnmatch(bc_check_id, pattern))) for pattern
+            in pattern_list)
 
     def within_threshold(self, severity: Severity) -> bool:
         above_min = (not self.check_threshold) or self.check_threshold.level <= severity.level

--- a/tests/common/test_runner_filter.py
+++ b/tests/common/test_runner_filter.py
@@ -342,6 +342,45 @@ class TestRunnerFilter(unittest.TestCase):
         self.assertFalse(instance.within_threshold(Severities[BcSeverities.MEDIUM]))
         self.assertTrue(instance.within_threshold(Severities[BcSeverities.HIGH]))
 
+    def test_include_local_skip_local(self):
+        instance = RunnerFilter(include_all_checkov_policies=False)
+        self.assertFalse(instance.should_run_check(check_id='CKV_AWS_789'))
+
+    def test_include_local_run_local(self):
+        instance = RunnerFilter(include_all_checkov_policies=True)
+        self.assertTrue(instance.should_run_check(check_id='CKV_AWS_789'))
+
+    def test_include_local_skip_platform(self):
+        instance = RunnerFilter(include_all_checkov_policies=False)
+        self.assertTrue(instance.should_run_check(check_id='CKV_AWS_789', bc_check_id='BC_AWS_789'))
+
+    def test_include_local_run_platform(self):
+        instance = RunnerFilter(include_all_checkov_policies=True)
+        self.assertTrue(instance.should_run_check(check_id='CKV_AWS_789', bc_check_id='BC_AWS_789'))
+
+    def test_include_local_skip_custom(self):
+        instance = RunnerFilter(include_all_checkov_policies=False)
+        instance.notify_external_check("EXT_CHECK_999")
+        self.assertTrue(instance.should_run_check(check_id='EXT_CHECK_999'))
+
+    def test_include_local_run_custom(self):
+        instance = RunnerFilter(include_all_checkov_policies=True)
+        instance.notify_external_check("EXT_CHECK_999")
+        self.assertTrue(instance.should_run_check(check_id='EXT_CHECK_999'))
+
+    def test_include_local_skip_local_explicit_run(self):
+        instance = RunnerFilter(checks=['CKV_AWS_789'], include_all_checkov_policies=False)
+        self.assertTrue(instance.should_run_check(check_id='CKV_AWS_789'))
+
+    def test_include_local_skip_local_implicit_run(self):
+        instance = RunnerFilter(skip_checks=['CKV_AWS_123'], include_all_checkov_policies=False)
+        self.assertFalse(instance.should_run_check(check_id='CKV_AWS_789'))
+
+    def test_include_local_skip_local_severity(self):
+        # this case should not actually be possible (no severities if not a platform check), but testing the logic anyways
+        instance = RunnerFilter(checks=['HIGH'], include_all_checkov_policies=False)
+        self.assertFalse(instance.should_run_check(check_id='CKV_AWS_789', severity=Severities[BcSeverities.HIGH]))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

With this change, by default, if using an API key, checkov will only run policies that exist in the platform (currently in the BC platform, regardless of API key type - because the results should match what they see in the platform). Platform policies are identified by the existence if `bc_id` on the check (in some cases, runners are responsible for setting this on their own checks, if they load them in a nonstandard way, like the secrets runner).

Also adds the flag `--include-all-checkov-policies` to include OOTB policies that only exist in checkov. Custom policies loaded locally will still run without this flag.

So, specifically:

* if no API key, run all checkov policies and all local custom policies
* with API key and without the `--include...` flag, run all policies that exist in the platform, all platform custom policies, and all local custom policies
* you can also `--check` specific check IDs to include them if they are checkov-only, without including all checkov policies
* with an API key and `--include...`, then runs all policies (same as the current behavior before this change)