### PR TITLE
Make severity filters case-insensiive

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -164,7 +164,8 @@ class Report:
         soft_fail_threshold = None
         # soft fail on the highest severity threshold in the list
         for val in convert_csv_string_arg_to_list(soft_fail_on):
-            if val in Severities:
+            if val.upper() in Severities:
+                val = val.upper()
                 if not soft_fail_threshold or Severities[val].level > soft_fail_threshold.level:
                     soft_fail_threshold = Severities[val]
             else:
@@ -177,7 +178,8 @@ class Report:
         hard_fail_threshold = None
         # hard fail on the lowest threshold in the list
         for val in convert_csv_string_arg_to_list(hard_fail_on):
-            if val in Severities:
+            if val.upper() in Severities:
+                val = val.upper()
                 if not hard_fail_threshold or Severities[val].level < hard_fail_threshold.level:
                     hard_fail_threshold = Severities[val]
             else:

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -50,14 +50,16 @@ class RunnerFilter(object):
 
         # split out check/skip thresholds so we can access them easily later
         for val in (checks or []):
-            if val in Severities:
+            if val.upper() in Severities:
+                val = val.upper()
                 if not self.check_threshold or self.check_threshold.level > Severities[val].level:
                     self.check_threshold = Severities[val]
             else:
                 self.checks.append(val)
 
         for val in (skip_checks or []):
-            if val in Severities:
+            if val.upper() in Severities:
+                val = val.upper()
                 if not self.skip_check_threshold or self.skip_check_threshold.level < Severities[val].level:
                     self.skip_check_threshold = Severities[val]
             else:

--- a/tests/common/output/test_get_exit_code.py
+++ b/tests/common/output/test_get_exit_code.py
@@ -76,6 +76,8 @@ class TestGetExitCode(unittest.TestCase):
                                                           hard_fail_on=None)
         positive_test_soft_fail_on_code_one_sev = r.get_exit_code(None, soft_fail_on=['LOW', 'CKV_AWS_16'],
                                                           hard_fail_on=None)
