### PR TITLE
add check for restricting port 80

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/SecurityGroupUnrestrictedIngress80.py
+++ b/checkov/cloudformation/checks/resource/aws/SecurityGroupUnrestrictedIngress80.py
@@ -1,0 +1,10 @@
+from checkov.cloudformation.checks.resource.aws.AbsSecurityGroupUnrestrictedIngress import \
+    AbsSecurityGroupUnrestrictedIngress
+
+
+class SecurityGroupUnrestrictedIngress80(AbsSecurityGroupUnrestrictedIngress):
+    def __init__(self):
+        super().__init__(check_id="CKV_AWS_260", port=80)
+
+
+check = SecurityGroupUnrestrictedIngress80()

--- a/checkov/terraform/checks/resource/aws/SecurityGroupUnrestrictedIngress80.py
+++ b/checkov/terraform/checks/resource/aws/SecurityGroupUnrestrictedIngress80.py
@@ -1,0 +1,9 @@
+from checkov.terraform.checks.resource.aws.AbsSecurityGroupUnrestrictedIngress import AbsSecurityGroupUnrestrictedIngress
+
+
+class SecurityGroupUnrestrictedIngress80(AbsSecurityGroupUnrestrictedIngress):
+    def __init__(self):
+        super().__init__(check_id="CKV_AWS_260", port=80)
+
+
+check = SecurityGroupUnrestrictedIngress80()

--- a/checkov/terraform/checks/resource/azure/NSGRuleHTTPAccessRestricted.py
+++ b/checkov/terraform/checks/resource/azure/NSGRuleHTTPAccessRestricted.py
@@ -1,0 +1,13 @@
+from checkov.terraform.checks.resource.azure.NSGRulePortAccessRestricted import NSGRulePortAccessRestricted
+
+
+class NSGRuleHTTPAccessRestricted(NSGRulePortAccessRestricted):
+    def __init__(self) -> None:
+        super().__init__(
+            name="Ensure that HTTP (port 80) access is restricted from the internet",
+            check_id="CKV_AZURE_160",
+            port=80,
+        )
+
+
+check = NSGRuleHTTPAccessRestricted()

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeFirewallUnrestrictedIngress80.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeFirewallUnrestrictedIngress80.py
@@ -1,0 +1,16 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.gcp.AbsGoogleComputeFirewallUnrestrictedIngress import AbsGoogleComputeFirewallUnrestrictedIngress
+
+PORT = 80
+
+
+class GoogleComputeFirewallUnrestrictedIngress80(AbsGoogleComputeFirewallUnrestrictedIngress):
+    def __init__(self):
+        name = "Ensure Google compute firewall ingress does not allow unrestricted http port 80 access"
+        id = "CKV_GCP_106"
+        supported_resources = ['google_compute_firewall']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources, port=PORT)
+
+
+check = GoogleComputeFirewallUnrestrictedIngress80()

--- a/tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress80/SecurityGroupUnrestrictedIngress80-FAILED-2.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress80/SecurityGroupUnrestrictedIngress80-FAILED-2.yaml
@@ -1,0 +1,18 @@
+Description: Security Group Example
+Parameters:
+  SSHLocation:
+    Description: The IP address range that can be used to SSH to the EC2 instances
+    Type: String
+    Default: '::/0'
+Resources:
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable SSH access via port 80
+      SecurityGroupIngress:
+      - Description: SSH Ingress
+        IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIpv6: !Ref 'SSHLocation'
+

--- a/tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress80/SecurityGroupUnrestrictedIngress80-FAILED-3.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress80/SecurityGroupUnrestrictedIngress80-FAILED-3.yaml
@@ -1,0 +1,18 @@
+Description: Security Group Example
+Parameters:
+  SSHLocation:
+    Description: The IP address range that can be used to SSH to the EC2 instances
+    Type: String
+    Default: '0000:0000:0000:0000:0000:0000:0000:0000/0'
+Resources:
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable SSH access via port 80
+      SecurityGroupIngress:
+      - Description: SSH Ingress
+        IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIpv6: !Ref 'SSHLocation'
+

--- a/tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress80/SecurityGroupUnrestrictedIngress80-FAILED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress80/SecurityGroupUnrestrictedIngress80-FAILED.yaml
@@ -1,0 +1,22 @@
+Description: Security Group Example
+Parameters:
+  SSHLocation:
+    Description: The IP address range that can be used to SSH to the EC2 instances
+    Type: String
+    MinLength: 9
+    MaxLength: 18
+    Default: 0.0.0.0/0
+    AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
+    ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
+Resources:
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable SSH access via port 22
+      SecurityGroupIngress:
+      - Description: SSH Ingress
+        IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIp: !Ref 'SSHLocation'
+

