### PR TITLE
Fix CFN boolean as string checks

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -9,5 +9,8 @@ ignore_templates:
   - tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentCredentials/sam.yaml
   # includes tests with booleans as strings
   - tests/cloudformation/checks/resource/aws/example_ECRImageScanning/*
+  - tests/cloudformation/checks/resource/aws/example_ALBDropHttpHeaders/*
+  - tests/cloudformation/checks/resource/aws/example_ELBv2AccessLogs/*
+  - tests/cloudformation/checks/resource/aws/example_RedShiftSSL/*
 ignore_checks:
   - W

--- a/checkov/cloudformation/checks/resource/aws/ALBDropHttpHeaders.py
+++ b/checkov/cloudformation/checks/resource/aws/ALBDropHttpHeaders.py
@@ -14,13 +14,13 @@ class ALBDropHttpHeaders(BaseResourceCheck):
     def scan_resource_conf(self, conf):
         # ALB is default loadbalancer type if not explicitly set
         alb = True
-        
+
         properties = conf.get("Properties")
         lb_type = properties.get("Type")
         if lb_type and lb_type != 'application':
             alb = False
 
-        # If lb is alb then drop headers must be present and true 
+        # If lb is alb then drop headers must be present and true
         if alb:
             lb_attributes = properties.get('LoadBalancerAttributes', {})
             if isinstance(lb_attributes, list):
@@ -28,7 +28,7 @@ class ALBDropHttpHeaders(BaseResourceCheck):
                     key = item.get('Key')
                     if key == 'routing.http.drop_invalid_header_fields.enabled':
                         value = item.get('Value')
-                        if type(value) == bool:
+                        if isinstance(value, bool):
                             value = str(value).lower()
                         if value == "true":
                             return CheckResult.PASSED

--- a/checkov/cloudformation/checks/resource/aws/ALBDropHttpHeaders.py
+++ b/checkov/cloudformation/checks/resource/aws/ALBDropHttpHeaders.py
@@ -26,9 +26,12 @@ class ALBDropHttpHeaders(BaseResourceCheck):
             if isinstance(lb_attributes, list):
                 for item in lb_attributes:
                     key = item.get('Key')
-                    value = item.get('Value')
-                    if key == 'routing.http.drop_invalid_header_fields.enabled' and value == "true":
-                        return CheckResult.PASSED
+                    if key == 'routing.http.drop_invalid_header_fields.enabled':
+                        value = item.get('Value')
+                        if type(value) == bool:
+                            value = str(value).lower()
+                        if value == "true":
+                            return CheckResult.PASSED
             return CheckResult.FAILED
 
         # If lb is not alb then check is not valid

--- a/checkov/cloudformation/checks/resource/aws/ELBv2AccessLogs.py
+++ b/checkov/cloudformation/checks/resource/aws/ELBv2AccessLogs.py
@@ -16,8 +16,12 @@ class ELBv2AccessLogs(BaseResourceCheck):
                 if isinstance(conf['Properties']['LoadBalancerAttributes'], list):
                     for item in conf['Properties']['LoadBalancerAttributes']:
                         if 'Key' in item.keys() and 'Value' in item.keys():
-                            if item['Key'] == "access_logs.s3.enabled" and item['Value'] == "true":
-                                return CheckResult.PASSED
+                            if item['Key'] == "access_logs.s3.enabled":
+                                value = item['Value']
+                                if type(value) == bool:
+                                    value = str(value).lower()
+                                if value == "true":
+                                    return CheckResult.PASSED
         return CheckResult.FAILED
 
 

--- a/checkov/cloudformation/checks/resource/aws/ELBv2AccessLogs.py
+++ b/checkov/cloudformation/checks/resource/aws/ELBv2AccessLogs.py
@@ -18,7 +18,7 @@ class ELBv2AccessLogs(BaseResourceCheck):
                         if 'Key' in item.keys() and 'Value' in item.keys():
                             if item['Key'] == "access_logs.s3.enabled":
                                 value = item['Value']
-                                if type(value) == bool:
+                                if isinstance(value, bool):
                                     value = str(value).lower()
                                 if value == "true":
                                     return CheckResult.PASSED

--- a/checkov/cloudformation/checks/resource/aws/RedShiftSSL.py
+++ b/checkov/cloudformation/checks/resource/aws/RedShiftSSL.py
@@ -15,8 +15,12 @@ class RedShiftSSL(BaseResourceCheck):
         params = conf.get("Properties", {}).get("Parameters", {})
 
         for param in params:
-            if param.get("ParameterName") == "require_ssl" and param.get("ParameterValue") == "true":
-                return CheckResult.PASSED
+            if param.get("ParameterName") == "require_ssl":
+                value = param.get("ParameterValue")
+                if type(value) == bool:
+                    value = str(value).lower()
+                if value == "true":
+                    return CheckResult.PASSED
 
         return CheckResult.FAILED
 

--- a/checkov/cloudformation/checks/resource/aws/RedShiftSSL.py
+++ b/checkov/cloudformation/checks/resource/aws/RedShiftSSL.py
@@ -17,7 +17,7 @@ class RedShiftSSL(BaseResourceCheck):
         for param in params:
             if param.get("ParameterName") == "require_ssl":
                 value = param.get("ParameterValue")
-                if type(value) == bool:
+                if isinstance(value, bool):
                     value = str(value).lower()
                 if value == "true":
                     return CheckResult.PASSED

--- a/tests/cloudformation/checks/resource/aws/example_ALBDropHttpHeaders/FAIL.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ALBDropHttpHeaders/FAIL.yaml
@@ -4,14 +4,14 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Name: test
-      Subnets: 
+      Subnets:
         - test-0
         - test-1
   FailExplicitALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Name: test
-      Subnets: 
+      Subnets:
         - test-0
         - test-1
       Type: application
@@ -19,21 +19,43 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Name: test
-      Subnets: 
+      Subnets:
         - test-0
         - test-1
       Type: application
       LoadBalancerAttributes:
         - Key: routing.http.drop_invalid_header_fields.enabled
           Value: "false"
+  FailExplicitFalse2:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: test
+      Subnets:
+        - test-0
+        - test-1
+      Type: application
+      LoadBalancerAttributes:
+        - Key: routing.http.drop_invalid_header_fields.enabled
+          Value: false
   FailKeyNotExist:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Name: test
-      Subnets: 
+      Subnets:
         - test-0
         - test-1
       Type: application
       LoadBalancerAttributes:
         - Key: deletion_protection.enabled
           Value: "true"
+  FailKeyNotExist2:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: test
+      Subnets:
+        - test-0
+        - test-1
+      Type: application
+      LoadBalancerAttributes:
+        - Key: deletion_protection.enabled
+          Value: true

--- a/tests/cloudformation/checks/resource/aws/example_ALBDropHttpHeaders/PASS.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ALBDropHttpHeaders/PASS.yaml
@@ -10,6 +10,16 @@ Resources:
       LoadBalancerAttributes:
         - Key: routing.http.drop_invalid_header_fields.enabled
           Value: "true"
+  PassDefaultTypeBool:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: test
+      Subnets:
+        - test-0
+        - test-1
+      LoadBalancerAttributes:
+        - Key: routing.http.drop_invalid_header_fields.enabled
+          Value: true
   PassExplicitALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:

--- a/tests/cloudformation/checks/resource/aws/example_ELBv2AccessLogs/ELBv2AccessLogs-FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ELBv2AccessLogs/ELBv2AccessLogs-FAILED.yml
@@ -7,7 +7,7 @@ Resources:
       LoadBalancerAttributes:
       - Key: access_logs.s3.enabled
         Value: "false"
-      - Key: access_logs.s3.bucket 
+      - Key: access_logs.s3.bucket
         Value: MyBucket
       Subnets:
       - SubnetID0
@@ -29,3 +29,15 @@ Resources:
       Subnets:
       - SubnetID0
       - SubnetID1
+  Resource3:
+    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Properties:
+      Name: MyLB
+      LoadBalancerAttributes:
+        - Key: access_logs.s3.enabled
+          Value: false
+        - Key: access_logs.s3.bucket
+          Value: MyBucket
+      Subnets:
+        - SubnetID0
+        - SubnetID1

--- a/tests/cloudformation/checks/resource/aws/example_ELBv2AccessLogs/ELBv2AccessLogs-PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ELBv2AccessLogs/ELBv2AccessLogs-PASSED.yml
@@ -12,3 +12,15 @@ Resources:
       Subnets:
       - SubnetID0
       - SubnetID1
+  Resource1:
+    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Properties:
+      Name: MyLB
+      LoadBalancerAttributes:
+        - Key: access_logs.s3.enabled
+          Value: true
+        - Key: access_logs.s3.bucket
+          Value: MyBucket
+      Subnets:
+        - SubnetID0
+        - SubnetID1

--- a/tests/cloudformation/checks/resource/aws/example_RedShiftSSL/RedShiftSSL-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RedShiftSSL/RedShiftSSL-FAILED.yaml
@@ -8,6 +8,14 @@ Resources:
       Parameters:
         - ParameterName: "enable_user_activity_logging"
           ParameterValue: "true"
+  RedshiftParameterGroupDefault2:
+    Type: AWS::Redshift::ClusterParameterGroup
+    Properties:
+      Description: parameter group
+      ParameterGroupFamily: redshift-1.0
+      Parameters:
+        - ParameterName: "enable_user_activity_logging"
+          ParameterValue: true
   RedshiftParameterGroupDisabled:
     Type: AWS::Redshift::ClusterParameterGroup
     Properties:
@@ -16,3 +24,11 @@ Resources:
       Parameters:
         - ParameterName: "require_ssl"
           ParameterValue: "false"
+  RedshiftParameterGroupDisabled2:
+    Type: AWS::Redshift::ClusterParameterGroup
+    Properties:
+      Description: parameter group
+      ParameterGroupFamily: redshift-1.0
+      Parameters:
+        - ParameterName: "require_ssl"
+          ParameterValue: false

--- a/tests/cloudformation/checks/resource/aws/example_RedShiftSSL/RedShiftSSL-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RedShiftSSL/RedShiftSSL-PASSED.yaml
@@ -8,3 +8,11 @@ Resources:
       Parameters:
         - ParameterName: "require_ssl"
           ParameterValue: "true"
+  RedshiftParameterGroupEnabledBool:
+    Type: AWS::Redshift::ClusterParameterGroup
+    Properties:
+      Description: parameter group
+      ParameterGroupFamily: redshift-1.0
+      Parameters:
+        - ParameterName: "require_ssl"
+          ParameterValue: true

--- a/tests/cloudformation/checks/resource/aws/test_ALBDropHttpHeaders.py
+++ b/tests/cloudformation/checks/resource/aws/test_ALBDropHttpHeaders.py
@@ -23,6 +23,7 @@ class TestALBDropHttpHeaders(unittest.TestCase):
 
         passing_resources = {
             "AWS::ElasticLoadBalancingV2::LoadBalancer.PassDefaultType",
+            "AWS::ElasticLoadBalancingV2::LoadBalancer.PassDefaultTypeBool",
             "AWS::ElasticLoadBalancingV2::LoadBalancer.PassExplicitALB",
             "AWS::ElasticLoadBalancingV2::LoadBalancer.PassMultipleAttributes",
         }
@@ -39,7 +40,7 @@ class TestALBDropHttpHeaders(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary['passed'], 3)
+        self.assertEqual(summary['passed'], 4)
         self.assertEqual(summary['failed'], 4)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/cloudformation/checks/resource/aws/test_ALBDropHttpHeaders.py
+++ b/tests/cloudformation/checks/resource/aws/test_ALBDropHttpHeaders.py
@@ -7,7 +7,7 @@ from checkov.runner_filter import RunnerFilter
 
 
 class TestALBDropHttpHeaders(unittest.TestCase):
-    
+
     def test_summary(self):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -17,7 +17,7 @@ class TestALBDropHttpHeaders(unittest.TestCase):
 
         for record in report.failed_checks:
             self.assertEqual(record.check_id, check.id)
-        
+
         for record in report.passed_checks:
             self.assertEqual(record.check_id, check.id)
 
@@ -32,7 +32,9 @@ class TestALBDropHttpHeaders(unittest.TestCase):
             "AWS::ElasticLoadBalancingV2::LoadBalancer.FailDefaultType",
             "AWS::ElasticLoadBalancingV2::LoadBalancer.FailExplicitALB",
             "AWS::ElasticLoadBalancingV2::LoadBalancer.FailExplicitFalse",
+            "AWS::ElasticLoadBalancingV2::LoadBalancer.FailExplicitFalse2",
             "AWS::ElasticLoadBalancingV2::LoadBalancer.FailKeyNotExist",
+            "AWS::ElasticLoadBalancingV2::LoadBalancer.FailKeyNotExist2",
         }
 
         # 2 Unknown resources are tested which are properly silently ignored
@@ -41,7 +43,7 @@ class TestALBDropHttpHeaders(unittest.TestCase):
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
         self.assertEqual(summary['passed'], 4)
-        self.assertEqual(summary['failed'], 4)
+        self.assertEqual(summary['failed'], 6)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
         self.assertEqual(passing_resources, passed_check_resources)

--- a/tests/cloudformation/checks/resource/aws/test_ELBv2AccessLogs.py
+++ b/tests/cloudformation/checks/resource/aws/test_ELBv2AccessLogs.py
@@ -16,7 +16,7 @@ class TestELBv2AccessLogs(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 3)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/cloudformation/checks/resource/aws/test_ELBv2AccessLogs.py
+++ b/tests/cloudformation/checks/resource/aws/test_ELBv2AccessLogs.py
@@ -17,7 +17,7 @@ class TestELBv2AccessLogs(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 2)
-        self.assertEqual(summary['failed'], 3)
+        self.assertEqual(summary['failed'], 4)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/cloudformation/checks/resource/aws/test_RedShiftSSL.py
+++ b/tests/cloudformation/checks/resource/aws/test_RedShiftSSL.py
@@ -22,13 +22,15 @@ class TestRedShiftSSL(unittest.TestCase):
         failing_resources = {
             "AWS::Redshift::ClusterParameterGroup.RedshiftParameterGroupDefault",
             "AWS::Redshift::ClusterParameterGroup.RedshiftParameterGroupDisabled",
+            "AWS::Redshift::ClusterParameterGroup.RedshiftParameterGroupDefault2",
+            "AWS::Redshift::ClusterParameterGroup.RedshiftParameterGroupDisabled2",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
         self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["failed"], 4)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/cloudformation/checks/resource/aws/test_RedShiftSSL.py
+++ b/tests/cloudformation/checks/resource/aws/test_RedShiftSSL.py
@@ -17,6 +17,7 @@ class TestRedShiftSSL(unittest.TestCase):
 
         passing_resources = {
             "AWS::Redshift::ClusterParameterGroup.RedshiftParameterGroupEnabled",
+            "AWS::Redshift::ClusterParameterGroup.RedshiftParameterGroupEnabledBool",
         }
         failing_resources = {
             "AWS::Redshift::ClusterParameterGroup.RedshiftParameterGroupDefault",
@@ -26,7 +27,7 @@ class TestRedShiftSSL(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["passed"], 2)
         self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes 3 checks that only look for boolean values as strings, and fail if you provide an actual boolean (e.g., `attribute: true` instead of `attribute: "true"`)