### PR TITLE
Run the custom policies download after policy metadata

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -18,7 +18,7 @@ CFN_RESOURCE_TYPE_IDENTIFIER = re.compile(r"^[a-zA-Z0-9]+::[a-zA-Z0-9]+::[a-zA-Z
 
 class CustomPoliciesIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration):
-        super().__init__(bc_integration, order=0)
+        super().__init__(bc_integration, order=1)  # must be after policy metadata
         self.platform_policy_parser = NXGraphCheckParser()
         self.policies_url = f"{self.bc_integration.api_url}/api/v1/policies/table/data"
         self.bc_cloned_checks: Dict[str, List[dict]] = defaultdict(list)

--- a/tests/common/integration_features/test_integration_features.py
+++ b/tests/common/integration_features/test_integration_features.py
@@ -1,0 +1,18 @@
+import unittest
+
+from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as policy_metadata_integration
+from checkov.common.bridgecrew.integration_features.features.custom_policies_integration import integration as custom_policies_integration
+from checkov.common.bridgecrew.integration_features.features.fixes_integration import integration as fixes_integration
+from checkov.common.bridgecrew.integration_features.features.repo_config_integration import integration as repo_config_integration
+from checkov.common.bridgecrew.integration_features.features.suppressions_integration import integration as suppressions_integration
+
+
+class TestSuppressionsIntegration(unittest.TestCase):
+    def test_feature_order(self):
+        self.assertGreater(fixes_integration.order, max([i.order for i in [policy_metadata_integration, custom_policies_integration, repo_config_integration, suppressions_integration]]))
+        self.assertGreater(custom_policies_integration.order, policy_metadata_integration.order)
+        self.assertGreater(suppressions_integration.order, policy_metadata_integration.order)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Specifies an order for policy metadata and custom policy integrations, which we found was platform-dependent. The result was that custom policies did not run on Windows. This behavior must've changed at some point recently, as it only recently started getting reported (but then was widespread, for Windows-only).

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