--- a/tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress80/SecurityGroupUnrestrictedIngress80-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress80/SecurityGroupUnrestrictedIngress80-PASSED.yaml
@@ -1,0 +1,22 @@
+Description: Security Group Example
+Parameters:
+  SSHLocation:
+    Description: The IP address range that can be used to SSH to the EC2 instances
+    Type: String
+    MinLength: 9
+    MaxLength: 18
+    Default: 10.10.10.0/24
+    AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
+    ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
+Resources:
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable SSH access via port 80
+      SecurityGroupIngress:
+      - Description: SSH Ingress
+        IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIp: !Ref 'SSHLocation'
+

--- a/tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress80/SecurityGroupUnrestrictedIngress80-UNKNOWN.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_SecurityGroupUnrestrictedIngress80/SecurityGroupUnrestrictedIngress80-UNKNOWN.yaml
@@ -1,0 +1,12 @@
+Description: Security Group Example
+Parameters:
+  SSHLocation:
+    Description: The IP address range that can be used to SSH to the EC2 instances
+    Type: String
+    Default: '::/0'
+Resources:
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable SSH access via port 80
+      SecurityGroupIngress: 'hello80'

--- a/tests/cloudformation/checks/resource/aws/test_SecurityGroupUnrestrictedIngress80.py
+++ b/tests/cloudformation/checks/resource/aws/test_SecurityGroupUnrestrictedIngress80.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.cloudformation.checks.resource.aws.SecurityGroupUnrestrictedIngress80 import check
+from checkov.cloudformation.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestSecurityGroupUnrestrictedIngress80(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_SecurityGroupUnrestrictedIngress80"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 3)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngress80.py
+++ b/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngress80.py
@@ -1,0 +1,408 @@
+import unittest
+
+import hcl2
+
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.aws.SecurityGroupUnrestrictedIngress80 import check
+
+
+class TestSecurityGroupUnrestrictedIngress80(unittest.TestCase):
+
+    def test_failure_ipv4(self):
+        hcl_res = hcl2.loads("""
+        resource "aws_security_group" "bar-sg" {
+          name   = "sg-bar"
+          vpc_id = aws_vpc.main.id
+        
+          ingress {
+            from_port = 80
+            to_port   = 80
+            protocol  = "tcp"
+            cidr_blocks = ["192.168.0.0/16", "0.0.0.0/0"]
+            description = "foo"
+          }
+        
+          egress {
+            from_port = 0
+            to_port   = 0
+            protocol  = "-1"
+            cidr_blocks = ["0.0.0.0/0"]
+          }
+        }  
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_0_0(self):
+        hcl_res = hcl2.loads("""
+        resource "aws_security_group" "bar-sg" {
+          name   = "sg-bar"
+          vpc_id = aws_vpc.main.id
+
+          ingress {
+            from_port = 0
+            to_port   = 0
+            protocol  = "tcp"
+            cidr_blocks = ["192.168.0.0/16", "0.0.0.0/0"]
+            description = "foo"
+          }
+
+          egress {
+            from_port = 0
+            to_port   = 0
+            protocol  = "-1"
+            cidr_blocks = ["0.0.0.0/0"]
+          }
+        }  
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_ipv6(self):
+        hcl_res = hcl2.loads("""
+        resource "aws_security_group" "bar-sg" {
+          name   = "sg-bar"
+          vpc_id = aws_vpc.main.id
+
+          ingress {
+            from_port = 80
+            to_port   = 80
+            protocol  = "tcp"
+            ipv6_cidr_blocks = ["192.168.0.0/16", "::/0"]
+            description = "foo"
+          }
+
+          egress {
+            from_port = 0
+            to_port   = 0
+            protocol  = "-1"
+            cidr_blocks = ["0.0.0.0/0"]
+          }
+        }  
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_different_port(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port = 222
+    to_port   = 222
+    protocol  = "tcp"
+    cidr_blocks = ["192.168.0.0/16", "0.0.0.0/0"]
+    description = "foo"
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}  
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_no_cidr(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    security_groups = [aws_security_group.foo-sg.id]
+    description = "foo"
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_null_cidr(self):
+        hcl_res = hcl2.loads("""
+    resource "aws_security_group" "bar-sg" {
+      name   = "sg-bar"
+      vpc_id = aws_vpc.main.id
+
+      ingress = [{
+        from_port = 80
+        to_port   = 80
+        protocol  = "tcp"
+        security_groups = [aws_security_group.foo-sg.id]
+        description = "foo"
+        cidr_blocks = null
+      }]
+
+      egress = [{
+        from_port = 0
+        to_port   = 0
+        protocol  = "-1"
+        cidr_blocks = null
+      }]
+    }
+            """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_null_ipv6(self):
+        hcl_res = hcl2.loads("""
+    resource "aws_security_group" "bar-sg" {
+      name   = "sg-bar"
+      vpc_id = aws_vpc.main.id
+
+      ingress = [{
+        ipv6_cidr_blocks = null
+        from_port = 80
+        to_port   = 80
+        protocol  = "tcp"
+        security_groups = [aws_security_group.foo-sg.id]
+        description = "foo"
+        cidr_blocks = null
+      }]
+
+      egress = [{
+        from_port = 0
+        to_port   = 0
+        protocol  = "-1"
+        cidr_blocks = null
+      }]
+    }
+            """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_cidr(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = ["192.168.0.0/16"]
+    description = "foo"
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_failure_combined_ingress(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    security_groups = [aws_security_group.foo-sg.id]
+    cidr_blocks = ["192.168.0.0/16", "0.0.0.0/0"]
+    description = "foo"
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_combined_ingress(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    security_groups = [aws_security_group.foo-sg.id]
+    cidr_blocks = ["192.168.0.0/16"]
+    description = "foo"
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_egress_only(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_ingress_rules_list(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "inline_rules" {
+  description = "SG with inline rules"
+  ingress = [
+    {
+      cidr_blocks      = ["0.0.0.0/0"]
+      description      = "Wide Open"
+      from_port        = 0
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = []
+      protocol         = "-1"
+      self             = false
+      to_port          = 65535
+    }
+  ]
+}
+""")
+        conf = hcl_res['resource'][0]['aws_security_group']['inline_rules']
+        result = check.scan_resource_conf(conf)
+        self.assertEqual(result, CheckResult.FAILED)
+
+    def test_failure_separate_rule_cidr(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group" "bar-sg" {
+  name   = "sg-bar"
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_security_group_rule" "ingress" {
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["192.168.0.0/16", "0.0.0.0/0"]
+  security_group_id = aws_security_group.bar-sg.id
+}
+        """)
+
+        resource_conf = hcl_res['resource'][0]['aws_security_group']['bar-sg']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+        resource_conf = hcl_res['resource'][1]['aws_security_group_rule']['ingress']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_pass_separate_rule_cidr(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group_rule" "ingress" {
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["192.168.0.0/16"]
+  security_group_id = aws_security_group.bar-sg.id
+}
+        """)
+
+        resource_conf = hcl_res['resource'][0]['aws_security_group_rule']['ingress']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_unknown_separate_rule_egress(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group_rule" "egress" {
+  type              = "egress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.bar-sg.id
+}
+        """)
+
+        resource_conf = hcl_res['resource'][0]['aws_security_group_rule']['egress']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+
+    def test_pass_separate_rule_source_sg(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group_rule" "ingress" {
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  source_security_group_id       = "sg-123456"
+  security_group_id = aws_security_group.bar-sg.id
+}
+        """)
+
+        resource_conf = hcl_res['resource'][0]['aws_security_group_rule']['ingress']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_pass_separate_rule_different_port(self):
+        hcl_res = hcl2.loads("""
+resource "aws_security_group_rule" "ingress" {
+  type              = "ingress"
+  from_port         = 222
+  to_port           = 222
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.bar-sg.id
+}
+        """)
+
+        resource_conf = hcl_res['resource'][0]['aws_security_group_rule']['ingress']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/azure/example_NSGRuleHTTPAccessRestricted/main.tf
+++ b/tests/terraform/checks/resource/azure/example_NSGRuleHTTPAccessRestricted/main.tf
@@ -1,0 +1,131 @@
+# pass
+
+resource "azurerm_network_security_rule" "https" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = 443
+  source_address_prefix  = "Internet"
+}
+
+resource "azurerm_network_security_rule" "http_restricted_prefixes" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = 80
+  source_address_prefixes = [
+    "123.123.123.123/32",
+    "10.0.0.0/16"
+  ]
+}
+
+resource "azurerm_network_security_group" "http_restricted" {
+  name                = "example"
+  location            = "azurerm_resource_group.example.location"
+  resource_group_name = "azurerm_resource_group.example.name"
+
+  security_rule {
+    name      = "example"
+    access    = "Allow"
+    direction = "Inbound"
+    priority  = 100
+    protocol  = "Tcp"
+
+    destination_port_range = 80
+    source_address_prefix  = "10.0.0.0/16"
+  }
+}
+
+# fail
+
+resource "azurerm_network_security_rule" "http" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range  = 80
+  source_address_prefix   = "*"
+  destination_port_ranges = null
+  source_address_prefixes = null
+}
+
+resource "azurerm_network_security_rule" "all" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = "*"
+  source_address_prefix  = "Internet"
+}
+
+resource "azurerm_network_security_rule" "range" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = "10-100"
+  source_address_prefix  = "Internet"
+}
+
+resource "azurerm_network_security_rule" "ranges_prefixes" {
+  name                        = "example"
+  access                      = "Allow"
+  direction                   = "Inbound"
+  network_security_group_name = "azurerm_network_security_group.example.name"
+  priority                    = 100
+  protocol                    = "Tcp"
+  resource_group_name         = "azurerm_resource_group.example.name"
+
+  destination_port_range = null
+  source_address_prefix  = null
+  destination_port_ranges = [
+    80,
+    443
+  ]
+  source_address_prefixes = [
+    "Internet",
+    "10.0.0.0/16"
+  ]
+}
+
+resource "azurerm_network_security_group" "ranges" {
+  name                = "example"
+  location            = "azurerm_resource_group.example.location"
+  resource_group_name = "azurerm_resource_group.example.name"
+
+  security_rule {
+    name      = "example"
+    access    = "Allow"
+    direction = "Inbound"
+    priority  = 100
+    protocol  = "Tcp"
+
+    destination_port_ranges = [
+      "10-100",
+      "8000-9000"
+    ]
+    source_address_prefix = "*"
+  }
+}

