### PR TITLE
Convert Bicep parsing error to warning

### DIFF
--- a/checkov/bicep/parser.py
+++ b/checkov/bicep/parser.py
@@ -18,8 +18,8 @@ class Parser:
 
         try:
             template = self.bicep_parser.parse(text=content)
-        except Exception as e:
-            logging.warning(f"[bicep] Couldn't parse {file_path}: {e}")
+        except Exception:
+            logging.debug(f"[bicep] Couldn't parse {file_path}", exc_info=True)
             return None, None
 
         file_lines = [(idx + 1, line) for idx, line in enumerate(content.splitlines(keepends=True))]

--- a/checkov/bicep/parser.py
+++ b/checkov/bicep/parser.py
@@ -18,8 +18,8 @@ class Parser:
 
         try:
             template = self.bicep_parser.parse(text=content)
-        except Exception:
-            logging.error(f"[bicep] Couldn't parse {file_path}", exc_info=True)
+        except Exception as e:
+            logging.warning(f"[bicep] Couldn't parse {file_path}: {e}")
             return None, None
 
         file_lines = [(idx + 1, line) for idx, line in enumerate(content.splitlines(keepends=True))]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Instead of logging an error when bicep parsing failed, log a warning.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
