### PR TITLE
Add details to default PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,32 @@
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
+
+## Description
+
+*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*
+
+Fixes # (issue)
+
+
+## New/Edited policies (Delete if not relevant)
+
+### Description
+*Include a description of what makes it a violation and any relevant external links.*
+
+### Fix
+*How do I fix the issue in code and/or in runtime?*
+
+### Category
+Kubernetes, IAM, Networking, Storage, Compute, Public, Secrets, Supply Chain, Monitoring
+
+### Severity
+LOW, MEDIUM, HIGH, CRITICAL
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my feature, policy, or fix is effective and works
+- [ ] New and existing pytest tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,13 +13,8 @@ Fixes # (issue)
 *Include a description of what makes it a violation and any relevant external links.*
 
 ### Fix
-*How do I fix the issue in code and/or in runtime?*
+*How does someone fix the issue in code and/or in runtime?*
 
-### Category
-Kubernetes, IAM, Networking, Storage, Compute, Public, Secrets, Supply Chain, Monitoring
-
-### Severity
-LOW, MEDIUM, HIGH, CRITICAL
 
 ## Checklist:
 
@@ -28,5 +23,5 @@ LOW, MEDIUM, HIGH, CRITICAL
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that prove my feature, policy, or fix is effective and works
-- [ ] New and existing pytest tests pass locally with my changes
+- [ ] New and existing tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules


### PR DESCRIPTION
I added a more descriptive pull request template. This will really lighten the load on the PM team, especially for new policies.

There is no Issues UI dropdown equivalent. You can link to templates ([example](https://github.com/kenji-miyake/test-pr-template/blob/main/.github/PULL_REQUEST_TEMPLATE.md)), but I liked this option better.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
