### PR TITLE
Ensure security group has stateless ingress security rules

### DIFF
--- a/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
+++ b/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
@@ -13,7 +13,9 @@ class SecurityGroupsIngressStatelessSecurityRules(BaseResourceCheck):
     def scan_resource_conf(self, conf):
         stateless = conf.get('stateless')
         direction = conf.get('direction')
+        self.evaluated_keys = ["direction"]
         if direction[0] == 'INGRESS':
+            self.evaluated_keys.append("stateless")
             if stateless is None or stateless[0] is False:
                 return CheckResult.FAILED
             return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
+++ b/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
@@ -1,0 +1,23 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class SecurityGroupsIngressStatelessSecurityRules(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure security groups has stateless ingress security rules"
+        id = "CKV_OCI_20"
+        supported_resources = ['oci_core_network_security_group_security_rule']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        stateless = conf.get('stateless')
+        direction = conf.get('direction')
+        if direction[0] == 'INGRESS':
+            if stateless is None or stateless[0] is False:
+                return CheckResult.FAILED
+            return CheckResult.PASSED
+        return CheckResult.SKIPPED
+
+
+check = SecurityGroupsIngressStatelessSecurityRules()

--- a/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
+++ b/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
@@ -21,5 +21,4 @@ class SecurityGroupsIngressStatelessSecurityRules(BaseResourceCheck):
             return CheckResult.PASSED
         return CheckResult.UNKNOWN
 
-
 check = SecurityGroupsIngressStatelessSecurityRules()

--- a/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
+++ b/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
@@ -17,7 +17,7 @@ class SecurityGroupsIngressStatelessSecurityRules(BaseResourceCheck):
             if stateless is None or stateless[0] is False:
                 return CheckResult.FAILED
             return CheckResult.PASSED
-        return CheckResult.SKIPPED
+        return CheckResult.UNKNOWN
 
 
 check = SecurityGroupsIngressStatelessSecurityRules()

--- a/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
+++ b/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
@@ -5,7 +5,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 class SecurityGroupsIngressStatelessSecurityRules(BaseResourceCheck):
     def __init__(self):
         name = "Ensure security groups has stateless ingress security rules"
-        id = "CKV_OCI_20"
+        id = "CKV_OCI_21"
         supported_resources = ['oci_core_network_security_group_security_rule']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
+++ b/checkov/terraform/checks/resource/oci/SecurityGroupsIngressStatelessSecurityRules.py
@@ -4,7 +4,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 
 class SecurityGroupsIngressStatelessSecurityRules(BaseResourceCheck):
     def __init__(self):
-        name = "Ensure security groups has stateless ingress security rules"
+        name = "Ensure security group has stateless ingress security rules"
         id = "CKV_OCI_21"
         supported_resources = ['oci_core_network_security_group_security_rule']
         categories = [CheckCategories.NETWORKING]

--- a/tests/terraform/checks/resource/oci/example_SecurityGroupsIngressStatelessSecurityRules/main.tf
+++ b/tests/terraform/checks/resource/oci/example_SecurityGroupsIngressStatelessSecurityRules/main.tf
@@ -19,7 +19,6 @@ resource "oci_core_network_security_group_security_rule" "fail1" {
   protocol                  = var.network_security_group_security_rule_protocol
 }
 
-
 resource "oci_core_network_security_group_security_rule" "skip" {
   network_security_group_id = oci_core_network_security_group.test_network_security_group.id
   direction                 = "EGRESS"
@@ -33,4 +32,3 @@ resource "oci_core_network_security_group_security_rule" "skip1" {
   protocol                  = var.network_security_group_security_rule_protocol
   stateless                 = false
 }
-

--- a/tests/terraform/checks/resource/oci/example_SecurityGroupsIngressStatelessSecurityRules/main.tf
+++ b/tests/terraform/checks/resource/oci/example_SecurityGroupsIngressStatelessSecurityRules/main.tf
@@ -1,0 +1,36 @@
+
+resource "oci_core_network_security_group_security_rule" "pass" {
+  network_security_group_id = oci_core_network_security_group.test_network_security_group.id
+  direction                 = "INGRESS"
+  protocol                  = var.network_security_group_security_rule_protocol
+  stateless                 = true
+}
+
+resource "oci_core_network_security_group_security_rule" "fail" {
+  network_security_group_id = oci_core_network_security_group.test_network_security_group.id
+  direction                 = "INGRESS"
+  protocol                  = var.network_security_group_security_rule_protocol
+  stateless                 = false
+}
+
+resource "oci_core_network_security_group_security_rule" "fail1" {
+  network_security_group_id = oci_core_network_security_group.test_network_security_group.id
+  direction                 = "INGRESS"
+  protocol                  = var.network_security_group_security_rule_protocol
+}
+
+
+resource "oci_core_network_security_group_security_rule" "skip" {
+  network_security_group_id = oci_core_network_security_group.test_network_security_group.id
+  direction                 = "EGRESS"
+  protocol                  = var.network_security_group_security_rule_protocol
+  stateless                 = true
+}
+
+resource "oci_core_network_security_group_security_rule" "skip1" {
+  network_security_group_id = oci_core_network_security_group.test_network_security_group.id
+  direction                 = "EGRESS"
+  protocol                  = var.network_security_group_security_rule_protocol
+  stateless                 = false
+}
+

--- a/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
@@ -24,9 +24,6 @@ class TestSecurityGroupsIngressStatelessSecurityRules(unittest.TestCase):
             "oci_core_network_security_group_security_rule.fail1",
         }
 
-        skipped_resources = {
-        }
-
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
         skipped_check_resources = set([c.resource for c in report.skipped_checks])

--- a/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
@@ -36,6 +36,5 @@ class TestSecurityGroupsIngressStatelessSecurityRules(unittest.TestCase):
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
@@ -27,7 +27,6 @@ class TestSecurityGroupsIngressStatelessSecurityRules(unittest.TestCase):
         skipped_resources = {
             "oci_core_network_security_group_security_rule.skip",
             "oci_core_network_security_group_security_rule.skip1",
-
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])