--- a/tests/terraform/checks/resource/azure/test_NSGRuleHTTPAccessRestricted.py
+++ b/tests/terraform/checks/resource/azure/test_NSGRuleHTTPAccessRestricted.py
@@ -1,0 +1,46 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.azure.NSGRuleHTTPAccessRestricted import check
+from checkov.terraform.runner import Runner
+
+
+class TestNSGRuleSSHAccessRestricted(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_NSGRuleHTTPAccessRestricted"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "azurerm_network_security_rule.https",
+            "azurerm_network_security_rule.http_restricted_prefixes",
+            "azurerm_network_security_group.http_restricted",
+        }
+        failing_resources = {
+            "azurerm_network_security_rule.all",
+            "azurerm_network_security_rule.range",
+            "azurerm_network_security_rule.ranges_prefixes",
+            "azurerm_network_security_rule.http",
+            "azurerm_network_security_group.ranges",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["failed"], 5)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/gcp/example_GoogleComputeFirewallUnrestrictedIngress80/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleComputeFirewallUnrestrictedIngress80/main.tf
@@ -1,0 +1,89 @@
+# pass
+
+resource "google_compute_firewall" "restricted" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80"]
+  }
+
+  source_ranges = ["172.1.2.3/32"]
+  target_tags   = ["ssh"]
+}
+
+resource "google_compute_firewall" "allow_different_int" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = [4624]
+  }
+
+  source_ranges = ["172.1.2.3/32"]
+  target_tags   = ["ssh"]
+}
+
+resource "google_compute_firewall" "allow_null" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = null
+  }
+
+  source_ranges = ["172.1.2.3/32"]
+  target_tags   = ["ssh"]
+}
+
+# fail
+
+resource "google_compute_firewall" "allow_all" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "google_compute_firewall" "allow_http_int" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = [80]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "google_compute_firewall" "allow_multiple" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["1024-65535", "80"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+# unknown
+
+resource "google_compute_firewall" "allow_unknown" {
+  name    = "example"
+  network = "google_compute_network.vpc.name"
+
+  allow = "var.backends"
+
+  source_ranges = ["0.0.0.0/0"]
+}

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeFirewallUnrestrictedIngress80.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeFirewallUnrestrictedIngress80.py
@@ -1,0 +1,46 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.gcp.GoogleComputeFirewallUnrestrictedIngress80 import check
+from checkov.terraform.runner import Runner
+
+
+class TestGoogleComputeFirewallUnrestrictedIngress22(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_GoogleComputeFirewallUnrestrictedIngress80"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "google_compute_firewall.restricted",
+            "google_compute_firewall.allow_null",
+            "google_compute_firewall.allow_different_int",
+        }
+
+        failing_resources = {
+            "google_compute_firewall.allow_multiple",
+            "google_compute_firewall.allow_http_int",
+            "google_compute_firewall.allow_all",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+        self.assertEqual(summary["resource_count"], 7)  # 1 unknown
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)


## New/Edited policies (Delete if not relevant)

 - CKV_AWS_260
 - CKV_AZURE_160
 - CKV_GCP_106

### Description
This is an existing policy for Prisma Cloud that some customers want to have mirrored in their code scan results. And at this point, port 80 should be pretty easily avoided.

### Fix
Do not allow port 80 from the internet in a firewall / SG rule.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
