### PR TITLE
Allow 'Name' and 'Version' (with caps) in Chart.yaml

### DIFF
--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -156,24 +156,26 @@ class Runner(BaseRunner):
             processed_chart_dir_and_meta.append((chart_dir.replace(root_folder, ""), chart_meta))
             target_dir = chart_dir.replace(root_folder, f'{self.target_folder_path}/')
             target_dir.replace("//", "/")
+            chart_name = chart_meta.get('name', chart_meta.get('Name'))
+            chart_version = chart_meta.get('version', chart_meta.get('Version'))
             if target_dir.endswith('/'):
                 target_dir = target_dir[:-1]
-            if target_dir.endswith(chart_meta["name"]):
-                target_dir = target_dir[:-len(chart_meta["name"])]
+            if target_dir.endswith(chart_name):
+                target_dir = target_dir[:-len(chart_name)]
             logging.info(
-                f"Processing chart found at: {chart_dir}, name: {chart_meta['name']}, version: {chart_meta['version']}")
+                f"Processing chart found at: {chart_dir}, name: {chart_name}, version: {chart_version}")
             # dependency list is nicer to parse than dependency update.
             helm_binary_list_chart_deps = subprocess.Popen([self.helm_command, 'dependency', 'list', chart_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # nosec
             o, e = helm_binary_list_chart_deps.communicate()
             logging.debug(
-                f"Ran helm command to get dependency output. Chart: {chart_meta['name']}. dir: {target_dir}. Output: {str(o, 'utf-8')}. Errors: {str(e, 'utf-8')}")
+                f"Ran helm command to get dependency output. Chart: {chart_name}. dir: {target_dir}. Output: {str(o, 'utf-8')}. Errors: {str(e, 'utf-8')}")
             if e:
                 if "Warning: Dependencies" in str(e, 'utf-8'):
                     logging.info(
-                        f"V1 API chart without Chart.yaml dependancies. Skipping chart dependancy list for {chart_meta['name']} at dir: {chart_dir}. Working dir: {target_dir}. Error details: {str(e, 'utf-8')}")
+                        f"V1 API chart without Chart.yaml dependancies. Skipping chart dependancy list for {chart_name} at dir: {chart_dir}. Working dir: {target_dir}. Error details: {str(e, 'utf-8')}")
                 else:
                     logging.info(
-                        f"Error processing helm dependancies for {chart_meta['name']} at source dir: {chart_dir}. Working dir: {target_dir}. Error details: {str(e, 'utf-8')}")
+                        f"Error processing helm dependancies for {chart_name} at source dir: {chart_dir}. Working dir: {target_dir}. Error details: {str(e, 'utf-8')}")
 
             helm_command_args = [self.helm_command, 'template', '--dependency-update', chart_dir]
             if runner_filter.var_files:
@@ -186,11 +188,11 @@ class Runner(BaseRunner):
                 proc = subprocess.Popen(helm_command_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # nosec
                 o, e = proc.communicate()
                 logging.debug(
-                    f"Ran helm command to template chart output. Chart: {chart_meta['name']}. dir: {target_dir}. Output: {str(o, 'utf-8')}. Errors: {str(e, 'utf-8')}")
+                    f"Ran helm command to template chart output. Chart: {chart_name}. dir: {target_dir}. Output: {str(o, 'utf-8')}. Errors: {str(e, 'utf-8')}")
 
             except Exception:
                 logging.info(
-                    f"Error processing helm chart {chart_meta['name']} at dir: {chart_dir}. Working dir: {target_dir}.",
+                    f"Error processing helm chart {chart_name} at dir: {chart_dir}. Working dir: {target_dir}.",
                     exc_info=True,
                 )
 

--- a/tests/helm/runner/resources/infrastructure/helm-tiller/pwnchart/Chart.yaml
+++ b/tests/helm/runner/resources/infrastructure/helm-tiller/pwnchart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes Goat helm-tiller
-name: pwnchart
+Name: pwnchart
 version: 0.1.0


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Allows first-letter capitalization for the attributes we read from `Chart.yaml`. There seem to be mixed messages on whether this is allowed, but the [docs](https://docs.helm.sh/docs/chart_template_guide/builtin_objects/) do reference them in caps at one point, and I have a customer with a working chart with caps, so we should handle it.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
