### PR TITLE
fix CKV_AZURE_116 to reflect changes in v2.97.0 of Terraform Azure provider

### DIFF
--- a/checkov/terraform/checks/resource/azure/AKSUsesAzurePoliciesAddon.py
+++ b/checkov/terraform/checks/resource/azure/AKSUsesAzurePoliciesAddon.py
@@ -11,7 +11,7 @@ class AKSUsesAzurePoliciesAddon(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):
-        return "addon_profile/[0]/azure_policy/[0]/enabled"
+        return "azure_policy_enabled"
 
 
 check = AKSUsesAzurePoliciesAddon()

--- a/checkov/terraform/checks/resource/azure/AKSUsesAzurePoliciesAddon.py
+++ b/checkov/terraform/checks/resource/azure/AKSUsesAzurePoliciesAddon.py
@@ -1,8 +1,10 @@
-from checkov.common.models.enums import CheckCategories
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from typing import Dict, List, Any
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
 
-class AKSUsesAzurePoliciesAddon(BaseResourceValueCheck):
+class AKSUsesAzurePoliciesAddon(BaseResourceCheck):
     def __init__(self):
         name = "Ensure that AKS uses Azure Policies Add-on"
         id = "CKV_AZURE_116"
@@ -10,8 +12,20 @@ class AKSUsesAzurePoliciesAddon(BaseResourceValueCheck):
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return "azure_policy_enabled"
+    def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
+        # since Azure provider v2.97.0
+        azure_policy_enabled = conf.get("azure_policy_enabled", [None])[0]
+        if azure_policy_enabled:
+            self.evaluated_keys = ["azure_policy_enabled"]
+            return CheckResult.PASSED
+        # up to and including Azure provider v2.96.0
+        addon_profile = conf.get("addon_profile", [None])[0]
+        if addon_profile and isinstance(addon_profile, dict):
+            azure_policy = addon_profile.get("azure_policy", [None])[0]
+            if azure_policy and isinstance(azure_policy, dict) and azure_policy.get("enabled", [None])[0]:
+                self.evaluated_keys = ["addon_profile/[0]/azure_policy/[0]/enabled"]
+                return CheckResult.PASSED
+        return CheckResult.FAILED
 
 
 check = AKSUsesAzurePoliciesAddon()

--- a/checkov/terraform/checks/resource/azure/AKSUsesAzurePoliciesAddon.py
+++ b/checkov/terraform/checks/resource/azure/AKSUsesAzurePoliciesAddon.py
@@ -19,11 +19,11 @@ class AKSUsesAzurePoliciesAddon(BaseResourceCheck):
             self.evaluated_keys = ["azure_policy_enabled"]
             return CheckResult.PASSED
         # up to and including Azure provider v2.96.0
+        self.evaluated_keys = ["addon_profile/[0]/azure_policy/[0]/enabled"]
         addon_profile = conf.get("addon_profile", [None])[0]
         if addon_profile and isinstance(addon_profile, dict):
             azure_policy = addon_profile.get("azure_policy", [None])[0]
             if azure_policy and isinstance(azure_policy, dict) and azure_policy.get("enabled", [None])[0]:
-                self.evaluated_keys = ["addon_profile/[0]/azure_policy/[0]/enabled"]
                 return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/tests/terraform/checks/resource/azure/test_AKSUsesAzurePoliciesAddon.py
+++ b/tests/terraform/checks/resource/azure/test_AKSUsesAzurePoliciesAddon.py
@@ -43,18 +43,84 @@ class TestAKSUsesAzurePoliciesAddon(unittest.TestCase):
                   resource_group_name = azurerm_resource_group.example.name
                   dns_prefix          = "exampleaks1"
 
-                  azure_policy_enabled = false
-                  
+                  addon_profile {
+                    azure_policy {
+                      enabled = false
+                    }
+                  }
+
                   default_node_pool {
                     name       = "default"
                     node_count = 1
                     vm_size    = "Standard_D2_v2"
                   }
-                
+
                   identity {
                     type = "SystemAssigned"
                   }
