### PR TITLE
Replace deprecated logging.warn with logging.warning

### DIFF
--- a/checkov/common/checks_infra/solvers/attribute_solvers/regex_match_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/regex_match_attribute_solver.py
@@ -18,5 +18,5 @@ class RegexMatchAttributeSolver(BaseAttributeSolver):
         try:
             return re.match(str(self.value), str(attr)) is not None
         except re.error as e:
-            logging.warn(f'failed to run regex {self.value} for attribute: {attr}, ', e)
+            logging.warning(f'failed to run regex {self.value} for attribute: {attr}, ', e)
             return False


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
