### PR TITLE
Fix accessing non dictionary CFN resources

### DIFF
--- a/checkov/cloudformation/parser/__init__.py
+++ b/checkov/cloudformation/parser/__init__.py
@@ -65,7 +65,7 @@ def parse(
 
     if isinstance(template, dict):
         resources = template.get(TemplateSections.RESOURCES.value, None)
-        if resources:
+        if resources and isinstance(resources, dict):
             if "__startline__" in resources:
                 del resources["__startline__"]
             if "__endline__" in resources:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Handling a bug in cloudformation parser, when trying to parse a malformed file with resources not being a dictionary.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
