### PR TITLE
add possibility to adjust parallelization type

### DIFF
--- a/checkov/cloudformation/context_parser.py
+++ b/checkov/cloudformation/context_parser.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import itertools
 import logging
 import operator
 from functools import reduce
-from typing import List, Tuple, Optional, Union, Generator
+from typing import List, Tuple, Optional, Union, Generator, Any
 
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as metadata_integration
 from checkov.common.parsers.node import DictNode, StrNode, ListNode
@@ -13,7 +15,7 @@ ENDLINE = "__endline__"
 STARTLINE = "__startline__"
 
 
-class ContextParser(object):
+class ContextParser:
     """
     CloudFormation template context parser
     """
@@ -141,8 +143,8 @@ class ContextParser(object):
 
     @staticmethod
     def search_deep_keys(
-        search_text: str, cfn_dict: Union[StrNode, ListNode, DictNode], path: List[str]
-    ) -> List[List[Union[int, str]]]:
+        search_text: str, cfn_dict: StrNode | ListNode | dict[str, Any], path: list[str]
+    ) -> list[list[int | str]]:
         """Search deep for keys and get their values"""
         keys: List[List[Union[int, str]]] = []
         if isinstance(cfn_dict, dict):

--- a/checkov/common/models/enums.py
+++ b/checkov/common/models/enums.py
@@ -40,3 +40,10 @@ class ContextCategories(Enum):
     RESOURCE = 6
     VARIABLE = 7
     OUTPUT = 8
+
+
+class ParallelizationType(str, Enum):
+    FORK = "fork"
+    SPAWN = "spawn"
+    THREAD = "thread"
+    NONE = "none"

--- a/checkov/common/parallelizer/parallel_runner.py
+++ b/checkov/common/parallelizer/parallel_runner.py
@@ -23,7 +23,7 @@ class ParallelRunner:
     def __init__(self, workers_number: int | None = None) -> None:
         self.workers_number = workers_number if workers_number else (os.cpu_count() or 1)
         self.os = platform.system()
-        self.type = os.getenv("CHECKOV_PARALLELIZATION_TYPE", ParallelizationType.SPAWN)
+        self.type = os.getenv("CHECKOV_PARALLELIZATION_TYPE", ParallelizationType.THREAD)
 
     def run_function(self, func: Callable[[I], O], items: list[I], group_size: int | None = None) -> Iterable[O]:
         if self.type == ParallelizationType.FORK:

--- a/checkov/common/parallelizer/parallel_runner.py
+++ b/checkov/common/parallelizer/parallel_runner.py
@@ -1,30 +1,49 @@
+# flake8: noqa: E741
+
+from __future__ import annotations
+
 import concurrent.futures
 import multiprocessing
 import os
 import platform
-from typing import Any, List, Generator, Iterator, Callable, Optional
+from collections.abc import Iterator, Iterable
+from multiprocessing.pool import Pool
+from typing import Generator, Callable, TypeVar, TYPE_CHECKING
+
+from checkov.common.models.enums import ParallelizationType
+
+if TYPE_CHECKING:
+    from multiprocessing.connection import Connection
+
+I = TypeVar("I")
+O = TypeVar("O")
 
 
 class ParallelRunner:
-    def __init__(self, workers_number=None):
-        self.workers_number = workers_number if workers_number else os.cpu_count()
+    def __init__(self, workers_number: int | None = None) -> None:
+        self.workers_number = workers_number if workers_number else (os.cpu_count() or 1)
         self.os = platform.system()
+        self.type = os.getenv("CHECKOV_PARALLELIZATION_TYPE", ParallelizationType.SPAWN)
 
-    def run_function(self, func: Callable[[Any], Any], items: List[Any], group_size: Optional[int] = None) -> Iterator:
-        if self.os == 'Windows' or os.getenv("PYCHARM_HOSTED") == "1":
-            # PYCHARM_HOSTED env variable equals 1 when debugging via jetbrains IDE.
-            # To prevent JetBrains IDE from crashing on debug use multi threading
+    def run_function(self, func: Callable[[I], O], items: list[I], group_size: int | None = None) -> Iterable[O]:
+        if self.type == ParallelizationType.FORK:
+            return self._run_function_multiprocess_fork(func, items, group_size)
+        elif self.type == ParallelizationType.SPAWN:
+            return self._run_function_multiprocess_spawn(func, items)
+        elif self.type == ParallelizationType.THREAD:
             return self._run_function_multithreaded(func, items)
         else:
-            return self._run_function_multiprocess(func, items, group_size)
+            # no parallelization, just create a generator
+            return (func(item) for item in items)
 
