### PR TITLE
K8 root container checks refactor and safeguard

### DIFF
--- a/checkov/kubernetes/checks/resource/base_root_container_check.py
+++ b/checkov/kubernetes/checks/resource/base_root_container_check.py
@@ -35,12 +35,8 @@ class BaseK8sRootContainerCheck(BaseK8Check):
             if "spec" in conf:
                 spec = conf["spec"]
         elif conf['kind'] == 'CronJob':
-            if "spec" in conf:
-                if "jobTemplate" in conf["spec"]:
-                    if "spec" in conf["spec"]["jobTemplate"]:
-                        if "template" in conf["spec"]["jobTemplate"]["spec"]:
-                            if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
-                                spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+            if "spec" in conf and "jobTemplate" in conf["spec"] and "spec" in conf["spec"]["jobTemplate"] and "template" in conf["spec"]["jobTemplate"]["spec"] and "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
+                spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
             inner_spec = self.get_inner_entry(conf, "spec")
             spec = inner_spec if inner_spec else spec
@@ -48,12 +44,11 @@ class BaseK8sRootContainerCheck(BaseK8Check):
 
     @staticmethod
     def check_runAsNonRoot(spec):
-        if spec.get("securityContext"):
-            if "runAsNonRoot" in spec["securityContext"]:
-                if spec["securityContext"]["runAsNonRoot"]:
-                    return "PASSED"
-                else:
-                    return "FAILED"
+        if spec.get("securityContext") and "runAsNonRoot" in spec["securityContext"]:
+            if spec["securityContext"]["runAsNonRoot"]:
+                return "PASSED"
+            else:
+                return "FAILED"
         return "ABSENT"
 
     @staticmethod

--- a/checkov/kubernetes/checks/resource/base_root_container_check.py
+++ b/checkov/kubernetes/checks/resource/base_root_container_check.py
@@ -1,0 +1,67 @@
+from abc import abstractmethod
+from typing import Dict, Any, Optional
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.common.multi_signature import multi_signature
+from checkov.kubernetes.checks.resource.base_spec_check import BaseK8Check
+from checkov.kubernetes.checks.resource.registry import registry
+
+
+class BaseK8sRootContainerCheck(BaseK8Check):
+
+    def __init__(
+            self,
+            name: str,
+            id: str,
+            guideline: Optional[str] = None,
+    ) -> None:
+        supported_kind = ('Pod', 'Deployment', 'DaemonSet', 'StatefulSet', 'ReplicaSet', 'ReplicationController',
+                          'Job', 'CronJob')
+        categories = (CheckCategories.KUBERNETES,)
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind,
+                         guideline=guideline)
+        registry.register(self)
+
+    @multi_signature()
+    @abstractmethod
+    def scan_spec_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
+        """Return result of Kubernetes rooot container check."""
+        raise NotImplementedError()
+
+    def extract_spec(self, conf: Dict[str, Any]) -> Dict:
+        spec = {}
+
+        if conf['kind'] == 'Pod':
+            if "spec" in conf:
+                spec = conf["spec"]
+        elif conf['kind'] == 'CronJob':
+            if "spec" in conf:
+                if "jobTemplate" in conf["spec"]:
+                    if "spec" in conf["spec"]["jobTemplate"]:
+                        if "template" in conf["spec"]["jobTemplate"]["spec"]:
+                            if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
+                                spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+        else:
+            inner_spec = self.get_inner_entry(conf, "spec")
+            spec = inner_spec if inner_spec else spec
+        return spec
+
+    @staticmethod
+    def check_runAsNonRoot(spec):
+        if spec.get("securityContext"):
+            if "runAsNonRoot" in spec["securityContext"]:
+                if spec["securityContext"]["runAsNonRoot"]:
+                    return "PASSED"
+                else:
+                    return "FAILED"
+        return "ABSENT"
+
+    @staticmethod
+    def check_runAsUser(spec: Dict[str, Any], uid: int) -> str:
+        if spec.get("securityContext") and isinstance(spec.get("securityContext"), dict):
+            if "runAsUser" in spec["securityContext"]:
+                if isinstance(spec["securityContext"]["runAsUser"], int) and spec["securityContext"]["runAsUser"] >= uid:
+                    return "PASSED"
+                else:
+                    return "FAILED"
+        return "ABSENT"

--- a/checkov/kubernetes/checks/resource/base_root_container_check.py
+++ b/checkov/kubernetes/checks/resource/base_root_container_check.py
@@ -53,10 +53,9 @@ class BaseK8sRootContainerCheck(BaseK8Check):
 
     @staticmethod
     def check_runAsUser(spec: Dict[str, Any], uid: int) -> str:
