### PR TITLE
Ensure no security groups rules allow ingress from 0.0.0.0:0 to port …

### DIFF
--- a/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
@@ -17,7 +17,7 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
         tcp_options = conf.get('tcp_options')
         self.evaluated_keys = ["direction"]
         if direction and direction[0] != 'INGRESS':
-            return CheckResult.PASSED
+            return CheckResult.UNKNOWN
         if source and source[0] != "0.0.0.0/0":
             return CheckResult.PASSED
         elif (tcp_options is None and (protocol[0] == 'all' or protocol[0] == '6')) \

--- a/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
@@ -18,6 +18,7 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
         self.evaluated_keys = ["direction"]
         if direction and direction[0] != 'INGRESS':
             return CheckResult.UNKNOWN
+        self.evaluated_keys.append("source")
         if source and source[0] != "0.0.0.0/0":
             return CheckResult.PASSED
         elif (tcp_options is None and (protocol[0] == 'all' or protocol[0] == '6')) \

--- a/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
@@ -15,6 +15,7 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
         source = conf.get('source')
         protocol = conf.get('protocol')
         tcp_options = conf.get('tcp_options')
+        self.evaluated_keys = ["direction"]
         if direction and direction[0] != 'INGRESS':
             return CheckResult.PASSED
         if source and source[0] != "0.0.0.0/0":

--- a/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
@@ -4,7 +4,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 
 class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
     def __init__(self, check_id, port):
-        name = f"Ensure no security groups rules allow ingress from 0.0.0.0:0 to port {port}"
+        name = f"Ensure no security groups rules allow ingress from 0.0.0.0/0 to port {port}"
         supported_resources = ['oci_core_network_security_group_security_rule']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=check_id, categories=categories, supported_resources=supported_resources)

--- a/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
@@ -1,0 +1,33 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
+    def __init__(self, check_id, port):
+        name = f"Ensure no security groups rules allow ingress from 0.0.0.0:0 to port {port}"
+        supported_resources = ['oci_core_network_security_group_security_rule']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=check_id, categories=categories, supported_resources=supported_resources)
+        self.port = port
+
+    def scan_resource_conf(self, conf):
+        direction = conf.get('direction')
+        source = conf.get('source')
+        protocol = conf.get('protocol')
+        tcp_options = conf.get('tcp_options')
+        if direction and direction[0] != 'INGRESS':
+            return CheckResult.PASSED
+        if source and source[0] != "0.0.0.0/0":
+            return CheckResult.PASSED
+        elif (tcp_options is None and (protocol[0] == 'all' or protocol[0] == '6')) \
+                or tcp_options and self.scan_protocol_conf(tcp_options) is False:
+            return CheckResult.FAILED
+        return CheckResult.PASSED
+
+    def scan_protocol_conf(self, protocol_name):
+        """ scan tcp_options configuration"""
+        max_port = protocol_name[0]['source_port_range'][0]['max'][0]
+        min_port = protocol_name[0]['source_port_range'][0]['min'][0]
+        if min_port <= self.port <= max_port:
+            return False
+        return True

--- a/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
@@ -23,6 +23,7 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
             return CheckResult.PASSED
         elif (tcp_options is None and (protocol[0] == 'all' or protocol[0] == '6')) \
                 or tcp_options and self.scan_protocol_conf(tcp_options) is False:
+            self.evaluated_keys.append("protocol")
             return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
@@ -3,7 +3,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 
 
 class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
-    def __init__(self, check_id, port):
+    def __init__(self, check_id: str, port: int) -> None:
         name = f"Ensure no security groups rules allow ingress from 0.0.0.0/0 to port {port}"
         supported_resources = ['oci_core_network_security_group_security_rule']
         categories = [CheckCategories.NETWORKING]

--- a/checkov/terraform/checks/resource/oci/SecurityGroupUnrestrictedIngress22.py
+++ b/checkov/terraform/checks/resource/oci/SecurityGroupUnrestrictedIngress22.py
@@ -4,7 +4,7 @@ from checkov.terraform.checks.resource.oci.AbsSecurityGroupUnrestrictedIngress i
 
 class SecurityGroupUnrestrictedIngress22(AbsSecurityGroupUnrestrictedIngress):
     def __init__(self):
-        super().__init__(check_id="CKV_OCI_24", port=22)
+        super().__init__(check_id="CKV_OCI_22", port=22)
 
 
-check = AbsSecurityGroupUnrestrictedIngress("CKV_OCI_24", 22)
+check = AbsSecurityGroupUnrestrictedIngress("CKV_OCI_22", 22)

--- a/checkov/terraform/checks/resource/oci/SecurityGroupUnrestrictedIngress22.py
+++ b/checkov/terraform/checks/resource/oci/SecurityGroupUnrestrictedIngress22.py
@@ -1,0 +1,10 @@
+from checkov.terraform.checks.resource.oci.AbsSecurityGroupUnrestrictedIngress import \
+    AbsSecurityGroupUnrestrictedIngress
+
+
+class SecurityGroupUnrestrictedIngress22(AbsSecurityGroupUnrestrictedIngress):
+    def __init__(self):
+        super().__init__(check_id="CKV_OCI_24", port=22)
+
+
+check = AbsSecurityGroupUnrestrictedIngress("CKV_OCI_24", 22)

