### PR TITLE
support var element rendering in Bicep

### DIFF
--- a/checkov/bicep/graph_builder/local_graph.py
+++ b/checkov/bicep/graph_builder/local_graph.py
@@ -21,6 +21,7 @@ from typing_extensions import Literal, TypeAlias
 from checkov.bicep.graph_builder.graph_components.block_types import BlockType
 from checkov.bicep.graph_builder.graph_components.blocks import BicepBlock
 from checkov.bicep.graph_builder.variable_rendering.renderer import BicepVariableRenderer
+from checkov.bicep.utils import adjust_value
 from checkov.common.graph.graph_builder.graph_components.edge import Edge
 from checkov.common.graph.graph_builder.local_graph import LocalGraph
 from checkov.common.graph.graph_builder.utils import filter_sub_keys
@@ -303,7 +304,7 @@ class BicepLocalGraph(LocalGraph):
 
     @staticmethod
     def update_config_value(config: list[Any] | dict[str, Any], key: int | str, new_value: Any) -> None:
-        new_value = BicepLocalGraph.adjust_value(config[key], new_value)  # type:ignore[index]
+        new_value = adjust_value(config[key], new_value)  # type:ignore[index]
         if new_value is None:
             # couldn't find key in in value object
             return
@@ -331,29 +332,6 @@ class BicepLocalGraph(LocalGraph):
                 return BicepLocalGraph.adjust_key(config, new_key, new_key_parts)
 
         return key, key_parts
-
-    @staticmethod
-    def adjust_value(element_name: str, value: Any) -> Any:
-        """Adjusts the value, if the 'element_name' references a nested key
-
-        Ex:
-        element_name = publicKey.keyData
-        value = {"keyData": "key-data", "path": "path"}
-
-        returns new_value = "key-data"
-        """
-
-        if "." in element_name:
-            key_parts = element_name.split(".")
-            new_value = value.get(key_parts[1])
-
-            if new_value is None:
-                # couldn't find key in in value object
-                return None
-
-            return BicepLocalGraph.adjust_value(".".join(key_parts[1:]), new_value)
-
-        return value
 
     def get_resources_types_in_graph(self) -> list[str]:
         pass

--- a/checkov/bicep/graph_builder/variable_rendering/renderer.py
+++ b/checkov/bicep/graph_builder/variable_rendering/renderer.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 from pycep.transformer import BicepElement
 
 from checkov.bicep.graph_builder.graph_components.block_types import BlockType
+from checkov.bicep.utils import adjust_value
 from checkov.common.graph.graph_builder import Edge
 from checkov.common.graph.graph_builder.variable_rendering.renderer import VariableRenderer
 
@@ -41,8 +42,12 @@ class BicepVariableRenderer(VariableRenderer):
             vertex = self.local_graph.vertices[dest_index]
 
             if vertex.block_type == BlockType.PARAM:
-                default = vertex.attributes.get("default")
-                if default:
-                    return "default", default
+                new_value = vertex.attributes.get("default")
+                if new_value:
+                    new_value = adjust_value(element_name=origin_value, value=new_value)
+                    return "default", new_value
+            elif vertex.block_type == BlockType.VAR:
+                new_value = adjust_value(element_name=origin_value, value=vertex.attributes["value"])
+                return "value", new_value
 
         return None, None

--- a/checkov/cloudformation/graph_builder/graph_components/blocks.py
+++ b/checkov/cloudformation/graph_builder/graph_components/blocks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import List, Dict, Any, Optional
 
@@ -68,6 +70,12 @@ class CloudformationBlock(Block):
                 obj_to_update[key_to_update] = attribute_value
             else:
                 logging.info(f"Failed to update an attribute, values: {obj_to_update}, {key_to_update}, {attribute_value}")
