### PR TITLE
Detect relevant frameworks with --file

### DIFF
--- a/checkov/arm/runner.py
+++ b/checkov/arm/runner.py
@@ -18,6 +18,9 @@ ARM_POSSIBLE_ENDINGS = [".json"]
 class Runner(BaseRunner):
     check_type = CheckType.ARM
 
+    def __init__(self):
+        super().__init__(file_extensions=ARM_POSSIBLE_ENDINGS)
+
     def run(
         self,
         root_folder: str,

--- a/checkov/bicep/runner.py
+++ b/checkov/bicep/runner.py
@@ -46,8 +46,9 @@ class Runner(BaseRunner):
         source: str = "Bicep",
         graph_class: Type[BicepLocalGraph] = BicepLocalGraph,
         graph_manager: GraphManager | None = None,
-        external_registries: list[BaseRegistry] | None = None,
+        external_registries: list[BaseRegistry] | None = None
     ) -> None:
+        super().__init__(file_extensions=['.bicep'])
         self.external_registries = external_registries if external_registries else []
         self.graph_class = graph_class
         self.graph_manager: BicepGraphManager = (

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -35,8 +35,9 @@ class Runner(BaseRunner):
         source: str = "CloudFormation",
         graph_class: Type[LocalGraph] = CloudformationLocalGraph,
         graph_manager: Optional[GraphManager] = None,
-        external_registries: Optional[List[BaseRegistry]] = None,
+        external_registries: Optional[List[BaseRegistry]] = None
     ) -> None:
+        super().__init__(file_extensions=['.json', '.yml', '.yaml'])
         self.external_registries = [] if external_registries is None else external_registries
         self.graph_class = graph_class
         self.graph_manager = (

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -26,6 +26,7 @@ from checkov.common.output.report import Report, merge_reports, CheckType
 from checkov.common.runners.base_runner import BaseRunner, CHECKOV_CREATE_GRAPH
 from checkov.runner_filter import RunnerFilter
 
+
 class Runner(BaseRunner):
     check_type = CheckType.CLOUDFORMATION
 
@@ -37,7 +38,7 @@ class Runner(BaseRunner):
         graph_manager: Optional[GraphManager] = None,
         external_registries: Optional[List[BaseRegistry]] = None
     ) -> None:
-        super().__init__(file_extensions=['.json', '.yml', '.yaml'])
+        super().__init__(file_extensions=['.json', '.yml', '.yaml', '.template'])
         self.external_registries = [] if external_registries is None else external_registries
         self.graph_class = graph_class
         self.graph_manager = (

--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -48,6 +48,10 @@ class BaseRunner(ABC):
     graph_manager: GraphManager | None = None
     graph_registry: Registry | None = None
 
+    def __init__(self, file_extensions=Optional[List[str]], file_names=Optional[List[str]]):
+        self.file_extensions = file_extensions
+        self.file_names = file_names
+
     @abstractmethod
     def run(
             self,
@@ -58,6 +62,21 @@ class BaseRunner(ABC):
             collect_skip_comments: bool = True,
     ) -> Report:
         pass
+
+    def should_scan_file(self, filename: str) -> bool:
+        # runners that are always applicable can do nothing and be included
+        if not self.file_extensions and not self.file_names:
+            return True
+
+        basename = os.path.basename(filename)
+        if basename and self.file_names and basename in self.file_names:
+            return True
+
+        extension = os.path.splitext(filename)
+        if extension and self.file_extensions and extension in self.file_extensions:
+            return True
+
+        return False
 
     def set_external_data(
             self,

--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -4,7 +4,7 @@ import itertools
 import os
 import re
 from abc import ABC, abstractmethod
-from typing import List, Dict, Optional, Any, Union, TYPE_CHECKING
+from typing import List, Dict, Optional, Any, Union, TYPE_CHECKING, Iterable
 
 from checkov.common.graph.checks_infra.base_check import BaseGraphCheck
 from checkov.common.output.report import Report
@@ -48,7 +48,7 @@ class BaseRunner(ABC):
     graph_manager: GraphManager | None = None
     graph_registry: Registry | None = None
 
-    def __init__(self, file_extensions=Optional[List[str]], file_names=Optional[List[str]]):
+    def __init__(self, file_extensions: Optional[Iterable[str]] = [], file_names: Optional[Iterable[str]] = []):
         self.file_extensions = file_extensions
         self.file_names = file_names
 
@@ -72,7 +72,7 @@ class BaseRunner(ABC):
         if basename and self.file_names and basename in self.file_names:
             return True
 
-        extension = os.path.splitext(filename)
+        extension = os.path.splitext(filename)[1]
         if extension and self.file_extensions and extension in self.file_extensions:
             return True
 

--- a/checkov/common/runners/object_runner.py
+++ b/checkov/common/runners/object_runner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 from abc import abstractmethod
-from typing import Any, TYPE_CHECKING, Callable
+from typing import Any, TYPE_CHECKING, Callable, Optional, Iterable
 
 from checkov.common.output.record import Record
 from checkov.common.output.report import Report
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 
 class Runner(BaseRunner):
+
     def _load_files(
         self,
         files_to_load: list[str],

--- a/checkov/common/runners/object_runner.py
+++ b/checkov/common/runners/object_runner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 from abc import abstractmethod
-from typing import Any, TYPE_CHECKING, Callable, Optional, Iterable
+from typing import Any, TYPE_CHECKING, Callable
 
 from checkov.common.output.record import Record
 from checkov.common.output.report import Report

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -245,6 +245,12 @@ class RunnerRegistry:
             return
         self.runners = [runner for runner in self.runners if runner.check_type in self.runner_filter.framework]
 
+    def filter_runners_for_files(self, files: List[str]):
+        if not files:
+            return
+
+        self.runners = [runner for runner in self.runners if any(runner.should_scan_file(file) for file in files)]
+
     def remove_runner(self, runner: BaseRunner) -> None:
         if runner in self.runners:
             self.runners.remove(runner)

--- a/checkov/dockerfile/runner.py
+++ b/checkov/dockerfile/runner.py
@@ -16,6 +16,9 @@ from checkov.runner_filter import RunnerFilter
 class Runner(BaseRunner):
     check_type = CheckType.DOCKERFILE
 
+    def should_scan_file(self, filename: str) -> bool:
+        return is_docker_file(os.path.basename(filename))
+
     def run(self, root_folder=None, external_checks_dir=None, files=None, runner_filter=RunnerFilter(),
             collect_skip_comments=True):
         report = Report(self.check_type)

--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -26,6 +26,10 @@ class Runner(BaseRunner):
     helm_command = 'helm'
     system_deps = True
 
+    def __init__(self):
+        super().__init__()
+        self.file_names = ['Chart.yaml']
+
     @staticmethod
     def find_chart_directories(root_folder, files, excluded_paths):
         chart_directories = []

--- a/checkov/json_doc/runner.py
+++ b/checkov/json_doc/runner.py
@@ -12,6 +12,9 @@ from checkov.common.runners.object_runner import Runner as ObjectRunner
 class Runner(ObjectRunner):
     check_type = CheckType.JSON
 
+    def __init__(self):
+        super().__init__(file_extensions=['.json'])
+
     def import_registry(self) -> BaseCheckRegistry:
         from checkov.json_doc.registry import registry
         return registry

--- a/checkov/json_doc/runner.py
+++ b/checkov/json_doc/runner.py
@@ -12,7 +12,7 @@ from checkov.common.runners.object_runner import Runner as ObjectRunner
 class Runner(ObjectRunner):
     check_type = CheckType.JSON
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.file_extensions = ['.json']
 

--- a/checkov/json_doc/runner.py
+++ b/checkov/json_doc/runner.py
@@ -13,7 +13,8 @@ class Runner(ObjectRunner):
     check_type = CheckType.JSON
 
     def __init__(self):
-        super().__init__(file_extensions=['.json'])
+        super().__init__()
+        self.file_extensions = ['.json']
 
     def import_registry(self) -> BaseCheckRegistry:
         from checkov.json_doc.registry import registry

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -29,6 +29,7 @@ class Runner(BaseRunner):
         graph_manager: Optional[GraphManager] = None,
         external_registries: Optional[List[BaseRegistry]] = None
     ) -> None:
+        super().__init__(file_extensions=['.yml', '.yaml'])
         self.external_registries = [] if external_registries is None else external_registries
         self.check_type = CheckType.KUBERNETES
         self.graph_class = graph_class

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -139,6 +139,9 @@ class Runner(BaseRunner):
     templateRendererCommand = None
     target_folder_path = ''
 
+    def __init__(self):
+        super().__init__(file_names=Runner.kustomizeSupportedFileTypes)
+
     def get_k8s_target_folder_path(self):
         return self.target_folder_path
 

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -323,7 +323,10 @@ def add_parser_args(parser: ArgumentParser) -> None:
                help='IaC root directory (can not be used together with --file).')
     parser.add('--add-check', action='store_true', help="Generate a new check via CLI prompt")
     parser.add('-f', '--file', action='append',
-               help='IaC file(can not be used together with --directory)')
+               help='File to scan (can not be used together with --directory). With this option, Checkov will attempt '
+                    'to filter the runners based on the file type. For example, if you specify a ".tf" file, only the '
+                    'terraform and secrets frameworks will be included. You can further limit this (e.g., skip secrets) '
+                    'by using the --skip-framework argument.')
     parser.add('--skip-path', action='append',
                help='Path (file or directory) to skip, using regular expression logic, relative to current '
                     'working directory. Word boundaries are not implicit; i.e., specifying "dir1" will skip any '
@@ -355,12 +358,12 @@ def add_parser_args(parser: ArgumentParser) -> None:
                default=False,
                help='in case of CLI output, do not display code blocks')
     parser.add('--framework',
-               help='filter scan to run only on specific infrastructure code frameworks',
+               help='Filter scan to run only on specific infrastructure code frameworks',
                choices=checkov_runners + ["all"],
-               default=['all'],
+               default=None,
                nargs="+")
     parser.add('--skip-framework',
-               help='filter scan to skip specific infrastructure code frameworks. \n'
+               help='Filter scan to skip specific infrastructure code frameworks. \n'
                     'will be included automatically for some frameworks if system dependencies '
                     'are missing.',
                choices=checkov_runners,

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -287,6 +287,7 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
         exit_code = runner_registry.print_reports([result], config, url=url)
         return exit_code
     elif config.file:
+        runner_registry.filter_runners_for_files(config.file)
         scan_reports = runner_registry.run(external_checks_dir=external_checks_dir, files=config.file,
                                            repo_root_for_plan_enrichment=config.repo_root_for_plan_enrichment)
         if baseline:
@@ -360,7 +361,7 @@ def add_parser_args(parser: ArgumentParser) -> None:
     parser.add('--framework',
                help='Filter scan to run only on specific infrastructure code frameworks',
                choices=checkov_runners + ["all"],
-               default=None,
+               default=["all"],
                nargs="+")
     parser.add('--skip-framework',
                help='Filter scan to skip specific infrastructure code frameworks. \n'

--- a/checkov/openapi/runner.py
+++ b/checkov/openapi/runner.py
@@ -15,7 +15,8 @@ class Runner(YamlRunner, JsonRunner):
     check_type = CheckType.OPENAPI
 
     def __init__(self):
-        super().__init__(file_extensions=['.json', '.yml', '.yaml'])
+        super().__init__()
+        self.file_extensions = ['.json', '.yml', '.yaml']
 
     def import_registry(self) -> BaseCheckRegistry:
         from checkov.openapi.checks.registry import openapi_registry

--- a/checkov/openapi/runner.py
+++ b/checkov/openapi/runner.py
@@ -14,6 +14,9 @@ logger = logging.getLogger(__name__)
 class Runner(YamlRunner, JsonRunner):
     check_type = CheckType.OPENAPI
 
+    def __init__(self):
+        super().__init__(file_extensions=['.json', '.yml', '.yaml'])
+
     def import_registry(self) -> BaseCheckRegistry:
         from checkov.openapi.checks.registry import openapi_registry
         return openapi_registry

--- a/checkov/openapi/runner.py
+++ b/checkov/openapi/runner.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class Runner(YamlRunner, JsonRunner):
     check_type = CheckType.OPENAPI
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.file_extensions = ['.json', '.yml', '.yaml']
 

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -12,6 +12,7 @@ from checkov.common.bridgecrew.vulnerability_scanning.integrations.docker_image_
 from checkov.common.images.image_referencer import ImageReferencer
 from checkov.common.output.report import Report, CheckType, merge_reports
 from checkov.common.runners.base_runner import filter_ignored_paths, strtobool
+from checkov.dockerfile.utils import is_docker_file
 from checkov.runner_filter import RunnerFilter
 from checkov.sca_package.runner import Runner as PackageRunner
 
@@ -26,7 +27,9 @@ class Runner(PackageRunner):
         self._check_class = f"{image_scanner.__module__}.{image_scanner.__class__.__qualname__}"
         self.raw_report: Optional[Dict[str, Any]] = None
         self.image_referencers: Optional[ImageReferencer] = None
-        self.file_names = ['Dockerfile']
+
+    def should_scan_file(self, filename: str) -> bool:
+        return is_docker_file(os.path.basename(filename))
 
     def scan(
             self,

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -26,6 +26,7 @@ class Runner(PackageRunner):
         self._check_class = f"{image_scanner.__module__}.{image_scanner.__class__.__qualname__}"
         self.raw_report: Optional[Dict[str, Any]] = None
         self.image_referencers: Optional[ImageReferencer] = None
+        self.file_names = ['Dockerfile']
 
     def scan(
             self,

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -20,6 +20,7 @@ class Runner(PackageRunner):
     check_type = CheckType.SCA_IMAGE
 
     def __init__(self) -> None:
+        super().__init__()
         self._check_class: Optional[str] = None
         self._code_repo_path: Optional[Path] = None
         self._check_class = f"{image_scanner.__module__}.{image_scanner.__class__.__qualname__}"

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -29,7 +29,7 @@ class Runner(PackageRunner):
         self.image_referencers: Optional[ImageReferencer] = None
 
     def should_scan_file(self, filename: str) -> bool:
-        return is_docker_file(os.path.basename(filename))
+        return is_docker_file(os.path.basename(filename))  # type:ignore[no-any-return]
 
     def scan(
             self,

--- a/checkov/sca_package/runner.py
+++ b/checkov/sca_package/runner.py
@@ -25,6 +25,7 @@ SUPPORTED_PACKAGE_FILES = {
     "requirements.txt"
 }
 
+
 class Runner(BaseRunner):
     check_type = CheckType.SCA_PACKAGE
 

--- a/checkov/sca_package/runner.py
+++ b/checkov/sca_package/runner.py
@@ -29,6 +29,7 @@ class Runner(BaseRunner):
     check_type = CheckType.SCA_PACKAGE
 
     def __init__(self):
+        super().__init__(file_names=SUPPORTED_PACKAGE_FILES)
         self._check_class: Optional[str] = None
         self._code_repo_path: Optional[Path] = None
 

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -43,6 +43,9 @@ SINGLE_ITEM_SECTIONS = [
 class Runner(BaseRunner):
     check_type = CheckType.SERVERLESS
 
+    def __init__(self):
+        super().__init__(file_names=SLS_FILE_MASK)
+
     def run(self, root_folder, external_checks_dir=None, files=None, runner_filter=RunnerFilter(), collect_skip_comments=True):
         report = Report(self.check_type)
         files_list = []

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -21,6 +21,7 @@ class Runner(TerraformRunner):
 
     def __init__(self):
         super().__init__()
+        self.file_extensions = ['.json']  # override what gets set from the TF runner
         self.template_lines = {}
         self.graph_registry = get_graph_checks_registry(super().check_type)
 

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -54,6 +54,7 @@ class Runner(BaseRunner):
         graph_class: Type[LocalGraph] = TerraformLocalGraph,
         graph_manager: Optional[GraphManager] = None
     ) -> None:
+        super().__init__(file_extensions=['.tf', '.hcl'])
         self.external_registries = [] if external_registries is None else external_registries
         self.graph_class = graph_class
         self.parser = parser

--- a/checkov/yaml_doc/runner.py
+++ b/checkov/yaml_doc/runner.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 class Runner(ObjectRunner):
     check_type = CheckType.YAML
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.file_extensions = ['.yaml', '.yml']
 

--- a/checkov/yaml_doc/runner.py
+++ b/checkov/yaml_doc/runner.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
 class Runner(ObjectRunner):
     check_type = CheckType.YAML
 
+    def __init__(self):
+        super().__init__()
+        self.file_extensions = ['.yaml', '.yml']
+
     def import_registry(self) -> BaseCheckRegistry:
         from checkov.yaml_doc.registry import registry
 

--- a/tests/common/runner_registry/test_runner_registry.py
+++ b/tests/common/runner_registry/test_runner_registry.py
@@ -8,6 +8,7 @@ from checkov.cloudformation.runner import Runner as cfn_runner
 from checkov.common.runners.runner_registry import RunnerRegistry
 from checkov.common.util.banner import banner
 from checkov.kubernetes.runner import Runner as k8_runner
+from checkov.main import DEFAULT_RUNNERS
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.runner import Runner as tf_runner
 
@@ -127,6 +128,48 @@ class TestRunnerRegistry(unittest.TestCase):
         output = captured_output.getvalue()
 
         assert 'code_block' in output
+
+    def test_runner_file_filter(self):
+        runner_filter = RunnerFilter(framework=None, checks=None, skip_checks=None)
+        runner_registry = RunnerRegistry(
+            banner, runner_filter, *DEFAULT_RUNNERS
+        )
+        runner_registry.filter_runners_for_files([])
+        self.assertEqual(set(runner_registry.runners), set(DEFAULT_RUNNERS))
+
+        runner_filter = RunnerFilter(framework=['all'], checks=None, skip_checks=None)
+        runner_registry = RunnerRegistry(
+            banner, runner_filter, *DEFAULT_RUNNERS
+        )
+        runner_registry.filter_runners_for_files([])
+        self.assertEqual(set(runner_registry.runners), set(DEFAULT_RUNNERS))
+
+        runner_filter = RunnerFilter(framework=['all'], checks=None, skip_checks=None)
+        runner_registry = RunnerRegistry(
+            banner, runner_filter, *DEFAULT_RUNNERS
+        )
+        runner_registry.filter_runners_for_files(['main.tf'])
+        self.assertEqual(set(r.check_type for r in runner_registry.runners), {'terraform', 'secrets'})
+
+        runner_registry = RunnerRegistry(
+            banner, runner_filter, *DEFAULT_RUNNERS
+        )
+        runner_registry.filter_runners_for_files(['main.tf', 'requirements.txt'])
+        self.assertEqual(set(r.check_type for r in runner_registry.runners), {'terraform', 'secrets', 'sca_package'})
+
+        runner_filter = RunnerFilter(framework=['terraform'], checks=None, skip_checks=None)
+        runner_registry = RunnerRegistry(
+            banner, runner_filter, *DEFAULT_RUNNERS
+        )
+        runner_registry.filter_runners_for_files(['main.tf'])
+        self.assertEqual(set(r.check_type for r in runner_registry.runners), {'terraform'})
+
+        runner_filter = RunnerFilter(framework=['all'], skip_framework=['secrets'], checks=None, skip_checks=None)
+        runner_registry = RunnerRegistry(
+            banner, runner_filter, *DEFAULT_RUNNERS
+        )
+        runner_registry.filter_runners_for_files(['main.tf'])
+        self.assertEqual(set(r.check_type for r in runner_registry.runners), {'terraform'})
 
 
 if __name__ == "__main__":

--- a/tests/common/runner_registry/test_runner_registry.py
+++ b/tests/common/runner_registry/test_runner_registry.py
@@ -5,6 +5,7 @@ import os
 import io
 from unittest.mock import patch
 from checkov.cloudformation.runner import Runner as cfn_runner
+from checkov.common.output.report import CheckType
 from checkov.common.runners.runner_registry import RunnerRegistry
 from checkov.common.util.banner import banner
 from checkov.kubernetes.runner import Runner as k8_runner
@@ -130,21 +131,16 @@ class TestRunnerRegistry(unittest.TestCase):
         assert 'code_block' in output
 
     def test_runner_file_filter(self):
-        runner_filter = RunnerFilter(framework=None, checks=None, skip_checks=None)
+        checkov_runners = [value for attr, value in CheckType.__dict__.items() if not attr.startswith("__")]
+
+        runner_filter = RunnerFilter(framework=['all'], runners=checkov_runners)
         runner_registry = RunnerRegistry(
             banner, runner_filter, *DEFAULT_RUNNERS
         )
         runner_registry.filter_runners_for_files([])
         self.assertEqual(set(runner_registry.runners), set(DEFAULT_RUNNERS))
 
-        runner_filter = RunnerFilter(framework=['all'], checks=None, skip_checks=None)
-        runner_registry = RunnerRegistry(
-            banner, runner_filter, *DEFAULT_RUNNERS
-        )
-        runner_registry.filter_runners_for_files([])
-        self.assertEqual(set(runner_registry.runners), set(DEFAULT_RUNNERS))
-
-        runner_filter = RunnerFilter(framework=['all'], checks=None, skip_checks=None)
+        runner_filter = RunnerFilter(framework=['all'], runners=checkov_runners)
         runner_registry = RunnerRegistry(
             banner, runner_filter, *DEFAULT_RUNNERS
         )
@@ -157,19 +153,26 @@ class TestRunnerRegistry(unittest.TestCase):
         runner_registry.filter_runners_for_files(['main.tf', 'requirements.txt'])
         self.assertEqual(set(r.check_type for r in runner_registry.runners), {'terraform', 'secrets', 'sca_package'})
 
-        runner_filter = RunnerFilter(framework=['terraform'], checks=None, skip_checks=None)
+        runner_filter = RunnerFilter(framework=['terraform'], runners=checkov_runners)
         runner_registry = RunnerRegistry(
             banner, runner_filter, *DEFAULT_RUNNERS
         )
         runner_registry.filter_runners_for_files(['main.tf'])
         self.assertEqual(set(r.check_type for r in runner_registry.runners), {'terraform'})
 
-        runner_filter = RunnerFilter(framework=['all'], skip_framework=['secrets'], checks=None, skip_checks=None)
+        runner_filter = RunnerFilter(framework=['all'], skip_framework=['secrets'], runners=checkov_runners)
         runner_registry = RunnerRegistry(
             banner, runner_filter, *DEFAULT_RUNNERS
         )
         runner_registry.filter_runners_for_files(['main.tf'])
         self.assertEqual(set(r.check_type for r in runner_registry.runners), {'terraform'})
+
+        runner_filter = RunnerFilter(framework=['all'], skip_framework=['terraform'], runners=checkov_runners)
+        runner_registry = RunnerRegistry(
+            banner, runner_filter, *DEFAULT_RUNNERS
+        )
+        runner_registry.filter_runners_for_files(['main.tf'])
+        self.assertEqual(set(r.check_type for r in runner_registry.runners), {'secrets'})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

When scanning files (not directories), only run the frameworks that are relevant for the file type.

Note: In most cases, runner declare their supported files in the `super().__init__` call to `BaseRunner`. In some cases, runners have to override what gets set by their parent class. For example, Helm uses the K8s runner, but only looks for `Chart.yaml`.