### PR TITLE
Flake8 - All Rules followed Outside of Checkov and Tests

### DIFF
--- a/admissioncontroller/whorf.py
+++ b/admissioncontroller/whorf.py
@@ -1,5 +1,5 @@
 from flask import Flask, request, jsonify
-from os import environ, remove, getenv 
+from os import remove, getenv
 import logging
 import json
 import subprocess
@@ -11,9 +11,11 @@ webhook = Flask(__name__)
 
 webhook.logger.setLevel(logging.INFO)
 
+
 @webhook.route('/', methods=['GET'])
 def hello():
     return "<h1 style='color:blue'>Ready!</h1>"
+
 
 @webhook.route('/validate', methods=['POST'])
 def validating_webhook():
@@ -31,19 +33,18 @@ def validating_webhook():
         webhook.logger.error('K8s UID failed security checks. Request rejected!')
         return admission_response(False, uid, response)
 
-
     jsonfile = "tmp/" + uid + "-req.json"
     yamlfile = "tmp/" + uid + "-req.yaml"
     configfile = "config/.checkov.yaml"
 
-
     ff = open(jsonfile, 'w+')
     yf = open(yamlfile, 'w+')
     json.dump(request_info, ff)
-    yaml.dump(todict(request_info["request"]["object"]),yf)
+    yaml.dump(todict(request_info["request"]["object"]), yf)
 
-    print("Running checkov") 
-    cp = subprocess.run(["checkov","--config-file",configfile,"-f",yamlfile], universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    print("Running checkov")
+    cp = subprocess.run(["checkov", "--config-file", configfile, "-f", yamlfile],
+                        universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     checkovresults = json.loads(cp.stdout)
 
@@ -55,8 +56,12 @@ def validating_webhook():
             remove(jsonfile)
             remove(yamlfile)
 
-    if cp.returncode != 0:
+    obj_kind_name = (
+        f'{request_info["request"]["object"]["kind"]}/'
+        f'{request_info["request"]["object"]["metadata"]["name"]}'
+    )
 
+    if cp.returncode != 0:
 
         # open configfile to check for hard fail CKVs
         with open(configfile, 'r') as config:
@@ -72,32 +77,35 @@ def validating_webhook():
                             hard_fails[ckv] = f"\n  Description: {fail['check_name']}"
                             if fail['guideline'] != "":
                                 hard_fails[ckv] += f"\n  Guidance: {fail['guideline']}"
-    
+
             finally:
                 print("hard fail error")
-        
+
             if (len(hard_fails) > 0):
                 response = f"\nCheckov found {len(hard_fails)} issues in violation of admission policy.\n"
-    
+
                 for ckv in hard_fails:
                     response = response + f"{ckv}:{hard_fails[ckv]}\n"
 
         response = response + f"Checkov found {checkovresults['summary']['failed']} total issues in this manifest.\n"
         response = response + f"\nFor complete details: {checkovresults['url']}\n"
-       
-    
-        webhook.logger.error(f'Object {request_info["request"]["object"]["kind"]}/{request_info["request"]["object"]["metadata"]["name"]} failed security checks. Request rejected!')
+
+        webhook.logger.error(f'Object {obj_kind_name} failed security checks. Request rejected!')
         return admission_response(False, uid, response)
 
     else:
-        webhook.logger.info(f'Object {request_info["request"]["object"]["kind"]}/{request_info["request"]["object"]["metadata"]["name"]} passed security checks. Allowing the request.')
-        return admission_response(True, uid, f"Checkov found {checkovresults['summary']['failed']} issues. None in violation of admission policy. {checkovresults['summary']['failed']} issues in this manifest!")
+        webhook.logger.info(f'Object {obj_kind_name} passed security checks. Allowing the request.')
+        admission_resp_msg = (
+            f'Checkov found {checkovresults["summary"]["failed"]} issues. None in violation of admission policy. '
+            f'{checkovresults["summary"]["failed"]} issues in this manifest!'
+        )
+        return admission_response(True, uid, admission_resp_msg)
 
 
 def todict(obj):
     if hasattr(obj, 'attribute_map'):
         result = {}
-        for k,v in getattr(obj, 'attribute_map').items():
+        for k, v in getattr(obj, 'attribute_map').items():
             val = getattr(obj, k)
             if val is not None:
                 result[v] = todict(val)

--- a/admissioncontroller/whorf.py
+++ b/admissioncontroller/whorf.py
@@ -43,8 +43,10 @@ def validating_webhook():
     yaml.dump(todict(request_info["request"]["object"]), yf)
 
     print("Running checkov")
-    cp = subprocess.run(["checkov", "--config-file", configfile, "-f", yamlfile],
-                        universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cp = subprocess.run(
+        ["checkov", "--config-file", configfile, "-f", yamlfile],
+        universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
 
     checkovresults = json.loads(cp.stdout)
 

--- a/performance_tests/test_checkov_performance.py
+++ b/performance_tests/test_checkov_performance.py
@@ -78,6 +78,7 @@ def test_cloudformation_performance(benchmark):
     benchmark(run_cloudformation_scan)
     assert benchmark.stats.stats.mean <= repo_threshold + (deviation_percent / 100) * repo_threshold
 
+
 @pytest.mark.benchmark(
     group="kubernetes-performance-tests",
     disable_gc=True,


### PR DESCRIPTION
Hello,

I have saw @gruebel slowly making way through the linting and this is to try to help with that.

This change handles all pep8 rules for any python outside of the main `./checkov` and `./tests` directory.

1 unused import, mainly whitespace and newlines.

I only did a minor refactor for the line-length limits. I have been a bit more DRY with one output message and otherwise have used a nice way for creating f strings in a pythonic multi-line way which I learned about through doing this.

e.g
```
foo = "foo"
bar = "bar"
new_string = (
  f'{foo}/'
  f'{bar}'
)
print(new_string)
```

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
