### PR TITLE
add image details to cli output

### DIFF
--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -4,6 +4,24 @@ from abc import abstractmethod
 import docker
 
 
+class Image:
+
+    def __init__(self, file_path: str, name: str, image_id: str, start_line: int, end_line: int):
+        """
+
+        :param file_path: example: 'checkov/integration_tests/example_workflow_file/.github/workflows/vulnerable_container.yaml'
+        :param name: example: 'node:14.16'
+        :param image_id: example: 'sha256:6a353e22ce'
+        :param start_line: example: 8
+        :param end_line: example: 16
+        """
+        self.end_line = end_line
+        self.start_line = start_line
+        self.image_id = image_id
+        self.name = name
+        self.file_path = file_path
+
+
 class ImageReferencer:
 
     @abstractmethod
@@ -17,11 +35,11 @@ class ImageReferencer:
         return False
 
     @abstractmethod
-    def get_images(self, file_path: str) -> [str]:
+    def get_images(self, file_path: str) -> [Image]:
         """
         Get container images mentioned in a file
         :param file_path: File to be inspected
-        :return: List of container image short ids mentioned in the file.
+        :return: List of container images objects mentioned in the file.
         """
         return []
 

--- a/checkov/github_actions/runner.py
+++ b/checkov/github_actions/runner.py
@@ -1,6 +1,6 @@
 import os
 
-from checkov.common.images.image_referencer import ImageReferencer
+from checkov.common.images.image_referencer import ImageReferencer, Image
 from checkov.common.output.report import CheckType
 from checkov.github_actions.checks.registry import registry
 from checkov.yaml_doc.runner import Runner as YamlRunner
@@ -52,8 +52,7 @@ class Runner(YamlRunner, ImageReferencer):
         #       options: --cpus 1
         Source: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-credentials-for-a-container-registry
 
-        :return: List of container image short ids mentioned in the file.
-        Example return value for a file with node:14.16 image: ['sha256:6a353e22ce']
+        :return: List of container image classes ids mentioned in the file.
         """
 
         images = set()
@@ -64,6 +63,8 @@ class Runner(YamlRunner, ImageReferencer):
             if isinstance(job_object, dict):
                 container = job_object.get("container", {})
                 image = None
+                start_line = container.get('__startline__', 0)
+                end_line = container.get('__endline__', 0)
                 if isinstance(container, dict):
                     image = container.get("image", "")
                 elif isinstance(container, str):
@@ -71,6 +72,8 @@ class Runner(YamlRunner, ImageReferencer):
                 if image:
                     image_id = self.pull_image(image)
                     if image_id:
-                        images.add(image_id)
+                        image_obj = Image(file_path=file_path, name=image, image_id=image_id, start_line=start_line,
+                                          end_line=end_line)
+                        images.add(image_obj)
 
         return images

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -188,7 +188,7 @@ class Runner(PackageRunner):
 
     def get_image_id_report(self, dockerfile_path: str, image_id: str, runner_filter: RunnerFilter) -> Report:
         """
