### PR TITLE
Handle securityContext specified within cronjob template spec

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/Seccomp.py
+++ b/checkov/kubernetes/checks/resource/k8s/Seccomp.py
@@ -42,6 +42,12 @@ class Seccomp(BaseK8Check):
                         if "template" in conf["spec"]["jobTemplate"]["spec"]:
                             if "metadata" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 metadata = conf["spec"]["jobTemplate"]["spec"]["template"]["metadata"]
+                            elif "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
+                                if "metadata" in conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]:
+                                    metadata = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]["metadata"]
+                                elif "securityContext" in conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]:
+                                    security_profile = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]["securityContext"].get("seccompProfile", {}).get("type")
+                                    return CheckResult.PASSED if security_profile == 'RuntimeDefault' else CheckResult.FAILED
         else:
             inner_metadata = self.get_inner_entry(conf, "metadata")
             metadata = inner_metadata if inner_metadata else metadata

--- a/tests/kubernetes/checks/example_Seccomp/cronjob-seccomp-securityContext-PASSED.yaml
+++ b/tests/kubernetes/checks/example_Seccomp/cronjob-seccomp-securityContext-PASSED.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cronjob-securityContext-passed
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: "test-job0"
+              image: "nginx:alpine"
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 100m
+                  ephemeral-storage: 1Mi
+                  memory: 512Mi
+                limits:
+                  cpu: 100m
+                  ephemeral-storage: 10Gi
+                  memory: 512Mi
+              securityContext:
+                privileged: false
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - all
+          restartPolicy: OnFailure

--- a/tests/kubernetes/checks/test_Seccomp.py
+++ b/tests/kubernetes/checks/test_Seccomp.py
@@ -19,13 +19,14 @@ class TestSeccomp(unittest.TestCase):
         passed_resources = [check.resource for check in report.passed_checks]
         failed_resources = [check.resource for check in report.failed_checks]
 
-        self.assertEqual(summary["passed"], 7)
+        self.assertEqual(summary["passed"], 8)
         self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 
         expected_passed_resources = [
             "CronJob.default.cronjob-passed",
+            "CronJob.default.cronjob-securityContext-passed",
             "Deployment.default.seccomp-passed-deployment",
             "Deployment.default.seccomp-passed-metadata-annotations",
             "Pod.default.seccomp-passed-metadata-annotations-docker",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**


## New/Edited policies (Delete if not relevant)

CKV_K8S_31

### Description

Enables specifying the `seccompProfile` nested in a CronJob template spec, as opposed to only looking at metadata annotations. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
