### PR TITLE
remove unneeded move operation in helm error handler

### DIFF
--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -150,13 +150,13 @@ class Runner(BaseRunner):
                         o, e = proc.communicate()
                         logging.debug(
                             f"Ran helm command to template chart output. Chart: {chart_meta['name']}. dir: {target_dir}. Output: {str(o, 'utf-8')}")
-                
+
                     except Exception:
                         logging.info(
                             f"Error processing helm chart {chart_meta['name']} at dir: {chart_dir}. Working dir: {target_dir}.",
                             exc_info=True,
                         )
-              
+
 
                 output = str(o, 'utf-8')
                 reader = io.StringIO(output)
@@ -215,12 +215,12 @@ class Runner(BaseRunner):
                     report.resources.update(chart_results.resources)
 
                 except Exception:
-                    logging.warning("Failed to run Kubernetes runner", exc_info=True)
-                    with tempfile.TemporaryDirectory() as save_error_dir:
-                        logging.debug(
-                            f"Error running k8s scan on {chart_meta['name']}. Scan dir: {target_dir}. Saved context dir: {save_error_dir}")
+                    logging.warning(f"Failed to run Kubernetes runner on chart {chart_meta['name']}", exc_info=True)
+                    # with tempfile.TemporaryDirectory() as save_error_dir:
                         # TODO this will crash the run when target_dir gets cleaned up, since it no longer exists
                         # we either need to copy or find another way to extract whatever we want to get from this (the TODO below)
+                        # logging.debug(
+                        #    f"Error running k8s scan on {chart_meta['name']}. Scan dir: {target_dir}. Saved context dir: {save_error_dir}")
                         # shutil.move(target_dir, save_error_dir)
 
                         # TODO: Export helm dependancies for the chart we've extracted in chart_dependencies

--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -217,13 +217,13 @@ class Runner(BaseRunner):
                 except Exception:
                     logging.warning(f"Failed to run Kubernetes runner on chart {chart_meta['name']}", exc_info=True)
                     # with tempfile.TemporaryDirectory() as save_error_dir:
-                        # TODO this will crash the run when target_dir gets cleaned up, since it no longer exists
-                        # we either need to copy or find another way to extract whatever we want to get from this (the TODO below)
-                        # logging.debug(
-                        #    f"Error running k8s scan on {chart_meta['name']}. Scan dir: {target_dir}. Saved context dir: {save_error_dir}")
-                        # shutil.move(target_dir, save_error_dir)
+                    # TODO this will crash the run when target_dir gets cleaned up, since it no longer exists
+                    # we either need to copy or find another way to extract whatever we want to get from this (the TODO below)
+                    # logging.debug(
+                    #    f"Error running k8s scan on {chart_meta['name']}. Scan dir: {target_dir}. Saved context dir: {save_error_dir}")
+                    # shutil.move(target_dir, save_error_dir)
 
-                        # TODO: Export helm dependancies for the chart we've extracted in chart_dependencies
+                    # TODO: Export helm dependancies for the chart we've extracted in chart_dependencies
         return report
 
 

--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -219,7 +219,9 @@ class Runner(BaseRunner):
                     with tempfile.TemporaryDirectory() as save_error_dir:
                         logging.debug(
                             f"Error running k8s scan on {chart_meta['name']}. Scan dir: {target_dir}. Saved context dir: {save_error_dir}")
-                        shutil.move(target_dir, save_error_dir)
+                        # TODO this will crash the run when target_dir gets cleaned up, since it no longer exists
+                        # we either need to copy or find another way to extract whatever we want to get from this (the TODO below)
+                        # shutil.move(target_dir, save_error_dir)
 
                         # TODO: Export helm dependancies for the chart we've extracted in chart_dependencies
         return report


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

If the k8s runner raises an exception for a helm chart, then the exception handler is guaranteed to crash the overall checkov run:

* `shutil.move(target_dir, save_error_dir)` moves the `target_dir` `TemporaryDirectory` to another place
* When `target_dir` gets automatically cleaned up, Checkov crashes due to the resulting `No such file or directory` error

It seems like (based on the TODO on line 226) that there is more work that might happen to do something with this failed result, so for now I just commented out the whole second temp dir.