+
+    def update_inner_attribute(
+        self, attribute_key: str, nested_attributes: list[Any] | dict[str, Any], value_to_update: Any
+    ) -> None:
+        # this overrides the parent method, which doesn't work as expected with CloudFormation
+        pass
 
     @staticmethod
     def _should_add_previous_breadcrumbs(change_origin_id: Optional[int],

--- a/checkov/terraform/graph_builder/graph_components/blocks.py
+++ b/checkov/terraform/graph_builder/graph_components/blocks.py
@@ -2,7 +2,6 @@ import os
 from typing import Union, Dict, Any, List, Optional, Set
 
 from checkov.common.graph.graph_builder.graph_components.blocks import Block
-from checkov.common.graph.graph_builder.variable_rendering.breadcrumb_metadata import BreadcrumbMetadata
 from checkov.common.util.consts import RESOLVED_MODULE_ENTRY_NAME
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 from checkov.terraform.graph_builder.utils import remove_module_dependency_in_path
@@ -61,43 +60,6 @@ class TerraformBlock(Block):
                 return attribute[1]
 
         return None
-
-    def update_attribute(
-        self, attribute_key: str, attribute_value: Any, change_origin_id: int,
-            previous_breadcrumbs: List[BreadcrumbMetadata], attribute_at_dest: str
-    ) -> None:
-        self.update_inner_attribute(attribute_key, self.attributes, attribute_value)
-        super().update_attribute(attribute_key, attribute_value, change_origin_id, previous_breadcrumbs, attribute_at_dest)
-
-    def update_inner_attribute(
-        self, attribute_key: str, nested_attributes: Union[List[Any], Dict[str, Any]], value_to_update: Any
-    ) -> None:
-        split_key = attribute_key.split(".")
-        i = 1
-        curr_key = ".".join(split_key[0:i])
-        if isinstance(nested_attributes, list):
-            if curr_key.isnumeric():
-                curr_key_int = int(curr_key)
-                if curr_key_int < len(nested_attributes):
-                    if not isinstance(nested_attributes[curr_key_int], dict):
-                        nested_attributes[curr_key_int] = value_to_update
-                    else:
-                        self.update_inner_attribute(
-                            ".".join(split_key[i:]), nested_attributes[curr_key_int], value_to_update
-                        )
-            else:
-                for inner in nested_attributes:
-                    self.update_inner_attribute(curr_key, inner, value_to_update)
-        elif isinstance(nested_attributes, dict):
-            while curr_key not in nested_attributes and i <= len(split_key):
-                i += 1
-                curr_key = ".".join(split_key[0:i])
-            if attribute_key in nested_attributes.keys():
-                nested_attributes[attribute_key] = value_to_update
-            if len(split_key) == 1 and len(curr_key) > 0:
-                nested_attributes[curr_key] = value_to_update
-            elif curr_key in nested_attributes.keys():
-                self.update_inner_attribute(".".join(split_key[i:]), nested_attributes[curr_key], value_to_update)
 
     @classmethod
     def get_inner_attributes(

--- a/tests/bicep/graph/graph_builder/examples/mixed/main.bicep
+++ b/tests/bicep/graph/graph_builder/examples/mixed/main.bicep
@@ -1,0 +1,64 @@
+param virtualMachineName string = 'example-vm'
+
+param exampleId string = 'example-id'
+
+param publicKey2 object = {
+  keyData: 'key-data-2'
+  path: 'path-2'
+}
+
+var nicId = [
+  {
+    id: exampleId
+  }
+]
+
+var publicKey4 = {
+  keyData: 'key-data-4'
+  path: {
+    name: publicKey2.path
+  }
+}
+
+resource vm 'Microsoft.Compute/virtualMachines@2021-11-01' = {
+  name: virtualMachineName
+  location: location
+  properties: {
+    networkProfile: {
+      networkInterfaces: nicId
+    }
+    osProfile: {
+      linuxConfiguration: {
+        ssh: {
+          publicKeys: [
+            {
+              keyData: 'key-data-1'
+              path: 'path-1'
+            }
+            publicKey2
+            {
+              keyData: keyData3
+              path: 'path-3'
+            }
+            {
+              keyData: publicKey4.keyData
+              path: publicKey4.path.name
+            }
+          ]
+        }
+      }
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: publisher
+      }
+    }
+  }
+  tags: {
+    displayName: 'Container Registry'
+    'container.registry.name': acrName
+    'container.registry': {
+      name: acrNestedName
+    }
+  }
+}

--- a/tests/bicep/graph/graph_builder/examples/variable/main.bicep
+++ b/tests/bicep/graph/graph_builder/examples/variable/main.bicep
@@ -1,0 +1,72 @@
+var virtualMachineName = 'example-vm'
+
+var location = 'westeurope'
+
+var acrName = 'exmaple-acr'
+
+var acrNestedName = 'exmaple-nested-acr'
+
+var keyData3 = 'key-data-3'
+
+var publisher = 'MicrosoftWindowsServer'
+
+var nicId = [
+  {
+    id: 'example-id'
+  }
+]
+
+var publicKey2 = {
+  keyData: 'key-data-2'
+  path: 'path-2'
+}
+
+var publicKey4 = {
+  keyData: 'key-data-4'
+  path: {
+    name: 'path-4'
+  }
+}
+
+resource vm 'Microsoft.Compute/virtualMachines@2021-11-01' = {
+  name: virtualMachineName
+  location: location
+  properties: {
+    networkProfile: {
+      networkInterfaces: nicId
+    }
+    osProfile: {
+      linuxConfiguration: {
+        ssh: {
+          publicKeys: [
+            {
+              keyData: 'key-data-1'
+              path: 'path-1'
+            }
+            publicKey2
+            {
+              keyData: keyData3
+              path: 'path-3'
+            }
+            {
+              keyData: publicKey4.keyData
+              path: publicKey4.path.name
+            }
+          ]
+        }
+      }
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: publisher
+      }
+    }
+  }
+  tags: {
+    displayName: 'Container Registry'
+    'container.registry.name': acrName
+    'container.registry': {
+      name: acrNestedName
+    }
+  }
+}