--- a/tests/terraform/checks/resource/oci/example_SecurityGroupUnrestrictedIngress22/main.tf
+++ b/tests/terraform/checks/resource/oci/example_SecurityGroupUnrestrictedIngress22/main.tf
@@ -1,0 +1,99 @@
+
+resource "oci_core_network_security_group_security_rule" "pass" {
+    network_security_group_id = oci_core_network_security_group.sg.id
+    direction = "EGRESS"
+    protocol = "all"
+    source = "0.0.0.0/0"
+
+    tcp_options {
+        source_port_range {
+            max = 22
+            min = 22
+        }
+    }
+}
+
+resource "oci_core_network_security_group_security_rule" "pass1" {
+    network_security_group_id = oci_core_network_security_group.sg.id
+    direction = "EGRESS"
+    protocol = "all"
+    source = "0.0.0.0/0"
+}
+
+resource "oci_core_network_security_group_security_rule" "pass2" {
+    network_security_group_id = oci_core_network_security_group.sg.id
+    direction = "INGRESS"
+    protocol = "all"
+    source = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+
+    tcp_options {
+        source_port_range {
+            max = 25
+            min = 25
+        }
+    }
+}
+
+resource "oci_core_network_security_group_security_rule" "pass3" {
+    network_security_group_id = oci_core_network_security_group.sg.id
+    direction = "INGRESS"
+    protocol = "all"
+    source = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+
+    tcp_options {
+        source_port_range {
+            max = 21
+            min = 1
+        }
+    }
+}
+
+
+resource "oci_core_network_security_group_security_rule" "fail" {
+    network_security_group_id = oci_core_network_security_group.sg.id
+    direction = "INGRESS"
+    protocol = "all"
+    source = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+
+    tcp_options {
+        source_port_range {
+            max = 22
+            min = 22
+        }
+    }
+}
+
+resource "oci_core_network_security_group_security_rule" "fail1" {
+    network_security_group_id = oci_core_network_security_group.sg.id
+    direction = "INGRESS"
+    protocol = "all"
+    source = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+
+    tcp_options {
+        source_port_range {
+            max = 25
+            min = 21
+        }
+    }
+}
+
+resource "oci_core_network_security_group_security_rule" "fail2" {
+    network_security_group_id = oci_core_network_security_group.sg.id
+    direction = "INGRESS"
+    protocol = "all"
+    source = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+}
+
+
+
+
+
+
+
+
+

--- a/tests/terraform/checks/resource/oci/example_SecurityGroupUnrestrictedIngress22/main.tf
+++ b/tests/terraform/checks/resource/oci/example_SecurityGroupUnrestrictedIngress22/main.tf
@@ -88,12 +88,3 @@ resource "oci_core_network_security_group_security_rule" "fail2" {
     source = "0.0.0.0/0"
     source_type = "CIDR_BLOCK"
 }
-
-
-
-
-
-
-
-
-

--- a/tests/terraform/checks/resource/oci/test_SecurityGroupUnrestrictedIngress22.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityGroupUnrestrictedIngress22.py
@@ -42,4 +42,3 @@ class TestSecurityGroupUnrestrictedIngress22(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/terraform/checks/resource/oci/test_SecurityGroupUnrestrictedIngress22.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityGroupUnrestrictedIngress22.py
@@ -16,8 +16,6 @@ class TestSecurityGroupUnrestrictedIngress22(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            "oci_core_network_security_group_security_rule.pass",
-            "oci_core_network_security_group_security_rule.pass1",
             "oci_core_network_security_group_security_rule.pass2",
             "oci_core_network_security_group_security_rule.pass3",
 
@@ -31,7 +29,7 @@ class TestSecurityGroupUnrestrictedIngress22(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 4)
+        self.assertEqual(summary["passed"], 2)
         self.assertEqual(summary["failed"], 3)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)

--- a/tests/terraform/checks/resource/oci/test_SecurityGroupUnrestrictedIngress22.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityGroupUnrestrictedIngress22.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.oci.SecurityGroupUnrestrictedIngress22 import check
+from checkov.terraform.runner import Runner
+
+
+class TestSecurityGroupUnrestrictedIngress22(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_SecurityGroupUnrestrictedIngress22"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "oci_core_network_security_group_security_rule.pass",
+            "oci_core_network_security_group_security_rule.pass1",
+            "oci_core_network_security_group_security_rule.pass2",
+            "oci_core_network_security_group_security_rule.pass3",
+
+        }
+        failing_resources = {
+            "oci_core_network_security_group_security_rule.fail",
+            "oci_core_network_security_group_security_rule.fail1",
+            "oci_core_network_security_group_security_rule.fail2",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 4)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
resolved #1973

OCI security group doesn't allow unrestricted ingress access to port 22