### PR TITLE
output baseline skipped in results

### DIFF
--- a/checkov/common/output/baseline.py
+++ b/checkov/common/output/baseline.py
@@ -69,15 +69,15 @@ class Baseline:
             scan_report.skipped_checks = [
                 check for check in scan_report.skipped_checks if self._is_check_in_baseline(check)
             ]
-            failed_checks = []
-            for check in scan_report.failed_checks:
-                if not self._is_check_in_baseline(check):
-                    failed_checks.append(check)
-                elif self.output_skipped:
-                    check.check_result["suppress_comment"] = "baseline-skipped"
-                    check.check_result["result"] = CheckResult.SKIPPED
-                    scan_report.skipped_checks.append(check)
-            scan_report.failed_checks = failed_checks
+            if self.output_skipped:
+                for check in scan_report.failed_checks:
+                    if self._is_check_in_baseline(check):
+                        check.check_result["suppress_comment"] = "baseline-skipped"
+                        check.check_result["result"] = CheckResult.SKIPPED
+                        scan_report.skipped_checks.append(check)
+            scan_report.failed_checks = [
+                check for check in scan_report.failed_checks if not self._is_check_in_baseline(check)
+            ]
 
     def _is_check_in_baseline(self, check: Record) -> bool:
         failed_check_id = check.check_id

--- a/checkov/common/output/baseline.py
+++ b/checkov/common/output/baseline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections import defaultdict
+from checkov.common.models.enums import CheckResult
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -11,10 +12,11 @@ if TYPE_CHECKING:
 
 
 class Baseline:
-    def __init__(self) -> None:
+    def __init__(self, output_skipped: bool = False) -> None:
         self.path = ""
         self.path_failed_checks_map: dict[str, list[_BaselineFinding]] = defaultdict(list)
         self.failed_checks: list[_BaselineFailedChecks] = []
+        self.output_skipped = output_skipped
 
     def add_findings_from_report(self, report: Report) -> None:
         for check in report.failed_checks:
@@ -67,9 +69,15 @@ class Baseline:
             scan_report.skipped_checks = [
                 check for check in scan_report.skipped_checks if self._is_check_in_baseline(check)
             ]
-            scan_report.failed_checks = [
-                check for check in scan_report.failed_checks if not self._is_check_in_baseline(check)
-            ]
+            failed_checks = []
+            for check in scan_report.failed_checks:
+                if not self._is_check_in_baseline(check):
+                    failed_checks.append(check)
+                elif self.output_skipped:
+                    check.check_result["suppress_comment"] = "baseline-skipped"
+                    check.check_result["result"] = CheckResult.SKIPPED
+                    scan_report.skipped_checks.append(check)
+            scan_report.failed_checks = failed_checks
 
     def _is_check_in_baseline(self, check: Record) -> bool:
         failed_check_id = check.check_id

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -233,7 +233,7 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
 
     baseline = None
     if config.baseline:
-        baseline = Baseline()
+        baseline = Baseline(config.output_baseline_as_skipped)
         baseline.from_json(config.baseline)
 
     external_checks_dir = get_external_checks_dir(config)
@@ -497,6 +497,9 @@ def add_parser_args(parser: ArgumentParser) -> None:
     parser.add('--skip-cve-package',
                help='filter scan to run on all packages but a specific package identifier (denylist), You can '
                     'specify this argument multiple times to skip multiple packages', action='append', default=None)
+    parser.add('--output-baseline-as-skipped',
+            help="output checks that are skipped due to baseline file presence",
+            action='store_true', default=False)
 
 
 def get_external_checks_dir(config: Any) -> Any:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -494,12 +494,12 @@ def add_parser_args(parser: ArgumentParser) -> None:
         ),
         default=None,
     )
+    parser.add('--output-baseline-as-skipped',
+        help="output checks that are skipped due to baseline file presence",
+        action='store_true', default=False)
     parser.add('--skip-cve-package',
                help='filter scan to run on all packages but a specific package identifier (denylist), You can '
                     'specify this argument multiple times to skip multiple packages', action='append', default=None)
-    parser.add('--output-baseline-as-skipped',
-            help="output checks that are skipped due to baseline file presence",
-            action='store_true', default=False)
 
 
 def get_external_checks_dir(config: Any) -> Any:

--- a/docs/2.Basics/CLI Command Reference.md
+++ b/docs/2.Basics/CLI Command Reference.md
@@ -47,6 +47,7 @@ nav_order: 2
 | `--show-config` | prints all args and config settings and where they came from (eg. commandline, config file, environment variable or default)
 | `--create-baseline` | Alongside outputting the findings, save all results to .checkov.baseline file so future runs will not re-flag the same noise. Works only with `--directory` flag | 
 | `--baseline BASELINE` | Use a .checkov.baseline file to compare current results with a known baseline. Report will include only failed checks that are new with respect to the provided baseline | 
+| `--output-baseline-as-skipped` | Output checks that are skipped due to baseline file presence | 
 | `-s`, `--soft-fail` | Runs checks but suppresses error code | 
 | `--soft-fail-on SOFT_FAIL_ON` | Exits with a 0 exit code for specified checks. You can specify multiple checks separated by comma delimiter | 
 | `--hard-fail-on HARD_FAIL_ON` | Exits with a non-zero exit code for specified checks. You can specify multiple checks separated by comma delimiter | 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

added boolean flag `--output-baseline-as-skipped` to output skipped checks due to baseline in the results report.

Fixes [#1502](https://github.com/bridgecrewio/checkov/issues/1502)
