### PR TITLE
Revert removal of async from run_scan and catch FileExistsError

### DIFF
--- a/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
@@ -70,7 +70,11 @@ class ImageScanner:
 
             if self.should_download():
                 if not os.path.exists(bridgecrew_dir):
-                    os.makedirs(bridgecrew_dir)
+                    try:
+                        os.makedirs(bridgecrew_dir)
+                    except FileExistsError:
+                        # In multi-processing, this might meet a race condition
+                        pass
                 self.cleanup_scan()
                 docker_image_scanning_integration.download_twistcli(self.twistcli_path)
         except Exception:

--- a/checkov/sca_package/scanner.py
+++ b/checkov/sca_package/scanner.py
@@ -47,7 +47,7 @@ class Scanner:
 
         return scan_results
 
-    def run_scan(self, input_path: Path) -> dict:
+    async def run_scan(self, input_path: Path) -> dict:
         logging.info(f"Start to scan package file {input_path}")
 
         request_body = {

--- a/tests/sca_package/test_scanner.py
+++ b/tests/sca_package/test_scanner.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 import responses
 
@@ -58,9 +59,8 @@ def test_run_scan(mock_bc_integration, scan_result2):
     )
 
     # when
-    result = Scanner().run_scan(
-        input_path=Path(EXAMPLES_DIR / "requirements.txt"),
-    )
+    scanner = Scanner()
+    result = asyncio.run(scanner.run_scan((Path(EXAMPLES_DIR / "requirements.txt"))))
 
     # then
     assert len(result) == len(scan_result2)
@@ -99,9 +99,7 @@ def test_run_scan_fail_on_scan(mock_bc_integration):
     )
 
     # when
-    result = Scanner().run_scan(
-        input_path=Path(EXAMPLES_DIR / "requirements.txt"),
-    )
+    result = asyncio.run(Scanner().run_scan(input_path=Path(EXAMPLES_DIR / "requirements.txt")))
 
     # then
     assert result == {}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
