### PR TITLE
GKE nodes shielded by default in v4.0.0

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GKEEnableShieldedNodes.py
+++ b/checkov/terraform/checks/resource/gcp/GKEEnableShieldedNodes.py
@@ -1,7 +1,7 @@
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
 from checkov.common.models.enums import CheckCategories
 
-class GKEEnableShieldedNodes(BaseResourceValueCheck):
+class GKEEnableShieldedNodes(BaseResourceNegativeValueCheck):
     def __init__(self):
         name = "Ensure Shielded GKE Nodes are Enabled"
         id = "CKV_GCP_71"
@@ -12,7 +12,7 @@ class GKEEnableShieldedNodes(BaseResourceValueCheck):
     def get_inspected_key(self):
         return 'enable_shielded_nodes'
 
-    def get_expected_value(self):
-        return True
+    def get_forbidden_values(self):
+        return [False]
 
 check = GKEEnableShieldedNodes()

--- a/tests/terraform/checks/resource/gcp/test_GKEEnableShieldedNodes.py
+++ b/tests/terraform/checks/resource/gcp/test_GKEEnableShieldedNodes.py
@@ -17,18 +17,18 @@ class TestGKEEnableShieldedNodes(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            'google_container_cluster.success'
+            'google_container_cluster.success1',
+            'google_container_cluster.success2'
         }
         failing_resources = {
-            'google_container_cluster.fail1',
-            'google_container_cluster.fail2' 
+            'google_container_cluster.fail'
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 1)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/terraform/checks/resource/gcp/test_GKEEnableShieldedNodes/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GKEEnableShieldedNodes/main.tf
@@ -1,5 +1,4 @@
-
-resource "google_container_cluster" "fail1" {
+resource "google_container_cluster" "success1" {
   name               = var.name
   location           = var.location
   initial_node_count = 1
@@ -73,7 +72,7 @@ resource "google_container_cluster" "fail1" {
   resource_labels = var.resource_labels
 }
 
-resource "google_container_cluster" "fail2" {
+resource "google_container_cluster" "fail" {
   name               = var.name
   location           = var.location
   initial_node_count = 1
@@ -149,7 +148,7 @@ resource "google_container_cluster" "fail2" {
   resource_labels = var.resource_labels
 }
 
-resource "google_container_cluster" "success" {
+resource "google_container_cluster" "success2" {
   name               = var.name
   location           = var.location
   initial_node_count = 1


### PR DESCRIPTION
Fix for #2341 
Not sure if there should be a check that the correct GCP provider is being used, or the assumption is that the latest is being used?
