### PR TITLE
Add proxy authentication headers

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -157,13 +157,17 @@ class BcPlatformIntegration:
         if ca_certificate:
             os.environ['REQUESTS_CA_BUNDLE'] = ca_certificate
             try:
+                parsed_url = urllib3.util.parse_url(os.environ['https_proxy'])
                 self.http = urllib3.ProxyManager(os.environ['https_proxy'], cert_reqs='REQUIRED',
-                                                 ca_certs=ca_certificate)
+                                                 ca_certs=ca_certificate,
+                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth))
             except KeyError:
                 self.http = urllib3.PoolManager(cert_reqs='REQUIRED', ca_certs=ca_certificate)
         else:
             try:
-                self.http = urllib3.ProxyManager(os.environ['https_proxy'])
+                parsed_url = urllib3.util.parse_url(os.environ['https_proxy'])
+                self.http = urllib3.ProxyManager(os.environ['https_proxy'],
+                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth))
             except KeyError:
                 self.http = urllib3.PoolManager()
 

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -157,17 +157,17 @@ class BcPlatformIntegration:
         if ca_certificate:
             os.environ['REQUESTS_CA_BUNDLE'] = ca_certificate
             try:
-                parsed_url = urllib3.util.parse_url(os.environ['https_proxy'])
+                parsed_url = urllib3.util.parse_url(os.environ['https_proxy']) # type:ignore[no-untyped-call]
                 self.http = urllib3.ProxyManager(os.environ['https_proxy'], cert_reqs='REQUIRED',
                                                  ca_certs=ca_certificate,
-                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth))
+                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth)) # type:ignore[no-untyped-call]
             except KeyError:
                 self.http = urllib3.PoolManager(cert_reqs='REQUIRED', ca_certs=ca_certificate)
         else:
             try:
-                parsed_url = urllib3.util.parse_url(os.environ['https_proxy'])
+                parsed_url = urllib3.util.parse_url(os.environ['https_proxy']) # type:ignore[no-untyped-call]
                 self.http = urllib3.ProxyManager(os.environ['https_proxy'],
-                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth))
+                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth)) # type:ignore[no-untyped-call]
             except KeyError:
                 self.http = urllib3.PoolManager()
 

--- a/checkov/common/vcs/base_vcs_dal.py
+++ b/checkov/common/vcs/base_vcs_dal.py
@@ -44,13 +44,17 @@ class BaseVCSDAL:
         if ca_certificate:
             os.environ['REQUESTS_CA_BUNDLE'] = ca_certificate
             try:
+                parsed_url = urllib3.util.parse_url(os.environ['https_proxy'])
                 self.http = urllib3.ProxyManager(os.environ['https_proxy'], cert_reqs='REQUIRED',
-                                                 ca_certs=ca_certificate)
+                                                 ca_certs=ca_certificate,
+                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth))
             except KeyError:
                 self.http = urllib3.PoolManager(cert_reqs='REQUIRED', ca_certs=ca_certificate)
         else:
             try:
-                self.http = urllib3.ProxyManager(os.environ['https_proxy'])
+                parsed_url = urllib3.util.parse_url(os.environ['https_proxy'])
+                self.http = urllib3.ProxyManager(os.environ['https_proxy'],
+                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth))
             except KeyError:
                 self.http = urllib3.PoolManager()
 

--- a/checkov/common/vcs/base_vcs_dal.py
+++ b/checkov/common/vcs/base_vcs_dal.py
@@ -44,17 +44,17 @@ class BaseVCSDAL:
         if ca_certificate:
             os.environ['REQUESTS_CA_BUNDLE'] = ca_certificate
             try:
-                parsed_url = urllib3.util.parse_url(os.environ['https_proxy'])
+                parsed_url = urllib3.util.parse_url(os.environ['https_proxy']) # type:ignore[no-untyped-call]
                 self.http = urllib3.ProxyManager(os.environ['https_proxy'], cert_reqs='REQUIRED',
                                                  ca_certs=ca_certificate,
-                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth))
+                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth)) # type:ignore[no-untyped-call]
             except KeyError:
                 self.http = urllib3.PoolManager(cert_reqs='REQUIRED', ca_certs=ca_certificate)
         else:
             try:
-                parsed_url = urllib3.util.parse_url(os.environ['https_proxy'])
+                parsed_url = urllib3.util.parse_url(os.environ['https_proxy']) # type:ignore[no-untyped-call]
                 self.http = urllib3.ProxyManager(os.environ['https_proxy'],
-                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth))
+                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth)) # type:ignore[no-untyped-call]
             except KeyError:
                 self.http = urllib3.PoolManager()
 


### PR DESCRIPTION
## Description

This PR allow mappings and guidelines to be downloaded behind proxies requiring authentication.

Otherwise :

```
2022-06-07 14:36:01,903 [MainThread  ] [WARNI]  Failed to get the checkov mappings and guidelines from https://www.bridgecrew.cloud/api/v1/guidelines
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 700, in urlopen
    self._prepare_proxy(conn)
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 994, in _prepare_proxy
    conn.connect()
  File "/usr/local/lib/python3.7/site-packages/urllib3/connection.py", line 369, in connect
    self._tunnel()
  File "/usr/local/lib/python3.7/http/client.py", line 931, in _tunnel
    message.strip()))
OSError: Tunnel connection failed: 407 Proxy Authentication Required

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/checkov/common/bridgecrew/platform_integration.py", line 570, in get_public_run_config
    request = self.http.request("GET", self.guidelines_api_url, headers=headers)
  File "/usr/local/lib/python3.7/site-packages/urllib3/request.py", line 75, in request
    method, url, fields=fields, headers=headers, **urlopen_kw
  File "/usr/local/lib/python3.7/site-packages/urllib3/request.py", line 96, in request_encode_url
    return self.urlopen(method, url, **extra_kw)
  File "/usr/local/lib/python3.7/site-packages/urllib3/poolmanager.py", line 533, in urlopen
    return super(ProxyManager, self).urlopen(method, url, redirect=redirect, **kw)
  File "/usr/local/lib/python3.7/site-packages/urllib3/poolmanager.py", line 376, in urlopen
    response = conn.urlopen(method, u.request_uri, **kw)
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 826, in urlopen
    **response_kw
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 826, in urlopen
    **response_kw
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 826, in urlopen
    **response_kw
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 786, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "/usr/local/lib/python3.7/site-packages/urllib3/util/retry.py", line 592, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='www.bridgecrew.cloud', port=443): Max retries exceeded with url: /api/v1/guidelines (Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 407 Proxy Authentication Required')))
```

Kind regards,