### PR TITLE
add grant cases for S3 ACL

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/S3PublicACLRead.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/S3PublicACLRead.yaml
@@ -137,6 +137,24 @@ definition:
                   attribute: acl
                   operator: not_equals
                   value: authenticated-read
+            - and:
+                - cond_type: attribute
+                  resource_types:
+                    - aws_s3_bucket_acl
+                  attribute: access_control_policy
+                  operator: exists
+                - or:
+                    - cond_type: attribute
+                      resource_types:
+                        - aws_s3_bucket_acl
+                      attribute: access_control_policy.grant
+                      operator: not_exists
+                    - cond_type: attribute
+                      resource_types:
+                        - aws_s3_bucket_acl
+                      attribute: access_control_policy.grant.*.grantee.uri
+                      operator: not_equals
+                      value: "http://acs.amazonaws.com/groups/global/AllUsers"
     - and:
       - cond_type: filter
         attribute: resource_type

--- a/checkov/terraform/checks/graph_checks/aws/S3PublicACLWrite.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/S3PublicACLWrite.yaml
@@ -101,6 +101,24 @@ definition:
                   attribute: acl
                   operator: not_equals
                   value: public-read-write
+            - and:
+                - cond_type: attribute
+                  resource_types:
+                    - aws_s3_bucket_acl
+                  attribute: access_control_policy
+                  operator: exists
+                - or:
+                    - cond_type: attribute
+                      resource_types:
+                        - aws_s3_bucket_acl
+                      attribute: access_control_policy.grant
+                      operator: not_exists
+                    - cond_type: attribute
+                      resource_types:
+                        - aws_s3_bucket_acl
+                      attribute: access_control_policy.grant.*.grantee.uri
+                      operator: not_equals
+                      value: "http://acs.amazonaws.com/groups/global/AllUsers"
     - and:
       - cond_type: filter
         attribute: resource_type

--- a/tests/terraform/graph/checks/resources/S3PublicACLRead/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3PublicACLRead/expected.yaml
@@ -5,6 +5,8 @@ pass:
   - "aws_s3_bucket.no_acl"
   - "aws_s3_bucket.unknown_var_legacy"
   - "aws_s3_bucket.unknown_var_v4_legacy"
+  - "aws_s3_bucket.no_grant"
+  - "aws_s3_bucket.grant_onwer"
 fail:
   - "aws_s3_bucket.public_read"
   - "aws_s3_bucket.public_read_write"
@@ -14,3 +16,4 @@ fail:
   - "aws_s3_bucket.public_read_write_v4"
   - "aws_s3_bucket.website_v4"
   - "aws_s3_bucket.authenticated_read_v4"
+  - "aws_s3_bucket.grant_public_read_all"

--- a/tests/terraform/graph/checks/resources/S3PublicACLRead/main.tf
+++ b/tests/terraform/graph/checks/resources/S3PublicACLRead/main.tf
@@ -69,6 +69,41 @@ resource "aws_s3_bucket_acl" "unknown_var_v4_legacy" {
   acl    = "${local.whatever}"
 }
 
+resource "aws_s3_bucket" "no_grant" {
+  bucket = "example"
+}
+
+resource "aws_s3_bucket_acl" "no_grant" {
+  bucket = aws_s3_bucket.no_grant.bucket
+
+  access_control_policy {
+    owner {
+      id = data.aws_canonical_user_id.this.id
+    }
+  }
+}
+
+resource "aws_s3_bucket" "grant_onwer" {
+  bucket = "example"
+}
+
+resource "aws_s3_bucket_acl" "grant_onwer" {
+  bucket = aws_s3_bucket.grant_onwer.bucket
+
+  access_control_policy {
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "READ"
+    }
+  }
+}
+
 # fail
 resource "aws_s3_bucket" "public_read_v4" {
   bucket = "example"
@@ -105,4 +140,32 @@ resource "aws_s3_bucket" "authenticated_read_v4" {
 resource "aws_s3_bucket_acl" "authenticated_read_v4" {
   bucket = aws_s3_bucket.authenticated_read_v4.id
   acl    = "authenticated-read"
+}
+
+resource "aws_s3_bucket" "grant_public_read_all" {
+  bucket = "example"
+}
+
+resource "aws_s3_bucket_acl" "grant_public_read_all" {
+  bucket = aws_s3_bucket.grant_public_read_all.bucket
+
+  access_control_policy {
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "READ"
+    }
+    grant {
+      grantee {
+        type = "Group"
+        uri  = "http://acs.amazonaws.com/groups/global/AllUsers"
+      }
+      permission = "READ"
+    }
+  }
 }

--- a/tests/terraform/graph/checks/resources/S3PublicACLWrite/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3PublicACLWrite/expected.yaml
@@ -5,6 +5,9 @@ pass:
   - "aws_s3_bucket.no_acl"
   - "aws_s3_bucket.unknown_var_legacy"
   - "aws_s3_bucket.unknown_var_v4_legacy"
+  - "aws_s3_bucket.no_grant"
+  - "aws_s3_bucket.grant_onwer"
 fail:
   - "aws_s3_bucket.public_read_write"
   - "aws_s3_bucket.public_read_write_v4"
+  - "aws_s3_bucket.grant_public_write_all"

--- a/tests/terraform/graph/checks/resources/S3PublicACLWrite/main.tf
+++ b/tests/terraform/graph/checks/resources/S3PublicACLWrite/main.tf
@@ -54,6 +54,41 @@ resource "aws_s3_bucket_acl" "unknown_var_v4_legacy" {
   acl    = "${local.whatever}"
 }
 
+resource "aws_s3_bucket" "no_grant" {
+  bucket = "example"
+}
+
+resource "aws_s3_bucket_acl" "no_grant" {
+  bucket = aws_s3_bucket.no_grant.bucket
+
+  access_control_policy {
+    owner {
+      id = data.aws_canonical_user_id.this.id
+    }
+  }
+}
+
+resource "aws_s3_bucket" "grant_onwer" {
+  bucket = "example"
+}
+
+resource "aws_s3_bucket_acl" "grant_onwer" {
+  bucket = aws_s3_bucket.grant_onwer.bucket
+
+  access_control_policy {
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "READ"
+    }
+  }
+}
+
 # fail
 
 resource "aws_s3_bucket" "public_read_write_v4" {
@@ -63,4 +98,32 @@ resource "aws_s3_bucket" "public_read_write_v4" {
 resource "aws_s3_bucket_acl" "public_read_write_v4" {
   bucket = aws_s3_bucket.public_read_write_v4.id
   acl    = "public-read-write"
+}
+
+resource "aws_s3_bucket" "grant_public_write_all" {
+  bucket = "example"
+}
+
+resource "aws_s3_bucket_acl" "grant_public_write_all" {
+  bucket = aws_s3_bucket.grant_public_write_all.bucket
+
+  access_control_policy {
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "READ"
+    }
+    grant {
+      grantee {
+        type = "Group"
+        uri  = "http://acs.amazonaws.com/groups/global/AllUsers"
+      }
+      permission = "WRITE"
+    }
+  }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes https://github.com/bridgecrewio/checkov/issues/2399#issuecomment-1095191013

Added use cases for S3 Bucket ACL in combination with `access_control_policy` and `grant`