### PR TITLE
Support branch protection rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_PAT_SECRET }}
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v4.4.0
@@ -258,6 +260,8 @@ jobs:
     needs: bump-version
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_PAT_SECRET }}
       - name: get versions
         run: |
           checkov_version=${{ needs.bump-version.outputs.version }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: [ self-hosted, public, linux, x64 ]
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_PAT_SECRET }}
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v4.4.0

--- a/.github/workflows/pipenv-update.yml
+++ b/.github/workflows/pipenv-update.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_PAT_SECRET }}
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v4.4.0


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

We want to add a branch protection rule for master branch, that requires a minimal amount of reviewers on every PR and restricts who can push to the branch.
Adding that would break some of the current github actions workflows, since they would try to push to master without the right permissions.
The PR implements checking out to the code with a PAT that has permissions to push to master, in every job that runs `git commit` or `git push`.