### PR TITLE
add argo workflows runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **Checkov** is a static code analysis tool for infrastructure as code (IaC) and also a software composition analysis (SCA) tool for images and open source packages.
 
-It scans cloud infrastructure provisioned using [Terraform](https://terraform.io/), [Terraform plan](docs/7.Scan%20Examples/Terraform%20Plan%20Scanning.md), [Cloudformation](docs/7.Scan%20Examples/Cloudformation.md), [AWS SAM](docs/7.Scan%20Examples/AWS%20SAM.md), [Kubernetes](docs/7.Scan%20Examples/Kubernetes.md), [Helm charts](docs/7.Scan%20Examples/Helm.md),[Kustomize](docs/7.Scan%20Examples/Kustomize.md), [Dockerfile](docs/7.Scan%20Examples/Dockerfile.md),  [Serverless](docs/7.Scan%20Examples/Serverless%20Framework.md), [Bicep](docs/7.Scan%20Examples/Bicep.md), [OpenAPI](docs/7.Scan%20Examples/OpenAPI.md) or [ARM Templates](docs/7.Scan%20Examples/Azure%20ARM%20templates.md) and detects security and compliance misconfigurations using graph-based scanning.
+It scans cloud infrastructure provisioned using [Terraform](https://terraform.io/), [Terraform plan](docs/7.Scan%20Examples/Terraform%20Plan%20Scanning.md), [Cloudformation](docs/7.Scan%20Examples/Cloudformation.md), [AWS SAM](docs/7.Scan%20Examples/AWS%20SAM.md), [Kubernetes](docs/7.Scan%20Examples/Kubernetes.md), [Helm charts](docs/7.Scan%20Examples/Helm.md), [Kustomize](docs/7.Scan%20Examples/Kustomize.md), [Dockerfile](docs/7.Scan%20Examples/Dockerfile.md),  [Serverless](docs/7.Scan%20Examples/Serverless%20Framework.md), [Bicep](docs/7.Scan%20Examples/Bicep.md), [OpenAPI](docs/7.Scan%20Examples/OpenAPI.md) or [ARM Templates](docs/7.Scan%20Examples/Azure%20ARM%20templates.md) and detects security and compliance misconfigurations using graph-based scanning.
 
 It performs [Software Composition Analysis (SCA) scanning](docs/7.Scan%20Examples/Sca.md) which is a scan of open source packages and images for Common Vulnerabilities and Exposures (CVEs).
  
@@ -42,6 +42,7 @@ Checkov also powers [**Bridgecrew**](https://bridgecrew.io/?utm_source=github&ut
 
  * [Over 1000 built-in policies](docs/5.Policy%20Index/all.md) cover security and compliance best practices for AWS, Azure and Google Cloud.
  * Scans Terraform, Terraform Plan, CloudFormation, AWS SAM, Kubernetes, Dockerfile, Serverless framework, Bicep and ARM template files.
+ * Scans Argo Workflows, BitBucket Pipelines, GitHub Actions and GitLab CI workflow files
  * Supports Context-awareness policies based on in-memory graph-based scanning.
  * Supports Python format for attribute policies and YAML format for both attribute and composite policies.
  * Detects [AWS credentials](docs/2.Basics/Scanning%20Credentials%20and%20Secrets.md) in EC2 Userdata, Lambda environment variables and Terraform providers.

--- a/checkov/argo_workflows/__init__.py
+++ b/checkov/argo_workflows/__init__.py
@@ -1,0 +1,1 @@
+from checkov.argo_workflows.checks import *  # noqa

--- a/checkov/argo_workflows/checks/__init__.py
+++ b/checkov/argo_workflows/checks/__init__.py
@@ -1,0 +1,1 @@
+from checkov.argo_workflows.checks.template import *  # noqa

--- a/checkov/argo_workflows/checks/base_argo_workflows_check.py
+++ b/checkov/argo_workflows/checks/base_argo_workflows_check.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from checkov.common.checks.base_check import BaseCheck
 from checkov.argo_workflows.checks.registry import registry
 
 if TYPE_CHECKING:
-    from checkov.common.models.enums import CheckCategories
+    from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class BaseArgoWorkflowsCheck(BaseCheck):
@@ -18,7 +19,7 @@ class BaseArgoWorkflowsCheck(BaseCheck):
         categories: Iterable[CheckCategories],
         supported_entities: Iterable[str],
         block_type: str,
-        path: str | None = None
+        path: str | None = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -29,3 +30,12 @@ class BaseArgoWorkflowsCheck(BaseCheck):
         )
         self.path = path
         registry.register(self)
+
+    def scan_entity_conf(self, conf: dict[str, Any], entity_type: str) -> tuple[CheckResult, dict[str, Any]]:  # type:ignore[override]  # return type is different than the base class
+        self.entity_type = entity_type
+
+        return self.scan_conf(conf)
+
+    @abstractmethod
+    def scan_conf(self, conf: dict[str, Any]) -> tuple[CheckResult, dict[str, Any]]:
+        pass

--- a/checkov/argo_workflows/checks/base_argo_workflows_check.py
+++ b/checkov/argo_workflows/checks/base_argo_workflows_check.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from checkov.common.checks.base_check import BaseCheck
+from checkov.argo_workflows.checks.registry import registry
+
+if TYPE_CHECKING:
+    from checkov.common.models.enums import CheckCategories
+
+
+class BaseArgoWorkflowsCheck(BaseCheck):
+    def __init__(
+        self,
+        name: str,
+        id: str,
+        categories: Iterable[CheckCategories],
+        supported_entities: Iterable[str],
+        block_type: str,
+        path: str | None = None
+    ) -> None:
+        super().__init__(
+            name=name,
+            id=id,
+            categories=categories,
+            supported_entities=supported_entities,
+            block_type=block_type,
+        )
+        self.path = path
+        registry.register(self)

--- a/checkov/argo_workflows/checks/base_argo_workflows_check.py
+++ b/checkov/argo_workflows/checks/base_argo_workflows_check.py
@@ -31,7 +31,7 @@ class BaseArgoWorkflowsCheck(BaseCheck):
         self.path = path
         registry.register(self)
 
-    def scan_entity_conf(self, conf: dict[str, Any], entity_type: str) -> tuple[CheckResult, dict[str, Any]]:  # type:ignore[override]  # return type is different than the base class
+    def scan_entity_conf(self, conf: dict[str, Any], entity_type: str) -> tuple[CheckResult, dict[str, Any]]:  # type:ignore[override]  # multi_signature decorator is problematic
         self.entity_type = entity_type
 
         return self.scan_conf(conf)

--- a/checkov/argo_workflows/checks/registry.py
+++ b/checkov/argo_workflows/checks/registry.py
@@ -1,0 +1,3 @@
+from checkov.yaml_doc.base_registry import Registry
+
+registry = Registry()

--- a/checkov/argo_workflows/checks/template/DefaultServiceAccount.py
+++ b/checkov/argo_workflows/checks/template/DefaultServiceAccount.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.argo_workflows.checks.base_argo_workflows_check import BaseArgoWorkflowsCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.yaml_doc.enums import BlockType
+
+
+class DefaultServiceAccount(BaseArgoWorkflowsCheck):
+    def __init__(self) -> None:
+        name = "Ensure Workflow pods are not using the default ServiceAccount"
+        id = "CKV_ARGO_1"
+        super().__init__(
+            name=name,
+            id=id,
+            categories=(CheckCategories.IAM,),
+            supported_entities=("spec",),
+            block_type=BlockType.OBJECT,
+        )
+
+    def scan_entity_conf(self, conf: dict[str, Any], entity_type: str) -> tuple[CheckResult, dict[str, Any]]:  # type:ignore[override]  # return type is different than the base class
+        if "serviceAccountName" in conf.keys() and conf["serviceAccountName"] != "default":
+            return CheckResult.PASSED, conf
+
+        return CheckResult.FAILED, conf
+
+
+check = DefaultServiceAccount()

--- a/checkov/argo_workflows/checks/template/DefaultServiceAccount.py
+++ b/checkov/argo_workflows/checks/template/DefaultServiceAccount.py
@@ -19,7 +19,7 @@ class DefaultServiceAccount(BaseArgoWorkflowsCheck):
             block_type=BlockType.OBJECT,
         )
 
-    def scan_entity_conf(self, conf: dict[str, Any], entity_type: str) -> tuple[CheckResult, dict[str, Any]]:  # type:ignore[override]  # return type is different than the base class
+    def scan_conf(self, conf: dict[str, Any]) -> tuple[CheckResult, dict[str, Any]]:
         if "serviceAccountName" in conf.keys() and conf["serviceAccountName"] != "default":
             return CheckResult.PASSED, conf
 

--- a/checkov/argo_workflows/checks/template/RunAsNonRoot.py
+++ b/checkov/argo_workflows/checks/template/RunAsNonRoot.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.argo_workflows.checks.base_argo_workflows_check import BaseArgoWorkflowsCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.yaml_doc.enums import BlockType
+
+
+class RunAsNonRoot(BaseArgoWorkflowsCheck):
+    def __init__(self) -> None:
+        name = "Ensure Workflow pods are running as non-root user"
+        id = "CKV_ARGO_2"
+        super().__init__(
+            name=name,
+            id=id,
+            categories=(CheckCategories.IAM,),
+            supported_entities=("spec",),
+            block_type=BlockType.OBJECT,
+        )
+
+    def scan_conf(self, conf: dict[str, Any]) -> tuple[CheckResult, dict[str, Any]]:
+        security_context = conf.get("securityContext")
+
+        if isinstance(security_context, dict) and security_context.get("runAsNonRoot") is True:
+            return CheckResult.PASSED, conf
+
+        return CheckResult.FAILED, conf
+
+
+check = RunAsNonRoot()

--- a/checkov/argo_workflows/checks/template/__init__.py
+++ b/checkov/argo_workflows/checks/template/__init__.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+modules = Path(__file__).parent.glob("*.py")
+__all__ = [f.stem for f in modules if f.is_file() and not f.stem == "__init__"]

--- a/checkov/argo_workflows/runner.py
+++ b/checkov/argo_workflows/runner.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from checkov.common.images.image_referencer import ImageReferencer, Image
 from checkov.common.output.report import CheckType
 from checkov.yaml_doc.runner import Runner as YamlRunner
 
@@ -12,8 +14,10 @@ from checkov.argo_workflows.checks.registry import registry as template_registry
 if TYPE_CHECKING:
     from checkov.common.checks.base_check_registry import BaseCheckRegistry
 
+API_VERSION_PATTERN = re.compile(r"^apiVersion:\s*argoproj.io/", re.MULTILINE)
 
-class Runner(YamlRunner):
+
+class Runner(YamlRunner, ImageReferencer):
     check_type = CheckType.ARGO_WORKFLOWS  # noqa: CCE003
 
     block_type_registries = {  # noqa: CCE003
@@ -27,13 +31,106 @@ class Runner(YamlRunner):
         return self.block_type_registries["template"]
 
     def _parse_file(
-        self, f: str
+        self, f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
-        if not f.endswith((".yaml", ",yml")):
+        content = self._get_workflow_file_content(file_path=f)
+        if content:
+            return super()._parse_file(f=f, file_content=content)
+
+        return None
+
+    def _get_workflow_file_content(self, file_path: str) -> str | None:
+        if not file_path.endswith((".yaml", ",yml")):
             return None
 
-        content = Path(f).read_text()
-        if "apiVersion" in content and "argoproj.io/" in content:
-            return super()._parse_file(f)
+        content = Path(file_path).read_text()
+        match = re.search(API_VERSION_PATTERN, content)
+        if match:
+            return content
+
+        return None
+
+    def is_workflow_file(self, file_path: str) -> bool:
+        return self._get_workflow_file_content(file_path=file_path) is not None
+
+    def get_images(self, file_path: str) -> set[Image]:
+        """Get container images mentioned in a file
+
+        Argo Workflows file can have a job and services run within a container.
+
+        in the following sample file we can see a node:14.16 image:
+
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        metadata:
+          generateName: template-defaults-
+        spec:
+          entrypoint: main
+          templates:
+            - name: main
+              steps:
+                - - name: retry-backoff
+                    template: retry-backoff
+                - - name: whalesay
+                    template: whalesay
+
+            - name: whalesay
+              container:
+                image: argoproj/argosay:v2
+                command: [cowsay]
+                args: ["hello world"]
+
+            - name: retry-backoff
+              container:
+                image: python:alpine3.6
+                command: ["python", -c]
+                # fail with a 66% probability
+                args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]
+
+        Source: https://github.com/argoproj/argo-workflows/blob/master/examples/template-defaults.yaml
+
+        :return: List of container image short ids mentioned in the file.
+        Example return value for a file with node:14.16 image: ['sha256:6a353e22ce']
+        """
+
+        images: set[Image] = set()
+        parsed_file = self._parse_file(file_path)
+
+        if not parsed_file:
+            return images
+
+        workflow, workflow_line_numbers = parsed_file
+
+        if not isinstance(workflow, dict):
+            # make type checking happy
+            return images
+
+        spec = workflow.get("spec")
+        if spec:
+            templates = spec.get("templates")
+            if isinstance(templates, list):
+                for template in templates:
+                    container = template.get("container")
+                    if container:
+                        image = self.extract_image(file_path=file_path, container=container)
+                        if image:
+                            images.add(image)
+
+        return images
+
+    def extract_image(self, file_path: str, container: dict[str, Any]) -> Image | None:
+        image_name = container.get("image")
+        if image_name and isinstance(image_name, str):
+            start_line = container.get("__startline__", 0)
+            end_line = container.get("__endline__", 0)
+            image_id = self.inspect(image_name)
+            if image_id:
+                return Image(
+                    file_path=file_path,
+                    name=image_name,
+                    image_id=image_id,
+                    start_line=start_line,
+                    end_line=end_line,
+                )
 
         return None

--- a/checkov/argo_workflows/runner.py
+++ b/checkov/argo_workflows/runner.py
@@ -115,6 +115,11 @@ class Runner(YamlRunner, ImageReferencer):
                         image = self.extract_image(file_path=file_path, container=container)
                         if image:
                             images.add(image)
+                    script = template.get("script")
+                    if script:
+                        image = self.extract_image(file_path=file_path, container=script)
+                        if image:
+                            images.add(image)
 
         return images
 

--- a/checkov/argo_workflows/runner.py
+++ b/checkov/argo_workflows/runner.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from checkov.common.output.report import CheckType
+from checkov.yaml_doc.runner import Runner as YamlRunner
+
+# Import of the checks registry for a specific resource type
+from checkov.argo_workflows.checks.registry import registry as template_registry
+
+if TYPE_CHECKING:
+    from checkov.common.checks.base_check_registry import BaseCheckRegistry
+
+
+class Runner(YamlRunner):
+    check_type = CheckType.ARGO_WORKFLOWS  # noqa: CCE003
+
+    block_type_registries = {  # noqa: CCE003
+        "template": template_registry,
+    }
+
+    def require_external_checks(self) -> bool:
+        return False
+
+    def import_registry(self) -> BaseCheckRegistry:
+        return self.block_type_registries["template"]
+
+    def _parse_file(
+        self, f: str
+    ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
+        if not f.endswith((".yaml", ",yml")):
+            return None
+
+        content = Path(f).read_text()
+        if "apiVersion" in content and "argoproj.io/" in content:
+            return super()._parse_file(f)
+
+        return None

--- a/checkov/common/checks/base_check.py
+++ b/checkov/common/checks/base_check.py
@@ -88,13 +88,17 @@ class BaseCheck(metaclass=MultiSignatureMeta):
 
     @multi_signature()
     @abstractmethod
-    def scan_entity_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
+    def scan_entity_conf(self, conf: dict[str, Any], entity_type: str) -> CheckResult | tuple[CheckResult, dict[str, Any]]:
         raise NotImplementedError()
 
     @classmethod
     @scan_entity_conf.add_signature(args=["self", "conf"])
-    def _scan_entity_conf_self_conf(cls, wrapped: Callable[..., CheckResult]) -> Callable[..., CheckResult]:
-        def wrapper(self: "BaseCheck", conf: Dict[str, Any], entity_type: Optional[str] = None) -> CheckResult:
+    def _scan_entity_conf_self_conf(
+        cls, wrapped: Callable[..., CheckResult | tuple[CheckResult, dict[str, Any]]]
+    ) -> Callable[..., CheckResult | tuple[CheckResult, dict[str, Any]]]:
+        def wrapper(
+            self: "BaseCheck", conf: Dict[str, Any], entity_type: Optional[str] = None
+        ) -> CheckResult | tuple[CheckResult, dict[str, Any]]:
             # keep default argument for entity_type so old code, that doesn't set it, will work.
             return wrapped(self, conf)
 

--- a/checkov/common/checks/object_registry.py
+++ b/checkov/common/checks/object_registry.py
@@ -191,7 +191,7 @@ class Registry(BaseCheckRegistry):
 
         result = check_result["result"]
 
-        if result == CheckResult.SKIPPED:
+        if isinstance(result, CheckResult) and result == CheckResult.SKIPPED:
             results[result_key] = {
                 "check": check,
                 "result": result,

--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import abstractmethod
+from collections.abc import Iterable
 from typing import cast
 
 import docker
@@ -36,7 +37,7 @@ class ImageReferencer:
         return False
 
     @abstractmethod
-    def get_images(self, file_path: str) -> list[Image]:
+    def get_images(self, file_path: str) -> Iterable[Image]:
         """
         Get container images mentioned in a file
         :param file_path: File to be inspected

--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from abc import abstractmethod
 from collections.abc import Iterable
-from typing import cast
+from typing import cast, Any
 
 import docker
 
@@ -23,6 +23,18 @@ class Image:
         self.image_id = image_id
         self.name = name
         self.file_path = file_path
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+
+        return False
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
+
+    def __hash__(self) -> int:
+        return hash((self.file_path, self.name, self.image_id, self.start_line, self.end_line))
 
 
 class ImageReferencer:

--- a/checkov/common/multi_signature.py
+++ b/checkov/common/multi_signature.py
@@ -76,7 +76,7 @@ class multi_signature:
     """
 
     def __init__(self) -> None:
-        self.__wrappers__: dict[Any, Callable[..., _MultiT]] = {}
+        self.__wrappers__: dict[tuple[tuple[str, ...], Any, Any], Callable[..., _MultiT]] = {}
 
     def __call__(self, fn: Callable[..., _MultiT]) -> _MultiSignataureMethod:
         fn.add_signature = self.add_signature  # type:ignore[attr-defined]

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -31,6 +31,7 @@ init(autoreset=True)
 @dataclass
 class CheckType:
     BITBUCKET_PIPELINES = "bitbucket_pipelines"
+    ARGO_WORKFLOWS = "argo_workflows"
     ARM = "arm"
     BICEP = "bicep"
     CLOUDFORMATION = "cloudformation"

--- a/checkov/common/parsers/yaml/loader.py
+++ b/checkov/common/parsers/yaml/loader.py
@@ -24,13 +24,14 @@ def loads(content: str) -> list[dict[str, Any]]:
     return template
 
 
-def load(filename: str | Path) -> tuple[list[dict[str, Any]], list[tuple[int, str]]]:
+def load(filename: str | Path, content: str | None = None) -> tuple[list[dict[str, Any]], list[tuple[int, str]]]:
     """
     Load the given YAML file
     """
 
-    file_path = filename if isinstance(filename, Path) else Path(filename)
-    content = file_path.read_text()
+    if not content:
+        file_path = filename if isinstance(filename, Path) else Path(filename)
+        content = file_path.read_text()
 
     file_lines = [(idx + 1, line) for idx, line in enumerate(content.splitlines(keepends=True))]
 

--- a/checkov/common/parsers/yaml/parser.py
+++ b/checkov/common/parsers/yaml/parser.py
@@ -10,12 +10,14 @@ import checkov.common.parsers.yaml.loader as loader
 logger = logging.getLogger(__name__)
 
 
-def parse(filename: str) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
+def parse(
+    filename: str, file_content: str | None = None
+) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
     template = None
     template_lines = None
     try:
         if filename.endswith(".yaml") or filename.endswith(".yml"):
-            (template, template_lines) = loader.load(filename)
+            (template, template_lines) = loader.load(filename, file_content)
 
         if template and template_lines:
             if isinstance(template, list):

--- a/checkov/common/typing.py
+++ b/checkov/common/typing.py
@@ -16,7 +16,7 @@ _ScannerCallableAlias: TypeAlias = Callable[
 
 
 class _CheckResult(TypedDict, total=False):
-    result: "CheckResult"
+    result: "CheckResult" | tuple["CheckResult", dict[str, Any]]
     suppress_comment: str
     evaluated_keys: list[str]
     results_configuration: dict[str, Any] | None

--- a/checkov/common/util/docs_generator.py
+++ b/checkov/common/util/docs_generator.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Tuple, Union
 
 from tabulate import tabulate
 
+from checkov.argo_workflows.checks.registry import registry as argo_workflows_registry
 from checkov.arm.registry import arm_resource_registry, arm_parameter_registry
 from checkov.bicep.checks.param.registry import registry as bicep_param_registry
 from checkov.bicep.checks.resource.registry import registry as bicep_resource_registry
@@ -117,6 +118,8 @@ def get_checks(frameworks: Optional[List[str]] = None, use_bc_ids: bool = False,
         add_from_repository(bitbucket_configuration_registry, "bitbucket_configuration", "bitbucket_configuration")
     if any(x in framework_list for x in ("all", "bitbucket_pipelines")):
         add_from_repository(bitbucket_pipelines_registry, "bitbucket_pipelines", "bitbucket_pipelines")
+    if any(x in framework_list for x in ("all", "argo_workflows")):
+        add_from_repository(argo_workflows_registry, "argo_workflows", "Argo Workflows")
     if any(x in framework_list for x in ("all", "arm")):
         add_from_repository(arm_resource_registry, "resource", "arm")
         add_from_repository(arm_parameter_registry, "parameter", "arm")

--- a/checkov/example_runner/runner.py
+++ b/checkov/example_runner/runner.py
@@ -43,7 +43,7 @@ class Runner(YamlRunner):
         return self.block_type_registries["jobs"]
 
     def _parse_file(
-        self, f: str
+        self, f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         # EDIT" add conditional here to ensure this file is something we should parse.
         # Below is this example for github actions

--- a/checkov/json_doc/base_registry.py
+++ b/checkov/json_doc/base_registry.py
@@ -158,7 +158,7 @@ class Registry(BaseCheckRegistry):
         result = check_result["result"]
         result_key = f'{entity_type}.{entity_name}.{check.id}'
 
-        if result == CheckResult.SKIPPED:
+        if isinstance(result, CheckResult) and result == CheckResult.SKIPPED:
             results[result_key] = {
                 "check": check,
                 "result": result,

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -17,6 +17,7 @@ from urllib3.exceptions import MaxRetryError
 
 import checkov.logging_init  # noqa  # should be imported before the others to ensure correct logging setup
 
+from checkov.argo_workflows.runner import Runner as argo_workflows_runner
 from checkov.arm.runner import Runner as arm_runner
 from checkov.bitbucket.runner import Runner as bitbucket_configuration_runner
 from checkov.bitbucket_pipelines.runner import Runner as bitbucket_pipelines_runner
@@ -90,7 +91,8 @@ DEFAULT_RUNNERS = (
     github_actions_runner(),
     bicep_runner(),
     openapi_runner(),
-    sca_image_runner()
+    sca_image_runner(),
+    argo_workflows_runner(),
 )
 
 

--- a/checkov/openapi/runner.py
+++ b/checkov/openapi/runner.py
@@ -28,7 +28,9 @@ class Runner(YamlRunner, JsonRunner):
         from checkov.openapi.checks.registry import openapi_registry
         return openapi_registry
 
-    def _parse_file(self, f: str) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
+    def _parse_file(
+        self, f: str, file_content: str | None = None
+    ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         if f.endswith(".json"):
             return self.parse_format(f, JsonRunner._parse_file)
         elif f.endswith(".yml") or f.endswith(".yaml"):

--- a/checkov/yaml_doc/base_registry.py
+++ b/checkov/yaml_doc/base_registry.py
@@ -194,7 +194,7 @@ class Registry(BaseCheckRegistry):
 
         result = check_result["result"]
 
-        if result == CheckResult.SKIPPED:
+        if isinstance(result, CheckResult) and result == CheckResult.SKIPPED:
             results[result_key] = {
                 "check": check,
                 "result": result,

--- a/checkov/yaml_doc/runner.py
+++ b/checkov/yaml_doc/runner.py
@@ -23,10 +23,9 @@ class Runner(ObjectRunner):
         return registry
 
     def _parse_file(
-        self, f: str
+        self, f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
-        content: tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None = parse(f)
-        return content
+        return parse(f, file_content)
 
     def get_start_end_lines(
         self, end: int, result_config: dict[str, Any] | list[dict[str, Any]], start: int

--- a/docs/6.Contribution/Contribute New Argo Workflows Policies.md
+++ b/docs/6.Contribution/Contribute New Argo Workflows Policies.md
@@ -1,0 +1,111 @@
+---
+layout: default
+published: true
+title: Contribute New Argo Workflows configuration policy
+nav_order: 5
+---
+
+# Contribute New Argo Workflows configuration policy
+
+In this example, we'll add support for a new Argo Workflows configuration check to validate the usage of a user defined ServiceAccount.
+
+## Add a Check
+
+Go to `checkov/argo_workflows/checks/template` and add `DefaultServiceAccount.py`:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.argo_workflows.checks.base_argo_workflows_check import BaseArgoWorkflowsCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.yaml_doc.enums import BlockType
+
+
+class DefaultServiceAccount(BaseArgoWorkflowsCheck):
+    def __init__(self) -> None:
+        name = "Ensure Workflow pods are not using the default ServiceAccount"
+        id = "CKV_ARGO_1"
+        super().__init__(
+            name=name,
+            id=id,
+            categories=(CheckCategories.IAM,),
+            supported_entities=("spec",),
+            block_type=BlockType.OBJECT,
+        )
+
+    def scan_conf(self, conf: dict[str, Any]) -> tuple[CheckResult, dict[str, Any]]:
+        if "serviceAccountName" in conf.keys() and conf["serviceAccountName"] != "default":
+            return CheckResult.PASSED, conf
+
+        return CheckResult.FAILED, conf
+
+
+check = DefaultServiceAccount()
+```
+
+### Adding a Test
+
+Create a new folder under `tests/argo_workflows/checks/template` with the name of your check `example_DefaultServiceAccount` for adding example configuration files.
+Try to add at least 2 test cases, one passing and one failing. 
+
+`pass.yaml`:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: hello-world-
+spec:
+  serviceAccountName: custom-sa
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]
+```
+
+Lastly add the test file `test_DefaultServiceAccount.py` to scan the example files.
+
+```python
+from pathlib import Path
+
+from checkov.argo_workflows.runner import Runner
+from checkov.argo_workflows.checks.template.DefaultServiceAccount import check
+from checkov.runner_filter import RunnerFilter
+
+
+def test_examples():
+    # given
+    test_files_dir = Path(__file__).parent / "example_DefaultServiceAccount"
+
+    # when
+    report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+    # then
+    summary = report.get_summary()
+
+    passing_resources = {
+        f"{test_files_dir}/pass.yaml.spec.spec.CKV_ARGO_1[6:14]",
+    }
+
+    failing_resources = {
+        f"{test_files_dir}/fail_default.yaml.spec.spec.CKV_ARGO_1[6:14]",
+        f"{test_files_dir}/fail_none.yaml.spec.spec.CKV_ARGO_1[6:13]",
+    }
+
+    passed_check_resources = {c.resource for c in report.passed_checks}
+    failed_check_resources = {c.resource for c in report.failed_checks}
+
+    assert summary["passed"] == len(passing_resources)
+    assert summary["failed"] == len(failing_resources)
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0
+
+    assert passed_check_resources == passing_resources
+    assert failed_check_resources == failing_resources
+```
+
+So there you have it! A new check will be scanned once your contribution is merged!

--- a/docs/7.Scan Examples/Argo Workflows.md
+++ b/docs/7.Scan Examples/Argo Workflows.md
@@ -1,0 +1,70 @@
+---
+layout: default
+published: true
+title: Argo Workflows configuration scanning
+nav_order: 20
+---
+
+# Argo Workflows configuration scanning
+Checkov supports the evaluation of policies on your Argo Workflows files.
+When using checkov to scan a directory that contains Argo Workflows specs and templates it will validate if the file is compliant with Argo Workflows best practices such as usage of securityContext and non default serviceAccountName, and more.  
+
+Full list of Argo Workflows policies checks can be found [here](https://www.checkov.io/5.Policy%20Index/argo_workflows.html).
+
+### Example misconfigured OpenAPI
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: hello-world-
+spec:
+  entrypoint: whalesay
+  serviceAccountName: custom-sa
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]
+```
+### Running in CLI
+
+```bash
+checkov -d . --framework argo_workflows
+```
+
+### Example output
+```bash
+ 
+       _               _              
+   ___| |__   ___  ___| | _______   __
+  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
+ | (__| | | |  __/ (__|   < (_) \ V / 
+  \___|_| |_|\___|\___|_|\_\___/ \_/  
+                                      
+By bridgecrew.io | version: 2.0.1210
+
+
+openapi scan results:
+
+Passed checks: 1, Failed checks: 1, Skipped checks: 0
+
+Check: CKV_ARGO_1: "Ensure Workflow pods are not using the default ServiceAccount"
+        PASSED for resource: /hello_world.yaml.spec.spec.CKV_ARGO_1[6:14]
+        File: /hello_world.yaml:6-15
+Check: CKV_ARGO_2: "Ensure Workflow pods are running as non-root user"
+        FAILED for resource: /hello_world.yaml.spec.spec.CKV_ARGO_2[6:14]
+        File: /hello_world.yaml:6-15
+
+                6  |   entrypoint: whalesay
+                7  |   serviceAccountName: custom-sa
+                8  |   templates:
+                9  |   - name: whalesay
+                10 |     container:
+                11 |       image: docker/whalesay:latest
+                12 |       command: [cowsay]
+                13 |       args: ["hello world"]
+
+
+```

--- a/tests/argo_workflows/checks/template/example_DefaultServiceAccount/fail_default.yaml
+++ b/tests/argo_workflows/checks/template/example_DefaultServiceAccount/fail_default.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: hello-world-
+spec:
+  entrypoint: whalesay
+  serviceAccountName: default
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]

--- a/tests/argo_workflows/checks/template/example_DefaultServiceAccount/fail_none.yaml
+++ b/tests/argo_workflows/checks/template/example_DefaultServiceAccount/fail_none.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: archive-location-
+  generateName: hello-world-
 spec:
   entrypoint: whalesay
   templates:
@@ -10,6 +10,3 @@ spec:
       image: docker/whalesay:latest
       command: [cowsay]
       args: ["hello world"]
-    # archiveLocation allows configuring the archive location for a specific step
-    archiveLocation:
-      archiveLogs: true

--- a/tests/argo_workflows/checks/template/example_DefaultServiceAccount/pass.yaml
+++ b/tests/argo_workflows/checks/template/example_DefaultServiceAccount/pass.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: hello-world-
+spec:
+  entrypoint: whalesay
+  serviceAccountName: custom-sa
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]

--- a/tests/argo_workflows/checks/template/example_RunAsNonRoot/fail.yaml
+++ b/tests/argo_workflows/checks/template/example_RunAsNonRoot/fail.yaml
@@ -1,0 +1,12 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: hello-world-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]

--- a/tests/argo_workflows/checks/template/example_RunAsNonRoot/pass.yaml
+++ b/tests/argo_workflows/checks/template/example_RunAsNonRoot/pass.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: hello-world-
+spec:
+  entrypoint: whalesay
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 8737
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]

--- a/tests/argo_workflows/checks/template/test_DefaultServiceAccount.py
+++ b/tests/argo_workflows/checks/template/test_DefaultServiceAccount.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from checkov.argo_workflows.runner import Runner
+from checkov.argo_workflows.checks.template.DefaultServiceAccount import check
+from checkov.runner_filter import RunnerFilter
+
+
+def test_examples():
+    # given
+    test_files_dir = Path(__file__).parent / "example_DefaultServiceAccount"
+
+    # when
+    report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+    # then
+    summary = report.get_summary()
+
+    passing_resources = {
+        f"{test_files_dir}/pass.yaml.spec.spec.CKV_ARGO_1[6:14]",
+    }
+
+    failing_resources = {
+        f"{test_files_dir}/fail_default.yaml.spec.spec.CKV_ARGO_1[6:14]",
+        f"{test_files_dir}/fail_none.yaml.spec.spec.CKV_ARGO_1[6:13]",
+    }
+
+    passed_check_resources = {c.resource for c in report.passed_checks}
+    failed_check_resources = {c.resource for c in report.failed_checks}
+
+    assert summary["passed"] == len(passing_resources)
+    assert summary["failed"] == len(failing_resources)
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0
+
+    assert passed_check_resources == passing_resources
+    assert failed_check_resources == failing_resources

--- a/tests/argo_workflows/checks/template/test_RunAsNonRoot.py
+++ b/tests/argo_workflows/checks/template/test_RunAsNonRoot.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from checkov.argo_workflows.runner import Runner
+from checkov.argo_workflows.checks.template.RunAsNonRoot import check
+from checkov.runner_filter import RunnerFilter
+
+
+def test_examples():
+    # given
+    test_files_dir = Path(__file__).parent / "example_RunAsNonRoot"
+
+    # when
+    report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+    # then
+    summary = report.get_summary()
+
+    passing_resources = {
+        f"{test_files_dir}/pass.yaml.spec.spec.CKV_ARGO_2[6:16]",
+    }
+
+    failing_resources = {
+        f"{test_files_dir}/fail.yaml.spec.spec.CKV_ARGO_2[6:13]",
+    }
+
+    passed_check_resources = {c.resource for c in report.passed_checks}
+    failed_check_resources = {c.resource for c in report.failed_checks}
+
+    assert summary["passed"] == len(passing_resources)
+    assert summary["failed"] == len(failing_resources)
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0
+
+    assert passed_check_resources == passing_resources
+    assert failed_check_resources == failing_resources

--- a/tests/argo_workflows/examples/archive_location.yaml
+++ b/tests/argo_workflows/examples/archive_location.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: archive-location-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]
+    # archiveLocation allows configuring the archive location for a specific step
+    archiveLocation:
+      archiveLogs: true

--- a/tests/argo_workflows/examples/hello_world.yaml
+++ b/tests/argo_workflows/examples/hello_world.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: archive-location-
+spec:
+  entrypoint: whalesay
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 8737
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]
+    # archiveLocation allows configuring the archive location for a specific step
+    archiveLocation:
+      archiveLogs: true

--- a/tests/argo_workflows/examples/scripts_python.yaml
+++ b/tests/argo_workflows/examples/scripts_python.yaml
@@ -1,0 +1,35 @@
+# https://github.com/argoproj/argo-workflows/blob/master/examples/scripts-python.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: scripts-python-
+spec:
+  entrypoint: python-script-example
+  templates:
+  - name: python-script-example
+    steps:
+    - - name: generate
+        template: gen-random-int
+    - - name: print
+        template: print-message
+        arguments:
+          parameters:
+          - name: message
+            value: "{{steps.generate.outputs.result}}"
+
+  - name: gen-random-int
+    script:
+      image: python:alpine3.6
+      command: [python]
+      source: |
+        import random
+        i = random.randint(1, 100)
+        print(i)
+  - name: print-message
+    inputs:
+      parameters:
+      - name: message
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo result was: {{inputs.parameters.message}}"]

--- a/tests/argo_workflows/test_runner.py
+++ b/tests/argo_workflows/test_runner.py
@@ -6,9 +6,25 @@ from checkov.runner_filter import RunnerFilter
 EXAMPLES_DIR = Path(__file__).parent / "examples"
 
 
+def test_runner_passing_check():
+    # given
+    test_file = EXAMPLES_DIR / "hello_world.yaml"
+
+    # when
+    report = Runner().run(root_folder="", files=[str(test_file)], runner_filter=RunnerFilter(checks=["CKV_ARGO_2"]))
+
+    # then
+    summary = report.get_summary()
+
+    assert summary["passed"] == 1
+    assert summary["failed"] == 0
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0
+
+
 def test_runner_failing_check():
     # given
-    test_file = EXAMPLES_DIR / "archive_location.yaml"
+    test_file = EXAMPLES_DIR / "hello_world.yaml"
 
     # when
     report = Runner().run(root_folder="", files=[str(test_file)], runner_filter=RunnerFilter(checks=["CKV_ARGO_1"]))

--- a/tests/argo_workflows/test_runner.py
+++ b/tests/argo_workflows/test_runner.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from checkov.argo_workflows.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+EXAMPLES_DIR = Path(__file__).parent / "examples"
+
+
+def test_runner_failing_check():
+    # given
+    test_file = EXAMPLES_DIR / "archive_location.yaml"
+
+    # when
+    report = Runner().run(root_folder="", files=[str(test_file)], runner_filter=RunnerFilter(checks=["CKV_ARGO_1"]))
+
+    # then
+    summary = report.get_summary()
+
+    assert summary["passed"] == 0
+    assert summary["failed"] == 1
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0

--- a/tests/terraform/util/test_doc_generator.py
+++ b/tests/terraform/util/test_doc_generator.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import inspect
 from pathlib import Path
-from typing import List, Set, Optional
 
 import pytest
 
@@ -23,18 +24,54 @@ def test_get_checks_returned_check_number():
 @pytest.mark.parametrize(
     "input_frameworks,expected_frameworks",
     [
-        (["all"], {"arm", "Bicep", "Cloudformation", "dockerfile", "Kubernetes", "secrets", "serverless", "Terraform",
-                   "github_configuration", "gitlab_configuration", "bitbucket_configuration", "bitbucket_pipelines",
-                   "github_actions", "OpenAPI", "gitlab_ci"}),
-        (None, {"arm", "Bicep", "Cloudformation", "dockerfile", "Kubernetes", "secrets", "serverless", "Terraform",
-                "github_configuration", "bitbucket_pipelines", "gitlab_configuration", "bitbucket_configuration",
-                "github_actions", "OpenAPI", "gitlab_ci"}),
+        (
+            ["all"],
+            {
+                "Argo Workflows",
+                "arm",
+                "Bicep",
+                "Cloudformation",
+                "dockerfile",
+                "Kubernetes",
+                "secrets",
+                "serverless",
+                "Terraform",
+                "github_configuration",
+                "gitlab_configuration",
+                "bitbucket_configuration",
+                "bitbucket_pipelines",
+                "github_actions",
+                "OpenAPI",
+                "gitlab_ci",
+            },
+        ),
+        (
+            None,
+            {
+                "Argo Workflows",
+                "arm",
+                "Bicep",
+                "Cloudformation",
+                "dockerfile",
+                "Kubernetes",
+                "secrets",
+                "serverless",
+                "Terraform",
+                "github_configuration",
+                "bitbucket_pipelines",
+                "gitlab_configuration",
+                "bitbucket_configuration",
+                "github_actions",
+                "OpenAPI",
+                "gitlab_ci",
+            },
+        ),
         (["terraform"], {"Terraform"}),
         (["cloudformation", "serverless"], {"Cloudformation", "serverless"}),
     ],
     ids=["all", "none", "terraform", "multiple"],
 )
-def test_get_checks_returned_frameworks(input_frameworks: Optional[List[str]], expected_frameworks: Set[str]):
+def test_get_checks_returned_frameworks(input_frameworks: list[str] | None, expected_frameworks: set[str]):
     # when
     checks = get_checks(input_frameworks)
 

--- a/tests/test_runner_filter.py
+++ b/tests/test_runner_filter.py
@@ -17,6 +17,7 @@ from checkov.runner_filter import RunnerFilter
             ["all"],
             ["terraform", "secrets"],
             {
+                "argo_workflows",
                 "arm",
                 "bicep",
                 "cloudformation",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

- Add new runner for Argo Workflows
- Add check `DefaultServiceAccount` to ensure the `default` ServiceAccount is not used
- Add check `CKV_ARGO_1` and `CKV_ARGO_2`


## New/Edited policies

### CKV_ARGO_1 - Ensure Workflow pods are not using the default ServiceAccount

### Description
By default all pods/containers in a workflow run with the default service account. This gives each pod the ability to communicate with Kubernetes API and easily become over-permissioned.

### Fix
Create a custom service account with least privileged and add it to the spec.
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: example-
spec:
  entrypoint: main
+ serviceAccountName: <specific service account name>
  ...
```

### CKV_ARGO_2 - Ensure Workflow pods are running as non-root user

### Description
Same as here https://docs.bridgecrew.io/docs/bc_k8s_22 🙂 

### Fix
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: example-
spec:
  entrypoint: main
  securityContext:
+   runAsNonRoot: true
+   runAsUser: <specific user>
  ...
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
