### PR TITLE
make the skip pattern a regex, not a glob

### DIFF
--- a/tests/cloudformation/test_graph_manager.py
+++ b/tests/cloudformation/test_graph_manager.py
@@ -14,7 +14,7 @@ class TestCloudformationGraphManager(TestCase):
         root_dir = os.path.realpath(os.path.join(TEST_DIRNAME, "./runner/resources"))
         graph_manager = CloudformationGraphManager(db_connector=NetworkxConnector())
         local_graph, definitions = graph_manager.build_graph_from_source_directory(root_dir, render_variables=False,
-                                                                                   excluded_paths=["skip*"])
+                                                                                   excluded_paths=["skip.*"])
 
         expected_resources_by_file = {
             os.path.join(root_dir, "no_properties.yaml"): [


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Makes the `skip` argument a regex, since that is the expected format (not a glob).

The test fails on my computer, because it skips all paths matching `skip*`, which includes anything under my home directory (`/Users/mikeurbanski/`) 💯 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
