### PR TITLE
Multiple K8 checks type safety, aws_dlm_lifecycle_policy enhancement 

### DIFF
--- a/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryption.py
+++ b/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryption.py
@@ -19,8 +19,9 @@ class DLMScheduleCrossRegionEncryption(BaseResourceCheck):
                 for idx, schedule in enumerate(schedules):
                     if schedule.get("cross_region_copy_rule") and isinstance(schedule.get("cross_region_copy_rule"), list) and all(isinstance(rule, dict) for rule in schedule.get("cross_region_copy_rule")):
                         for c_idx, cross_schedule_rule in enumerate(schedule.get("cross_region_copy_rule")):
-                            self.evaluated_keys.append(f"policy_details/schedule/{idx}/cross_region_copy_rule/{c_idx}/encrypted")
                             if cross_schedule_rule.get("encrypted") != [True]:
+                                self.evaluated_keys = [
+                                    f"policy_details/schedule/{idx}/cross_region_copy_rule/{c_idx}/encrypted"]
                                 return CheckResult.FAILED
                         return CheckResult.PASSED
         return CheckResult.UNKNOWN

--- a/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryption.py
+++ b/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryption.py
@@ -17,12 +17,12 @@ class DLMScheduleCrossRegionEncryption(BaseResourceCheck):
             if policy.get("schedule") and isinstance(policy.get("schedule"), list):
                 schedules = policy.get("schedule")
                 for idx, schedule in enumerate(schedules):
-                    if schedule.get("cross_region_copy_rule") and isinstance(schedule.get("cross_region_copy_rule"), list):
-                        cross = schedule.get("cross_region_copy_rule")[0]
-                        if cross.get("encrypted") == [True]:
-                            return CheckResult.PASSED
-                        self.evaluated_keys = [f"policy_details/schedule/{idx}/cross_region_copy_rule/encrypted"]
-                        return CheckResult.FAILED
+                    if schedule.get("cross_region_copy_rule") and isinstance(schedule.get("cross_region_copy_rule"), list) and all(isinstance(rule, dict) for rule in schedule.get("cross_region_copy_rule")):
+                        for c_idx, cross_schedule_rule in enumerate(schedule.get("cross_region_copy_rule")):
+                            self.evaluated_keys.append(f"policy_details/schedule/{idx}/cross_region_copy_rule/{c_idx}/encrypted")
+                            if cross_schedule_rule.get("encrypted") != [True]:
+                                return CheckResult.FAILED
+                        return CheckResult.PASSED
         return CheckResult.UNKNOWN
 
 

--- a/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryption.py
+++ b/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryption.py
@@ -17,9 +17,9 @@ class DLMScheduleCrossRegionEncryption(BaseResourceCheck):
             if policy.get("schedule") and isinstance(policy.get("schedule"), list):
                 schedules = policy.get("schedule")
                 for idx, schedule in enumerate(schedules):
-                    if schedule.get("cross_region_copy_rule") and isinstance(schedule.get("cross_region_copy_rule"), list) and all(isinstance(rule, dict) for rule in schedule.get("cross_region_copy_rule")):
+                    if schedule.get("cross_region_copy_rule") and isinstance(schedule.get("cross_region_copy_rule"), list):
                         for c_idx, cross_schedule_rule in enumerate(schedule.get("cross_region_copy_rule")):
-                            if cross_schedule_rule.get("encrypted") != [True]:
+                            if isinstance(cross_schedule_rule, dict) and cross_schedule_rule.get("encrypted") != [True]:
                                 self.evaluated_keys = [
                                     f"policy_details/schedule/{idx}/cross_region_copy_rule/{c_idx}/encrypted"]
                                 return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryptionWithCMK.py
+++ b/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryptionWithCMK.py
@@ -19,7 +19,7 @@ class DLMScheduleCrossRegionEncryptionWithCMK(BaseResourceCheck):
                 for idx, schedule in enumerate(schedules):
                     if schedule.get("cross_region_copy_rule") and isinstance(schedule.get("cross_region_copy_rule"), list):
                         for c_idx, cross_schedule_rule in enumerate(schedule.get("cross_region_copy_rule")):
