### PR TITLE
create one graph in helm runner

### DIFF
--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -42,9 +42,21 @@ class K8sHelmRunner(k8_runner):
         if external_checks_dir:
             for directory in external_checks_dir:
                 registry.load_external_checks(directory)
-        chart_results = super().run(root_folder, external_checks_dir=external_checks_dir, runner_filter=runner_filter)
-        fix_report_paths(chart_results, root_folder)
-        return chart_results
+        try:
+            chart_results = super().run(root_folder, external_checks_dir=external_checks_dir, runner_filter=runner_filter)
+            fix_report_paths(chart_results, root_folder)
+            return chart_results
+        except Exception:
+            logging.warning(f"Failed to run Kubernetes runner on charts {self.chart_dir_and_meta}", exc_info=True)
+            # with tempfile.TemporaryDirectory() as save_error_dir:
+            # TODO this will crash the run when target_dir gets cleaned up, since it no longer exists
+            # we either need to copy or find another way to extract whatever we want to get from this (the TODO below)
+            # logging.debug(
+            #    f"Error running k8s scan on {chart_meta['name']}. Scan dir: {target_dir}. Saved context dir: {save_error_dir}")
+            # shutil.move(target_dir, save_error_dir)
+
+            # TODO: Export helm dependancies for the chart we've extracted in chart_dependencies
+            return report
 
 
 class Runner(BaseRunner):

--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -174,7 +174,7 @@ class Runner(BaseRunner):
         processed_chart_dir_and_meta = []
         for chart_dir, chart_meta in chart_dir_and_meta:
             processed_chart_dir_and_meta.append((chart_dir.replace(root_folder, ""), chart_meta))
-            target_dir = chart_dir.replace(root_folder, self.target_folder_path)
+            target_dir = chart_dir.replace(root_folder, f'{self.target_folder_path}/')
             logging.info(
                 f"Processing chart found at: {chart_dir}, name: {chart_meta['name']}, version: {chart_meta['version']}")
             # dependency list is nicer to parse than dependency update.

--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -35,37 +35,16 @@ class K8sHelmRunner(k8_runner):
         self.chart_dir_and_meta = []
 
     def run(self, root_folder: str | None, external_checks_dir: list[str] | None = None, files: list[str] | None = None,
-            runner_filter: RunnerFilter = RunnerFilter(), collect_skip_comments: bool = True, helmChart: str = None) -> Report:
+            runner_filter: RunnerFilter = RunnerFilter(), collect_skip_comments: bool = True) -> Report:
         report = Report(self.check_type)
         if not self.chart_dir_and_meta:
             return report
         if external_checks_dir:
             for directory in external_checks_dir:
                 registry.load_external_checks(directory)
-        for chart_dir, chart_meta in self.chart_dir_and_meta:
-            try:
-                target_dir = f'{root_folder}{chart_dir}'
-                chart_results = super().run(target_dir, external_checks_dir=external_checks_dir,
-                                            runner_filter=runner_filter, helmChart=chart_meta['name'])
-                fix_report_paths(chart_results, target_dir)
-                logging.debug(f"Sucessfully ran k8s scan on {chart_meta['name']}. Scan dir : {target_dir}")
-                report.failed_checks.extend(chart_results.failed_checks)
-                report.passed_checks.extend(chart_results.passed_checks)
-                report.parsing_errors.extend(chart_results.parsing_errors)
-                report.skipped_checks.extend(chart_results.skipped_checks)
-                report.resources.update(chart_results.resources)
-
-            except Exception:
-                logging.warning(f"Failed to run Kubernetes runner on chart {chart_meta['name']}", exc_info=True)
-                # with tempfile.TemporaryDirectory() as save_error_dir:
-                # TODO this will crash the run when target_dir gets cleaned up, since it no longer exists
-                # we either need to copy or find another way to extract whatever we want to get from this (the TODO below)
-                # logging.debug(
-                #    f"Error running k8s scan on {chart_meta['name']}. Scan dir: {target_dir}. Saved context dir: {save_error_dir}")
-                # shutil.move(target_dir, save_error_dir)
-
-                # TODO: Export helm dependancies for the chart we've extracted in chart_dependencies
-        return report
+        chart_results = super().run(root_folder, external_checks_dir=external_checks_dir, runner_filter=runner_filter)
+        fix_report_paths(chart_results, root_folder)
+        return chart_results
 
 
 class Runner(BaseRunner):

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -40,7 +40,7 @@ class Runner(BaseRunner):
         self.definitions_raw = {}
         self.report_mutator_data = None
 
-    def run(self, root_folder, external_checks_dir=None, files=None, runner_filter=RunnerFilter(), collect_skip_comments=True, helmChart=None):
+    def run(self, root_folder, external_checks_dir=None, files=None, runner_filter=RunnerFilter(), collect_skip_comments=True):
         report = Report(self.check_type)
         if self.context is None or self.definitions is None:
             if files or root_folder:
@@ -67,15 +67,15 @@ class Runner(BaseRunner):
                 self.graph_manager.save_graph(local_graph)
                 self.definitions = local_graph.definitions
 
-        report = self.check_definitions(root_folder, runner_filter, report, collect_skip_comments=collect_skip_comments, helmChart=helmChart)
+        report = self.check_definitions(root_folder, runner_filter, report, collect_skip_comments=collect_skip_comments)
 
         if CHECKOV_CREATE_GRAPH:
-            graph_report = self.get_graph_checks_report(root_folder, runner_filter, helmChart=helmChart)
+            graph_report = self.get_graph_checks_report(root_folder, runner_filter)
             merge_reports(report, graph_report)
 
         return report
 
-    def check_definitions(self, root_folder, runner_filter, report, collect_skip_comments=True, helmChart=None,):
+    def check_definitions(self, root_folder, runner_filter, report, collect_skip_comments=True):
         for k8_file in self.definitions.keys():
             # There are a few cases here. If -f was used, there could be a leading / because it's an absolute path,
             # or there will be no leading slash; root_folder will always be none.
@@ -103,7 +103,7 @@ class Runner(BaseRunner):
 
         return report
 
-    def get_graph_checks_report(self, root_folder: str, runner_filter: RunnerFilter, helmChart) -> Report:
+    def get_graph_checks_report(self, root_folder: str, runner_filter: RunnerFilter) -> Report:
         report = Report(self.check_type)
         checks_results = self.run_graph_checks_results(runner_filter)
         report = self.mutateKubernetesGraphResults(root_folder, runner_filter, report, checks_results)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

in order to create one graph in helm runner - call Kubernetes runner once for all the chart dirs.
remove `helmChart` unused parameter.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