-        if spec.get("securityContext") and isinstance(spec.get("securityContext"), dict):
-            if "runAsUser" in spec["securityContext"]:
-                if isinstance(spec["securityContext"]["runAsUser"], int) and spec["securityContext"]["runAsUser"] >= uid:
-                    return "PASSED"
-                else:
-                    return "FAILED"
+        if spec.get("securityContext") and isinstance(spec.get("securityContext"), dict) and "runAsUser" in spec["securityContext"]:
+            if isinstance(spec["securityContext"]["runAsUser"], int) and spec["securityContext"]["runAsUser"] >= uid:
+                return "PASSED"
+            else:
+                return "FAILED"
         return "ABSENT"

--- a/checkov/kubernetes/checks/resource/k8s/RootContainers.py
+++ b/checkov/kubernetes/checks/resource/k8s/RootContainers.py
@@ -1,8 +1,8 @@
-from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.kubernetes.checks.resource.base_spec_check import BaseK8Check
+from checkov.common.models.enums import CheckResult
+from checkov.kubernetes.checks.resource.base_root_container_check import BaseK8sRootContainerCheck
 
 
-class RootContainers(BaseK8Check):
+class RootContainers(BaseK8sRootContainerCheck):
     def __init__(self):
         # CIS-1.3 1.7.6
         # CIS-1.5 5.2.6
@@ -12,41 +12,20 @@ class RootContainers(BaseK8Check):
         # Location: CronJob.spec.jobTemplate.spec.template.spec.securityContext.runAsUser / runAsNonRoot
         # Location: *.spec.template.spec.securityContext.runAsUser / runAsNonRoot
         id = "CKV_K8S_23"
-        supported_kind = ('Pod', 'Deployment', 'DaemonSet', 'StatefulSet', 'ReplicaSet', 'ReplicationController',
-                          'Job', 'CronJob')
-        categories = (CheckCategories.KUBERNETES,)
-        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
+        super().__init__(name=name, id=id)
 
     def scan_spec_conf(self, conf):
-        spec = {}
-
-        if conf['kind'] == 'Pod':
-            if "spec" in conf:
-                spec = conf["spec"]
-        elif conf['kind'] == 'CronJob':
-            if "spec" in conf:
-                if "jobTemplate" in conf["spec"]:
-                    if "spec" in conf["spec"]["jobTemplate"]:
-                        if "template" in conf["spec"]["jobTemplate"]["spec"]:
-                            if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
-                                spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
-        else:
-            inner_spec = self.get_inner_entry(conf, "spec")
-            spec = inner_spec if inner_spec else spec
+        spec = self.extract_spec(conf)
 
         # Collect results
         if spec:
-            results = {}
-            results["pod"] = {}
-            results["container"] = []
-            results["pod"]["runAsNonRoot"] = check_runAsNonRoot(spec)
-            results["pod"]["runAsUser"] = check_runAsUser(spec)
+            results = {"pod": {}, "container": []}
+            results["pod"]["runAsNonRoot"] = self.check_runAsNonRoot(spec)
+            results["pod"]["runAsUser"] = self.check_runAsUser(spec, 1)
 
             if spec.get("containers"):
                 for c in spec["containers"]:
-                    cresults = {}
-                    cresults["runAsNonRoot"] = check_runAsNonRoot(c)
-                    cresults["runAsUser"] = check_runAsUser(c)
+                    cresults = {"runAsNonRoot": self.check_runAsNonRoot(c), "runAsUser": self.check_runAsUser(c, 1)}
                     results["container"].append(cresults)
 
             # Evaluate pass / fail
@@ -88,25 +67,3 @@ class RootContainers(BaseK8Check):
 
 
 check = RootContainers()
-
-
-def check_runAsNonRoot(spec):
-    if spec.get("securityContext"):
-        if "runAsNonRoot" in spec["securityContext"]:
-            if spec["securityContext"]["runAsNonRoot"]:
-                return "PASSED"
-            else:
-                return "FAILED"
-    return "ABSENT"
-
-
-def check_runAsUser(spec):
-    if spec.get("securityContext"):
-        if "runAsUser" in spec["securityContext"]:
-            if not isinstance(spec["securityContext"], dict):
-                return "FAILED"
-            if isinstance(spec["securityContext"]["runAsUser"], int) and spec["securityContext"]["runAsUser"] > 0:
-                return "PASSED"
-            else:
-                return "FAILED"
-    return "ABSENT"

