### PR TITLE
fix K8sHelmRunner check_type

### DIFF
--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -25,14 +25,13 @@ K8_POSSIBLE_ENDINGS = [".yaml", ".yml", ".json"]
 
 
 class K8sHelmRunner(k8_runner):
-    check_type = CheckType.HELM
-
     def __init__(self, graph_class: Type[LocalGraph] = KubernetesLocalGraph,
                  db_connector: NetworkxConnector = NetworkxConnector(),
                  source: str = "Kubernetes",
                  graph_manager: Optional[GraphManager] = None,
                  external_registries: Optional[List[BaseRegistry]] = None) -> None:
         super().__init__(graph_class, db_connector, source, graph_manager, external_registries)
+        self.check_type = CheckType.HELM
         self.chart_dir_and_meta = []
 
     def run(self, root_folder: str | None, external_checks_dir: list[str] | None = None, files: list[str] | None = None,

--- a/tests/helm/test_runner.py
+++ b/tests/helm/test_runner.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 import unittest
+
+from checkov.common.output.report import CheckType
 from checkov.runner_filter import RunnerFilter
 from checkov.helm.runner import Runner
 
@@ -35,6 +37,7 @@ class TestRunnerValid(unittest.TestCase):
         all_checks = report.failed_checks + report.passed_checks
         self.assertEqual(len(report.passed_checks), 0)
         self.assertEqual(len(report.failed_checks), 1)
+        self.assertEqual(report.check_type, CheckType.HELM)
         for record in all_checks:
             self.assertIn(record.repo_file_path, record.file_path)
 


### PR DESCRIPTION
assign K8sHelmRunner check_type after calling the Kubernetes runner init function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
