### PR TITLE
Minor fix for output format github_failed_only

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -398,14 +398,18 @@ class Report:
                     record.guideline,
                 ]
             )
-        output_data = tabulate(
-            result,
-            headers=["check_id", "file", "resource", "check_name", "guideline"],
-            tablefmt="github",
-            showindex=True,
-        ) + "\n\n---\n\n"
-        print(output_data)
-        return output_data
+        if result:
+            table = tabulate(
+                result,
+                headers=["check_id", "file", "resource", "check_name", "guideline"],
+                tablefmt="github",
+                showindex=True,
+            )
+            output_data = f"### {self.check_type} scan results:\n\n{table}\n\n---\n"
+            print(output_data)
+            return output_data
+        else:
+            return "\n\n---\n\n"
 
     def get_test_suite(self, properties: Optional[Dict[str, Any]] = None, use_bc_ids: bool = False) -> TestSuite:
         """Creates a test suite for the JUnit XML report"""


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

When using `github_failed_only` format, the table does not say which check the table corresponds to and also it prints the table even though there are no failed checks.

E.g.:
```
checkov -d .       --output github_failed_only --soft-fail                                         
2022-06-14 15:47:33,410 [MainThread  ] [WARNI]  Failed to download module git::https://githubstage.mmm.com/DSC/terraform-aws-sonarqube-dcg-393.git?ref=v1.3.0:None
| check_id   | file   | resource   | check_name   | guideline   |
|------------|--------|------------|--------------|-------------|


---
```

This small PR will first see if the check results are populated before creating a table and will also a title for each table

Fixes # (issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