-    def _run_function_multiprocess(self, func: Callable[[Any], Any], items: List[Any], group_size: Optional[int]) \
-            -> Generator[Any, None, None]:
+    def _run_function_multiprocess_fork(
+        self, func: Callable[[I], O], items: list[I], group_size: int | None
+    ) -> Generator[O, None, None]:
         if not group_size:
             group_size = int(len(items) / self.workers_number) + 1
-        groups_of_items = [items[i: i + group_size] for i in range(0, len(items), group_size)]
+        groups_of_items = [items[i : i + group_size] for i in range(0, len(items), group_size)]
 
-        def func_wrapper(original_func, items_group, connection):
+        def func_wrapper(original_func: Callable[[I], O], items_group: list[I], connection: Connection) -> None:
             for item in items_group:
                 result = original_func(item)
                 connection.send(result)
@@ -33,8 +52,9 @@ class ParallelRunner:
         processes = []
         for group_of_items in groups_of_items:
             parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
-            process = multiprocessing.get_context("fork").Process(target=func_wrapper,
-                                                                  args=(func, group_of_items, child_conn))
+            process = multiprocessing.get_context("fork").Process(
+                target=func_wrapper, args=(func, group_of_items, child_conn)
+            )
             processes.append((process, parent_conn, len(group_of_items)))
             process.start()
 
@@ -45,7 +65,12 @@ class ParallelRunner:
                 except EOFError:
                     pass
 
-    def _run_function_multithreaded(self, func: Callable[[Any], Any], items: List[Any]) -> Iterator:
+    def _run_function_multiprocess_spawn(self, func: Callable[[I], O], items: list[I]) -> list[O]:
+        with Pool(processes=1, context=multiprocessing.get_context("spawn")) as p:
+            chunksize = int(len(items) / self.workers_number) + 1
+            return p.map(func, items, chunksize=chunksize)
+
+    def _run_function_multithreaded(self, func: Callable[[I], O], items: list[I]) -> Iterator[O]:
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.workers_number) as executor:
             return executor.map(func, items)
 

