### PR TITLE
Add jsonpath_not_exists operator

### DIFF
--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -29,10 +29,11 @@ from checkov.common.checks_infra.solvers import (
     LessThanAttributeSolver,
     LessThanOrEqualAttributeSolver,
     JsonpathEqualsAttributeSolver,
-    JsonpathExistsAttributeSolver
+    JsonpathExistsAttributeSolver,
+    JsonpathNotExistsAttributeSolver,
+    SubsetAttributeSolver,
+    NotSubsetAttributeSolver
 )
-from checkov.common.checks_infra.solvers.attribute_solvers.not_subset_attribute_solver import NotSubsetAttributeSolver
-from checkov.common.checks_infra.solvers.attribute_solvers.subset_attribute_solver import SubsetAttributeSolver
 from checkov.common.checks_infra.solvers.connections_solvers.connection_one_exists_solver import \
     ConnectionOneExistsSolver
 from checkov.common.graph.checks_infra.base_check import BaseGraphCheck
@@ -70,7 +71,8 @@ operators_to_attributes_solver_classes: dict[str, Type[BaseAttributeSolver]] = {
     "subset": SubsetAttributeSolver,
     "not_subset": NotSubsetAttributeSolver,
     "jsonpath_equals": JsonpathEqualsAttributeSolver,
-    "jsonpath_exists": JsonpathExistsAttributeSolver
+    "jsonpath_exists": JsonpathExistsAttributeSolver,
+    "jsonpath_not_exists": JsonpathNotExistsAttributeSolver
 }
 
 operators_to_complex_solver_classes: dict[str, Type[BaseComplexSolver]] = {

--- a/checkov/common/checks_infra/solvers/attribute_solvers/__init__.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/__init__.py
@@ -18,3 +18,6 @@ from checkov.common.checks_infra.solvers.attribute_solvers.less_than_attribute_s
 from checkov.common.checks_infra.solvers.attribute_solvers.less_than_or_equal_attribute_solver import LessThanOrEqualAttributeSolver  # noqa
 from checkov.common.checks_infra.solvers.attribute_solvers.jsonpath_equals_attribute_solver import JsonpathEqualsAttributeSolver  # noqa
 from checkov.common.checks_infra.solvers.attribute_solvers.jsonpath_exists_attribute_solver import JsonpathExistsAttributeSolver  # noqa
+from checkov.common.checks_infra.solvers.attribute_solvers.jsonpath_not_exists_attribute_solver import JsonpathNotExistsAttributeSolver  # noqa
+from checkov.common.checks_infra.solvers.attribute_solvers.subset_attribute_solver import SubsetAttributeSolver  # noqa
+from checkov.common.checks_infra.solvers.attribute_solvers.not_subset_attribute_solver import NotSubsetAttributeSolver  # noqa

--- a/checkov/common/checks_infra/solvers/attribute_solvers/jsonpath_equals_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/jsonpath_equals_attribute_solver.py
@@ -15,16 +15,21 @@ class JsonpathEqualsAttributeSolver(BaseAttributeSolver):
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         return str(vertex.get(attribute)) == str(self.value)  # type:ignore[arg-type]  # due to attribute can be None
 
+    def _get_attribute_matches(self, vertex: Dict[str, Any]) -> List[str]:
+        attribute_matches = []
+        parsed_attr = parse(self.attribute)
+        for match in parsed_attr.find(vertex):
+            full_path = str(match.full_path)
+            if full_path not in vertex:
+                vertex[full_path] = match.value
+
+            attribute_matches.append(full_path)
+
+        return attribute_matches
+
     def get_operation(self, vertex: Dict[str, Any]) -> bool:
         if self.attribute:
-            attribute_matches = []
-            parsed_attr = parse(self.attribute)
-            for match in parsed_attr.find(vertex):
-                full_path = str(match.full_path)
-                if full_path not in vertex:
-                    vertex[full_path] = match.value
-
-                attribute_matches.append(full_path)
+            attribute_matches = self._get_attribute_matches(vertex)
 
             return self.resource_type_pred(vertex, self.resource_types) and len(attribute_matches) > 0 and all(
                 self._get_operation(vertex=vertex, attribute=attr) for attr in attribute_matches

--- a/checkov/common/checks_infra/solvers/attribute_solvers/jsonpath_not_exists_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/jsonpath_not_exists_attribute_solver.py
@@ -1,0 +1,22 @@
+from typing import List, Optional, Any, Dict
+
+from checkov.common.checks_infra.solvers.attribute_solvers.jsonpath_exists_attribute_solver import JsonpathExistsAttributeSolver
+from checkov.common.graph.checks_infra.enums import Operators
+
+
+class JsonpathNotExistsAttributeSolver(JsonpathExistsAttributeSolver):
+    operator = Operators.JSONPATH_NOT_EXISTS
+
+    def __init__(self, resource_types: List[str], attribute: Optional[str], value: Any) -> None:
+        super().__init__(resource_types=resource_types,
+                         attribute=attribute, value=value)
+
+    def get_operation(self, vertex: Dict[str, Any]) -> bool:
+        if self.attribute:
+            attribute_matches = self._get_attribute_matches(vertex)
+            return len(attribute_matches) == 0
+
+        return super().get_operation(vertex)
+
+    def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
+        return not super()._get_operation(vertex, attribute)  # type:ignore[arg-type]  # due to attribute can be None

--- a/checkov/common/checks_infra/solvers/attribute_solvers/jsonpath_not_exists_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/jsonpath_not_exists_attribute_solver.py
@@ -19,4 +19,4 @@ class JsonpathNotExistsAttributeSolver(JsonpathExistsAttributeSolver):
         return super().get_operation(vertex)
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
-        return not super()._get_operation(vertex, attribute)  # type:ignore[arg-type]  # due to attribute can be None
+        return not super()._get_operation(vertex, attribute)

--- a/checkov/common/graph/checks_infra/enums.py
+++ b/checkov/common/graph/checks_infra/enums.py
@@ -47,3 +47,4 @@ class Operators:
     OR = 'or'
     JSONPATH_EQUALS = 'jsonpath_equals'
     JSONPATH_EXISTS = 'jsonpath_exists'
+    JSONPATH_NOT_EXISTS = 'jsonpath_not_exists'

--- a/docs/3.Custom Policies/YAML Custom Policies.md
+++ b/docs/3.Custom Policies/YAML Custom Policies.md
@@ -97,6 +97,7 @@ definition:
 | Not Subset            | `not_subset`            |
 | Json Path Equals      | `jsonpath_equals`       |
 | Json Path Exists      | `jsonpath_exists`       |
+| Json Path Not Exists      | `jsonpath_not_exists`       |
 
 ### Attribute Condition: Keys and Values
 
@@ -105,7 +106,7 @@ definition:
 | `cond_type` | string | Must be `attribute`                                                                                                                                                                                                                                                                                      |
 | `resource_type` | collection of strings | Use either `all` or `[resource types from list]`                                                                                                                                                                                                                                                         |
 | `attribute` | string | Attribute of defined resource types. For example, `automated_snapshot_retention_period`                                                                                                                                                                                                                  |
-| `operator` | string | - `equals`, `not_equals`, `regex_match`, `not_regex_match`, `exists`, `not exists`, `any`, `contains`, `not_contains`, `within`, `starting_with`, `not_starting_with`, `ending_with`, `not_ending_with`, `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `jsonpath_equals`, `jsonpath_exists` |
+| `operator` | string | - `equals`, `not_equals`, `regex_match`, `not_regex_match`, `exists`, `not exists`, `any`, `contains`, `not_contains`, `within`, `starting_with`, `not_starting_with`, `ending_with`, `not_ending_with`, `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `jsonpath_equals`, `jsonpath_exists`, `jsonpath_not_exists` |
 | `value` (not relevant for operator: `exists`/`not_exists`) | string | User input.                                                                                                                                                                                                                                                                                              |
 
 

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/AzureSecureRule.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/AzureSecureRule.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "AzureSecureRule"
+scope:
+  provider: "AZURE"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "azurerm_resource_group"
+    - "azurerm_network_security_group"
+  attribute: "security_rule[?(@.name == 'rule_we_do not_care_about')].source_address_prefixes"
+  operator: "jsonpath_not_exists"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/CkSshPortOpenForAll.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/CkSshPortOpenForAll.yaml
@@ -1,0 +1,17 @@
+metadata:
+  id: "CkSshPortOpenForAll"
+scope:
+  provider: "AWS"
+definition:
+  and:
+    - cond_type: "attribute"
+      resource_types:
+        - "aws_security_group"
+      attribute: "ingress[?(@.to_port == 22 & @.from_port == 22)].cidr_blocks[*]"
+      operator: "jsonpath_not_exists"
+    - cond_type: "attribute"
+      resource_types:
+        - "aws_security_group"
+      attribute: "ingress[?(@.to_port == 443 & @.from_port == 443)].cidr_blocks[?(@ == '8.0.4.19/92')]"
+      operator: "jsonpath_not_exists"
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/PublicDBSG.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/PublicDBSG.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "PublicDBSG"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "aws_db_security_group"
+    - "aws_security_group"
+  attribute: "ingress.cidr_blocks"
+  operator: "jsonpath_not_exists"
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/example.tf
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/example.tf
@@ -1,0 +1,17 @@
+resource "xyz" "fail" {
+  arr {
+    name = "a"
+    value = "a"
+  }
+  arr {
+    name = "b"
+    value = "x"
+  }
+}
+
+resource "xyz" "pass" {
+  arr {
+    name = "b"
+    value = "x"
+  }
+}

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/example.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/example.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "example"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+  - "xyz"
+  attribute: "arr[?(@.name == 'a')]"
+  operator: "jsonpath_not_exists"
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/test_solver.py
@@ -1,0 +1,47 @@
+import os
+
+from tests.terraform.graph.checks_infra.test_base import TestBaseSolver
+
+TEST_DIRNAME = os.path.dirname(os.path.realpath(__file__))
+
+
+class TestJsonpathNotExistsSolver(TestBaseSolver):
+    def setUp(self):
+        self.checks_dir = TEST_DIRNAME
+        super().setUp()
+
+    def test_jsonpath_not_exists_solver_simple(self):
+        root_folder = '../../../resources/public_security_groups'
+        check_id = "PublicDBSG"
+        should_fail = ['aws_security_group.aws_security_group_private']
+        should_pass = ['aws_db_security_group.aws_db_security_group_public']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_jsonpath_not_exists_solver_wildcard(self):
+        root_folder = '../../../resources/security_group_multiple_rules3'
+        check_id = "CkSshPortOpenForAll"
+        should_fail = ['aws_security_group.sg1']
+        should_pass = ['aws_security_group.sg2', 'aws_security_group.sg3']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_jsonpath_not_exists_azure_rule(self):
+        root_folder = '../../../resources/azure_secure_rule'
+        check_id = "AzureSecureRule"
+        should_fail = ['azurerm_network_security_group.sg_fail']
+        should_pass = ['azurerm_network_security_group.sg_fail2']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_jsonpath_not_exists_example(self):
+        root_folder = './'
+        check_id = "example"
+        should_pass = ['xyz.pass']
+        should_fail = ['xyz.fail']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Adds the `jsonpath_not_exists` operator as the inverse to `jsonpath_exists`. This required overriding `JsonpathEqualsSolver.get_operation`, which does not delegate to the `_get_operation` method if it can't find the attribute. This caused every evaluation result to return `False`.

I think that the path to `_get_operation` is not actually going to occur. But I am not sure why the jsonpathequals class has the `if self.attributes` check, so I maintained that logic.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
