### PR TITLE
fix freeze of checkov when TF parsing fails

### DIFF
--- a/checkov/common/checks_infra/registry.py
+++ b/checkov/common/checks_infra/registry.py
@@ -30,9 +30,9 @@ class Registry(BaseRegistry):
 
     def _load_checks_from_dir(self, directory: str, external_check: bool) -> None:
         dir = os.path.expanduser(directory)
-        self.logger.info("Loading external checks from {}".format(dir))
+        self.logger.debug("Loading external checks from {}".format(dir))
         for root, d_names, f_names in os.walk(dir):
-            self.logger.info(f"Searching through {d_names} and {f_names}")
+            self.logger.debug(f"Searching through {d_names} and {f_names}")
             for file in f_names:
                 file_ending = os.path.splitext(file)[1]
                 if file_ending in CHECKS_POSSIBLE_ENDING:

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -67,7 +67,7 @@ class RunnerFilter(object):
                 self.framework = set(runners) - set(skip_framework)
             else:
                 self.framework = set(self.framework) - set(skip_framework)
-        logging.info(f"Resultant set of frameworks (removing skipped frameworks): {','.join(self.framework)}")
+        logging.debug(f"Resultant set of frameworks (removing skipped frameworks): {','.join(self.framework)}")
 
         self.download_external_modules = download_external_modules
         self.external_modules_download_path = external_modules_download_path

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -716,7 +716,7 @@ Load JSON or HCL, depending on filename.
                 else:
                     return non_malformed_definitions
     except Exception as e:
-        logging.debug(f'failed while parsing file {file_path}', exc_info=e)
+        logging.debug(f'failed while parsing file {file_path}', exc_info=True)
         parsing_errors[file_path] = e
         return None
 
@@ -774,9 +774,8 @@ def _remove_module_dependency_in_path(path):
 def _safe_index(sequence_hopefully, index) -> Optional[Any]:
     try:
         return sequence_hopefully[index]
-    except IndexError as e:
-        logging.debug(f'Failed to parse index int ({index}) out of {sequence_hopefully}')
-        logging.debug(e, stack_info=True)
+    except IndexError:
+        logging.debug(f'Failed to parse index int ({index}) out of {sequence_hopefully}', exc_info=True)
         return None
 
 

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -360,7 +360,7 @@ class Runner(BaseRunner):
             parse_result = self.parser.parse_file(file=file, parsing_errors=file_parsing_errors, scan_hcl=scan_hcl)
             # the exceptions type can un-pickleable so we need to cast them to Exception
             for path, e in file_parsing_errors.items():
-                file_parsing_errors[path] = Exception(str(e))
+                file_parsing_errors[path] = Exception(e.__repr__())
             return file, parse_result, file_parsing_errors
 
         results = parallel_runner.run_function(parse_file, files)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #2717

I also lowered the log level for some log messages, `debug` should be more than enough 🙂 