--- a/checkov/common/parsers/json/__init__.py
+++ b/checkov/common/parsers/json/__init__.py
@@ -33,7 +33,10 @@ def load(filename: str, allow_nulls: bool = True) -> tuple[dict[str, Any], tuple
     return (json.loads(content, cls=Decoder, allow_nulls=allow_nulls), file_lines)
 
 
-def parse(filename: str, allow_nulls: bool = True, out_parsing_errors: Dict[str, str] = {}) -> tuple[dict[str, Any], tuple[int, str]] | tuple[None, None]:
+def parse(filename: str, allow_nulls: bool = True, out_parsing_errors: dict[str, str] | None = None) -> tuple[dict[str, Any], tuple[int, str]] | tuple[None, None]:
+    if out_parsing_errors is None:
+        out_parsing_errors = {}
+
     template = None
     template_lines = None
     error = None

--- a/checkov/common/util/config_utils.py
+++ b/checkov/common/util/config_utils.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import os
 
 from pathlib import Path
 
 
-def config_file_paths(dir_path):
-    return [os.path.join(dir_path, '.checkov.yaml'), os.path.join(dir_path, '.checkov.yml')]
+def config_file_paths(dir_path: str | os.PathLike[str]) -> list[str]:
+    return [os.path.join(dir_path, ".checkov.yaml"), os.path.join(dir_path, ".checkov.yml")]
 
 
-def get_default_config_paths(argv):
+def get_default_config_paths(argv: list[str]) -> list[str]:
     """
     Checkov looks for .checkov.yml or .checkov.yaml file in the directory (--directory) against which it is run.
     If that does not have the config file, the current working directory is checked followed by checking the user's
@@ -19,11 +21,12 @@ def get_default_config_paths(argv):
     cwd_path = config_file_paths(Path.cwd())
     dir_paths = []
     for i, v in enumerate(argv):
-        if v in ['-d', '--directory']:
+        if v in ["-d", "--directory"]:
             dir_paths += config_file_paths(argv[i + 1])
     return dir_paths + cwd_path + home_paths
 
 
-def should_scan_hcl_files():
+def should_scan_hcl_files() -> bool:
     from checkov.common.models.consts import SCAN_HCL_FLAG  # prevent circular import
+
     return os.getenv(SCAN_HCL_FLAG, default="false").lower() == "true"

--- a/checkov/common/util/decorators.py
+++ b/checkov/common/util/decorators.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from functools import wraps
+from timeit import default_timer
+from typing import TypeVar, Callable
+
+from typing_extensions import ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+def time_it(func: Callable[P, T]) -> Callable[P, T]:
+    """Prints the time it took to execute the function"""
+
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        start = default_timer()
+        output = func(*args, **kwargs)
+        end = default_timer()
+
+        func_path = f"{func.__code__.co_filename.replace('.py', '')}.{func.__name__}"
+        print(f"'{func_path}' took: {timedelta(seconds=end - start)}")
+
+        return output
+    return wrapper

--- a/checkov/kubernetes/parser/parser.py
+++ b/checkov/kubernetes/parser/parser.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 import logging
+from typing import Any
+
 from yaml import YAMLError
 
 from checkov.kubernetes.parser import k8_yaml, k8_json
@@ -11,7 +15,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-def parse(filename):
+def parse(filename: str) -> tuple[list[dict[str, Any]], list[tuple[int, str]]] | tuple[None, None]:
     template = None
     template_lines = None
     valid_templates = []
@@ -26,27 +30,27 @@ def parse(filename):
                     if t and isinstance(t, dict) and 'apiVersion' in t.keys() and 'kind' in t.keys():
                         valid_templates.append(t)
             else:
-                return
+                return None, None
         else:
-            return
+            return None, None
     except IOError as e:
         if e.errno == 2:
             logger.error('Template file not found: %s', filename)
-            return
+            return None, None
         elif e.errno == 21:
             logger.error('Template references a directory, not a file: %s',
                          filename)
-            return
+            return None, None
         elif e.errno == 13:
             logger.error('Permission denied when accessing template file: %s',
                          filename)
-            return
+            return None, None
     except UnicodeDecodeError:
         logger.error('Cannot read file contents: %s', filename)
-        return
+        return None, None
     except YAMLError:
         if filename.endswith(".yaml") or filename.endswith(".yml"):
             logger.debug('Cannot read file contents: %s - is it a yaml?', filename)
-        return
+        return None, None
 
     return valid_templates, template_lines

--- a/checkov/kubernetes/parser/parser.py
+++ b/checkov/kubernetes/parser/parser.py
@@ -15,7 +15,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-def parse(filename: str) -> tuple[list[dict[str, Any]], list[tuple[int, str]]] | tuple[None, None]:
+def parse(filename: str) -> tuple[list[dict[str, Any]], list[tuple[int, str]]] | None:
     template = None
     template_lines = None
     valid_templates = []
@@ -30,27 +30,27 @@ def parse(filename: str) -> tuple[list[dict[str, Any]], list[tuple[int, str]]] |
                     if t and isinstance(t, dict) and 'apiVersion' in t.keys() and 'kind' in t.keys():
                         valid_templates.append(t)
             else:
-                return None, None
+                return None
         else:
-            return None, None
+            return None
     except IOError as e:
         if e.errno == 2:
             logger.error('Template file not found: %s', filename)
-            return None, None
+            return None
         elif e.errno == 21:
             logger.error('Template references a directory, not a file: %s',
                          filename)
-            return None, None
+            return None
         elif e.errno == 13:
             logger.error('Permission denied when accessing template file: %s',
                          filename)
-            return None, None
+            return None
     except UnicodeDecodeError:
         logger.error('Cannot read file contents: %s', filename)
-        return None, None
+        return None
     except YAMLError:
         if filename.endswith(".yaml") or filename.endswith(".yml"):
             logger.debug('Cannot read file contents: %s - is it a yaml?', filename)
-        return None, None
+        return None
 
     return valid_templates, template_lines

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import logging
 import os
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Any
 
 from checkov.cloudformation import cfn_utils
 from checkov.cloudformation.context_parser import ContextParser as CfnContextParser
@@ -209,7 +211,7 @@ class Runner(BaseRunner):
 
 def get_files_definitions(files: List[str], filepath_fn=None) \
         -> Tuple[Dict[str, DictNode], Dict[str, List[Tuple[int, str]]]]:
-    results = parallel_runner.run_function(lambda f: (f, parse(f)), files)
+    results = parallel_runner.run_function(_parse_file, files)
     definitions = {}
     definitions_raw = {}
     for file, result in results:
@@ -218,3 +220,8 @@ def get_files_definitions(files: List[str], filepath_fn=None) \
             definitions[path], definitions_raw[path] = result
 
     return definitions, definitions_raw
+
+
+# needed to be a separate function otherwise it can't be pickled
+def _parse_file(file: str) -> tuple[str, tuple[dict[str, Any], tuple[int, str]] | tuple[None, None] | None]:
+    return file, parse(file)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

- Changed the default multiprocess context method to `spawn`
- It can be adjusted via env `CHECKOV_PARALLELIZATION_TYPE` I'm still open for a better name
  - valid configs `fork`, `spawn`, `thread` or `none`
  - invalid config results in `none`
- also added a test to run a file parsing with each type and added an exclusion for `fork` + `Windows` = 💔 
- added/adjusted type hints
- added a decorator, which is meant for development to time function calls
