### PR TITLE
Added a new check for lambda functions URL AuthType

### DIFF
--- a/checkov/terraform/checks/resource/aws/LambdaFunctionURLAuth.py
+++ b/checkov/terraform/checks/resource/aws/LambdaFunctionURLAuth.py
@@ -5,10 +5,10 @@ from checkov.common.models.enums import CheckCategories
 class LambdaFunctionURLAuth(BaseResourceNegativeValueCheck):
 
     def __init__(self):
-        name = "Ensure that lambda URL functions AuthType is not None"
+        name = "Ensure that Lambda function URLs AuthType is not None"
         id = "CKV_AWS_258"
         supported_resources = ['aws_lambda_function_url']
-        categories = [CheckCategories.ENCRYPTION]
+        categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):

--- a/checkov/terraform/checks/resource/aws/LambdaFunctionURLAuth.py
+++ b/checkov/terraform/checks/resource/aws/LambdaFunctionURLAuth.py
@@ -19,4 +19,3 @@ class LambdaFunctionURLAuth(BaseResourceNegativeValueCheck):
 
 
 check = LambdaFunctionURLAuth()
-

--- a/checkov/terraform/checks/resource/aws/LambdaFunctionURLAuth.py
+++ b/checkov/terraform/checks/resource/aws/LambdaFunctionURLAuth.py
@@ -1,0 +1,22 @@
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class LambdaFunctionURLAuth(BaseResourceNegativeValueCheck):
+
+    def __init__(self):
+        name = "Ensure that lambda URL functions AuthType is not None"
+        id = "CKV_AWS_258"
+        supported_resources = ['aws_lambda_function_url']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "authorization_type"
+
+    def get_forbidden_values(self):
+        return ["NONE"]
+
+
+check = LambdaFunctionURLAuth()
+

--- a/tests/terraform/checks/resource/aws/example_LambdaFunctionURLAuth/main.tf
+++ b/tests/terraform/checks/resource/aws/example_LambdaFunctionURLAuth/main.tf
@@ -1,0 +1,10 @@
+resource "aws_lambda_function_url" "fail" {
+  function_name      = aws_lambda_function.test.function_name
+  authorization_type = "NONE"
+}
+
+resource "aws_lambda_function_url" "pass" {
+  function_name      = aws_lambda_function.test.function_name
+  qualifier          = "my_alias"
+  authorization_type = "AWS_IAM"
+}

--- a/tests/terraform/checks/resource/aws/test_LambdaFunctionURLAuth.py
+++ b/tests/terraform/checks/resource/aws/test_LambdaFunctionURLAuth.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.aws.LambdaFunctionURLAuth import check
+
+
+class TestLambdaFunctionURLAuth(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_LambdaFunctionURLAuth")
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_lambda_function_url.pass",
+        }
+        failing_resources = {
+            "aws_lambda_function_url.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Added a new check that lambda functions URL AuthType is not NONE:
The `authorization_type` is a required field and the options are `NONE` or `AWS_IAM `.

AWS link: [Here](https://aws.amazon.com/blogs/aws/announcing-aws-lambda-function-urls-built-in-https-endpoints-for-single-function-microservices/)
Terraform link: [Here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_url)