### PR TITLE
Pass module to platform for policy filtering

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -416,6 +416,9 @@ class BcPlatformIntegration(object):
         else:
             self.get_public_run_config()
 
+    def get_run_config_url(self):
+        return f'{self.platform_run_config_url}?module={"bc" if self.is_bc_token(self.bc_api_key) else "pc"}'
+
     def get_customer_run_config(self) -> None:
         if self.skip_download is True:
             logging.debug("Skipping customer run config API call")
@@ -429,7 +432,9 @@ class BcPlatformIntegration(object):
             headers = merge_dicts(get_auth_header(token), get_default_get_headers(self.bc_source, self.bc_source_version))
             if not self.http:
                 self.setup_http_manager()
-            request = self.http.request("GET", self.platform_run_config_url, headers=headers)
+            url = self.get_run_config_url()
+            logging.debug(f'Platform run config URL: {url}')
+            request = self.http.request("GET", url, headers=headers)
             self.customer_run_config_response = json.loads(request.data.decode("utf8"))
             logging.debug("Got customer run config from Bridgecrew BE")
         except Exception:

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -92,6 +92,13 @@ class TestBCApiUrl(unittest.TestCase):
         self.assertTrue(get_source_type('xyz').upload_results)
         self.assertTrue(get_source_type(None).upload_results)
 
+    def test_run_config_url(self):
+        instance = BcPlatformIntegration()
+        instance.bc_api_key = '00000000-0000-0000-0000-000000000000'
+        self.assertTrue(instance.get_run_config_url().endswith('/runConfiguration?module=bc'))
+        instance.bc_api_key = '00000000-0000-0000-0000-000000000000::1234=='
+        self.assertTrue(instance.get_run_config_url().endswith('/runConfiguration?module=pc'))
+
 
 def mock_customer_run_config():
     return {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Uses the `module` parameter of the run config endpoint to get the appropriate policy set based on token type.

The platform side of this is also live.