### PR TITLE
Ensure API Gateway EDGE is protected by WAF

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/APIProtectedByWAF.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/APIProtectedByWAF.yaml
@@ -37,12 +37,19 @@ definition:
         operator:  exists
         cond_type: connection
     - and:
-      - cond_type: attribute
-        resource_types:
-        - aws_api_gateway_rest_api
-        attribute: endpoint_configuration.types
-        operator: contains
-        value: REGIONAL
+      - or:
+        - cond_type: attribute
+          resource_types:
+          - aws_api_gateway_rest_api
+          attribute: endpoint_configuration.types
+          operator: contains
+          value: REGIONAL
+        - cond_type: attribute
+          resource_types:
+          - aws_api_gateway_rest_api
+          attribute: endpoint_configuration.types
+          operator: contains
+          value: EDGE
       - resource_types:
         - aws_api_gateway_rest_api
         connected_resource_types:

--- a/tests/terraform/graph/checks/resources/APIProtectedByWAF/expected.yaml
+++ b/tests/terraform/graph/checks/resources/APIProtectedByWAF/expected.yaml
@@ -1,6 +1,6 @@
 pass:
-  - "aws_api_gateway_stage.pass"
-  - "aws_api_gateway_stage.wafv2_pass"
+  - "aws_api_gateway_stage.regional"
+  - "aws_api_gateway_stage.wafv2_regional"
   - "aws_api_gateway_stage.no_api"
   - "aws_api_gateway_stage.private"
 fail:

--- a/tests/terraform/graph/checks/resources/APIProtectedByWAF/expected.yaml
+++ b/tests/terraform/graph/checks/resources/APIProtectedByWAF/expected.yaml
@@ -1,6 +1,7 @@
 pass:
   - "aws_api_gateway_stage.regional"
   - "aws_api_gateway_stage.wafv2_regional"
+  - "aws_api_gateway_stage.wafv2_edge"
   - "aws_api_gateway_stage.no_api"
   - "aws_api_gateway_stage.private"
 fail:

--- a/tests/terraform/graph/checks/resources/APIProtectedByWAF/main.tf
+++ b/tests/terraform/graph/checks/resources/APIProtectedByWAF/main.tf
@@ -1,4 +1,4 @@
-resource "aws_api_gateway_rest_api" "pass" {
+resource "aws_api_gateway_rest_api" "regional" {
   name = var.name
 
   policy = ""
@@ -56,24 +56,24 @@ resource "aws_api_gateway_stage" "no_api" {
   stage_name    = "example"
 }
 
-resource "aws_api_gateway_stage" "pass" {
+resource "aws_api_gateway_stage" "regional" {
   deployment_id = aws_api_gateway_deployment.example.id
-  rest_api_id   = aws_api_gateway_rest_api.pass.id
+  rest_api_id   = aws_api_gateway_rest_api.regional.id
   stage_name    = "example"
 }
 
-resource "aws_api_gateway_stage" "wafv2_pass" {
+resource "aws_api_gateway_stage" "wafv2_regional" {
   deployment_id = aws_api_gateway_deployment.example.id
-  rest_api_id   = aws_api_gateway_rest_api.pass.id
+  rest_api_id   = aws_api_gateway_rest_api.regional.id
   stage_name    = "example"
 }
 
-resource "aws_wafregional_web_acl_association" "pass" {
-  resource_arn = aws_api_gateway_stage.pass.arn
+resource "aws_wafregional_web_acl_association" "regional" {
+  resource_arn = aws_api_gateway_stage.regional.arn
   web_acl_id   = aws_wafregional_web_acl.foo.id
 }
 
-resource "aws_wafv2_web_acl_association" "pass" {
-  resource_arn = aws_api_gateway_stage.wafv2_pass.arn
+resource "aws_wafv2_web_acl_association" "regional" {
+  resource_arn = aws_api_gateway_stage.wafv2_regional.arn
   web_acl_id   = aws_wafv2_web_acl.foo.id
 }

--- a/tests/terraform/graph/checks/resources/APIProtectedByWAF/main.tf
+++ b/tests/terraform/graph/checks/resources/APIProtectedByWAF/main.tf
@@ -8,6 +8,16 @@ resource "aws_api_gateway_rest_api" "regional" {
   }
 }
 
+resource "aws_api_gateway_rest_api" "edge" {
+  name = var.name
+
+  policy = ""
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
 resource "aws_api_gateway_rest_api" "private" {
   name = var.name
 
@@ -75,5 +85,16 @@ resource "aws_wafregional_web_acl_association" "regional" {
 
 resource "aws_wafv2_web_acl_association" "regional" {
   resource_arn = aws_api_gateway_stage.wafv2_regional.arn
+  web_acl_id   = aws_wafv2_web_acl.foo.id
+}
+
+resource "aws_api_gateway_stage" "wafv2_edge" {
+  deployment_id = aws_api_gateway_deployment.example.id
+  rest_api_id   = aws_api_gateway_rest_api.edge.id
+  stage_name    = "example"
+}
+
+resource "aws_wafv2_web_acl_association" "edge" {
+  resource_arn = aws_api_gateway_stage.wafv2_edge.arn
   web_acl_id   = aws_wafv2_web_acl.foo.id
 }

--- a/tests/terraform/graph/checks/resources/APIProtectedByWAF/main.tf
+++ b/tests/terraform/graph/checks/resources/APIProtectedByWAF/main.tf
@@ -14,7 +14,7 @@ resource "aws_api_gateway_rest_api" "edge" {
   policy = ""
 
   endpoint_configuration {
-    types = ["REGIONAL"]
+    types = ["EDGE"]
   }
 }
 


### PR DESCRIPTION
Currently only the `REGIONAL` type of API Gateway can pass `CKV2_AWS_29`. I added the `EDGE` type as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.