### PR TITLE
RDSPostgreSQLLogFDWExtension handle versions without bugfix

### DIFF
--- a/checkov/terraform/checks/resource/aws/RDSPostgreSQLLogFDWExtension.py
+++ b/checkov/terraform/checks/resource/aws/RDSPostgreSQLLogFDWExtension.py
@@ -44,6 +44,9 @@ class RDSPostgreSQLLogFDWExtension(BaseResourceCheck):
                         return CheckResult.PASSED
                     elif major_version == 9 and minor_version == 6:
                         # PostgreSQL pre 10 used following versioning major.major.minor
+                        if len(version_parts) < 3:
+                            return CheckResult.UNKNOWN
+
                         bugfix_version = force_int(version_parts[2])
 
                         if bugfix_version is None:

--- a/tests/terraform/checks/resource/aws/example_RDSPostgreSQLLogFDWExtension/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSPostgreSQLLogFDWExtension/main.tf
@@ -52,7 +52,7 @@ resource "aws_db_instance" "postgres_unknown" {
 }
 
 
-resource "aws_db_instance" "fail_old_two_parts" {
+resource "aws_db_instance" "unknown_two_parts" {
   name           = "name"
   instance_class = "db.t3.micro"
   engine         = "postgres"

--- a/tests/terraform/checks/resource/aws/example_RDSPostgreSQLLogFDWExtension/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSPostgreSQLLogFDWExtension/main.tf
@@ -50,3 +50,11 @@ resource "aws_db_instance" "postgres_unknown" {
   engine         = "postgres"
   engine_version = var.engine_version
 }
+
+
+resource "aws_db_instance" "fail_old_two_parts" {
+  name           = "name"
+  instance_class = "db.t3.micro"
+  engine         = "postgres"
+  engine_version = "9.6"
+}

--- a/tests/terraform/checks/resource/aws/test_RDSPostgreSQLLogFDWExtension.py
+++ b/tests/terraform/checks/resource/aws/test_RDSPostgreSQLLogFDWExtension.py
@@ -34,7 +34,7 @@ class TestRDSPostgreSQLLogFDWExtension(unittest.TestCase):
         self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
-        self.assertEqual(summary["resource_count"], len(passing_resources) + len(failing_resources) + 3)  # 3 unknown
+        self.assertEqual(summary["resource_count"], len(passing_resources) + len(failing_resources) + 4)  # 4 unknown
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)


### PR DESCRIPTION
Handled a case where `engine_version` is not in `major.minor.bugfix` format.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