-                            if cross_schedule_rule.get("encrypted") != [True] or not cross_schedule_rule.get("cmk_arn"):
+                            if isinstance(cross_schedule_rule, dict) and (cross_schedule_rule.get("encrypted") != [True] or not cross_schedule_rule.get("cmk_arn")):
                                 self.evaluated_keys = [
                                     f"policy_details/schedule/{idx}/cross_region_copy_rule/{c_idx}/encrypted"]
                                 self.evaluated_keys = [

--- a/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryptionWithCMK.py
+++ b/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryptionWithCMK.py
@@ -18,11 +18,12 @@ class DLMScheduleCrossRegionEncryptionWithCMK(BaseResourceCheck):
                 schedules = policy.get("schedule")
                 for idx, schedule in enumerate(schedules):
                     if schedule.get("cross_region_copy_rule") and isinstance(schedule.get("cross_region_copy_rule"), list):
-                        cross = schedule.get("cross_region_copy_rule")[0]
-                        if cross.get("encrypted") == [True] and cross.get("cmk_arn"):
-                            return CheckResult.PASSED
-                        self.evaluated_keys = [f"policy_details/schedule/{idx}/cross_region_copy_rule/encrypted"]
-                        return CheckResult.FAILED
+                        for c_idx, cross_schedule_rule in enumerate(schedule.get("cross_region_copy_rule")):
+                            self.evaluated_keys.append(f"policy_details/schedule/{idx}/cross_region_copy_rule/{c_idx}/encrypted")
+                            self.evaluated_keys.append(f"policy_details/schedule/{idx}/cross_region_copy_rule/{c_idx}/cmk_arn")
+                            if cross_schedule_rule.get("encrypted") != [True] or not cross_schedule_rule.get("cmk_arn"):
+                                return CheckResult.FAILED
+                        return CheckResult.PASSED
         return CheckResult.UNKNOWN
 
 

--- a/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryptionWithCMK.py
+++ b/checkov/terraform/checks/resource/aws/DLMScheduleCrossRegionEncryptionWithCMK.py
@@ -19,9 +19,11 @@ class DLMScheduleCrossRegionEncryptionWithCMK(BaseResourceCheck):
                 for idx, schedule in enumerate(schedules):
                     if schedule.get("cross_region_copy_rule") and isinstance(schedule.get("cross_region_copy_rule"), list):
                         for c_idx, cross_schedule_rule in enumerate(schedule.get("cross_region_copy_rule")):
-                            self.evaluated_keys.append(f"policy_details/schedule/{idx}/cross_region_copy_rule/{c_idx}/encrypted")
-                            self.evaluated_keys.append(f"policy_details/schedule/{idx}/cross_region_copy_rule/{c_idx}/cmk_arn")
                             if cross_schedule_rule.get("encrypted") != [True] or not cross_schedule_rule.get("cmk_arn"):
+                                self.evaluated_keys = [
+                                    f"policy_details/schedule/{idx}/cross_region_copy_rule/{c_idx}/encrypted"]
+                                self.evaluated_keys = [
+                                    f"policy_details/schedule/{idx}/cross_region_copy_rule/{c_idx}/cmk_arn"]
                                 return CheckResult.FAILED
                         return CheckResult.PASSED
         return CheckResult.UNKNOWN

--- a/checkov/terraform/checks/resource/kubernetes/AllowedCapabilities.py
+++ b/checkov/terraform/checks/resource/kubernetes/AllowedCapabilities.py
@@ -17,8 +17,8 @@ class AllowedCapabilities(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        spec = conf['spec'][0]
-        if spec.get("container"):
+        spec = conf.get('spec', [None])[0]
+        if isinstance(spec, dict) and spec.get("container"):
             containers = spec.get("container")
 
             for idx, container in enumerate(containers):

--- a/checkov/terraform/checks/resource/kubernetes/AllowedCapabilitiesSysAdmin.py
+++ b/checkov/terraform/checks/resource/kubernetes/AllowedCapabilitiesSysAdmin.py
@@ -15,8 +15,8 @@ class AllowedCapabilitiesSysAdmin(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        spec = conf['spec'][0]
-        if spec.get("container"):
+        spec = conf.get('spec', [None])[0]
+        if isinstance(spec, dict) and spec.get("container"):
             containers = spec.get("container")
 
             for idx, container in enumerate(containers):

--- a/checkov/terraform/checks/resource/kubernetes/ContainerSecurityContext.py
+++ b/checkov/terraform/checks/resource/kubernetes/ContainerSecurityContext.py
@@ -16,8 +16,8 @@ class ContainerSecurityContext(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        spec = conf['spec'][0]
-        if spec.get("container"):
+        spec = conf.get('spec', [None])[0]
+        if isinstance(spec, dict) and spec.get("container"):
             containers = spec.get("container")
 
             for idx, container in enumerate(containers):

--- a/checkov/terraform/checks/resource/kubernetes/ImagePullPolicyAlways.py
+++ b/checkov/terraform/checks/resource/kubernetes/ImagePullPolicyAlways.py
@@ -1,4 +1,3 @@
-
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
@@ -20,8 +19,8 @@ class ImagePullPolicyAlways(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        spec = conf.get('spec')[0]
-        if spec:
+        spec = conf.get('spec', [None])[0]
+        if isinstance(spec, dict) and spec:
             containers = spec.get("container")
             for idx, container in enumerate(containers):
                 if not isinstance(container, dict):

--- a/checkov/terraform/checks/resource/kubernetes/ImageTagFixed.py
+++ b/checkov/terraform/checks/resource/kubernetes/ImageTagFixed.py
@@ -1,4 +1,3 @@
-
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
@@ -18,8 +17,8 @@ class ImageTagFixed(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        spec = conf.get('spec')[0]
-        if spec:
+        spec = conf.get('spec', [None])[0]
+        if isinstance(spec, dict):
             containers = spec.get("container")
             for idx, container in enumerate(containers):
                 if not isinstance(container, dict):

--- a/checkov/terraform/checks/resource/kubernetes/ImageTagFixed.py
+++ b/checkov/terraform/checks/resource/kubernetes/ImageTagFixed.py
@@ -18,7 +18,7 @@ class ImageTagFixed(BaseResourceCheck):
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf.get('spec', [None])[0]
-        if isinstance(spec, dict):
+        if isinstance(spec, dict) and spec.get("container"):
             containers = spec.get("container")
             for idx, container in enumerate(containers):
                 if not isinstance(container, dict):

--- a/checkov/terraform/checks/resource/kubernetes/LivenessProbe.py
+++ b/checkov/terraform/checks/resource/kubernetes/LivenessProbe.py
@@ -18,8 +18,8 @@ class LivenessProbe(BaseResourceValueCheck):
         return "spec/[0]/container/[0]/liveness_probe/[0]"
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        spec = conf.get('spec')[0]
-        if spec:
+        spec = conf.get('spec', [None])[0]
+        if spec and isinstance(spec, dict):
             containers = spec.get("container")
             for idx, container in enumerate(containers):
                 if not isinstance(container, dict):

--- a/checkov/terraform/checks/resource/kubernetes/MinimiseCapabilities.py
+++ b/checkov/terraform/checks/resource/kubernetes/MinimiseCapabilities.py
@@ -14,8 +14,8 @@ class MinimiseCapabilities(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        spec = conf['spec'][0]
-        if spec.get("container"):
+        spec = conf.get('spec', [None])[0]
+        if isinstance(spec, dict) and spec.get("container"):
             containers = spec.get("container")
 
             for idx, container in enumerate(containers):

--- a/checkov/terraform/checks/resource/kubernetes/PrivilegedContainerPSP.py
+++ b/checkov/terraform/checks/resource/kubernetes/PrivilegedContainerPSP.py
@@ -14,9 +14,9 @@ class PrivilegedContainersPSP(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        spec = conf["spec"][0]
+        spec = conf.get('spec', [None])[0]
         # for psp
-        if spec.get("privileged") == [True]:
+        if isinstance(spec, dict) and spec.get("privileged") == [True]:
             self.evaluated_keys = ["spec/[0]/privileged"]
             return CheckResult.FAILED
 

--- a/checkov/terraform/checks/resource/kubernetes/ReadinessProbe.py
+++ b/checkov/terraform/checks/resource/kubernetes/ReadinessProbe.py
@@ -18,8 +18,8 @@ class ReadinessProbe(BaseResourceValueCheck):
         return "spec/[0]/container/[0]/readiness_probe/[0]"
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        spec = conf.get('spec')[0]
-        if spec:
+        spec = conf.get('spec', [None])[0]
+        if isinstance(spec, dict) and spec:
             containers = spec.get("container")
             for idx, container in enumerate(containers):
                 if not isinstance(container, dict):

--- a/checkov/terraform/checks/resource/kubernetes/ReadonlyRootFilesystem.py
+++ b/checkov/terraform/checks/resource/kubernetes/ReadonlyRootFilesystem.py
@@ -13,8 +13,8 @@ class ReadonlyRootFilesystem(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
-        spec = conf['spec'][0]
-        if spec.get("container"):
+        spec = conf.get('spec', [None])[0]
+        if isinstance(spec, dict) and spec.get("container"):
             containers = spec.get("container")
 
             for idx, container in enumerate(containers):

--- a/tests/terraform/checks/resource/aws/example_DLMScheduleCrossRegionEncryption/main.tf
+++ b/tests/terraform/checks/resource/aws/example_DLMScheduleCrossRegionEncryption/main.tf
@@ -75,6 +75,16 @@ resource "aws_dlm_lifecycle_policy" "fail" {
 
       cross_region_copy_rule {
         target    = "us-west-2"
+        encrypted = true
+        cmk_arn   = aws_kms_key.dlm_cross_region_copy_cmk.arn
+        copy_tags = true
+        retain_rule {
+          interval      = 30
+          interval_unit = "DAYS"
+        }
+      }
+      cross_region_copy_rule {
+        target    = "us-west-2"
         encrypted = false
         cmk_arn   = aws_kms_key.dlm_cross_region_copy_cmk.arn
         copy_tags = true

--- a/tests/terraform/checks/resource/aws/example_DLMScheduleCrossRegionEncryptionWithCMK/main.tf
+++ b/tests/terraform/checks/resource/aws/example_DLMScheduleCrossRegionEncryptionWithCMK/main.tf
@@ -35,6 +35,17 @@ resource "aws_dlm_lifecycle_policy" "pass" {
           interval_unit = "DAYS"
         }
       }
+
+      cross_region_copy_rule {
+        target    = "us-west-2"
+        encrypted = true
+        cmk_arn   = aws_kms_key.dlm_cross_region_copy_cmk.arn
+        copy_tags = true
+        retain_rule {
+          interval      = 20
+          interval_unit = "DAYS"
+        }
+      }
     }
 
     target_tags = {
@@ -72,6 +83,17 @@ resource "aws_dlm_lifecycle_policy" "fail" {
       }
 
       copy_tags = false
+
+      cross_region_copy_rule {
+        target    = "us-west-2"
+        encrypted = true
+        cmk_arn   = aws_kms_key.dlm_cross_region_copy_cmk.arn
+        copy_tags = true
+        retain_rule {
+          interval      = 20
+          interval_unit = "DAYS"
+        }
+      }
 
       cross_region_copy_rule {
         target    = "us-west-2"


### PR DESCRIPTION
- Type safety for spec extraction of multiple k8 checks, 

- Enumerate multiple `cross_region_copy_rule instead` of only checking the first one

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
