### PR TITLE
explicitly handle lists and dicts in equals operator

### DIFF
--- a/checkov/common/checks_infra/solvers/attribute_solvers/equals_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/equals_attribute_solver.py
@@ -22,5 +22,7 @@ class EqualsAttributeSolver(BaseAttributeSolver):
             # handle cases like str(False) == "false"
             # generally self.value will be a string, but could be a bool if the policy was created straight from json
             return str(attr_val).lower() == str(self.value).lower()
+        elif (isinstance(attr_val, list) and isinstance(self.value, list)) or (isinstance(attr_val, dict) and isinstance(self.value, dict)):
+            return attr_val == self.value
         else:
             return str(attr_val) == str(self.value)

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/Complex.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/Complex.yaml
@@ -1,0 +1,41 @@
+metadata:
+  id: "Complex"
+scope:
+  provider: "AWS"
+definition:
+  and:
+    - cond_type: "attribute"
+      resource_types:
+        - "x"
+      attribute: "list"
+      operator: "equals"
+      value:
+        - "a"
+        - "list"
+        - "of values"
+    - cond_type: "attribute"
+      resource_types:
+        - "x"
+      attribute: "dict"
+      operator: "equals"
+      value:
+        a_key: "a value"
+        another: "another"
+    - cond_type: "attribute"
+      resource_types:
+        - "x"
+      attribute: "complex"
+      operator: "equals"
+      value:
+        - key: "value"
+          key2: "value2"
+          listkey:
+            - "list1"
+            - "list2"
+        - key: "value22"
+          key2: "value22"
+          listkey:
+            - "listx"
+            - "listy"
+
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/test_solver.py
@@ -48,3 +48,13 @@ class TestEqualsSolver(TestBaseSolver):
 
         super(TestEqualsSolver, self).run_test(root_folder=root_folder, expected_results=expected_results,
                                                check_id=check_id)
+
+    def test_equals_solver_complex(self):
+        root_folder = '../../../resources/complex'
+        check_id = "Complex"
+        should_pass = ['x.x1']
+        should_fail = ['x.x2']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        super(TestEqualsSolver, self).run_test(root_folder=root_folder, expected_results=expected_results,
+                                               check_id=check_id)

--- a/tests/terraform/graph/resources/complex/main.tf
+++ b/tests/terraform/graph/resources/complex/main.tf
@@ -1,0 +1,38 @@
+resource "x" "x1" {
+  list = ["a", "list", "of values"]
+  dict = {
+    another = "another"
+    a_key = "a value"
+  }
+  complex = [
+    {
+      key = "value"
+      key2 = "value2"
+      listkey = ["list1", "list2"]
+    },
+    {
+      key = "value22"
+      key2 = "value22"
+      listkey = ["listx", "listy"]
+    }
+  ]
+}
+
+resource "x" "x2" {
+  list = ["a", "list", "of values"]
+  dict = {
+    another = "another"
+    a_key = "a value"
+  }
+  complex = [
+    {
+      key = "value"
+      key2 = "value2"
+      listkey = ["list1", "list2"]
+    },
+    {
+      key = "value22"
+      key2 = "value22"
+    }
+  ]
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Explicitly handles comparisons for `list` and `dict` types in the `equals` operator. Previously, it would compare the string values, which generally worked for lists and some dicts, but not in all cases.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