-        THIS METHOD ONLY EXISTS FOR BACKWARD COMPATABILITY WITH IMAGE THAT COMES FROM CLI PARAMETER
+        THIS METHOD HANDLES CUSTOM IMAGE SCANNING THAT COMES DIRECTLY FROM CLI PARAMETERS
         """
         report = Report(self.check_type)
 

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -8,17 +8,17 @@ from typing import Optional, List, Union, Dict, Any
 import requests
 
 from checkov.common.bridgecrew.platform_integration import bc_integration
+from checkov.common.bridgecrew.platform_key import bridgecrew_dir
 from checkov.common.bridgecrew.vulnerability_scanning.image_scanner import image_scanner, TWISTCLI_FILE_NAME
 from checkov.common.bridgecrew.vulnerability_scanning.integrations.docker_image_scanning import \
     docker_image_scanning_integration
-from checkov.common.images.image_referencer import ImageReferencer
+from checkov.common.images.image_referencer import ImageReferencer, Image
 from checkov.common.output.report import Report, CheckType, merge_reports
 from checkov.common.runners.base_runner import filter_ignored_paths, strtobool
+from checkov.common.util.file_utils import compress_file_gzip_base64
 from checkov.dockerfile.utils import is_docker_file
 from checkov.runner_filter import RunnerFilter
 from checkov.sca_package.runner import Runner as PackageRunner
-from checkov.common.util.file_utils import compress_file_gzip_base64
-from checkov.common.bridgecrew.platform_key import bridgecrew_dir
 
 
 class Runner(PackageRunner):
@@ -94,9 +94,9 @@ class Runner(PackageRunner):
         image_id_sha = f"sha256:{image_id}" if not image_id.startswith("sha256:") else image_id
 
         request_body = {
-                "compressedResult": compress_file_gzip_base64(str(output_path)),
-                "compressionMethod": "gzip",
-                "id": image_id_sha
+            "compressedResult": compress_file_gzip_base64(str(output_path)),
+            "compressionMethod": "gzip",
+            "id": image_id_sha
         }
         response = requests.request(
             "POST", f"{self.base_url}/api/v1/vulnerabilities/scan-results",
@@ -127,7 +127,7 @@ class Runner(PackageRunner):
         if "dockerfile_path" in kwargs and "image_id" in kwargs:
             dockerfile_path = kwargs['dockerfile_path']
             image_id = kwargs['image_id']
-            return self.get_image_report(dockerfile_path, image_id, runner_filter)
+            return self.get_image_id_report(dockerfile_path, image_id, runner_filter)
 
         if not strtobool(os.getenv("CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING", "False")):
             # experimental flag on running image referencers
@@ -162,17 +162,33 @@ class Runner(PackageRunner):
             if image_referencer.is_workflow_file(abs_fname):
                 images = image_referencer.get_images(file_path=abs_fname)
                 for image in images:
-                    image_report = self.get_image_report(dockerfile_path=abs_fname, image_id=image,
+                    image_report = self.get_image_report(dockerfile_path=abs_fname, image=image,
                                                          runner_filter=runner_filter)
                     merge_reports(report, image_report)
 
-    def get_image_report(self, dockerfile_path: str, image_id: str, runner_filter: RunnerFilter) -> Report:
+    def get_image_report(self, dockerfile_path: str, image: Image, runner_filter: RunnerFilter) -> Report:
         """
 
         :param dockerfile_path: path of a file that might contain a container image
-        :param image_id: sha of an image
+        :param image: Image object
         :param runner_filter:
         :return: vulnerability report
+        """
+        report = Report(self.check_type)
+
+        scan_result = self.scan(image.image_id, dockerfile_path, runner_filter)
+        if scan_result is None:
+            return report
+        self.raw_report = scan_result
+        result = scan_result.get('results', [{}])[0]
+        vulnerabilities = result.get("vulnerabilities") or []
+        self.parse_vulns_to_records(report, result, f"{dockerfile_path} ({image.name} lines:{image.start_line}-{image.end_line} ({image.image_id}))", runner_filter, vulnerabilities,
+                                    file_abs_path=os.path.abspath(dockerfile_path))
+        return report
+
+    def get_image_id_report(self, dockerfile_path: str, image_id: str, runner_filter: RunnerFilter) -> Report:
+        """
+        THIS METHOD ONLY EXISTS FOR BACKWARD COMPATABILITY WITH IMAGE THAT COMES FROM CLI PARAMETER
         """
         report = Report(self.check_type)
 


### PR DESCRIPTION
Now image name and line numbers are printed alongside the sha. 

Thanks @eurogig for suggesting it to improve developer experience

```sh 
       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By bridgecrew.io | version: 2.0.1100 

sca_image scan results:

Passed checks: 0, Failed checks: 1061, Skipped checks: 0

	//Users/barak/Documents/dev/bridgecrew/checkov3/integration_tests/example_workflow_file/.github/workflows/vulnerable_container.yaml (node:14.1 lines:18-26 (sha256:a511eb5c14))
	┌────────────────────┬────────────────────┬────────────────────┬────────────────────┬────────────────────┬────────────────────┐
	│ Total CVEs: 681    │ critical: 48       │ high: 200          │ medium: 198        │ low: 235           │ skipped: 0         │
	├────────────────────┴────────────────────┴────────────────────┴────────────────────┴────────────────────┴────────────────────┤
	├────────────────────┬────────────────────┬────────────────────┬────────────────────┬────────────────────┬────────────────────┤
	│ Package            │ CVE ID             │ Severity           │ Current version    │ Fixed version      │ Compliant version  │
	├────────────────────┼────────────────────┼────────────────────┼────────────────────┼────────────────────┼────────────────────┤
	│ expat              │ CVE-2022-25315     │ critical           │ 2.2.0-2+deb9u3     │ 2.2.0.post2+deb9u5 │ 2.2.0.post2+deb9u5 │
	│                    │ CVE-2022-25236     │ critical           │                    │ 2.2.0.post2+deb9u5 │                 
```