--- a/checkov/kubernetes/checks/resource/k8s/RootContainersHighUID.py
+++ b/checkov/kubernetes/checks/resource/k8s/RootContainersHighUID.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.kubernetes.checks.resource.base_spec_check import BaseK8Check
+from checkov.common.models.enums import CheckResult
+from checkov.kubernetes.checks.resource.base_root_container_check import BaseK8sRootContainerCheck
 
 
-class RootContainersHighUID(BaseK8Check):
+class RootContainersHighUID(BaseK8sRootContainerCheck):
     def __init__(self) -> None:
         name = "Containers should run as a high UID to avoid host conflict"
         # runAsUser should be >= 10000 at pod spec or container level
@@ -14,47 +14,19 @@ class RootContainersHighUID(BaseK8Check):
         # Location: CronJob.spec.jobTemplate.spec.template.spec.securityContext.runAsUser
         # Location: *.spec.template.spec.securityContext.runAsUser
         id = "CKV_K8S_40"
-        supported_kind = (
-            "Pod",
-            "Deployment",
-            "DaemonSet",
-            "StatefulSet",
-            "ReplicaSet",
-            "ReplicationController",
-            "Job",
-            "CronJob",
-        )
-        categories = (CheckCategories.KUBERNETES,)
-        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
+        super().__init__(name=name, id=id)
 
     def scan_spec_conf(self, conf: dict[str, Any]) -> CheckResult:
-        spec = {}
-
-        if conf["kind"] == "Pod":
-            if "spec" in conf:
-                spec = conf["spec"]
-        elif conf["kind"] == "CronJob":
-            if "spec" in conf:
-                if "jobTemplate" in conf["spec"]:
-                    if "spec" in conf["spec"]["jobTemplate"]:
-                        if "template" in conf["spec"]["jobTemplate"]["spec"]:
-                            if "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
-                                spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
-        else:
-            inner_spec = self.get_inner_entry(conf, "spec")
-            spec = inner_spec if inner_spec else spec
+        spec = self.extract_spec(conf)
 
         # Collect results
         if spec:
-            results = {}
-            results["pod"] = {}
-            results["container"] = []
-            results["pod"]["runAsUser"] = check_runAsUser(spec)
+            results = {"pod": {}, "container": []}
+            results["pod"]["runAsUser"] = self.check_runAsUser(spec, 10000)
 
             if spec.get("containers"):
                 for c in spec["containers"]:
-                    cresults = {}
-                    cresults["runAsUser"] = check_runAsUser(c)
+                    cresults = {"runAsUser": self.check_runAsUser(c, 10000)}
                     results["container"].append(cresults)
 
             # Evaluate pass / fail - Container values override Pod values
@@ -95,13 +67,3 @@ class RootContainersHighUID(BaseK8Check):
 
 
 check = RootContainersHighUID()
-
-
-def check_runAsUser(spec: dict[str, Any]) -> str:
-    if spec.get("securityContext"):
-        if "runAsUser" in spec["securityContext"]:
-            if isinstance(spec["securityContext"]["runAsUser"], int) and spec["securityContext"]["runAsUser"] >= 10000:
-                return "PASSED"
-            else:
-                return "FAILED"
-    return "ABSENT"

--- a/tests/kubernetes/checks/example_RootContainersHighUID/rootContainersHighUIDFAILED.yaml
+++ b/tests/kubernetes/checks/example_RootContainersHighUID/rootContainersHighUIDFAILED.yaml
@@ -71,3 +71,20 @@ spec:
   - name: main2
     image: alpine
     command: ["/bin/sleep", "999999"]
+---
+# Pod securityContext is not a dict (FAILED)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod4
+spec:
+  securityContext:
+    runAsUser:65534
+    fsGroup:65534
+  containers:
+  - name: main
+    image: alpine
+    command: ["/bin/sleep", "999999"]
+  - name: main2
+    image: alpine
+    command: ["/bin/sleep", "999999"]

--- a/tests/kubernetes/checks/test_RootContainersHighUID.py
+++ b/tests/kubernetes/checks/test_RootContainersHighUID.py
@@ -17,7 +17,7 @@ class TestRootContainersHighUID(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 3)
-        self.assertEqual(summary['failed'], 5)
+        self.assertEqual(summary['failed'], 6)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
- Refactor `RootContainersHighUUID` and `RootContainers` to inherit from the same base class to avoid code duplication

- Safeguard against malformed `securityContext` attribute

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
