### PR TITLE
add RDS PostgreSQL version check to mitigate log_fdw exploit

### DIFF
--- a/checkov/terraform/checks/resource/aws/RDSPostgreSQLLogFDWExtension.py
+++ b/checkov/terraform/checks/resource/aws/RDSPostgreSQLLogFDWExtension.py
@@ -10,7 +10,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 class RDSPostgreSQLLogFDWExtension(BaseResourceCheck):
     def __init__(self) -> None:
         # https://aws.amazon.com/security/security-bulletins/AWS-2022-004/
-        name = "Ensure that RDS PostgreSQL instances use a non vulnerable version with the log_fdw extension"
+        name = "Ensure that RDS PostgreSQL instances use a non vulnerable version with the log_fdw extension (https://aws.amazon.com/security/security-bulletins/AWS-2022-004/)"
         id = "CKV_AWS_250"
         supported_resources = ("aws_rds_cluster", "aws_db_instance")
         categories = (CheckCategories.GENERAL_SECURITY,)

--- a/checkov/terraform/checks/resource/aws/RDSPostgreSQLLogFDWExtension.py
+++ b/checkov/terraform/checks/resource/aws/RDSPostgreSQLLogFDWExtension.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.common.util.type_forcers import force_int
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class RDSPostgreSQLLogFDWExtension(BaseResourceCheck):
+    def __init__(self) -> None:
+        # https://aws.amazon.com/security/security-bulletins/AWS-2022-004/
+        name = "Ensure that RDS PostgreSQL instances use a non vulnerable version with the log_fdw extension"
+        id = "CKV_AWS_250"
+        supported_resources = ("aws_rds_cluster", "aws_db_instance")
+        categories = (CheckCategories.GENERAL_SECURITY,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        self.evaluated_keys = ["engine"]
+
+        if conf.get("engine") == ["postgres"]:
+            self.evaluated_keys.append("engine_version")
+
+            engine_version = conf.get("engine_version")
+            if engine_version and isinstance(engine_version, list) and isinstance(engine_version[0], str):
+                version_parts = engine_version[0].split(".")
+                if 1 < len(version_parts) <= 3:
+                    major_version = force_int(version_parts[0])
+                    minor_version = force_int(version_parts[1])
+
+                    if major_version is None or minor_version is None:
+                        return CheckResult.UNKNOWN
+
+                    if major_version >= 14:
+                        return CheckResult.PASSED
+                    elif major_version == 13 and minor_version > 2:
+                        return CheckResult.PASSED
+                    elif major_version == 12 and minor_version > 6:
+                        return CheckResult.PASSED
+                    elif major_version == 11 and minor_version > 11:
+                        return CheckResult.PASSED
+                    elif major_version == 10 and minor_version > 16:
+                        return CheckResult.PASSED
+                    elif major_version == 9 and minor_version == 6:
+                        # PostgreSQL pre 10 used following versioning major.major.minor
+                        bugfix_version = force_int(version_parts[2])
+
+                        if bugfix_version is None:
+                            return CheckResult.UNKNOWN
+
+                        if bugfix_version > 21:
+                            return CheckResult.PASSED
+
+                    # everything older is not recommended to use anyway
+                    return CheckResult.FAILED
+        elif conf.get("engine") == ["aurora-postgresql"]:
+            self.evaluated_keys.append("engine_version")
+
+            engine_version = conf.get("engine_version")
+            if engine_version and isinstance(engine_version, list) and isinstance(engine_version[0], str):
+                version_parts = engine_version[0].split(".")
+                if len(version_parts) == 2:
+                    major_version = force_int(version_parts[0])
+                    minor_version = force_int(version_parts[1])
+
+                    if major_version is None or minor_version is None:
+                        return CheckResult.UNKNOWN
+
+                    if major_version >= 12:
+                        return CheckResult.PASSED
+                    elif major_version == 11 and minor_version > 8:
+                        return CheckResult.PASSED
+                    elif major_version == 10 and minor_version > 13:
+                        return CheckResult.PASSED
+
+                    # older versions are not available for Aurora cluster
+                    return CheckResult.FAILED
+
+        # probably a non PostgreSQL instance or we couldn't render it correctly
+        return CheckResult.UNKNOWN
+
+
+check = RDSPostgreSQLLogFDWExtension()

--- a/tests/terraform/checks/resource/aws/example_RDSPostgreSQLLogFDWExtension/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSPostgreSQLLogFDWExtension/main.tf
@@ -1,0 +1,52 @@
+# pass
+
+resource "aws_db_instance" "pass" {
+  name           = "name"
+  instance_class = "db.t3.micro"
+  engine         = "postgres"
+  engine_version = "13.3"
+}
+
+resource "aws_rds_cluster" "pass" {
+  engine = "aurora-postgresql"
+  engine_version = "11.9"
+}
+
+# fail
+
+resource "aws_db_instance" "fail" {
+  name           = "name"
+  instance_class = "db.t3.micro"
+  engine         = "postgres"
+  engine_version = "13.2"
+}
+
+resource "aws_rds_cluster" "fail" {
+  engine = "aurora-postgresql"
+  engine_version = "11.8"
+}
+
+resource "aws_db_instance" "fail_old" {
+  name           = "name"
+  instance_class = "db.t3.micro"
+  engine         = "postgres"
+  engine_version = "9.6.21"
+}
+
+# unknown
+
+resource "aws_rds_cluster" "mysql_v1" {
+}
+
+resource "aws_db_instance" "mysql" {
+  name           = "name"
+  engine         = "mysql"
+  instance_class = "db.t3.micro"
+}
+
+resource "aws_db_instance" "postgres_unknown" {
+  name           = "name"
+  instance_class = "db.t3.micro"
+  engine         = "postgres"
+  engine_version = var.engine_version
+}

--- a/tests/terraform/checks/resource/aws/test_RDSPostgreSQLLogFDWExtension.py
+++ b/tests/terraform/checks/resource/aws/test_RDSPostgreSQLLogFDWExtension.py
@@ -1,0 +1,44 @@
+import unittest
+from pathlib import Path
+
+from checkov.terraform.runner import Runner
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.RDSPostgreSQLLogFDWExtension import check
+
+
+class TestRDSPostgreSQLLogFDWExtension(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_RDSPostgreSQLLogFDWExtension"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_db_instance.pass",
+            "aws_rds_cluster.pass",
+        }
+        failing_resources = {
+            "aws_db_instance.fail",
+            "aws_db_instance.fail_old",
+            "aws_rds_cluster.fail",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+        self.assertEqual(summary["resource_count"], len(passing_resources) + len(failing_resources) + 3)  # 3 unknown
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Recently AWS published a security warning for their RDS PostgreSQL flavours to mitigate an exploit by leveraging `log_fdw` extension https://aws.amazon.com/security/security-bulletins/AWS-2022-004/

the 250th AWS Terraform check 🚀 next goal 500 🍻 
