### PR TITLE
Plan file parsing revision

### DIFF
--- a/checkov/cloudformation/parser/cfn_yaml.py
+++ b/checkov/cloudformation/parser/cfn_yaml.py
@@ -65,15 +65,15 @@ class NodeConstructor(SafeConstructor):
     def __init__(self, filename, content_type: ContentType = None):
         # Call the base class constructor
         super(NodeConstructor, self).__init__()
-        NodeConstructor.add_constructor(
+        self.add_constructor(
             u'tag:yaml.org,2002:map',
             NodeConstructor.construct_yaml_map)
 
-        NodeConstructor.add_constructor(
+        self.add_constructor(
             u'tag:yaml.org,2002:str',
             NodeConstructor.construct_yaml_str)
 
-        NodeConstructor.add_constructor(
+        self.add_constructor(
             u'tag:yaml.org,2002:seq',
             NodeConstructor.construct_yaml_seq)
         if content_type != ContentType.TFPLAN:

--- a/checkov/cloudformation/parser/cfn_yaml.py
+++ b/checkov/cloudformation/parser/cfn_yaml.py
@@ -16,6 +16,7 @@ from yaml.constructor import SafeConstructor
 from yaml.reader import Reader
 from yaml.resolver import Resolver
 from yaml.scanner import Scanner
+from charset_normalizer import from_path
 
 from checkov.common.parsers.node import StrNode, DictNode, ListNode
 
@@ -33,9 +34,11 @@ FN_PREFIX = 'Fn::'
 
 LOGGER = logging.getLogger(__name__)
 
+
 class ContentType(str, Enum):
     CFN = "CFN"
     SLS = "SLS"
+    TFPLAN = "TFPLAN"
 
 
 class CfnParseError(ConstructorError):
@@ -59,10 +62,24 @@ class NodeConstructor(SafeConstructor):
     Node Constructors for loading different types in Yaml
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename, content_type: ContentType = None):
         # Call the base class constructor
         super(NodeConstructor, self).__init__()
+        NodeConstructor.add_constructor(
+            u'tag:yaml.org,2002:map',
+            NodeConstructor.construct_yaml_map)
 
+        NodeConstructor.add_constructor(
+            u'tag:yaml.org,2002:str',
+            NodeConstructor.construct_yaml_str)
+
+        NodeConstructor.add_constructor(
+            u'tag:yaml.org,2002:seq',
+            NodeConstructor.construct_yaml_seq)
+        if content_type != ContentType.TFPLAN:
+            NodeConstructor.add_constructor(
+                u'tag:yaml.org,2002:null',
+                NodeConstructor.construct_yaml_null_error)
         self.filename = filename
 
     # To support lazy loading, the original constructors first yield
@@ -112,23 +129,6 @@ class NodeConstructor(SafeConstructor):
             node.start_mark.line, node.start_mark.column, ' ')
 
 
-NodeConstructor.add_constructor(
-    u'tag:yaml.org,2002:map',
-    NodeConstructor.construct_yaml_map)
-
-NodeConstructor.add_constructor(
-    u'tag:yaml.org,2002:str',
-    NodeConstructor.construct_yaml_str)
-
-NodeConstructor.add_constructor(
-    u'tag:yaml.org,2002:seq',
-    NodeConstructor.construct_yaml_seq)
-
-NodeConstructor.add_constructor(
-    u'tag:yaml.org,2002:null',
-    NodeConstructor.construct_yaml_null_error)
-
-
 class MarkedLoader(Reader, Scanner, Parser, Composer, NodeConstructor, Resolver):
     """
     Class for marked loading YAML
@@ -136,7 +136,7 @@ class MarkedLoader(Reader, Scanner, Parser, Composer, NodeConstructor, Resolver)
 
     # pylint: disable=non-parent-init-called,super-init-not-called
 
-    def __init__(self, stream, filename):
+    def __init__(self, stream, filename, content_type: ContentType = None):
         Reader.__init__(self, stream)
         Scanner.__init__(self)
         if cyaml:
@@ -146,7 +146,7 @@ class MarkedLoader(Reader, Scanner, Parser, Composer, NodeConstructor, Resolver)
         Composer.__init__(self)
         SafeConstructor.__init__(self)
         Resolver.__init__(self)
-        NodeConstructor.__init__(self, filename)
+        NodeConstructor.__init__(self, filename, content_type)
 
     def construct_mapping(self, node, deep=False):
         mapping = super(MarkedLoader, self).construct_mapping(node, deep=deep)
@@ -193,11 +193,11 @@ def construct_getatt(node):
     raise ValueError('Unexpected node type: {}'.format(type(node.value)))
 
 
-def loads(yaml_string, fname=None):
+def loads(yaml_string, fname=None, content_type: ContentType = None):
     """
     Load the given YAML string
     """
-    loader = MarkedLoader(yaml_string, fname)
+    loader = MarkedLoader(yaml_string, fname, content_type)
     loader.add_multi_constructor('!', multi_constructor)
 
     template = loader.get_single_data()
@@ -214,13 +214,19 @@ def load(filename: Path, content_type: ContentType) -> Tuple[DictNode, List[Tupl
     """
 
     file_path = filename if isinstance(filename, Path) else Path(filename)
-    content = file_path.read_text()
+    try:
+        content = file_path.read_text()
+    except UnicodeDecodeError:
+        LOGGER.info(f"Encoding for file {filename} is not UTF-8, trying to detect it")
+        content = str(from_path(filename).best())
 
     if content_type == ContentType.CFN and "Resources" not in content:
         return {}, []
     elif content_type == ContentType.SLS and "provider" not in content:
         return {}, []
+    elif content_type == ContentType.TFPLAN and "planned_values" not in content:
+        return {}, []
 
     file_lines = [(idx + 1, line) for idx, line in enumerate(content.splitlines(keepends=True))]
 
-    return (loads(content, filename), file_lines)
+    return loads(content, filename, content_type), file_lines

--- a/checkov/terraform/context_parsers/tf_plan/__init__.py
+++ b/checkov/terraform/context_parsers/tf_plan/__init__.py
@@ -16,6 +16,7 @@ def parse(filename, out_parsing_errors: Dict[str, str]):
         (template, template_lines) = cfn_yaml.load(filename, ContentType.TFPLAN)
     except Exception as e:
         out_parsing_errors[filename] = str(e)
+        return None, None
 
     if (
         template is not None

--- a/checkov/terraform/context_parsers/tf_plan/__init__.py
+++ b/checkov/terraform/context_parsers/tf_plan/__init__.py
@@ -1,7 +1,8 @@
 import logging
 from typing import Dict
 
-from checkov.common.parsers.json import parse as json_parse
+from checkov.cloudformation.parser.cfn_yaml import ContentType
+from checkov.cloudformation.parser import cfn_yaml
 from checkov.common.parsers.node import DictNode
 
 LOGGER = logging.getLogger(__name__)
@@ -11,7 +12,10 @@ def parse(filename, out_parsing_errors: Dict[str, str]):
     """
         Decode filename into an object
     """
-    (template, template_lines) = json_parse(filename, out_parsing_errors=out_parsing_errors)
+    try:
+        (template, template_lines) = cfn_yaml.load(filename, ContentType.TFPLAN)
+    except Exception as e:
+        out_parsing_errors[filename] = str(e)
 
     if (
         template is not None

--- a/tests/terraform/parser/test_plan_parser.py
+++ b/tests/terraform/parser/test_plan_parser.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from checkov.terraform.plan_parser import parse_tf_plan
-
+from checkov.common.parsers.node import StrNode
 
 class TestPlanFileParser(unittest.TestCase):
 
@@ -14,8 +14,8 @@ class TestPlanFileParser(unittest.TestCase):
         resource_attributes = next(iter(resource_definition.values()))
         resource_tags = resource_attributes['tags'][0]
         for tag_key, tag_value in resource_tags.items():
-            if tag_key not in ['start_line', 'end_line']:
-                self.assertIsInstance(tag_value, str)
+            if tag_key not in ['__startline__', '__endline__', 'start_line', 'end_line']:
+                self.assertIsInstance(tag_value, StrNode)
 
     def test_more_tags_values_are_flattened(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -555,6 +555,22 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 
+    def test_runner_line_numbers(self):
+        # given
+        tf_file_path = Path(__file__).parent / "resources/plan_with_resource_reference/tfplan.json"
+
+        # when
+        report = Runner().run(
+            root_folder=None,
+            files=[str(tf_file_path)],
+            external_checks_dir=None,
+            runner_filter=RunnerFilter(framework=["terraform_plan"]),
+        )
+
+        # then
+        failed_check = report.failed_checks[0]
+        self.assertEqual(failed_check.file_line_range, [13, 19])
+
     def tearDown(self) -> None:
         resource_registry.checks = self.orig_checks
 


### PR DESCRIPTION
Leverage `cfn_yaml` parser to load a terraform plan file, in order to correctly compute resources line numbers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
