### PR TITLE
Document and enable monchrome console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,11 @@ To cancel skipping directories beginning with `.` override `IGNORE_HIDDEN_DIRECT
 You can override the default set of directories to skip by setting the environment variable `CKV_IGNORED_DIRECTORIES`.
  Note that if you want to preserve this list and add to it, you must include these values. For example, `CKV_IGNORED_DIRECTORIES=mynewdir` will skip only that directory, but not the others mentioned above. This variable is legacy functionality; we recommend using the `--skip-file` flag.
 
+#### Console Output
+
+The console output is in colour by default, to switch to a monochrome output, set the environment variable:
+`ANSI_COLORS_DISABLED`
+
 #### VSCODE Extension
 
 If you want to use checkov's within vscode, give a try to the vscode extension available at [vscode](https://marketplace.visualstudio.com/items?itemName=Bridgecrew.checkov)
@@ -411,7 +416,6 @@ Defaults:
   --external-modules-download-path:.external_modules
   --evaluate-variables:True
 ```
-
 ## Contributing
 
 Contribution is welcomed! 

--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -18,6 +18,8 @@ DEFAULT_SEVERITY = "none"  # equivalent to a score of 0.0 in the CVSS v3.0 Ratin
 
 OUTPUT_CODE_LINE_LIMIT = force_int(os.getenv('CHECKOV_OUTPUT_CODE_LINE_LIMIT')) or 50
 
+ANSI_COLORS_DISABLED  = bool(os.getenv('ANSI_COLORS_DISABLED'))
+
 class Record:
     check_id = ""
     check_name = ""
@@ -165,7 +167,8 @@ class Record:
         )
         code_lines = ""
         if self.code_block:
-            code_lines = "\n{}\n".format("".join([self._code_line_string(self.code_block)]))
+            ANSI_COLORS_DISABLED
+            code_lines = "\n{}\n".format("".join([self._code_line_string(self.code_block, not(ANSI_COLORS_DISABLED))]))
         caller_file_details = ""
         if self.caller_file_path and self.caller_file_line_range:
             caller_file_details = colored(

--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -167,7 +167,6 @@ class Record:
         )
         code_lines = ""
         if self.code_block:
-            ANSI_COLORS_DISABLED
             code_lines = "\n{}\n".format("".join([self._code_line_string(self.code_block, not(ANSI_COLORS_DISABLED))]))
         caller_file_details = ""
         if self.caller_file_path and self.caller_file_line_range:

--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -18,7 +18,7 @@ DEFAULT_SEVERITY = "none"  # equivalent to a score of 0.0 in the CVSS v3.0 Ratin
 
 OUTPUT_CODE_LINE_LIMIT = force_int(os.getenv('CHECKOV_OUTPUT_CODE_LINE_LIMIT')) or 50
 
-ANSI_COLORS_DISABLED  = bool(os.getenv('ANSI_COLORS_DISABLED'))
+ANSI_COLORS_DISABLED = bool(os.getenv('ANSI_COLORS_DISABLED'))
 
 class Record:
     check_id = ""


### PR DESCRIPTION
Resolve #2805 by using the `termcolor.py` existing setting of  `ANSI_COLORS_DISABLED`

