### PR TITLE
Flake8 - Unused imports removed under tests directory

### DIFF
--- a/tests/common/integration_features/test_custom_policies_integration.py
+++ b/tests/common/integration_features/test_custom_policies_integration.py
@@ -1,6 +1,5 @@
 import json
 import os
-import types
 import unittest
 
 from checkov.common.bridgecrew.integration_features.features.custom_policies_integration import \

--- a/tests/common/output/test_junit_report.py
+++ b/tests/common/output/test_junit_report.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from checkov.common.models.enums import CheckResult
 from checkov.common.output.report import Report
 from checkov.common.output.record import Record
-from checkov.common.runners.runner_registry import RunnerRegistry
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.runner import Runner as TerrafomrRunner
 

--- a/tests/kubernetes/test_base_registry.py
+++ b/tests/kubernetes/test_base_registry.py
@@ -2,9 +2,7 @@ import unittest
 from typing import Optional
 
 from checkov.common.bridgecrew.severities import Severity, Severities, BcSeverities
-from checkov.common.checks.base_check import BaseCheck
 from checkov.kubernetes.checks.resource.base_registry import Registry
-from checkov.kubernetes.checks.resource.base_spec_check import BaseK8Check
 from checkov.runner_filter import RunnerFilter
 
 

--- a/tests/terraform/checks/module/registry/example_external_dir/extra_checks/ModuleCheck.py
+++ b/tests/terraform/checks/module/registry/example_external_dir/extra_checks/ModuleCheck.py
@@ -1,4 +1,4 @@
-from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.common.models.enums import CheckResult
 from checkov.terraform.checks.module.base_module_check import BaseModuleCheck
 
 

--- a/tests/terraform/checks/module/registry/test_registry.py
+++ b/tests/terraform/checks/module/registry/test_registry.py
@@ -2,8 +2,6 @@ import os
 import unittest
 from unittest.mock import patch
 
-from checkov.runner_filter import RunnerFilter
-
 
 class TestRegistry(unittest.TestCase):
 

--- a/tests/terraform/checks/resource/aws/test_LambdaXrayEnabled.py
+++ b/tests/terraform/checks/resource/aws/test_LambdaXrayEnabled.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.LambdaXrayEnabled import check
-from checkov.common.models.enums import CheckResult
 from checkov.terraform.runner import Runner
 
 

--- a/tests/terraform/checks/resource/aws/test_MWAAWorkerLogsEnabled.py
+++ b/tests/terraform/checks/resource/aws/test_MWAAWorkerLogsEnabled.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from pathlib import Path
 

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from typing import Dict, Any
 # do not remove - prevents circular import
-from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as metadata_integration
 from checkov.common.bridgecrew.severities import BcSeverities, Severities
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.runner_filter import RunnerFilter

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Dict, Any
 from unittest import mock
 
-from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as metadata_integration
 from checkov.common.bridgecrew.severities import Severities, BcSeverities
 
 from checkov.common.checks_infra.registry import get_graph_checks_registry


### PR DESCRIPTION
Hello,

Continuing with linting. Focus on Flake8 F class errors - which are mainly unused imports.

This changes all code under `./tests` to restrict the amount of file changes per PR.

**Care**
When doing this you need to be careful that fixing lint errors doesn't accidentally break something.

In 2 files I have removed an unused import but there was a note in the import section saying not to remove some imports because they prevent a circular dependency. I couldn't see how this specific unused import could be required in the test but just need to be careful on that.

There were added in: https://github.com/bridgecrewio/checkov/pull/2394
e.g https://github.com/bridgecrewio/checkov/blob/master/tests/terraform/runner/test_runner.py - not clear how the unused import prevents a cycle or which import lines are in scope.

My hope is that regression checks are ok and my assumption is alright.

**Extra**
I have just noticed that @gruebel has also been doing this specific lint class - https://github.com/bridgecrewio/checkov/pull/2842 - but hopefully this still helps.

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