-                
+
+                  tags = {
+                    Environment = "Production"
+                  }
+                }
+        """)
+        resource_conf = hcl_res['resource'][0]['azurerm_kubernetes_cluster']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+
+    def test_failure3(self):
+        hcl_res = hcl2.loads("""
+                resource "azurerm_kubernetes_cluster" "example" {
+                  name                = "example-aks1"
+                  location            = azurerm_resource_group.example.location
+                  resource_group_name = azurerm_resource_group.example.name
+                  dns_prefix          = "exampleaks1"
+
+                  azure_policy {
+                    enabled = true
+                  }
+
+                  default_node_pool {
+                    name       = "default"
+                    node_count = 1
+                    vm_size    = "Standard_D2_v2"
+                  }
+
+                  identity {
+                    type = "SystemAssigned"
+                  }
+
+                  tags = {
+                    Environment = "Production"
+                  }
+                }
+        """)
+        resource_conf = hcl_res['resource'][0]['azurerm_kubernetes_cluster']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+
+    def test_failure4(self):
+        hcl_res = hcl2.loads("""
+                resource "azurerm_kubernetes_cluster" "example" {
+                  name                = "example-aks1"
+                  location            = azurerm_resource_group.example.location
+                  resource_group_name = azurerm_resource_group.example.name
+                  dns_prefix          = "exampleaks1"
+
+                  azure_policy_enabled = false
+
+                  default_node_pool {
+                    name       = "default"
+                    node_count = 1
+                    vm_size    = "Standard_D2_v2"
+                  }
+
+                  identity {
+                    type = "SystemAssigned"
+                  }
+
                   tags = {
                     Environment = "Production"
                   }
@@ -66,6 +132,40 @@ class TestAKSUsesAzurePoliciesAddon(unittest.TestCase):
 
 
     def test_success(self):
+        hcl_res = hcl2.loads("""
+                resource "azurerm_kubernetes_cluster" "example" {
+                  name                = "example-aks1"
+                  location            = azurerm_resource_group.example.location
+                  resource_group_name = azurerm_resource_group.example.name
+                  dns_prefix          = "exampleaks1"
+                  
+                  addon_profile {
+                    azure_policy {
+                      enabled = true
+                    }
+                  }
+
+                  default_node_pool {
+                    name       = "default"
+                    node_count = 1
+                    vm_size    = "Standard_D2_v2"
+                  }
+
+                  identity {
+                    type = "SystemAssigned"
+                  }
+
+                  tags = {
+                    Environment = "Production"
+                  }
+                }
+        """)
+        resource_conf = hcl_res['resource'][0]['azurerm_kubernetes_cluster']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+    def test_success2(self):
         hcl_res = hcl2.loads("""
                 resource "azurerm_kubernetes_cluster" "example" {
                   name                = "example-aks1"

--- a/tests/terraform/checks/resource/azure/test_AKSUsesAzurePoliciesAddon.py
+++ b/tests/terraform/checks/resource/azure/test_AKSUsesAzurePoliciesAddon.py
@@ -43,42 +43,7 @@ class TestAKSUsesAzurePoliciesAddon(unittest.TestCase):
                   resource_group_name = azurerm_resource_group.example.name
                   dns_prefix          = "exampleaks1"
 
-                  addon_profile {
-                    azure_policy {
-                      enabled = false
-                    }
-                  }
-                  
-                  default_node_pool {
-                    name       = "default"
-                    node_count = 1
-                    vm_size    = "Standard_D2_v2"
-                  }
-                
-                  identity {
-                    type = "SystemAssigned"
-                  }
-                
-                  tags = {
-                    Environment = "Production"
-                  }
-                }
-        """)
-        resource_conf = hcl_res['resource'][0]['azurerm_kubernetes_cluster']['example']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
-
-    def test_failure3(self):
-        hcl_res = hcl2.loads("""
-                resource "azurerm_kubernetes_cluster" "example" {
-                  name                = "example-aks1"
-                  location            = azurerm_resource_group.example.location
-                  resource_group_name = azurerm_resource_group.example.name
-                  dns_prefix          = "exampleaks1"
-
-                  azure_policy {
-                    enabled = true
-                  }
+                  azure_policy_enabled = false
                   
                   default_node_pool {
                     name       = "default"
@@ -107,11 +72,8 @@ class TestAKSUsesAzurePoliciesAddon(unittest.TestCase):
                   location            = azurerm_resource_group.example.location
                   resource_group_name = azurerm_resource_group.example.name
                   dns_prefix          = "exampleaks1"
-                  addon_profile {
-                    azure_policy {
-                      enabled = true
-                    }
-                  }
+                  
+                  azure_policy_enabled = true
 
                   default_node_pool {
                     name       = "default"


### PR DESCRIPTION
fixes #3006 

Unfortunately, I couldn't find the place to update the docs at https://docs.bridgecrew.io/docs/ensure-that-aks-uses-azure-policies-add-on. If someone can point me to the corresponding place, I will also update the docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.