### PR TITLE
Find malformed CFN YAML templates

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -16,5 +16,6 @@ ignore_templates:
   - tests/cloudformation/checks/resource/aws/example_SecurityGroupRuleDescription/*
   - tests/cloudformation/checks/resource/aws/example_SecurityGroupRuleDescription
   - tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress22/SecurityGroupUnrestrictedIngress22-UNKNOWN.yaml
+  - tests/cloudformation/checks/resource/*
 ignore_checks:
   - W

--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -17,5 +17,6 @@ ignore_templates:
   - tests/cloudformation/checks/resource/aws/example_SecurityGroupRuleDescription
   - tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress22/SecurityGroupUnrestrictedIngress22-UNKNOWN.yaml
   - tests/cloudformation/checks/resource/*
+  - tests/cloudformation/checks/resource/aws/example_IAMStarActionPolicyDocument/cfn_bad_iam_pass.yaml
 ignore_checks:
   - W

--- a/checkov/cloudformation/cfn_utils.py
+++ b/checkov/cloudformation/cfn_utils.py
@@ -217,7 +217,7 @@ def get_files_definitions(files: List[str], out_parsing_errors: Dict[str, str], 
 
 def validate_properties_in_resources_are_dict(template: DictNode) -> bool:
     template_resources = template.get("Resources")
-    for resource in template_resources.values():
-        if 'Properties' in resource and not isinstance(resource['Properties'], DictNode):
+    for resource_name, resource in template_resources.items():
+        if 'Properties' in resource and not isinstance(resource['Properties'], DictNode) or "." in resource_name:
             return False
     return True

--- a/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
+++ b/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
@@ -47,6 +47,8 @@ class BaseCloudsplainingIAMCheck(BaseResourceCheck):
                     if not policy_statement:
                         # When using unresolved Cfn functions, policy is an str
                         policy_doc = policy[policy_doc_key]
+                        if not isinstance(policy_doc, dict):
+                            return CheckResult.UNKNOWN
                         converted_policy_doc = convert_cloudformation_conf_to_iam_policy(policy_doc)
                         statement_key = 'Statement'
                         if statement_key in converted_policy_doc:

--- a/checkov/cloudformation/checks/resource/aws/IAMStarActionPolicyDocument.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMStarActionPolicyDocument.py
@@ -44,7 +44,7 @@ def check_policy(policy_block):
     if policy_block:
         if isinstance(policy_block, str):
             policy_block = ast.literal_eval(policy_block)
-        if 'Statement' in policy_block.keys():
+        if isinstance(policy_block, dict) and 'Statement' in policy_block.keys():
             for statement in force_list(policy_block['Statement']):
                 if 'Action' in statement and statement.get('Effect', ['Allow']) == 'Allow' and '*' in force_list(
                         statement['Action']):

--- a/checkov/cloudformation/graph_builder/utils.py
+++ b/checkov/cloudformation/graph_builder/utils.py
@@ -54,7 +54,8 @@ def get_referenced_vertices_in_value(
     if isinstance(value, dict):
         for key, sub_value in value.items():
             if key == IntrinsicFunctions.GET_ATT:
-                sub_value = '.'.join(sub_value) if isinstance(sub_value, list) else sub_value
+                sub_value = '.'.join(sub_value) if \
+                    isinstance(sub_value, list) and all(isinstance(s, str) for s in sub_value) else sub_value
             references_vertices += get_referenced_vertices_in_value(
                 sub_value, vertices_block_name_map
             )

--- a/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
@@ -265,19 +265,21 @@ class CloudformationVariableRenderer(VariableRenderer):
     def _evaluate_getatt_connection(value: List[str], dest_vertex_attributes: Dict[str, Any]) -> (
             Optional[str], Optional[str]):
         # value = [ "logicalNameOfResource", "attributeName" ]
-        if isinstance(value, list) and len(value) == 2:
-            resource_name = value[0]
-            attribute_name = value[1]
-            dest_name = dest_vertex_attributes.get(CustomAttributes.BLOCK_NAME).split('.')[-1]
-            attribute_at_dest = attribute_name
-            evaluated_value = dest_vertex_attributes.get(
-                attribute_at_dest)  # we extract only build time atts, not runtime
+        try:
+            if isinstance(value, list) and len(value) == 2:
+                resource_name = value[0]
+                attribute_at_dest = value[1]
+                dest_name = dest_vertex_attributes.get(CustomAttributes.BLOCK_NAME).split('.')[-1]
+                evaluated_value = dest_vertex_attributes.get(
+                    attribute_at_dest)  # we extract only build time atts, not runtime
 
-            if evaluated_value and \
-                    all(isinstance(element, str) for element in value) and \
-                    resource_name == dest_name and \
-                    dest_vertex_attributes.get(CustomAttributes.BLOCK_TYPE) == BlockType.RESOURCE:
-                return str(evaluated_value), attribute_at_dest
+                if evaluated_value and \
+                        all(isinstance(element, str) for element in value) and \
+                        resource_name == dest_name and \
+                        dest_vertex_attributes.get(CustomAttributes.BLOCK_TYPE) == BlockType.RESOURCE:
+                    return str(evaluated_value), attribute_at_dest
+        except TypeError as e:
+            logging.debug(f"unable to _evaluate_getatt_connection: {e}")
 
         return None, None
 

--- a/checkov/cloudformation/parser/cfn_yaml.py
+++ b/checkov/cloudformation/parser/cfn_yaml.py
@@ -165,9 +165,14 @@ def multi_constructor(loader, tag_suffix, node):
     if tag_suffix not in UNCONVERTED_SUFFIXES:
         tag_suffix = '{}{}'.format(FN_PREFIX, tag_suffix)
 
-    constructor = None
     if tag_suffix == 'Fn::GetAtt':
         constructor = construct_getatt
+    elif tag_suffix == "Ref" and (isinstance(node.value, list) or isinstance(node.value, dict)):
+        raise CfnParseError(
+            filename="",
+            message='Invalid !Ref: {}'.format(node.value),
+            line_number=0,
+            column_number=0)
     elif isinstance(node, ScalarNode):
         constructor = loader.construct_scalar
     elif isinstance(node, SequenceNode):

--- a/checkov/cloudformation/parser/cfn_yaml.py
+++ b/checkov/cloudformation/parser/cfn_yaml.py
@@ -99,6 +99,8 @@ class NodeConstructor(SafeConstructor):
             value = self.construct_object(value_node, False)
             if isinstance(key, dict):
                 key = frozenset(key.keys()), frozenset(key.values())
+            if isinstance(key, list):
+                key = frozenset(key)
             if key in mapping:
                 raise CfnParseError(
                     self.filename,

--- a/tests/cloudformation/checks/resource/aws/example_IAMStarActionPolicyDocument/cfn_bad_iam_pass.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_IAMStarActionPolicyDocument/cfn_bad_iam_pass.yaml
@@ -1,0 +1,13 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Test bad IAM policies
+Resources:
+  rIamPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+      - Fn::If:
+        - cCondition
+        - Statement: {}
+        - Statement: []

--- a/tests/cloudformation/checks/resource/aws/test_IAMStarActionPolicyDocument.py
+++ b/tests/cloudformation/checks/resource/aws/test_IAMStarActionPolicyDocument.py
@@ -16,7 +16,7 @@ class TestIAMStarActionPolicyDocument(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
         self.assertEqual(report.failed_checks[0].check_id, check.id)
-        self.assertEqual(summary['passed'], 4)
+        self.assertEqual(summary['passed'], 5)
         self.assertEqual(summary['failed'], 4)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/cloudformation/parser/cfn_bad_iam.yaml
+++ b/tests/cloudformation/parser/cfn_bad_iam.yaml
@@ -1,0 +1,32 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Test bad IAM policies
+Resources:
+  rIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument: {}
+      Policies:
+      - PolicyName: String
+        PolicyDocument:
+          Version: 'blah'
+          BadProperty: test
+          Statement: "Test"
+  rIamUser:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 'blah'
+        Statement:
+        - Resource: '*'
+          Effect: 'NotAllow'
+          Principal: [123456789012]
+  rIamPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+      - Fn::If:
+        - cCondition
+        - Statement: {}
+        - Statement: []

--- a/tests/cloudformation/parser/cfn_bad_name.yaml
+++ b/tests/cloudformation/parser/cfn_bad_name.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  with.dot:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: x
+  no_dot:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: y

--- a/tests/cloudformation/parser/cfn_with_ref_bad.yaml
+++ b/tests/cloudformation/parser/cfn_with_ref_bad.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "data-stage"
+
+Parameters:
+  ElasticsearchInstanceType:
+    Type: String
+    Default: r5.large.elasticsearch
+
+Resources:
+  ElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: !Join
+          - "-"
+          - - !Ref AWS::StackName
+            - "20200325"
+      ElasticsearchVersion: !Ref [1]
+      ElasticsearchClusterConfig:
+        InstanceCount: '1'
+        InstanceType: !Ref ElasticsearchInstanceType

--- a/tests/cloudformation/parser/test_cfn_yaml.py
+++ b/tests/cloudformation/parser/test_cfn_yaml.py
@@ -130,6 +130,17 @@ class TestCfnYaml(unittest.TestCase):
         self.assertEqual(entity_lines_range[0], 10)
         self.assertEqual(entity_lines_range[1], 20)
 
+    def test_parsing_error(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files = ["cfn_bad_name.yaml", "cfn_with_ref_bad.yaml", "cfn_bad_iam.yaml"]
+        report = Runner().run(None, files=[f'{current_dir}/{f}' for f in test_files], runner_filter=RunnerFilter())
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 6)
+        self.assertEqual(summary['failed'], 0)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
Catching some malformed CFN templates, using resources in https://github.com/aws-cloudformation/cfn-lint.

### Description
Identified issues:
1. Resource name with a `.` in its name.
2. Policy documents with invalid statement.
3. !Ref of a list object
4. Evaluating getatt when one of the elements is a list

### Fix
1-2. Identify these cases as malformed and set it as parsing error.
3-4. Make sure we don't fail variable rendering because of it.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
