### PR TITLE
refactor kustomize runner

### DIFF
--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -6,9 +6,7 @@ import shutil
 import subprocess  # nosec
 import tempfile
 from typing import List, Optional, Dict, Any, Type
-import string
 import yaml
-import random
 from checkov.common.graph.graph_builder import CustomAttributes
 from checkov.common.output.record import Record
 from checkov.common.output.report import Report, CheckType
@@ -365,8 +363,7 @@ class Runner(BaseRunner):
         kustomizeDirectories = self._findKustomizeDirectories(root_folder, files, runner_filter.excluded_paths)
         for kustomizedir in kustomizeDirectories:
             self.kustomizeProcessedFolderAndMeta[kustomizedir] = self._parseKustomization(kustomizedir)
-        random_folder = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
-        self.target_folder_path = f'/tmp/{random_folder}'
+        self.target_folder_path = tempfile.mkdtemp()
         for filePath in self.kustomizeProcessedFolderAndMeta:    
             logging.debug(f"Kustomization at {filePath} likley a {self.kustomizeProcessedFolderAndMeta[filePath]['type']}")
             if self.kustomizeProcessedFolderAndMeta[filePath]['type'] == 'overlay':

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -279,12 +279,12 @@ class Runner(BaseRunner):
                 logging.debug(f"Overlay based on {self.kustomizeProcessedFolderAndMeta[filePath]['validated_base']}, naming overlay {checkovKustomizeEnvNameByPath} for Checkov Results.")
             else:
                 checkovKustomizeEnvNameByPath = f"{pathlib.Path(filePath).stem}"
-                self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = str(checkovKustomizeEnvNameByPath)
+                self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = checkovKustomizeEnvNameByPath
                 logging.debug(f"Could not confirm base dir for Kustomize overlay/env. Using {checkovKustomizeEnvNameByPath} for Checkov Results.")
 
         except KeyError:
             checkovKustomizeEnvNameByPath = f"{pathlib.Path(filePath).stem}"
-            self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = str(checkovKustomizeEnvNameByPath)
+            self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = checkovKustomizeEnvNameByPath
             logging.debug(f"Could not confirm base dir for Kustomize overlay/env. Using {checkovKustomizeEnvNameByPath} for Checkov Results.")
 
     def _get_parsed_output(self, filePath, extractDir, output):

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -336,8 +336,7 @@ class Runner(BaseRunner):
             templateRenderCommandOptions = "kustomize"
         if self.templateRendererCommand == "kustomize":
             templateRenderCommandOptions = "build"
