### PR TITLE
Type safety in integer-comparing checks 

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/DefaultServiceAccountBinding.py
+++ b/checkov/kubernetes/checks/resource/k8s/DefaultServiceAccountBinding.py
@@ -18,7 +18,7 @@ class DefaultServiceAccountBinding(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def scan_spec_conf(self, conf: dict[str, Any]) -> CheckResult:
-        if "subjects" in conf:
+        if "subjects" in conf and isinstance(conf["subjects"], list):
             for subject in conf["subjects"]:
                 if subject["kind"] == "ServiceAccount":
                     if subject["name"] == "default":

--- a/checkov/terraform/checks/resource/azure/DataFactoryUsesGitRepository.py
+++ b/checkov/terraform/checks/resource/azure/DataFactoryUsesGitRepository.py
@@ -14,11 +14,11 @@ class DataFactoryUsesGitRepository(BaseResourceCheck):
 
     def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
         github = conf.get("github_configuration", [{}])[0]
-        if github.get("repository_name"):
+        if isinstance(github, dict) and github.get("repository_name"):
             self.evaluated_keys = ['github_configuration/[0]/repository_name']
             return CheckResult.PASSED
         vsts = conf.get("vsts_configuration", [{}])[0]
-        if vsts.get("repository_name"):
+        if isinstance(vsts, dict) and vsts.get("repository_name"):
             self.evaluated_keys = ['vsts_configuration/[0]/repository_name']
             return CheckResult.PASSED
         self.evaluated_keys = ['github_configuration', 'vsts_configuration']

--- a/checkov/terraform/checks/resource/github/BranchProtectionReviewNumTwo.py
+++ b/checkov/terraform/checks/resource/github/BranchProtectionReviewNumTwo.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from checkov.common.util.type_forcers import force_int
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
 
@@ -18,7 +19,7 @@ class BranchProtectionReviewNumTwo(BaseResourceCheck):
         if conf.get("required_pull_request_reviews") and isinstance(conf.get("required_pull_request_reviews"), list):
             review = conf.get("required_pull_request_reviews")[0]
             if review.get("required_approving_review_count") and isinstance(review.get("required_approving_review_count"),list):
-                count = review.get("required_approving_review_count")[0]
+                count = force_int(review.get("required_approving_review_count")[0])
                 if count >= 2:
                     return CheckResult.PASSED
         self.evaluated_keys = ["required_pull_request_reviews/[0]/required_approving_review_count"]

--- a/checkov/terraform/checks/resource/github/BranchProtectionReviewNumTwo.py
+++ b/checkov/terraform/checks/resource/github/BranchProtectionReviewNumTwo.py
@@ -20,7 +20,7 @@ class BranchProtectionReviewNumTwo(BaseResourceCheck):
             review = conf.get("required_pull_request_reviews")[0]
             if review.get("required_approving_review_count") and isinstance(review.get("required_approving_review_count"),list):
                 count = force_int(review.get("required_approving_review_count")[0])
-                if count >= 2:
+                if count and count >= 2:
                     return CheckResult.PASSED
         self.evaluated_keys = ["required_pull_request_reviews/[0]/required_approving_review_count"]
         return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/gitlab/RequireTwoApprovalsToMerge.py
+++ b/checkov/terraform/checks/resource/gitlab/RequireTwoApprovalsToMerge.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+from checkov.common.util.type_forcers import force_int
 
 
 class RequireTwoApprovalsToMerge(BaseResourceCheck):
@@ -17,7 +18,7 @@ class RequireTwoApprovalsToMerge(BaseResourceCheck):
     def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
         approvals = conf.get("approvals_before_merge")
         if approvals and isinstance(approvals, list):
-            if approvals[0] >= 2:
+            if force_int(approvals[0]) >= 2:
                 return CheckResult.PASSED
         self.evaluated_keys = ["approvals_before_merge"]
         return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/gitlab/RequireTwoApprovalsToMerge.py
+++ b/checkov/terraform/checks/resource/gitlab/RequireTwoApprovalsToMerge.py
@@ -18,7 +18,8 @@ class RequireTwoApprovalsToMerge(BaseResourceCheck):
     def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
         approvals = conf.get("approvals_before_merge")
         if approvals and isinstance(approvals, list):
-            if force_int(approvals[0]) >= 2:
+            num_approvals = force_int(approvals[0])
+            if num_approvals and num_approvals >= 2:
                 return CheckResult.PASSED
         self.evaluated_keys = ["approvals_before_merge"]
         return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
@@ -1,6 +1,6 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
-
+from checkov.common.util.type_forcers import force_int
 
 class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
     def __init__(self, check_id: str, port: int) -> None:
@@ -31,8 +31,8 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
         """ scan tcp_options configuration"""
         if 'source_port_range' not in protocol_name[0]:
             return False
-        max_port = protocol_name[0]['source_port_range'][0]['max'][0]
-        min_port = protocol_name[0]['source_port_range'][0]['min'][0]
-        if min_port <= self.port <= max_port:
+        max_port = force_int(protocol_name[0]['source_port_range'][0]['max'][0])
+        min_port = force_int(protocol_name[0]['source_port_range'][0]['min'][0])
+        if max_port and min_port and min_port <= self.port <= max_port:
             return False
         return True

--- a/checkov/terraform/checks/resource/oci/AbsSecurityListUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/oci/AbsSecurityListUnrestrictedIngress.py
@@ -1,5 +1,6 @@
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.common.util.type_forcers import force_int
 
 
 class AbsSecurityListUnrestrictedIngress(BaseResourceCheck):
@@ -36,9 +37,9 @@ class AbsSecurityListUnrestrictedIngress(BaseResourceCheck):
     def scan_protocol_conf(self, rule, protocol_name, idx):
         """ scan udp/tcp_options configuration"""
         if protocol_name in rule:
-            max_port = int(rule[protocol_name][0]['max'][0])
-            min_port = int(rule[protocol_name][0]['min'][0])
-            if min_port <= self.port and max_port >= self.port:
+            max_port = force_int(rule[protocol_name][0]['max'][0])
+            min_port = force_int(rule[protocol_name][0]['min'][0])
+            if min_port and max_port and min_port <= self.port <= max_port:
                 return CheckResult.SKIPPED
         self.evaluated_keys = [f'ingress_security_rules/[0]/[{idx}]/protocol/[0]/{protocol_name}']
         return CheckResult.FAILED


### PR DESCRIPTION
Use force_int on checks that compare numbers, protect against empty list in a K8 check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
