### PR TITLE
add graph creation skip to K8s and CFN runners

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
@@ -12,7 +12,7 @@ class IAMAdminPolicyDocument(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        my_properties = conf['Properties']
+        my_properties = conf.get("Properties")
         type = conf['Type']
 
         # catch for inline policies

--- a/checkov/cloudformation/checks/resource/aws/IAMStarActionPolicyDocument.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMStarActionPolicyDocument.py
@@ -13,7 +13,7 @@ class IAMStarActionPolicyDocument(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        myproperties = conf['Properties']
+        myproperties = conf.get("Properties")
         type = conf['Type']
 
         # catch for inline policies

--- a/checkov/common/graph/graph_builder/utils.py
+++ b/checkov/common/graph/graph_builder/utils.py
@@ -2,33 +2,21 @@ from __future__ import annotations
 
 import concurrent
 import hashlib
-import json
-from typing import Union, List, Dict, Any, Callable, Optional
+from typing import Any, Callable
 import concurrent.futures
 
 
-def stringify_value(value: Union[bool, int, float, str, List[str], Dict[str, Any]]) -> str:
-    if isinstance(value, bool):
-        value = str(value).lower()
-    elif isinstance(value, (float, int)):
-        value = str(value)
-    return json.dumps(value, indent=4, default=str)
-
-
-def calculate_hash(data: Union[bool, int, float, str, Dict[str, Any]]) -> str:
-    encoded_attributes = stringify_value(data)
-    sha256 = hashlib.sha256()
-    sha256.update(repr(encoded_attributes).encode("utf-8"))
-
+def calculate_hash(data: Any) -> str:
+    sha256 = hashlib.sha256(str(data).encode("utf-8"))
     return sha256.hexdigest()
 
 
-def join_trimmed_strings(char_to_join: str, str_lst: List[str], num_to_trim: int) -> str:
+def join_trimmed_strings(char_to_join: str, str_lst: list[str], num_to_trim: int) -> str:
     return char_to_join.join(str_lst[: len(str_lst) - num_to_trim])
 
 
 def run_function_multithreaded(
-    func: Callable[..., Any], data: List[List[Any]], max_group_size: int, num_of_workers: Optional[int] = None
+    func: Callable[..., Any], data: list[list[Any]], max_group_size: int, num_of_workers: int | None = None
 ) -> None:
     groups_of_data = [data[i : i + max_group_size] for i in range(0, len(data), max_group_size)]
     if not num_of_workers:

--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -15,8 +15,6 @@ if TYPE_CHECKING:
     from checkov.common.graph.checks_infra.registry import BaseRegistry
     from checkov.common.graph.graph_manager import GraphManager
 
-IGNORED_DIRECTORIES_ENV = os.getenv("CKV_IGNORED_DIRECTORIES", "node_modules,.terraform,.serverless")
-
 
 def strtobool(val: str) -> int:
     """Convert a string representation of truth to true (1) or false (0).
@@ -34,6 +32,8 @@ def strtobool(val: str) -> int:
         raise ValueError("invalid boolean value %r for environment variable CKV_IGNORE_HIDDEN_DIRECTORIES" % (val,))
 
 
+CHECKOV_CREATE_GRAPH = strtobool(os.getenv("CHECKOV_CREATE_GRAPH", "True"))
+IGNORED_DIRECTORIES_ENV = os.getenv("CKV_IGNORED_DIRECTORIES", "node_modules,.terraform,.serverless")
 IGNORE_HIDDEN_DIRECTORY_ENV = strtobool(os.getenv("CKV_IGNORE_HIDDEN_DIRECTORIES", "True"))
 
 ignored_directories = IGNORED_DIRECTORIES_ENV.split(",")

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -520,4 +520,12 @@ def normalize_config(config: Namespace) -> None:
 
 
 if __name__ == '__main__':
-    sys.exit(run())
+    from timeit import default_timer as timer
+    from datetime import timedelta
+
+    start = timer()
+
+    run()
+
+    end = timer()
+    print(f"elapsed time: {timedelta(seconds=end - start)}")

--- a/tests/cloudformation/checks/resource/aws/example_IAMAdminPolicyDocument/iam_role.unknown.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_IAMAdminPolicyDocument/iam_role.unknown.yaml
@@ -30,3 +30,6 @@ Resources:
                 }
               ]}
         - !Ref AWS::NoValue
+
+  CFNUserGroup:
+    Type: AWS::IAM::Group

--- a/tests/cloudformation/checks/resource/aws/example_IAMStarActionPolicyDocument/iam_role.unknown.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_IAMStarActionPolicyDocument/iam_role.unknown.yaml
@@ -35,3 +35,6 @@ Resources:
       Path: /
       Roles:
         - !Ref RootRole
+
+  CFNUserGroup:
+    Type: AWS::IAM::Group


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

- moved the env var `CHECKOV_CREATE_GRAPH` to the `BaseRunner`
- implemented graph creation skips for CFN and K8s runners (TF needs extra work, need to test it more)
- changed the `calculate_hash` to directly use the `str` conversion of the objects passed in, instead of `json.dump` them, which is much faster and the hash will still be reliable, but of course it is now different compared to the one before -> resulted in a reducing the scan time for my test repo by 30 seconds 🚀 
