### PR TITLE
Fix error in create definitions for plan files

### DIFF
--- a/checkov/terraform/plan_utils.py
+++ b/checkov/terraform/plan_utils.py
@@ -42,8 +42,9 @@ def create_definitions(
         for file in files:
             if file.endswith(".json"):
                 current_tf_definitions, current_definitions_raw = parse_tf_plan(file, out_parsing_errors)
-                tf_definitions[file] = current_tf_definitions
-                definitions_raw[file] = current_definitions_raw
+                if current_tf_definitions and current_definitions_raw:
+                    tf_definitions[file] = current_tf_definitions
+                    definitions_raw[file] = current_definitions_raw
             else:
                 logging.debug(f'Failed to load {file} as is not a .json file, skipping')
     return tf_definitions, definitions_raw

--- a/tests/terraform/runner/resources/plan/corrupted-tfplan.json
+++ b/tests/terraform/runner/resources/plan/corrupted-tfplan.json
@@ -1,0 +1,25 @@
+{
+    "format_version": "1.0",
+    "terraform_version": "0.14.0",
+    "values": {
+        "root_module": {
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
+                    "schema_version": 0,
+                    "values": {
+                        "id": "621124146446964903",
+                        "ami": "abc"
+                    },
+                    "sensitive_values": {
+                        "ami": true
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
save tf_definitions only for plan files that were successfully parsed.
add corrupted plan file to tests.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