+        positive_test_soft_fail_on_code_one_sev_lowercase = r.get_exit_code(None, soft_fail_on=['low', 'CKV_AWS_16'],
+                                                          hard_fail_on=None)
         positive_test_soft_fail_on_code_two_sev = r.get_exit_code(None, soft_fail_on=['LOW', 'HIGH'],
                                                                   hard_fail_on=None)
         positive_test_soft_fail_on_code_bc_id = r.get_exit_code(None, soft_fail_on=['BC_AWS_157', 'BC_AWS_16'],
@@ -83,6 +85,7 @@ class TestGetExitCode(unittest.TestCase):
 
         negative_test_soft_fail_on_code = r.get_exit_code(None, soft_fail_on=['CKV_AWS_157'], hard_fail_on=None)
         negative_test_soft_fail_on_code_one_sev = r.get_exit_code(None, soft_fail_on=['LOW'], hard_fail_on=None)
+        negative_test_soft_fail_on_code_one_sev_lowercase = r.get_exit_code(None, soft_fail_on=['low'], hard_fail_on=None)
         negative_test_soft_fail_on_code_bc_id = r.get_exit_code(None, soft_fail_on=['BC_AWS_157'], hard_fail_on=None)
 
         positive_test_soft_fail_on_wildcard_code = r.get_exit_code(None, soft_fail_on=['CKV_AWS*'])
@@ -94,6 +97,7 @@ class TestGetExitCode(unittest.TestCase):
         # When hard_fail_on=['check1', 'check2'], exit code should be 1 if any checks in the hard_fail_on list fail
         positive_test_hard_fail_on_code = r.get_exit_code(None, soft_fail_on=None, hard_fail_on=['CKV_AWS_157'])
         positive_test_hard_fail_on_code_one_sev = r.get_exit_code(None, soft_fail_on=None, hard_fail_on=['LOW'])
+        positive_test_hard_fail_on_code_one_sev_lowercase = r.get_exit_code(None, soft_fail_on=None, hard_fail_on=['low'])
         positive_test_hard_fail_on_code_bc_id = r.get_exit_code(None, soft_fail_on=None, hard_fail_on=['BC_AWS_157'])
 
         negative_test_hard_fail_on_code = r.get_exit_code(None, soft_fail_on=None,
@@ -109,10 +113,12 @@ class TestGetExitCode(unittest.TestCase):
         self.assertEqual(test_soft_fail, 0)
         self.assertEqual(positive_test_soft_fail_on_code, 0)
         self.assertEqual(positive_test_soft_fail_on_code_one_sev, 0)
+        self.assertEqual(positive_test_soft_fail_on_code_one_sev_lowercase, 0)
         self.assertEqual(positive_test_soft_fail_on_code_two_sev, 0)
         self.assertEqual(positive_test_soft_fail_on_code_bc_id, 0)
         self.assertEqual(negative_test_soft_fail_on_code, 1)
         self.assertEqual(negative_test_soft_fail_on_code_one_sev, 1)
+        self.assertEqual(negative_test_soft_fail_on_code_one_sev_lowercase, 1)
         self.assertEqual(negative_test_soft_fail_on_code_bc_id, 1)
 
         self.assertEqual(positive_test_soft_fail_on_wildcard_code, 0)
@@ -122,6 +128,7 @@ class TestGetExitCode(unittest.TestCase):
 
         self.assertEqual(positive_test_hard_fail_on_code, 1)
         self.assertEqual(positive_test_hard_fail_on_code_one_sev, 1)
+        self.assertEqual(positive_test_hard_fail_on_code_one_sev_lowercase, 1)
         self.assertEqual(positive_test_hard_fail_on_code_bc_id, 1)
         self.assertEqual(negative_test_hard_fail_on_code, 0)
         self.assertEqual(negative_test_hard_fail_on_code_bc_id, 0)

--- a/tests/common/test_runner_filter.py
+++ b/tests/common/test_runner_filter.py
@@ -128,16 +128,32 @@ class TestRunnerFilter(unittest.TestCase):
         instance = RunnerFilter(checks=["LOW"])
         self.assertTrue(instance.should_run_check(check_id='', severity=Severities[BcSeverities.LOW]))
 
+    def test_should_run_severity1_lowercase(self):
+        instance = RunnerFilter(checks=["low"])
+        self.assertTrue(instance.should_run_check(check_id='', severity=Severities[BcSeverities.LOW]))
+
     def test_should_run_severity2(self):
         instance = RunnerFilter(skip_checks=["LOW"])
+        self.assertTrue(instance.should_run_check(check_id='', severity=Severities[BcSeverities.HIGH]))
+
+    def test_should_run_severity2_lowercase(self):
+        instance = RunnerFilter(skip_checks=["low"])
         self.assertTrue(instance.should_run_check(check_id='', severity=Severities[BcSeverities.HIGH]))
 
     def test_should_skip_severity1(self):
         instance = RunnerFilter(checks=["HIGH"])
         self.assertFalse(instance.should_run_check(check_id='', severity=Severities[BcSeverities.LOW]))
 
+    def test_should_skip_severity1_lowercase(self):
+        instance = RunnerFilter(checks=["high"])
+        self.assertFalse(instance.should_run_check(check_id='', severity=Severities[BcSeverities.LOW]))
+
     def test_should_skip_severity2(self):
         instance = RunnerFilter(skip_checks=["LOW"])
+        self.assertFalse(instance.should_run_check(check_id='', severity=Severities[BcSeverities.LOW]))
+
+    def test_should_skip_severity2_lowercase(self):
+        instance = RunnerFilter(skip_checks=["low"])
         self.assertFalse(instance.should_run_check(check_id='', severity=Severities[BcSeverities.LOW]))
 
     def test_should_run_check_id(self):
@@ -241,6 +257,12 @@ class TestRunnerFilter(unittest.TestCase):
         self.assertEqual(instance.check_threshold, Severities[BcSeverities.LOW])
         self.assertEqual(instance.checks, [])
 
+    def test_check_severity_split_two_sev_lowercase(self):
+        instance = RunnerFilter(checks=['MEDIUM', 'low'])
+        # should take the lowest severity
+        self.assertEqual(instance.check_threshold, Severities[BcSeverities.LOW])
+        self.assertEqual(instance.checks, [])
+
     def test_check_severity_split_skip_one_sev(self):
         instance = RunnerFilter(skip_checks=['MEDIUM'])
         self.assertEqual(instance.skip_check_threshold, Severities[BcSeverities.MEDIUM])
@@ -248,6 +270,12 @@ class TestRunnerFilter(unittest.TestCase):
 
     def test_check_severity_split_skip_two_sev(self):
         instance = RunnerFilter(skip_checks=['LOW', 'MEDIUM'])
+        # should take the highest severity
+        self.assertEqual(instance.skip_check_threshold, Severities[BcSeverities.MEDIUM])
+        self.assertEqual(instance.skip_checks, [])
+
+    def test_check_severity_split_skip_two_sev_lowercase(self):
+        instance = RunnerFilter(skip_checks=['LOW', 'medium'])
         # should take the highest severity
         self.assertEqual(instance.skip_check_threshold, Severities[BcSeverities.MEDIUM])
         self.assertEqual(instance.skip_checks, [])


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Makes the severity values for the check/skip-check and soft/hard-fail-on flags case-insensitive. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
