### PR TITLE
List platform only policies

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
@@ -59,6 +59,8 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
 
                     if use_prisma_metadata and metadata.get('descriptiveTitle'):
                         check.name = metadata['descriptiveTitle']
+                else:
+                    check.bc_id = None
         except Exception:
             self.integration_feature_failures = True
             logging.debug('An error occurred loading policy metadata. Some metadata may be missing from the run.', exc_info=True)

--- a/checkov/common/models/consts.py
+++ b/checkov/common/models/consts.py
@@ -16,3 +16,4 @@ bridgecrew_token_pattern = re.compile(r"^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-
 panos_api_key_pattern = re.compile(r"^LUFRPT1[a-zA-Z0-9]+==\Z")  # nosec
 SLS_DEFAULT_VAR_PATTERN = re.compile(r"\${([^{}]+?)}")
 YAML_COMMENT_MARK = '#'
+ckv_check_id_pattern = re.compile(r"^CKV2?_[A-Za-z]*_[0-9]*$")

--- a/checkov/common/util/docs_generator.py
+++ b/checkov/common/util/docs_generator.py
@@ -61,7 +61,7 @@ def get_checks(frameworks: Optional[List[str]] = None, use_bc_ids: bool = False,
     printable_checks_list: list[tuple[str, str, str, str, str]] = []
     runner_filter = RunnerFilter(include_all_checkov_policies=include_all_checkov_policies)
 
-    def add_from_repository(registry: Union[BaseCheckRegistry, BaseGraphRegistry], checked_type: str, iac: str, runner_filter=runner_filter) -> None:
+    def add_from_repository(registry: Union[BaseCheckRegistry, BaseGraphRegistry], checked_type: str, iac: str, runner_filter: RunnerFilter=runner_filter) -> None:
         nonlocal printable_checks_list
         if isinstance(registry, BaseCheckRegistry):
             for entity, check in registry.all_checks():

--- a/checkov/common/util/docs_generator.py
+++ b/checkov/common/util/docs_generator.py
@@ -29,6 +29,7 @@ from checkov.terraform.checks.provider.registry import provider_registry
 from checkov.terraform.checks.resource.registry import resource_registry
 from checkov.openapi.checks.registry import openapi_registry
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as metadata_integration
+from checkov.runner_filter import RunnerFilter
 
 
 ID_PARTS_PATTERN = re.compile(r'([^_]*)_([^_]*)_(\d+)')
@@ -45,32 +46,35 @@ def get_compare_key(c: list[str] | tuple[str, ...]) -> list[tuple[str, str, int,
     return res
 
 
-def print_checks(frameworks: Optional[List[str]] = None, use_bc_ids: bool = False) -> None:
+def print_checks(frameworks: Optional[List[str]] = None, use_bc_ids: bool = False, include_all_checkov_policies: bool = True) -> None:
     framework_list = frameworks if frameworks else ["all"]
-    printable_checks_list = get_checks(framework_list, use_bc_ids=use_bc_ids)
+    printable_checks_list = get_checks(framework_list, use_bc_ids=use_bc_ids, include_all_checkov_policies=include_all_checkov_policies)
     print(
         tabulate(printable_checks_list, headers=["Id", "Type", "Entity", "Policy", "IaC"], tablefmt="github",
                  showindex=True))
     print("\n\n---\n\n")
 
 
-def get_checks(frameworks: Optional[List[str]] = None, use_bc_ids: bool = False) -> \
+def get_checks(frameworks: Optional[List[str]] = None, use_bc_ids: bool = False, include_all_checkov_policies: bool = True) -> \
         List[Tuple[str, str, int, int, str]]:
     framework_list = frameworks if frameworks else ["all"]
     printable_checks_list: list[tuple[str, str, str, str, str]] = []
+    runner_filter = RunnerFilter(include_all_checkov_policies=include_all_checkov_policies)
 
-    def add_from_repository(registry: Union[BaseCheckRegistry, BaseGraphRegistry], checked_type: str, iac: str) -> None:
+    def add_from_repository(registry: Union[BaseCheckRegistry, BaseGraphRegistry], checked_type: str, iac: str, runner_filter=runner_filter) -> None:
         nonlocal printable_checks_list
         if isinstance(registry, BaseCheckRegistry):
             for entity, check in registry.all_checks():
-                printable_checks_list.append((check.get_output_id(use_bc_ids), checked_type, entity, check.name, iac))
+                if runner_filter.should_run_check(check, check.id, check.bc_id, check.severity):
+                    printable_checks_list.append((check.get_output_id(use_bc_ids), checked_type, entity, check.name, iac))
         elif isinstance(registry, BaseGraphRegistry):
             for check in registry.checks:
-                if not check.resource_types:  # type:ignore[attr-defined]  # can be removed, when common.graph is also type checked
-                    # only for platform custom polices with resource_types == all
-                    check.resource_types = ['all']  # type:ignore[attr-defined]  # can be removed, when common.graph is also type checked
-                for rt in check.resource_types:  # type:ignore[attr-defined]  # can be removed, when common.graph is also type checked
-                    printable_checks_list.append((check.get_output_id(use_bc_ids), checked_type, rt, check.name, iac))
+                if runner_filter.should_run_check(check, check.id, check.bc_id, check.severity):
+                    if not check.resource_types:  # type:ignore[attr-defined]  # can be removed, when common.graph is also type checked
+                        # only for platform custom polices with resource_types == all
+                        check.resource_types = ['all']  # type:ignore[attr-defined]  # can be removed, when common.graph is also type checked
+                    for rt in check.resource_types:  # type:ignore[attr-defined]  # can be removed, when common.graph is also type checked
+                        printable_checks_list.append((check.get_output_id(use_bc_ids), checked_type, rt, check.name, iac))
 
     if any(x in framework_list for x in ("all", "terraform")):
         add_from_repository(resource_registry, "resource", "Terraform")

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -228,7 +228,7 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
     runner_filter.excluded_paths = runner_filter.excluded_paths + list(repo_config_integration.skip_paths)
 
     if config.list:
-        print_checks(frameworks=config.framework, use_bc_ids=config.output_bc_ids)
+        print_checks(frameworks=config.framework, use_bc_ids=config.output_bc_ids, include_all_checkov_policies=config.include_all_checkov_policies)
         return None
 
     baseline = None

--- a/integration_tests/run_integration_tests.sh
+++ b/integration_tests/run_integration_tests.sh
@@ -27,6 +27,7 @@ prepare_data () {
 #  export CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING=True #cant run it on M1 mac, docker image node:14.16 needed
   python checkov/main.py -s -d integration_tests/example_workflow_file/.github/workflows/ -o json --bc-api-key $BC_KEY --include-all-checkov-policies > checkov_report_workflow_cve.json
   python checkov/main.py -s -d integration_tests/example_workflow_file/bitbucket/ -o json --bc-api-key $BC_KEY --include-all-checkov-policies > checkov_report_bitbucket_pipelines_cve.json
+  python checkov/main.py -s --list --bc-api-key $BC_KEY --output-bc-ids > checkov_checks_list.txt
 }
 
 clone_repositories () {

--- a/integration_tests/test_checkov_platform_only_policies.py
+++ b/integration_tests/test_checkov_platform_only_policies.py
@@ -1,0 +1,33 @@
+import os
+import platform
+import sys
+import unittest
+import re
+
+from checkov.common.models.consts import ckv_check_id_pattern
+
+current_dir = os.path.dirname(os.path.realpath(__file__))
+
+
+class TestCheckovPlatformOnlyPolicies(unittest.TestCase):
+
+    def test_no_ckv_ids(self):
+        checks_list_path = os.path.join(current_dir, '..', 'checkov_checks_list.txt')
+        if sys.version_info[1] == 7 and platform.system() == 'Linux':
+            with open(checks_list_path, encoding='utf-8') as f:
+                for i, line in enumerate(f):
+                    if i in [0, 1]:
+                        # skip the header lines
+                        continue
+                    line = "".join(line.split())
+                    if type(line) == str and line:
+                        if line == "---":
+                            # end of table
+                            continue
+                        check_id = line.split('|')[2]
+                        ckv_ids = re.match(ckv_check_id_pattern, check_id)
+                        self.assertFalse(ckv_ids)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Bug fix:

1. Fixes an issue where even though you use a platform key (`--bc-api-key`) CKV2 policies that do not exist in the platform were still being run. 
2. Added an integration test to confirm that if an API key is used with the `--output-bc-ids` flag, no CKV ids will be present in `checkov --list`. 
3. That said, other check id formats - external checks, platform checks will be present. 

New behavior:

1. When you use --list with an API key, only platform checks will be printed.