### PR TITLE
allowing scan results post request to fail and continue

### DIFF
--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -103,8 +103,10 @@ class Runner(PackageRunner):
             headers=bc_integration.get_default_headers("POST"), data=json.dumps(request_body)
         )
 
-        response.raise_for_status()
-        logging.info(f"Successfully uploaded scan results to cache with id={image_id}")
+        if response.ok:
+            logging.info(f"Successfully uploaded scan results to cache with id={image_id}")
+        else:
+            logging.info(f"Failed to upload scan results to cache with id={image_id}")
 
         # delete the report file
         output_path.unlink()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

failure on saving to cache won't throw an exception and the flow will move on