--- a/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
@@ -26,8 +26,7 @@ class TestSecurityGroupsIngressStatelessSecurityRules(unittest.TestCase):
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
-        skipped_check_resources = set([c.resource for c in report.skipped_checks])
-
+        
         self.assertEqual(summary["passed"], 1)
         self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)

--- a/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
@@ -25,8 +25,6 @@ class TestSecurityGroupsIngressStatelessSecurityRules(unittest.TestCase):
         }
 
         skipped_resources = {
-            "oci_core_network_security_group_security_rule.skip",
-            "oci_core_network_security_group_security_rule.skip1",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
@@ -35,7 +33,7 @@ class TestSecurityGroupsIngressStatelessSecurityRules(unittest.TestCase):
 
         self.assertEqual(summary["passed"], 1)
         self.assertEqual(summary["failed"], 2)
-        self.assertEqual(summary["skipped"], 2)
+        self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 
         self.assertEqual(skipped_resources, skipped_check_resources)

--- a/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
@@ -33,7 +33,6 @@ class TestSecurityGroupsIngressStatelessSecurityRules(unittest.TestCase):
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 
-        self.assertEqual(skipped_resources, skipped_check_resources)
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
 

--- a/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
+++ b/tests/terraform/checks/resource/oci/test_SecurityGroupsIngressStatelessSecurityRules.py
@@ -1,0 +1,48 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.oci.SecurityGroupsIngressStatelessSecurityRules import check
+from checkov.terraform.runner import Runner
+
+
+class TestSecurityGroupsIngressStatelessSecurityRules(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_SecurityGroupsIngressStatelessSecurityRules"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "oci_core_network_security_group_security_rule.pass",
+        }
+
+        failing_resources = {
+            "oci_core_network_security_group_security_rule.fail",
+            "oci_core_network_security_group_security_rule.fail1",
+        }
+
+        skipped_resources = {
+            "oci_core_network_security_group_security_rule.skip",
+            "oci_core_network_security_group_security_rule.skip1",
+
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+        skipped_check_resources = set([c.resource for c in report.skipped_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 2)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(skipped_resources, skipped_check_resources)
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

resolved #1972

added check to ensure OCI Network Security Groups (NSG) has stateless security rules