### PR TITLE
When specifying API URL via arg, leverage it in vuln scanning

### DIFF
--- a/checkov/common/bridgecrew/vulnerability_scanning/integrations/twistcli.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/integrations/twistcli.py
@@ -13,15 +13,13 @@ from checkov.common.util.http_utils import get_default_post_headers, request_wra
 
 
 class TwistcliIntegration(ABC):
-    vulnerabilities_base_url = f"{bc_integration.api_url}/api/v1/vulnerabilities"
-    vulnerabilities_save_results_url = f"{vulnerabilities_base_url}/results"
-    twictcli_base_url = f"{vulnerabilities_base_url}/twistcli"
+    vulnerabilities_base_path = "/api/v1/vulnerabilities"
 
     def get_bc_api_key(self) -> str:
         return bc_integration.get_auth_token()
 
     def get_proxy_address(self) -> str:
-        return f"{self.vulnerabilities_base_url}/docker-images/twistcli/proxy"
+        return f"{bc_integration.api_url}{self.vulnerabilities_base_path}/docker-images/twistcli/proxy"
 
     def download_twistcli(self, cli_file_name: Path) -> None:
         # backwards compatibility, should be removed in a later stage
@@ -29,7 +27,8 @@ class TwistcliIntegration(ABC):
 
         os_type = platform.system().lower()
 
-        response = request_wrapper("GET", f"{self.twictcli_base_url}?os={os_type}",
+        response = request_wrapper("GET",
+                                   f"{bc_integration.api_url}{self.vulnerabilities_base_path}/twistcli?os={os_type}",
                                    headers=bc_integration.get_default_headers("GET"),
                                    should_call_raise_for_status=True)
 
@@ -47,7 +46,7 @@ class TwistcliIntegration(ABC):
             **kwargs,
         )
 
-        request_wrapper("POST", self.vulnerabilities_save_results_url,
+        request_wrapper("POST", f"{bc_integration.api_url}{self.vulnerabilities_base_path}/results",
                         headers=bc_integration.get_default_headers("POST"),
                         json=payload, should_call_raise_for_status=True)
 
@@ -74,7 +73,7 @@ class TwistcliIntegration(ABC):
 
         async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(resolver=aiohttp.AsyncResolver())) as session:
             async with session.post(
-                url=self.vulnerabilities_save_results_url, headers=headers, json=payload
+                url=f'{bc_integration.api_url}{self.vulnerabilities_base_path}/results', headers=headers, json=payload
             ) as response:
                 content = await response.text()
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
When using static imports, we didn't allow overriding the image scanning URLs according to the command argument, only via the `BC_API_URL` env var

### Description
We support overriding the default platform URL via env var and via command arg, but the vuln scanning only leveraged the former due to static importing. This allows overriding it via command arg.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