--- a/tests/bicep/graph/graph_builder/test_renderer.py
+++ b/tests/bicep/graph/graph_builder/test_renderer.py
@@ -40,3 +40,79 @@ def test_render_parameter():
             "'container.registry'": {"name": "exmaple-nested-acr"},
         },
     }
+
+
+def test_render_variable():
+    # given
+    test_dir = Path(__file__).parent / "examples/variable"
+    graph_manager = BicepGraphManager(db_connector=DBConnector())
+
+    # when
+    local_graph, _ = graph_manager.build_graph_from_source_directory(source_dir=str(test_dir), render_variables=True)
+
+    # then
+    vertex = local_graph.vertices[local_graph.vertices_by_name["vm"]]
+
+    assert vertex.config["config"] == {
+        "name": "example-vm",
+        "location": "westeurope",
+        "properties": {
+            "networkProfile": {"networkInterfaces": [{"id": "example-id"}]},
+            "osProfile": {
+                "linuxConfiguration": {
+                    "ssh": {
+                        "publicKeys": [
+                            {"keyData": "key-data-1", "path": "path-1"},
+                            {"keyData": "key-data-2", "path": "path-2"},
+                            {"keyData": "key-data-3", "path": "path-3"},
+                            {"keyData": "key-data-4", "path": "path-4"},
+                        ]
+                    }
+                }
+            },
+            "storageProfile": {"imageReference": {"publisher": "MicrosoftWindowsServer"}},
+        },
+        "tags": {
+            "displayName": "Container Registry",
+            "'container.registry.name'": "exmaple-acr",
+            "'container.registry'": {"name": "exmaple-nested-acr"},
+        },
+    }
+
+
+def test_render_mixed():
+    # given
+    test_dir = Path(__file__).parent / "examples/mixed"
+    graph_manager = BicepGraphManager(db_connector=DBConnector())
+
+    # when
+    local_graph, _ = graph_manager.build_graph_from_source_directory(source_dir=str(test_dir), render_variables=True)
+
+    # then
+    vertex = local_graph.vertices[local_graph.vertices_by_name["vm"]]
+
+    assert vertex.config["config"] == {
+        "name": "example-vm",
+        "location": "location",
+        "properties": {
+            "networkProfile": {"networkInterfaces": [{"id": "example-id"}]},
+            "osProfile": {
+                "linuxConfiguration": {
+                    "ssh": {
+                        "publicKeys": [
+                            {"keyData": "key-data-1", "path": "path-1"},
+                            {"keyData": "key-data-2", "path": "path-2"},
+                            {"keyData": "keyData3", "path": "path-3"},
+                            {"keyData": "key-data-4", "path": "path-2"},
+                        ]
+                    }
+                }
+            },
+            "storageProfile": {"imageReference": {"publisher": "publisher"}},
+        },
+        "tags": {
+            "displayName": "Container Registry",
+            "'container.registry.name'": "acrName",
+            "'container.registry'": {"name": "acrNestedName"},
+        },
+    }

--- a/tests/bicep/test_graph_manager.py
+++ b/tests/bicep/test_graph_manager.py
@@ -35,7 +35,7 @@ def test_build_graph_from_source_directory():
         "api_version": "2019-06-01",
         "existing": False,
         "config": {
-            "name": "diagStorageAccountName",
+            "name": "diags${uniqueString(resourceGroup().id)}",
             "location": {
                 "function": {
                     "type": "resource_group",
@@ -76,7 +76,7 @@ def test_build_graph_from_definitions():
         "api_version": "2019-06-01",
         "existing": False,
         "config": {
-            "name": "diagStorageAccountName",
+            "name": "diags${uniqueString(resourceGroup().id)}",
             "location": {
                 "function": {
                     "type": "resource_group",


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Added support for `var` element rendering in Bicep + chain rendering also works (ex. `param` -> `var` -> `resource`). I moved the `update_inner_attribute()` method from Terraform to common, because it perfectly works with Bicep, but somehow it doesn't with `CloudFormation`, need extra investigation, which I didn't want to invest for this PR 😄 Also added some missing type hints.
