### PR TITLE
Remove incorrect RBAC wildcard

### DIFF
--- a/checkov/kubernetes/checks/resource/base_rbac_check.py
+++ b/checkov/kubernetes/checks/resource/base_rbac_check.py
@@ -80,4 +80,4 @@ class BaseRbacK8sCheck(BaseK8Check):
 
     # Check if value is a K8s RBAC wildcard
     def is_wildcard(self, value: str) -> bool:
-        return value == "*" or value == "*/*"
+        return value == "*"

--- a/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-failed-2.yaml
+++ b/tests/kubernetes/checks/example_RbacApproveCertificateSigningRequests/clusterrole-failed-2.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: test
 rules:
 - apiGroups: ["certificates.k8s.io"]
-  resources: ["*/*"]
+  resources: ["*"]
   verbs: ["*"]


### PR DESCRIPTION
K8s RBAC doesn't consider `*/*` as a wildcard, only `*` or `*/<subresource>` (source: https://github.com/kubernetes/kubernetes/blob/acb85012ba9c5e9f723971ef706f396d9629e93e/pkg/apis/rbac/types.go#L45)

Don't check for  `*/*`.