### PR TITLE
improve image referencer pull performance

### DIFF
--- a/checkov/bitbucket_pipelines/runner.py
+++ b/checkov/bitbucket_pipelines/runner.py
@@ -95,7 +95,7 @@ class Runner(YamlRunner, ImageReferencer):
             for result in results:
                 image_name = result.get("image", None)
                 if image_name:
-                    image_id = self.pull_image(image_name)
+                    image_id = self.inspect(image_name)
                     image_obj = Image(file_path=file_path, name=image_name, image_id=image_id,
                                       start_line=result["__startline__"],
                                       end_line=result["__endline__"])
@@ -108,7 +108,7 @@ class Runner(YamlRunner, ImageReferencer):
         if root_image:
             for line_number, line_txt in workflow_line_numbers:
                 if "image" in line_txt and not line_txt.startswith(' '):
-                    image_id = self.pull_image(root_image)
+                    image_id = self.inspect(root_image)
                     image_obj = Image(
                         file_path=file_path,
                         name=root_image,

--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -44,16 +44,20 @@ class ImageReferencer:
         """
         return []
 
-    def pull_image(self, image_name: str) -> str:
+    def inspect(self, image_name: str) -> str:
         """
 
-        :param image_name: name of the image to be pulled locally using a "docker pull X" command
-        :return: short image id sha that is pulled locally. In case pull has failed None will be returned.
+        :param image_name: name of the image to be inspected locally using a "docker inspect X". If image does not exist try to pull it locally.
+        :return: short image id sha that is inspected. In case inspect has failed None will be returned.
         """
         try:
-            logging.info("Pulling docker image {}".format(image_name))
+            logging.info("Inspecting docker image {}".format(image_name))
             client = docker.from_env()
-            image = client.images.pull(image_name)
+            try:
+                image = client.images.get(image_name)
+            except Exception:
+                image = client.images.pull(image_name)
+                return cast(str, image.short_id)
             return cast(str, image.short_id)
         except Exception:
             logging.debug(f"failed to pull docker image={image_name}", exc_info=True)

--- a/checkov/github_actions/runner.py
+++ b/checkov/github_actions/runner.py
@@ -70,7 +70,7 @@ class Runner(YamlRunner, ImageReferencer):
                 elif isinstance(container, str):
                     image = container
                 if image:
-                    image_id = self.pull_image(image)
+                    image_id = self.inspect(image)
                     if image_id:
                         image_obj = Image(file_path=file_path, name=image, image_id=image_id, start_line=start_line,
                                           end_line=end_line)

--- a/checkov/gitlab_ci/runner.py
+++ b/checkov/gitlab_ci/runner.py
@@ -76,14 +76,14 @@ class Runner(YamlRunner, ImageReferencer):
                                 elif isinstance(service, str):
                                     imagename = service
                                 if imagename:
-                                    image_id = self.pull_image(imagename)
+                                    image_id = self.inspect(imagename)
                                     if image_id:
                                         image_obj = Image(file_path=file_path, name=imagename, image_id=image_id, start_line=start_line,
                                                         end_line=end_line)
                                         images.add(image_obj)
                                     imagename = ""      
                         if imagename:
-                            image_id = self.pull_image(imagename)
+                            image_id = self.inspect(imagename)
                             if image_id:
                                 image_obj = Image(file_path=file_path, name=imagename, image_id=image_id, start_line=start_line,
                                                   end_line=end_line)

--- a/tests/sca_image/test_runner.py
+++ b/tests/sca_image/test_runner.py
@@ -24,7 +24,7 @@ def test_image_referencer_trigger_image_flow_calls(mocker: MockerFixture, image_
 
     image_id_encoded = quote_plus(image_id)
 
-    mocker.patch('checkov.common.images.image_referencer.ImageReferencer.pull_image', return_value=image_id)
+    mocker.patch('checkov.common.images.image_referencer.ImageReferencer.inspect', return_value=image_id)
     mocker.patch('checkov.sca_image.runner.Runner.execute_scan', return_value=empty_report,
                  side_effect=create_output_path)
 


### PR DESCRIPTION
inspect if image sha exists locally. if not then pull. 

we should add a rest API call to check if the sha exists for the name remotely on the server. 