### PR TITLE
Add base_rbac_check for k8s along with CKV_K8S_155 & CKV_K8S_156

### DIFF
--- a/checkov/kubernetes/checks/resource/base_rbac_check.py
+++ b/checkov/kubernetes/checks/resource/base_rbac_check.py
@@ -3,7 +3,6 @@ from checkov.common.models.enums import CheckCategories, CheckResult
 from typing import Dict, Any, List
 
 
-
 class RbacOperation():
     """
     A collection of RBAC permissions that permit a certain operation within Kubernetes.
@@ -14,11 +13,8 @@ class RbacOperation():
         resources=["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]) 
     Rules matching an apiGroup, verb and resource should be able to perform the operation.
     """
-    def __init__(self, 
-        apigroups: List[str], 
-        verbs: List[str], 
-        resources: List[str]
-        ):
+    def __init__(self, apigroups: List[str], verbs: List[str],
+                 resources: List[str]):
         self.apigroups = apigroups
         self.verbs = verbs
         self.resources = resources
@@ -30,7 +26,7 @@ class BaseRbacK8sCheck(BaseK8Check):
     """
     def __init__(self, name, id, supported_entities=None):
         if supported_entities is None:
-            supported_entities = ["Role", "ClusterRole"] 
+            supported_entities = ["Role", "ClusterRole"]
         categories = [CheckCategories.KUBERNETES]
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities)
         # A role that grants *ALL* the RbacOperation in failing_operations fails this check
@@ -43,7 +39,7 @@ class BaseRbacK8sCheck(BaseK8Check):
             for rule in conf["rules"]:
                 # Check if the rule matches an RbacOperation this check looks for
                 for i in range(len(self.failing_operations)):
-                    if not role_can_do_operation_arr[i]: 
+                    if not role_can_do_operation_arr[i]:
                         # RbacOperation wasn't found yet, check rule
                         role_can_do_operation_arr[i] = self.rule_can(rule, self.failing_operations[i])
                 # If all operations were found, role / clusterRole failed the check
@@ -84,9 +80,7 @@ class BaseRbacK8sCheck(BaseK8Check):
                 if self.is_wildcard(value) or value in value_list:
                     return True
         return False
-    
+
     # Check if value is a K8s RBAC wildcard
     def is_wildcard(self, value: str) -> bool:
         return value == "*" or value == "*/*"
-
-

--- a/checkov/kubernetes/checks/resource/base_rbac_check.py
+++ b/checkov/kubernetes/checks/resource/base_rbac_check.py
@@ -1,0 +1,92 @@
+from checkov.kubernetes.checks.resource.base_spec_check import BaseK8Check
+from checkov.common.models.enums import CheckCategories, CheckResult
+from typing import Dict, Any, List
+
+
+
+class RbacOperation():
+    """
+    A collection of RBAC permissions that permit a certain operation within Kubernetes.
+    For example, the RbacOperation below denotes a write operation on admission webhooks.
+    control_webhooks = RbacOperation(
+        apigroups=["admissionregistration.k8s.io"],
+        verbs=["create", "update", "patch"],
+        resources=["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]) 
+    Rules matching an apiGroup, verb and resource should be able to perform the operation.
+    """
+    def __init__(self, 
+        apigroups: List[str], 
+        verbs: List[str], 
+        resources: List[str]
+        ):
+        self.apigroups = apigroups
+        self.verbs = verbs
+        self.resources = resources
+
+
+class BaseRbacK8sCheck(BaseK8Check):
+    """
+    Base class for checks that evaluate RBAC permissions in Roles and ClusterRoles
+    """
+    def __init__(self, name, id, supported_entities=None):
+        if supported_entities is None:
+            supported_entities = ["Role", "ClusterRole"] 
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities)
+        # A role that grants *ALL* the RbacOperation in failing_operations fails this check
+        self.failing_operations: RbacOperation = []
+
+    def scan_spec_conf(self, conf):
+        if isinstance(conf.get("rules"), list) and len(conf.get("rules")) > 0:
+            role_can_do_operation_arr = [False] * len(self.failing_operations)
+            # Go over all rules
+            for rule in conf["rules"]:
+                # Check if the rule matches an RbacOperation this check looks for
+                for i in range(len(self.failing_operations)):
+                    if not role_can_do_operation_arr[i]: 
+                        # RbacOperation wasn't found yet, check rule
+                        role_can_do_operation_arr[i] = self.rule_can(rule, self.failing_operations[i])
+                # If all operations were found, role / clusterRole failed the check
+                if False not in role_can_do_operation_arr:
+                    return CheckResult.FAILED
+        return CheckResult.PASSED
+
+    # Check if a rule has an apigroup, verb, and resource specified in @operation
+    def rule_can(self, rule: Dict[str, Any], operation: RbacOperation) -> bool:
+        return self.apigroup_or_wildcard(rule, operation.apigroups) and \
+            self.verb_or_wildcard(rule, operation.verbs) and \
+            self.resource_or_wildcard(rule, operation.resources)
+
+    def apigroup_or_wildcard(self, rule: Dict[str, Any], apigroups: List[str]) -> bool:
+        return self.value_or_wildcard(rule, "apiGroups", apigroups)
+
+    def verb_or_wildcard(self, rule: Dict[str, Any], verbs: List[str]) -> bool:
+        return self.value_or_wildcard(rule, "verbs", verbs)
+
+    def resource_or_wildcard(self, rule: Dict[str, Any], resources: List[str]) -> bool:
+        if "resources" in rule:
+            for granted_resource in rule["resources"]:
+                if self.is_wildcard(granted_resource):
+                    return True
+                for failing_resource in resources:
+                    if granted_resource == failing_resource:
+                        return True
+                    # Check for '*/subresource' syntax
+                    if "/" in failing_resource and "/" in granted_resource:
+                        if granted_resource == "*/" + failing_resource.split("/")[1]:
+                            return True
+        return False
+
+    # Check if rule has a key with a wildcard or a value from @value_list
+    def value_or_wildcard(self, rule: Dict[str, Any], key: str, value_list: List[str]) -> bool:
+        if key in rule:
+            for value in rule[key]:
+                if self.is_wildcard(value) or value in value_list:
+                    return True
+        return False
+    
+    # Check if value is a K8s RBAC wildcard
+    def is_wildcard(self, value: str) -> bool:
+        return value == "*" or value == "*/*"
+
+

--- a/checkov/kubernetes/checks/resource/k8s/RbacApproveCertificateSigningRequests.py
+++ b/checkov/kubernetes/checks/resource/k8s/RbacApproveCertificateSigningRequests.py
@@ -1,0 +1,24 @@
+from checkov.kubernetes.checks.resource.base_rbac_check import BaseRbacK8sCheck, RbacOperation
+
+class RbacApproveCertificateSigningRequests(BaseRbacK8sCheck):
+    def __init__(self):
+        name = "Minimize ClusterRoles that grant permissions to approve CertificateSigningRequests"
+        id = "CKV_K8S_156"
+        supported_entities = ["ClusterRole"]
+        super().__init__(name=name, id=id, supported_entities=supported_entities)
+        
+        # See https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
+        self.failing_operations =  [
+            RbacOperation(
+                apigroups=["certificates.k8s.io"],
+                verbs=["update", "patch"],
+                resources=["certificatesigningrequests/approval"]
+            ),    
+            RbacOperation(
+                apigroups=["certificates.k8s.io"],
+                verbs=["approve"],
+                resources=["signers"]
+            ),       
+        ]
+
+check = RbacApproveCertificateSigningRequests()

--- a/checkov/kubernetes/checks/resource/k8s/RbacApproveCertificateSigningRequests.py
+++ b/checkov/kubernetes/checks/resource/k8s/RbacApproveCertificateSigningRequests.py
@@ -1,24 +1,26 @@
 from checkov.kubernetes.checks.resource.base_rbac_check import BaseRbacK8sCheck, RbacOperation
 
+
 class RbacApproveCertificateSigningRequests(BaseRbacK8sCheck):
     def __init__(self):
         name = "Minimize ClusterRoles that grant permissions to approve CertificateSigningRequests"
         id = "CKV_K8S_156"
         supported_entities = ["ClusterRole"]
         super().__init__(name=name, id=id, supported_entities=supported_entities)
-        
+
         # See https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
-        self.failing_operations =  [
+        self.failing_operations = [
             RbacOperation(
                 apigroups=["certificates.k8s.io"],
                 verbs=["update", "patch"],
                 resources=["certificatesigningrequests/approval"]
-            ),    
+            ),
             RbacOperation(
                 apigroups=["certificates.k8s.io"],
                 verbs=["approve"],
                 resources=["signers"]
-            ),       
+            ),
         ]
+
 
 check = RbacApproveCertificateSigningRequests()

--- a/checkov/kubernetes/checks/resource/k8s/RbacControlWebhooks.py
+++ b/checkov/kubernetes/checks/resource/k8s/RbacControlWebhooks.py
@@ -1,0 +1,19 @@
+from checkov.kubernetes.checks.resource.base_rbac_check import BaseRbacK8sCheck, RbacOperation
+
+class RbacControlWebhooks(BaseRbacK8sCheck):
+    def __init__(self):
+        name = "Minimize ClusterRoles that grant control over validating or mutating admission webhook configurations"
+        id = "CKV_K8S_155"
+        supported_entities = ["ClusterRole"]
+        super().__init__(name=name, id=id, supported_entities=supported_entities)
+
+        self.failing_operations = [
+            RbacOperation(
+                apigroups=["admissionregistration.k8s.io"],
+                verbs=["create", "update", "patch"],
+                resources=["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+            ),        
+        ]
+
+
+check = RbacControlWebhooks()

--- a/checkov/kubernetes/checks/resource/k8s/RbacControlWebhooks.py
+++ b/checkov/kubernetes/checks/resource/k8s/RbacControlWebhooks.py
@@ -1,5 +1,6 @@
 from checkov.kubernetes.checks.resource.base_rbac_check import BaseRbacK8sCheck, RbacOperation
 
+
 class RbacControlWebhooks(BaseRbacK8sCheck):
     def __init__(self):
         name = "Minimize ClusterRoles that grant control over validating or mutating admission webhook configurations"
@@ -12,7 +13,7 @@ class RbacControlWebhooks(BaseRbacK8sCheck):
                 apigroups=["admissionregistration.k8s.io"],
                 verbs=["create", "update", "patch"],
                 resources=["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
-            ),        
+            ),
         ]
 
 

--- a/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-failed-1.yaml
+++ b/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-failed-1.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-should-fail-1
+  namespace: test
+rules:
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests/approval"]
+  verbs: ["update", "get"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["signers"]
+  verbs: ["approve"]

--- a/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-failed-2.yaml
+++ b/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-failed-2.yaml
@@ -1,0 +1,10 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-should-fail-2
+  namespace: test
+rules:
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["*/*"]
+  verbs: ["*"]

--- a/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-failed-3.yaml
+++ b/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-failed-3.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-should-fail-3
+  namespace: test
+rules:
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["*"]
+  verbs: ["approve"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["*/approval"]
+  verbs: ["update"]

--- a/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-passed-1.yaml
+++ b/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-passed-1.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-should-pass-1
+  namespace: test
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["approve"]
+- apiGroups: ["*"]
+  resources: ["pods"]
+  verbs: ["update", "patch", "get"]

--- a/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-passed-2.yaml
+++ b/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-passed-2.yaml
@@ -1,0 +1,10 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-should-pass-2
+  namespace: test
+rules:
+- apiGroups: ["", "extensions", "apps"]
+  resources: ["*"]
+  verbs: [""]

--- a/tests/kubernetes/checks/example_RbacControlWebhooks/clusterrole-failed-1.yaml
+++ b/tests/kubernetes/checks/example_RbacControlWebhooks/clusterrole-failed-1.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-should-fail-1
+  namespace: test
+rules:
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["create", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]

--- a/tests/kubernetes/checks/example_RbacControlWebhooks/clusterrole-failed-2.yaml
+++ b/tests/kubernetes/checks/example_RbacControlWebhooks/clusterrole-failed-2.yaml
@@ -1,0 +1,10 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-should-fail-2
+  namespace: test
+rules:
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["patch"]

--- a/tests/kubernetes/checks/example_RbacControlWebhooks/clusterrole-passed-1.yaml
+++ b/tests/kubernetes/checks/example_RbacControlWebhooks/clusterrole-passed-1.yaml
@@ -1,0 +1,10 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-should-pass-1
+  namespace: test
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get"]

--- a/tests/kubernetes/checks/example_RbacControlWebhooks/clusterrole-passed-2.yaml
+++ b/tests/kubernetes/checks/example_RbacControlWebhooks/clusterrole-passed-2.yaml
@@ -1,0 +1,10 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-should-pass-2
+  namespace: test
+rules:
+- apiGroups: ["*"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["get", "list", "watch"]

--- a/tests/kubernetes/checks/test_RbacApproveCertificateSigningRequests.py
+++ b/tests/kubernetes/checks/test_RbacApproveCertificateSigningRequests.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.kubernetes.checks.resource.k8s.RbacApproveCertificateSigningRequests import check
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestRbacApproveCertificateSigningRequests(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_RbacApproveCertificateSigningRequests"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'ClusterRole.test.test-should-pass-1',
+            'ClusterRole.test.test-should-pass-2'
+        }
+        failing_resources = {
+            'ClusterRole.test.test-should-fail-1',
+            'ClusterRole.test.test-should-fail-2',
+            'ClusterRole.test.test-should-fail-3'
+        }
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 3)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/kubernetes/checks/test_RbacControlWebhooks.py
+++ b/tests/kubernetes/checks/test_RbacControlWebhooks.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+from checkov.kubernetes.checks.resource.k8s.RbacControlWebhooks import check
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestRbacControlWebhooks(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_RbacControlWebhooks"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'ClusterRole.test.test-should-pass-1',
+            'ClusterRole.test.test-should-pass-2',
+        }
+        failing_resources = {
+            'ClusterRole.test.test-should-fail-1',
+            'ClusterRole.test.test-should-fail-2'
+        }
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Added `base_rbac_check` as a baseline for evaluating k8s Roles & ClusterRoles for excessive RBAC permissions
- Added CKV_K8S_155: Minimize ClusterRoles that grant control over validating or mutating admission webhook 
- Added CKV_K8S_156: Minimize ClusterRoles that grant permissions to approve CertificateSigningRequests