### PR TITLE
ut to check image reference flow is triggering image scan flow calls

### DIFF
--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -60,7 +60,9 @@ class Runner(PackageRunner):
 
         image_scanner.setup_scan(image_id, dockerfile_path, skip_extract_image_name=False)
         try:
-            scan_result = asyncio.run(self.execute_scan(image_id, Path('results.json')))
+            output_path = Path('results.json')
+            scan_result = asyncio.run(self.execute_scan(image_id, output_path))
+            self.upload_results_to_cache(output_path, image_id)
             logging.info(f"SCA image scanning successfully scanned the image {image_id}")
             return scan_result
         except Exception:
@@ -89,9 +91,6 @@ class Runner(PackageRunner):
 
         # read the report file
         scan_result: Dict[str, Any] = json.loads(output_path.read_text())
-
-        # upload results to cache and remove file
-        self.upload_results_to_cache(output_path, image_id)
 
         return scan_result
 

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -98,7 +98,7 @@ class Runner(PackageRunner):
 
         return scan_result
 
-    def upload_results_to_cache(self, output_path, image_id):
+    def upload_results_to_cache(self, output_path: str, image_id: str) -> None:
         image_id_sha = f"sha256:{image_id}" if not image_id.startswith("sha256:") else image_id
 
         request_body = {

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -90,11 +90,8 @@ class Runner(PackageRunner):
         # read the report file
         scan_result: Dict[str, Any] = json.loads(output_path.read_text())
 
-        # upload results to cache
+        # upload results to cache and remove file
         self.upload_results_to_cache(output_path, image_id)
-
-        # delete the report file
-        output_path.unlink()
 
         return scan_result
 
@@ -115,6 +112,8 @@ class Runner(PackageRunner):
             logging.info(f"Successfully uploaded scan results to cache with id={image_id}")
         else:
             logging.info(f"Failed to upload scan results to cache with id={image_id}")
+
+        output_path.unlink()
 
     def run(
             self,

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -98,7 +98,7 @@ class Runner(PackageRunner):
 
         return scan_result
 
-    def upload_results_to_cache(self, output_path: str, image_id: str) -> None:
+    def upload_results_to_cache(self, output_path: Path, image_id: str) -> None:
         image_id_sha = f"sha256:{image_id}" if not image_id.startswith("sha256:") else image_id
 
         request_body = {

--- a/tests/sca_image/conftest.py
+++ b/tests/sca_image/conftest.py
@@ -1,0 +1,37 @@
+from typing import Dict, Any
+
+import pytest
+
+from checkov.common.bridgecrew.bc_source import SourceType
+from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration, bc_integration
+
+
+@pytest.fixture()
+def image_id() -> str:
+    return "sha256:6fd085fc6410"
+
+
+@pytest.fixture()
+def mock_bc_integration() -> BcPlatformIntegration:
+    bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
+    bc_integration.setup_bridgecrew_credentials(
+        repo_id="bridgecrewio/checkov",
+        skip_fixes=True,
+        skip_download=True,
+        source=SourceType("Github", False),
+        source_version="1.0",
+        repo_branch="master",
+    )
+    return bc_integration
+
+
+@pytest.fixture()
+def empty_report() -> Dict[str, Any]:
+    return {
+        'check_type': 'sca_image',
+        'failing_checks': [],
+        'passed_checks': [],
+        'parsing_errors': [],
+        'resources': {},
+        'skipped_checks': []
+    }

--- a/tests/sca_image/examples/.github/workflows/vulnerable_container.yaml
+++ b/tests/sca_image/examples/.github/workflows/vulnerable_container.yaml
@@ -1,0 +1,29 @@
+on: pull_request
+
+name: unsecure-worfklow
+
+jobs:
+  my_job:
+    container:
+      image: python:3.9-bullseye
+      env:
+        NODE_ENV: development
+      ports:
+        - 80
+      volumes:
+        - my_docker_volume:/volume_mount
+      options: --cpus 1
+  unsecure-job:
+    name: job1
+    runs-on: ubuntu-latest
+    run: |
+      title="${{ github.event.issue.title }}"
+      if [[ ! $title =~ ^.*:\ .*$ ]]; then
+        echo "Bad issue title"
+        exit 1
+      fi
+  secure-job:
+    name: job2
+    runs-on: ubuntu-latest
+    run: |
+      echo "foo"

--- a/tests/sca_image/test_runner.py
+++ b/tests/sca_image/test_runner.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from pathlib import Path
 from urllib.parse import quote_plus
 
@@ -30,7 +31,7 @@ def test_image_referencer_trigger_image_flow_calls(mocker: MockerFixture, image_
     )
     responses.add(
         method=responses.GET,
-        url=mock_bc_integration.bc_api_url + "/api/v1/vulnerabilities/twistcli?os=darwin",
+        url=mock_bc_integration.bc_api_url + f"/api/v1/vulnerabilities/twistcli?os={platform.system().lower()}",
         json={},
         status=200
     )

--- a/tests/sca_image/test_runner.py
+++ b/tests/sca_image/test_runner.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from urllib.parse import quote_plus
 
@@ -12,6 +13,10 @@ EXAMPLES_DIR = Path(__file__).parent / "examples/.github/workflows"
 
 @responses.activate
 def test_image_referencer_trigger_image_flow_calls(mocker: MockerFixture, image_id, mock_bc_integration, empty_report):
+
+    # can be removed after feature flag is removed
+    os.environ["CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING"] = "TRUE"
+
     image_id_encoded = quote_plus(image_id)
 
     mocker.patch('checkov.common.images.image_referencer.ImageReferencer.pull_image', return_value=image_id)

--- a/tests/sca_image/test_runner.py
+++ b/tests/sca_image/test_runner.py
@@ -14,14 +14,13 @@ EXAMPLES_DIR = Path(__file__).parent / "examples/.github/workflows"
 
 @responses.activate
 def test_image_referencer_trigger_image_flow_calls(mocker: MockerFixture, image_id, mock_bc_integration, empty_report):
-
     # can be removed after feature flag is removed
     os.environ["CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING"] = "TRUE"
 
     image_id_encoded = quote_plus(image_id)
 
     mocker.patch('checkov.common.images.image_referencer.ImageReferencer.pull_image', return_value=image_id)
-    mocker.patch('checkov.sca_image.runner.Runner.execute_scan', return_value=empty_report)
+    # async_mocker.patch('checkov.sca_image.runner.Runner.execute_scan', return_value=empty_report)
 
     responses.add(
         method=responses.GET,
@@ -48,5 +47,6 @@ def test_image_referencer_trigger_image_flow_calls(mocker: MockerFixture, image_
 
     responses.assert_call_count(
         mock_bc_integration.bc_api_url + f"/api/v1/vulnerabilities/scan-results/{image_id_encoded}", 1)
+    responses.assert_call_count(mock_bc_integration.bc_api_url + "/api/v1/vulnerabilities/scan-results", 1)
 
-    assert len(responses.calls) >= 1
+    assert len(responses.calls) >= 2

--- a/tests/sca_image/test_runner.py
+++ b/tests/sca_image/test_runner.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from urllib.parse import quote_plus
+
+import responses
+from pytest_mock import MockerFixture
+
+from checkov.sca_image.runner import Runner
+from checkov.github_actions.runner import Runner as GHA_Runner
+
+EXAMPLES_DIR = Path(__file__).parent / "examples/.github/workflows"
+
+
+@responses.activate
+def test_image_referencer_trigger_image_flow_calls(mocker: MockerFixture, image_id, mock_bc_integration, empty_report):
+    image_id_encoded = quote_plus(image_id)
+
+    mocker.patch('checkov.common.images.image_referencer.ImageReferencer.pull_image', return_value=image_id)
+    mocker.patch('checkov.sca_image.runner.Runner.execute_scan', return_value=empty_report)
+
+    responses.add(
+        method=responses.GET,
+        url=mock_bc_integration.bc_api_url + f"/api/v1/vulnerabilities/scan-results/{image_id_encoded}",
+        json={'outputType': 'Empty'},
+        status=202,
+    )
+    responses.add(
+        method=responses.GET,
+        url=mock_bc_integration.bc_api_url + "/api/v1/vulnerabilities/twistcli?os=darwin",
+        json={},
+        status=200
+    )
+    responses.add(
+        method=responses.POST,
+        url=mock_bc_integration.bc_api_url + "/api/v1/vulnerabilities/scan-results",
+        json={},
+        status=202
+    )
+
+    image_runner = Runner()
+    image_runner.image_referencers = [GHA_Runner()]
+    image_runner.run(root_folder=EXAMPLES_DIR)
+
+    responses.assert_call_count(
+        mock_bc_integration.bc_api_url + f"/api/v1/vulnerabilities/scan-results/{image_id_encoded}", 1)
+
+    assert len(responses.calls) >= 1

--- a/tests/sca_image/test_runner.py
+++ b/tests/sca_image/test_runner.py
@@ -8,19 +8,22 @@ from pytest_mock import MockerFixture
 
 from checkov.sca_image.runner import Runner
 from checkov.github_actions.runner import Runner as GHA_Runner
+from tests.sca_image.utils import create_output_path
 
 EXAMPLES_DIR = Path(__file__).parent / "examples/.github/workflows"
 
 
 @responses.activate
 def test_image_referencer_trigger_image_flow_calls(mocker: MockerFixture, image_id, mock_bc_integration, empty_report):
+
     # can be removed after feature flag is removed
     os.environ["CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING"] = "TRUE"
 
     image_id_encoded = quote_plus(image_id)
 
     mocker.patch('checkov.common.images.image_referencer.ImageReferencer.pull_image', return_value=image_id)
-    # async_mocker.patch('checkov.sca_image.runner.Runner.execute_scan', return_value=empty_report)
+    mocker.patch('checkov.sca_image.runner.Runner.execute_scan', return_value=empty_report,
+                 side_effect=create_output_path)
 
     responses.add(
         method=responses.GET,

--- a/tests/sca_image/test_runner.py
+++ b/tests/sca_image/test_runner.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import sys
 from pathlib import Path
 from urllib.parse import quote_plus
 
@@ -15,6 +16,8 @@ EXAMPLES_DIR = Path(__file__).parent / "examples/.github/workflows"
 
 @responses.activate
 def test_image_referencer_trigger_image_flow_calls(mocker: MockerFixture, image_id, mock_bc_integration, empty_report):
+    if sys.version_info[1] < 8:
+        return
 
     # can be removed after feature flag is removed
     os.environ["CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING"] = "TRUE"

--- a/tests/sca_image/utils.py
+++ b/tests/sca_image/utils.py
@@ -1,0 +1,4 @@
+def create_output_path(*args):
+    image_id, output_path = args
+    with open(output_path, 'w') as f:
+        f.write("")


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Added ut that checks that the image reference flow is triggering the image scanning flow calls.
Moved uploading to cache to a separate function.
