### PR TITLE
Fix CFN bool case sensitivity

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -7,5 +7,7 @@ ignore_templates:
   - tests/cloudformation/checks/resource/aws/example_AthenaWorkgroupConfiguration/*
   # added resource with Properties, which is not supported by cfn-lint
   - tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentCredentials/sam.yaml
+  # includes tests with booleans as strings
+  - tests/cloudformation/checks/resource/aws/example_ECRImageScanning/*
 ignore_checks:
   - W

--- a/checkov/cloudformation/checks/resource/base_resource_value_check.py
+++ b/checkov/cloudformation/checks/resource/base_resource_value_check.py
@@ -79,6 +79,12 @@ class BaseResourceValueCheck(BaseResourceCheck):
                         return CheckResult.PASSED
                     if value in expected_values:
                         return CheckResult.PASSED
+
+                    # handle boolean case sensitivity (e.g., CFN accepts the string "true" as a boolean)
+                    if isinstance(value, str) and value.lower() in ('true', 'false'):
+                        value = value.lower() == 'true'
+                        if value in expected_values:
+                            return CheckResult.PASSED
                     return CheckResult.FAILED
 
         return self.missing_block_result

--- a/tests/cloudformation/checks/resource/aws/example_ECRImageScanning/FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ECRImageScanning/FAILED.yml
@@ -6,6 +6,12 @@ Resources:
       RepositoryName: "test"
       ImageScanningConfiguration:
         ScanOnPush: false
+  ImageScanFalseString:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: "test"
+      ImageScanningConfiguration:
+        ScanOnPush: "false"
   ImageScanNotSet:
     Type: AWS::ECR::Repository
     Properties: 

--- a/tests/cloudformation/checks/resource/aws/example_ECRImageScanning/PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ECRImageScanning/PASSED.yml
@@ -6,3 +6,9 @@ Resources:
       RepositoryName: "test"
       ImageScanningConfiguration:
         ScanOnPush: true
+  ImageScanTrueString:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: "test"
+      ImageScanningConfiguration:
+        ScanOnPush: "true"

--- a/tests/cloudformation/checks/resource/aws/test_ECRImageScanning.py
+++ b/tests/cloudformation/checks/resource/aws/test_ECRImageScanning.py
@@ -23,19 +23,21 @@ class TestECRImageScanning(unittest.TestCase):
             self.assertEqual(record.check_id, check.id)
 
         passing_resources = {
-            "AWS::ECR::Repository.ImageScanTrue"
+            "AWS::ECR::Repository.ImageScanTrue",
+            "AWS::ECR::Repository.ImageScanTrueString"
         }
 
         failing_resources = {
             "AWS::ECR::Repository.ImageScanFalse",
+            "AWS::ECR::Repository.ImageScanFalseString",
             "AWS::ECR::Repository.ImageScanNotSet"
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 3)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
         self.assertEqual(passing_resources, passed_check_resources)

--- a/tests/cloudformation/graph/checks/test_yaml_policies.py
+++ b/tests/cloudformation/graph/checks/test_yaml_policies.py
@@ -12,11 +12,15 @@ from checkov.common.output.report import Report
 from tests.common.graph.checks.test_yaml_policies_base import TestYamlPoliciesBase
 
 
+file_dir = os.path.dirname(__file__)
+
+
 class TestYamlPolicies(TestYamlPoliciesBase):
     def __init__(self, args):
         graph_manager = CloudformationGraphManager(db_connector=NetworkxConnector())
-        super().__init__(graph_manager, "checkov/cloudformation/checks/graph_checks",
-                         os.path.dirname(__file__) + "/test_checks", "cloudformation", __file__, args)
+        super().__init__(graph_manager,
+                         os.path.abspath(os.path.join(file_dir, "../../../../checkov/cloudformation/checks/graph_checks")),
+                         os.path.join(file_dir, "test_checks"), "cloudformation", __file__, args)
 
     def setUp(self) -> None:
         os.environ['UNIQUE_TAG'] = ''


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes an issue when checking CFN templates with boolean values as a string, i.e. `ScanOnPush: "true"`

Also fixes an issue with an unrelated graph check test where the check failed to load. I am not sure how this got through, as tests failed on `master` for me.