### PR TITLE
fixed file_path for bicep report

### DIFF
--- a/checkov/bicep/runner.py
+++ b/checkov/bicep/runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import logging
 from pathlib import Path
 from typing import cast, Type, TYPE_CHECKING, Any
@@ -59,6 +60,7 @@ class Runner(BaseRunner):
         self.context: dict[str, dict[str, Any]] = {}
         self.definitions: dict[Path, BicepJson] = {}
         self.definitions_raw: dict[Path, list[tuple[int, str]]] = {}
+        self.root_folder: Path | None = None
 
     def run(
         self,
@@ -69,6 +71,7 @@ class Runner(BaseRunner):
         collect_skip_comments: bool = True,
     ) -> Report:
         report = Report(Runner.check_type)
+        self.root_folder = root_folder
 
         if not self.context or not self.definitions:
             file_paths = get_scannable_file_paths(root_folder=root_folder, files=files)
@@ -148,7 +151,7 @@ class Runner(BaseRunner):
                                     check_name=check.name,
                                     check_result=check_result,
                                     code_block=file_code_lines[start_line - 1 : end_line],
-                                    file_path=str(cleaned_path),
+                                    file_path=self.extract_file_path_from_abs_path(cleaned_path),
                                     file_line_range=[start_line, end_line],
                                     resource=resource_id,
                                     check_class=check.__class__.__module__,
@@ -158,6 +161,9 @@ class Runner(BaseRunner):
                                 )
                                 record.set_guideline(check.guideline)
                                 report.add_record(record=record)
+
+    def extract_file_path_from_abs_path(self, path: Path) -> str:
+        return f"/{os.path.relpath(str(path), self.root_folder)}"
 
     def add_graph_check_results(self, report: Report, runner_filter: RunnerFilter) -> None:
         """Adds YAML check results to given report"""

--- a/checkov/bicep/runner.py
+++ b/checkov/bicep/runner.py
@@ -60,7 +60,7 @@ class Runner(BaseRunner):
         self.context: dict[str, dict[str, Any]] = {}
         self.definitions: dict[Path, BicepJson] = {}
         self.definitions_raw: dict[Path, list[tuple[int, str]]] = {}
-        self.root_folder: Path | None = None
+        self.root_folder: str | Path | None = None
 
     def run(
         self,

--- a/checkov/bicep/runner.py
+++ b/checkov/bicep/runner.py
@@ -163,7 +163,7 @@ class Runner(BaseRunner):
                                 report.add_record(record=record)
 
     def extract_file_path_from_abs_path(self, path: Path) -> str:
-        return f"/{os.path.relpath(str(path), self.root_folder)}"
+        return f"/{os.path.relpath(path, self.root_folder)}"
 
     def add_graph_check_results(self, report: Report, runner_filter: RunnerFilter) -> None:
         """Adds YAML check results to given report"""


### PR DESCRIPTION
Strip `file_path` attribute in bicep report from root folder

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
