### PR TITLE
check if paths is really a dict

### DIFF
--- a/checkov/openapi/checks/resource/v2/SecurityRequirement.py
+++ b/checkov/openapi/checks/resource/v2/SecurityRequirement.py
@@ -27,6 +27,9 @@ class SecurityRequirement(BaseOpenapiCheckV2):
         if 'paths' not in conf:
             return CheckResult.FAILED, conf
         paths = conf['paths']
+        if not isinstance(paths, dict):
+            return CheckResult.FAILED, conf
+
         for path, http_method in paths.items():
             if self.is_start_end_line(path):
                 continue


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

fixes a broken swagger file, if `paths` is set, but without any content

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