-        proc = subprocess.Popen([self.templateRendererCommand, templateRenderCommandOptions, filePath],
-                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # nosec
+        proc = subprocess.Popen([self.templateRendererCommand, templateRenderCommandOptions, filePath], stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # nosec
         output, _ = proc.communicate()
         logging.info(
             f"Ran kubectl to build Kustomize output. DIR: {filePath}. TYPE: {self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['type']}.")

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -6,9 +6,9 @@ import shutil
 import subprocess  # nosec
 import tempfile
 from typing import List, Optional, Dict, Any, Type
-
+import string
 import yaml
-
+import random
 from checkov.common.graph.graph_builder import CustomAttributes
 from checkov.common.output.record import Record
 from checkov.common.output.report import Report, CheckType
@@ -365,8 +365,8 @@ class Runner(BaseRunner):
         kustomizeDirectories = self._findKustomizeDirectories(root_folder, files, runner_filter.excluded_paths)
         for kustomizedir in kustomizeDirectories:
             self.kustomizeProcessedFolderAndMeta[kustomizedir] = self._parseKustomization(kustomizedir)
-        tmp_dir = tempfile.TemporaryDirectory()
-        self.target_folder_path = tmp_dir.name
+        random_folder = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+        self.target_folder_path = f'/tmp/{random_folder}'
         for filePath in self.kustomizeProcessedFolderAndMeta:    
             logging.debug(f"Kustomization at {filePath} likley a {self.kustomizeProcessedFolderAndMeta[filePath]['type']}")
             if self.kustomizeProcessedFolderAndMeta[filePath]['type'] == 'overlay':
@@ -406,6 +406,7 @@ class Runner(BaseRunner):
             report.parsing_errors += chart_results.parsing_errors
             report.skipped_checks += chart_results.skipped_checks
             report.resources.update(chart_results.resources)
+            shutil.rmtree(target_dir)
 
         except Exception:
             logging.warning("Failed to run Kubernetes runner", exc_info=True)

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -139,10 +139,10 @@ class Runner(BaseRunner):
     kustomizeFileMappings = {}
     kustomizeSupportedFileTypes = ('kustomization.yaml', 'kustomization.yml')
     templateRendererCommand = None
-    target_foler_path = ''
+    target_folder_path = ''
 
-    def get_k8s_target_foler_path(self):
-        return self.target_foler_path
+    def get_k8s_target_folder_path(self):
+        return self.target_folder_path
 
     def get_kustomize_metadata(self):
         return {'kustomizeMetadata': self.kustomizeProcessedFolderAndMeta,
@@ -366,7 +366,7 @@ class Runner(BaseRunner):
         for kustomizedir in kustomizeDirectories:
             self.kustomizeProcessedFolderAndMeta[kustomizedir] = self._parseKustomization(kustomizedir)
         tmp_dir = tempfile.TemporaryDirectory()
-        self.target_dir = tmp_dir.name
+        self.target_folder_path = tmp_dir.name
         for filePath in self.kustomize_runner.kustomizeProcessedFolderAndMeta:    
             logging.debug(f"Kustomization at {filePath} likley a {self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['type']}")
             if self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['type'] == 'overlay':
@@ -382,7 +382,7 @@ class Runner(BaseRunner):
                 logging.warning(f"env_or_base_path_prefix is None, filePath: {filePath}", exc_info=True)
                 continue
 
-            extractDir = self.target_dir + env_or_base_path_prefix
+            extractDir = self.target_folder_path + env_or_base_path_prefix
             os.makedirs(extractDir, exist_ok=True)
 
             logging.debug(f"Kustomize: Temporary directory for {filePath} at {extractDir}")
@@ -397,7 +397,7 @@ class Runner(BaseRunner):
         try:
             k8s_runner = K8sKustomizeRunner()
             # k8s_runner.run() will kick off both CKV_ and CKV2_ checks and return a merged results object.
-            target_dir = self.get_k8s_target_foler_path()
+            target_dir = self.get_k8s_target_folder_path()
             k8s_runner.report_mutator_data = self.get_kustomize_metadata()
             chart_results = k8s_runner.run(target_dir, external_checks_dir=None, runner_filter=runner_filter)
             logging.debug(f"Sucessfully ran k8s scan on Kustomization templated files in tmp scan dir : {target_dir}")

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -275,16 +275,16 @@ class Runner(BaseRunner):
             if pathlib.Path(self.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases']) == pathlib.Path(relativeToFullPath).resolve():
                 self.kustomizeProcessedFolderAndMeta[filePath]['validated_base'] = str(pathlib.Path(self.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases']))
                 checkovKustomizeEnvNameByPath = pathlib.Path(filePath).relative_to(pathlib.Path(self.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases']).parent)
-                self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = checkovKustomizeEnvNameByPath
+                self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = str(checkovKustomizeEnvNameByPath)
                 logging.debug(f"Overlay based on {self.kustomizeProcessedFolderAndMeta[filePath]['validated_base']}, naming overlay {checkovKustomizeEnvNameByPath} for Checkov Results.")
             else:
                 checkovKustomizeEnvNameByPath = f"{pathlib.Path(filePath).stem}"
-                self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = checkovKustomizeEnvNameByPath
+                self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = str(checkovKustomizeEnvNameByPath)
                 logging.debug(f"Could not confirm base dir for Kustomize overlay/env. Using {checkovKustomizeEnvNameByPath} for Checkov Results.")
 
         except KeyError:
             checkovKustomizeEnvNameByPath = f"{pathlib.Path(filePath).stem}"
-            self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = checkovKustomizeEnvNameByPath
+            self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = str(checkovKustomizeEnvNameByPath)
             logging.debug(f"Could not confirm base dir for Kustomize overlay/env. Using {checkovKustomizeEnvNameByPath} for Checkov Results.")
 
     def _get_parsed_output(self, filePath, extractDir, output):

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -139,9 +139,17 @@ class Runner(BaseRunner):
     kustomizeFileMappings = {}
     kustomizeSupportedFileTypes = ('kustomization.yaml', 'kustomization.yml')
     templateRendererCommand = None
+    target_foler_path = ''
+
+    def get_k8s_target_foler_path(self):
+        return self.target_foler_path
+
+    def get_kustomize_metadata(self):
+        return {'kustomizeMetadata': self.kustomizeProcessedFolderAndMeta,
+                'kustomizeFileMappings': self.kustomizeFileMappings}
 
     @staticmethod
-    def findKustomizeDirectories(root_folder, files, excluded_paths):
+    def _findKustomizeDirectories(root_folder, files, excluded_paths):
         kustomizeDirectories = []
         if not excluded_paths:
             excluded_paths = []
@@ -160,7 +168,7 @@ class Runner(BaseRunner):
         return kustomizeDirectories
 
     @staticmethod
-    def parseKustomization(parseKustomizationData):
+    def _parseKustomization(parseKustomizationData):
         # We may have multiple results for "kustomization.yaml" files. These could be:
         # - Base and Environment (overlay) DIR's for the same kustomize-powered deployment
         # - OR, Multiple different Kustomize-powered deployments
@@ -257,158 +265,155 @@ class Runner(BaseRunner):
             logging.info(f"Could not find usable tools locally to process {self.check_type} checks. Framework will be disabled for this run.")
             return self.check_type
 
-    def run(self, root_folder, external_checks_dir=None, files=None, runner_filter=RunnerFilter(), collect_skip_comments=True):
+    def _handle_overlay_case(self, filePath):
+        for parent in pathlib.Path(filePath).parents:
+            for potentialBase in self.kustomize_runner.potentialBases:
+                pathlibBaseObject = pathlib.Path(potentialBase)
+                potentialBasePath = pathlibBaseObject.parents[1]
+                if parent == potentialBasePath.resolve():
+                    self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases'] = str(pathlibBaseObject.parent)
+        try: 
+            relativeToFullPath = f"{filePath}/{self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['referenced_bases'][0]}"
+            if pathlib.Path(self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases']) == pathlib.Path(relativeToFullPath).resolve():
+                self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['validated_base'] = str(pathlib.Path(self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases']))
+                checkovKustomizeEnvNameByPath = pathlib.Path(filePath).relative_to(pathlib.Path(self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases']).parent)
+                self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = checkovKustomizeEnvNameByPath
+                logging.debug(f"Overlay based on {self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['validated_base']}, naming overlay {checkovKustomizeEnvNameByPath} for Checkov Results.")
+            else:
+                checkovKustomizeEnvNameByPath = f"{pathlib.Path(filePath).stem}"
+                self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = checkovKustomizeEnvNameByPath
+                logging.debug(f"Could not confirm base dir for Kustomize overlay/env. Using {checkovKustomizeEnvNameByPath} for Checkov Results.")
 
-        kustomizeDirectories = self.findKustomizeDirectories(root_folder, files, runner_filter.excluded_paths)
+        except KeyError:
+            checkovKustomizeEnvNameByPath = f"{pathlib.Path(filePath).stem}"
+            self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = checkovKustomizeEnvNameByPath
+            logging.debug(f"Could not confirm base dir for Kustomize overlay/env. Using {checkovKustomizeEnvNameByPath} for Checkov Results.")
 
-        report = Report(self.check_type)
-        for kustomizedir in kustomizeDirectories:
-            self.kustomizeProcessedFolderAndMeta[kustomizedir] = self.parseKustomization(kustomizedir)
-        
-        with tempfile.TemporaryDirectory() as target_dir:
-            for filePath in self.kustomizeProcessedFolderAndMeta:    
-                # Name our Kustomize overlays/environments.
-                # We try to validate any existing base references in the yaml and also find our own "bases" if possible as absolute paths.
-                # The delta of paths between the closest base and an overlay dir will be used as the env name for a given kustomize overlay
-                # as they dont have "names" per-se, and we need a unique resource name for the checkov results.
+    def _get_parsed_output(self, filePath, extractDir, output):
+        cur_source_file = None
+        cur_writer = None
+        last_line_dashes = False
+        line_num = 1
+        file_num = 0
 
-                logging.debug(f"Kustomization at {filePath} likley a {self.kustomizeProcessedFolderAndMeta[filePath]['type']}")
-                if self.kustomizeProcessedFolderAndMeta[filePath]['type'] == 'overlay':
-                    for parent in pathlib.Path(filePath).parents:
-                        for potentialBase in Runner.potentialBases:
-                            pathlibBaseObject = pathlib.Path(potentialBase)
-                            potentialBasePath = pathlibBaseObject.parents[1]
-                            if parent == potentialBasePath.resolve():
-                                self.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases'] = str(pathlibBaseObject.parent)
-                    # Normalize referenced bases vs calculated (referenced will usually be relative, calculated absolute)
-                    # TODO: If someone can show me an example where base: isnt relative:
-                    # if "../" in self.kustomizeProcessedFolderAndMeta[filePath]['referenced_bases']:
-                    # TODO: Validate if this breaks non POSIX windows paths, as everything else is handled by pathlib/os.paths
-                    try: 
-                        relativeToFullPath = f"{filePath}/{self.kustomizeProcessedFolderAndMeta[filePath]['referenced_bases'][0]}"
+        # page-to-file parser from helm framework works well, but we expect the file to start with --- in this case from Kustomize.
+        output = "---\n" + output
+        reader = io.StringIO(output)
+        for s in reader:
+            s = s.rstrip()
+            if s == '---':
+                last_line_dashes = True
+                continue
 
-
-                        if pathlib.Path(self.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases']) == pathlib.Path(relativeToFullPath).resolve():
-                            self.kustomizeProcessedFolderAndMeta[filePath]['validated_base'] = str(pathlib.Path(self.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases']))
-                            checkovKustomizeEnvNameByPath = pathlib.Path(filePath).relative_to(pathlib.Path(self.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases']).parent)
-                            self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = checkovKustomizeEnvNameByPath
-                            logging.debug(f"Overlay based on {self.kustomizeProcessedFolderAndMeta[filePath]['validated_base']}, naming overlay {checkovKustomizeEnvNameByPath} for Checkov Results.")
-                        else:
-                            checkovKustomizeEnvNameByPath = f"{pathlib.Path(filePath).stem}"
-                            self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = checkovKustomizeEnvNameByPath
-                            logging.debug(f"Could not confirm base dir for Kustomize overlay/env. Using {checkovKustomizeEnvNameByPath} for Checkov Results.")
-
-                    except KeyError:
-                        checkovKustomizeEnvNameByPath = f"{pathlib.Path(filePath).stem}"
-                        self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name'] = checkovKustomizeEnvNameByPath
-                        logging.debug(f"Could not confirm base dir for Kustomize overlay/env. Using {checkovKustomizeEnvNameByPath} for Checkov Results.")
-            
-
-                if self.templateRendererCommand == "kubectl":
-                    templateRenderCommandOptions = "kustomize"
-                if self.templateRendererCommand == "kustomize":
-                    templateRenderCommandOptions = "build"
-                    
-                # Template out the Kustomizations to Kubernetes YAML
-                try:
-                    proc = subprocess.Popen([self.templateRendererCommand, templateRenderCommandOptions, filePath], stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # nosec
-                    o, e = proc.communicate()
-                    logging.info(
-                        f"Ran {self.templateRendererCommand} to build Kustomize output. DIR: {filePath}. TYPE: {self.kustomizeProcessedFolderAndMeta[filePath]['type']}.")
-
-                except Exception:
-                    logging.warning(f"Error building Kustomize output at dir: {filePath}.", exc_info=True)
-                    continue
-
-                if self.kustomizeProcessedFolderAndMeta[filePath]['type'] == "overlay":
-                    if 'calculated_bases' not in self.kustomizeProcessedFolderAndMeta[filePath]:
-                        logging.debug(f"Kustomize: Overlay with unknown base. User may have specified overlay dir directly. {filePath}")
-                        envOrBasePathPrefix = ""
-                    else:
-                        basePathParents = pathlib.Path(self.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases']).parents
-                        mostSignificantBasePath = "/" + basePathParents._parts[-3] + "/" + basePathParents._parts[-2] + "/" + basePathParents._parts[-1]
-                        envOrBasePathPrefix = f"{mostSignificantBasePath}/{self.kustomizeProcessedFolderAndMeta[filePath]['overlay_name']}"
-
-                if self.kustomizeProcessedFolderAndMeta[filePath]['type'] == "base":
-                    # Validated base last three parents as a path
-                    basePathParents = pathlib.Path(self.kustomizeProcessedFolderAndMeta[filePath]['filePath']).parents
-                    mostSignificantBasePath = "/" + basePathParents._parts[-4] + "/" + basePathParents._parts[-3] + "/" + basePathParents._parts[-2]
-                    envOrBasePathPrefix = mostSignificantBasePath
-
-                extractDir = target_dir + envOrBasePathPrefix
-                os.makedirs(extractDir, exist_ok=True)
-
-                logging.debug(f"Kustomize: Temporary directory for {filePath} at {extractDir}")
-                output = str(o, 'utf-8')
-                cur_source_file = None
-                cur_writer = None
+            if last_line_dashes:
+                # The next line should contain a "apiVersion" line for the next Kubernetes manifest
+                # So we will close the old file, open a new file, and write the dashes from last iteration plus this line
+                source = file_num
+                file_num += 1 
+                if source != cur_source_file:
+                    if cur_writer:
+                        # Here we are about to close a "complete" file. The function will validate it looks like a K8S manifest before continuing.
+                        self.kustomize_runner._curWriterValidateStoreMapAndClose(cur_writer, filePath)
+                    file_path = os.path.join(extractDir, str(source))
+                    parent = os.path.dirname(file_path)
+                    os.makedirs(parent, exist_ok=True)
+                    cur_source_file = source
+                    cur_writer = open(os.path.join(extractDir, str(source)), 'a')
+                cur_writer.write('---' + os.linesep)
+                cur_writer.write(s + os.linesep)
                 last_line_dashes = False
-                line_num = 1
-                file_num = 0
+            else:
+                if not cur_writer:
+                    continue
+                else:
+                    cur_writer.write(s + os.linesep)
+            line_num += 1
+        return cur_writer
 
-                # page-to-file parser from helm framework works well, but we expect the file to start with --- in this case from Kustomize.
-                output = "---\n" + output
-                reader = io.StringIO(output)
-                
-                for s in reader:
-                    s = s.rstrip()
+    def _get_kubectl_output(self, filePath):
+        # Template out the Kustomizations to Kubernetes YAML
+        if self.templateRendererCommand == "kubectl":
+            templateRenderCommandOptions = "kustomize"
+        if self.templateRendererCommand == "kustomize":
+            templateRenderCommandOptions = "build"
+        proc = subprocess.Popen([self.templateRendererCommand, templateRenderCommandOptions, filePath],
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # nosec
+        output, _ = proc.communicate()
+        logging.info(
+            f"Ran kubectl to build Kustomize output. DIR: {filePath}. TYPE: {self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['type']}.")
+        return output
 
-                    if s == '---':
-                        last_line_dashes = True
-                        continue
+    def _get_env_or_base_path_prefix(self, filePath) -> str:
+        env_or_base_path_prefix = None
+        if self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['type'] == "overlay":
+            if 'calculated_bases' not in self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]:
+                logging.debug(f"Kustomize: Overlay with unknown base. User may have specified overlay dir directly. {filePath}")
+                env_or_base_path_prefix = ""
+            else:
+                basePathParents = pathlib.Path(self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['calculated_bases']).parents
+                mostSignificantBasePath = "/" + basePathParents._parts[-3] + "/" + basePathParents._parts[-2] + "/" + basePathParents._parts[-1]
+                env_or_base_path_prefix = f"{mostSignificantBasePath}/{self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['overlay_name']}"
 
-                    if last_line_dashes:
-                        # The next line should contain a "apiVersion" line for the next Kubernetes manifest
-                        # So we will close the old file, open a new file, and write the dashes from last iteration plus this line
-                        source = file_num
-                        file_num += 1 
-                        if source != cur_source_file:
-                            if cur_writer:
-                                # Here we are about to close a "complete" file. The function will validate it looks like a K8S manifest before continuing.
-                                self._curWriterValidateStoreMapAndClose(cur_writer, filePath)
-                                # 
-                            file_path = os.path.join(extractDir, str(source))
-                            parent = os.path.dirname(file_path)
-                            os.makedirs(parent, exist_ok=True)
-                            cur_source_file = source
-                            cur_writer = open(os.path.join(extractDir, str(source)), 'a')
-                        cur_writer.write('---' + os.linesep)
-                        cur_writer.write(s + os.linesep)
+        if self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['type'] == "base":
+            # Validated base last three parents as a path
+            basePathParents = pathlib.Path(self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['filePath']).parents
+            mostSignificantBasePath = "/" + basePathParents._parts[-4] + "/" + basePathParents._parts[-3] + "/" + basePathParents._parts[-2]
+            env_or_base_path_prefix = mostSignificantBasePath
 
-                        last_line_dashes = False
-                    
-                    else:
-                        
-                        if not cur_writer:
-                            continue
-                        else:
-                            cur_writer.write(s + os.linesep)
+        return env_or_base_path_prefix
 
-                    line_num += 1
-
-                if cur_writer:
-                    self._curWriterValidateStoreMapAndClose(cur_writer, filePath)
-
+    def run_kustomize_to_k8s(self, root_folder, files, runner_filter):
+        kustomizeDirectories = self._findKustomizeDirectories(root_folder, files, runner_filter.excluded_paths)
+        for kustomizedir in kustomizeDirectories:
+            self.kustomizeProcessedFolderAndMeta[kustomizedir] = self._parseKustomization(kustomizedir)
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.target_dir = tmp_dir.name
+        for filePath in self.kustomize_runner.kustomizeProcessedFolderAndMeta:    
+            logging.debug(f"Kustomization at {filePath} likley a {self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['type']}")
+            if self.kustomize_runner.kustomizeProcessedFolderAndMeta[filePath]['type'] == 'overlay':
+                self._handle_overlay_case(filePath)
             try:
-                k8s_runner = K8sKustomizeRunner()
-                report_mutator_data = {'kustomizeMetadata':self.kustomizeProcessedFolderAndMeta,
-                                       'kustomizeFileMappings':self.kustomizeFileMappings}
-                # k8s_runner.run() will kick off both CKV_ and CKV2_ checks and return a merged results object.
-                k8s_runner.report_mutator_data = report_mutator_data
-                chart_results = k8s_runner.run(target_dir, external_checks_dir=None, runner_filter=runner_filter)
-                logging.debug(f"Sucessfully ran k8s scan on Kustomization templated files in tmp scan dir : {target_dir}")
-                report.failed_checks += chart_results.failed_checks
-                report.passed_checks += chart_results.passed_checks
-                report.parsing_errors += chart_results.parsing_errors
-                report.skipped_checks += chart_results.skipped_checks
-                report.resources.update(chart_results.resources)
-
+                output = self._get_kubectl_output(filePath)
             except Exception:
-                logging.warning("Failed to run Kubernetes runner", exc_info=True)
-                with tempfile.TemporaryDirectory() as save_error_dir:
-                    logging.debug(
-                        f"Error running k8s scan on Scan dir: {target_dir}. Saved context dir: {save_error_dir}")
-                    shutil.move(target_dir, save_error_dir)
+                logging.warning(f"Error building Kustomize output at dir: {filePath}.", exc_info=True)
+                continue
+
+            env_or_base_path_prefix = self._get_env_or_base_path_prefix(filePath)
+            if env_or_base_path_prefix is None:
+                logging.warning(f"env_or_base_path_prefix is None, filePath: {filePath}", exc_info=True)
+                continue
+
+            extractDir = self.target_dir + env_or_base_path_prefix
+            os.makedirs(extractDir, exist_ok=True)
+
+            logging.debug(f"Kustomize: Temporary directory for {filePath} at {extractDir}")
+            output = str(output, 'utf-8')
+            cur_writer = self._get_parsed_output(filePath, extractDir, output)
+            if cur_writer:
+                self.kustomize_runner._curWriterValidateStoreMapAndClose(cur_writer, filePath)
+
+    def run(self, root_folder, external_checks_dir=None, files=None, runner_filter=RunnerFilter(), collect_skip_comments=True):
+        self.run_kustomize_to_k8s(root_folder, files, runner_filter)
+        report = Report(self.check_type)
+        try:
+            k8s_runner = K8sKustomizeRunner()
+            # k8s_runner.run() will kick off both CKV_ and CKV2_ checks and return a merged results object.
+            target_dir = self.get_k8s_target_foler_path()
+            k8s_runner.report_mutator_data = self.get_kustomize_metadata()
+            chart_results = k8s_runner.run(target_dir, external_checks_dir=None, runner_filter=runner_filter)
+            logging.debug(f"Sucessfully ran k8s scan on Kustomization templated files in tmp scan dir : {target_dir}")
+            report.failed_checks += chart_results.failed_checks
+            report.passed_checks += chart_results.passed_checks
+            report.parsing_errors += chart_results.parsing_errors
+            report.skipped_checks += chart_results.skipped_checks
+            report.resources.update(chart_results.resources)
+
+        except Exception:
+            logging.warning("Failed to run Kubernetes runner", exc_info=True)
+            with tempfile.TemporaryDirectory() as save_error_dir:
+                logging.debug(
+                    f"Error running k8s scan on Scan dir: {target_dir}. Saved context dir: {save_error_dir}")
+                shutil.move(target_dir, save_error_dir)
 
         return report
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Refactor kustomize `run` function to use -
1) `run_kustomize_to_k8s`
2) `get_k8s_target_foler_path`, `get_kustomize_metadata`

also fix a bug with `overlay_name` metadata