### PR TITLE
consider framework flags when used with outer_registry

### DIFF
--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -6,12 +6,12 @@ import json
 import logging
 import os
 import re
-from abc import abstractmethod
+
 from collections import defaultdict
 from collections.abc import Iterable
 from json import dumps
 from pathlib import Path
-from typing import List, Dict, Any, Tuple, Optional, cast, TYPE_CHECKING
+from typing import List, Dict, Any, Optional, cast, TYPE_CHECKING
 
 from typing_extensions import Literal
 

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -149,6 +149,7 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
     if outer_registry:
         runner_registry = outer_registry
         runner_registry.runner_filter = runner_filter
+        runner_registry.filter_runner_framework()
     else:
         runner_registry = RunnerRegistry(banner, runner_filter, *DEFAULT_RUNNERS)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from typing_extensions import Literal
+
+from checkov import main
+from checkov.common.runners.base_runner import BaseRunner
+from checkov.common.runners.runner_registry import RunnerRegistry
+from checkov.main import DEFAULT_RUNNERS
+from checkov.runner_filter import RunnerFilter
+
+if TYPE_CHECKING:
+    import argparse
+    from checkov.common.output.baseline import Baseline
+    from checkov.common.output.report import Report
+
+
+class CustomRunnerRegistry(RunnerRegistry):
+    def __init__(self, banner: str, runner_filter: RunnerFilter, *runners: BaseRunner) -> None:
+        super().__init__(banner, runner_filter, *runners)
+
+    def print_reports(
+        self,
+        scan_reports: list[Report],
+        config: argparse.Namespace,
+        url: str | None = None,
+        created_baseline_path: str | None = None,
+        baseline: Baseline | None = None,
+    ) -> Literal[0, 1]:
+        # result doesn't matter, just don't want it to print to console
+        return 0
+
+
+def test_run_with_outer_registry_and_framework_flag():
+    # given
+    custom_banner = "custom banner"
+    resource_dir = Path(__file__).parent / "common/runner_registry/example_multi_iac"
+    argv = ["-d", str(resource_dir), "--framework", "terraform"]
+
+    # when
+    main.outer_registry = CustomRunnerRegistry(custom_banner, RunnerFilter(), *DEFAULT_RUNNERS)
+    main.run(banner=custom_banner, argv=argv)
+
+    # then
+    assert len(main.outer_registry.runners) == 1
+    assert main.outer_registry.runners[0].check_type == "terraform"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

- the framework flags had no relevance on limiting runners, when used with `outer_registry`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
