### PR TITLE
add 'not' complex solver

### DIFF
--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -19,6 +19,7 @@ from checkov.common.checks_infra.solvers import (
     NotEndingWithAttributeSolver,
     AndSolver,
     OrSolver,
+    NotSolver,
     ConnectionExistsSolver,
     ConnectionNotExistsSolver,
     AndConnectionSolver,
@@ -80,6 +81,7 @@ operators_to_attributes_solver_classes: dict[str, Type[BaseAttributeSolver]] = {
 operators_to_complex_solver_classes: dict[str, Type[BaseComplexSolver]] = {
     "and": AndSolver,
     "or": OrSolver,
+    "not": NotSolver,
 }
 
 operator_to_connection_solver_classes: dict[str, Type[BaseConnectionSolver]] = {
@@ -126,6 +128,12 @@ class NXGraphCheckParser(BaseGraphCheckParser):
             check.type = SolverType.COMPLEX
             check.operator = complex_operator
             sub_solvers = raw_check.get(complex_operator, [])
+
+            # this allows flexibility for specifying the child conditions, and makes "not" more intuitive by
+            # not requiring an actual list
+            if isinstance(sub_solvers, dict):
+                sub_solvers = [sub_solvers]
+
             for sub_solver in sub_solvers:
                 check.sub_checks.append(self._parse_raw_check(sub_solver, resources_types))
             resources_types_of_sub_solvers = [

--- a/checkov/common/checks_infra/solvers/complex_solvers/__init__.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/__init__.py
@@ -1,2 +1,3 @@
 from checkov.common.checks_infra.solvers.complex_solvers.or_solver import OrSolver  # noqa
 from checkov.common.checks_infra.solvers.complex_solvers.and_solver import AndSolver  # noqa
+from checkov.common.checks_infra.solvers.complex_solvers.not_solver import NotSolver  # noqa

--- a/checkov/common/checks_infra/solvers/complex_solvers/not_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/not_solver.py
@@ -1,0 +1,23 @@
+from typing import List, Any, Dict
+
+from checkov.common.graph.checks_infra.enums import Operators
+from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
+from checkov.common.checks_infra.solvers.complex_solvers.base_complex_solver import BaseComplexSolver
+from functools import reduce
+
+
+class NotSolver(BaseComplexSolver):
+    operator = Operators.NOT
+
+    def __init__(self, solvers: List[BaseSolver], resource_types: List[str]) -> None:
+        if len(solvers) != 1:
+            raise Exception('The "not" operator must have exactly one child')
+        super().__init__(solvers, resource_types)
+
+    def _get_operation(self, *args: Any, **kwargs: Any) -> Any:
+        if len(args) != 1:
+            raise Exception('The "not" operator must have exactly one child')
+        return not args[0]
+
+    def get_operation(self, vertex: Dict[str, Any]) -> bool:
+        return not self.solvers[0].get_operation(vertex)

--- a/checkov/common/graph/checks_infra/enums.py
+++ b/checkov/common/graph/checks_infra/enums.py
@@ -45,6 +45,7 @@ class Operators:
     WITHIN = 'within'
     AND = 'and'
     OR = 'or'
+    NOT = 'not'
     JSONPATH_EQUALS = 'jsonpath_equals'
     JSONPATH_NOT_EQUALS = 'jsonpath_not_equals'
     JSONPATH_EXISTS = 'jsonpath_exists'

--- a/docs/3.Custom Policies/Examples.md
+++ b/docs/3.Custom Policies/Examples.md
@@ -372,3 +372,18 @@ definition:
           operator: "equals"
           value: "22"
 ```
+
+## Using a wildcard to evaluate all elements of a list
+
+The following policy will pass if and only if all of the `cidr_blocks` arrays within the `ingress` blocks of a security group do not contain `0.0.0.0/0`.
+
+```yaml
+definition:
+  not:
+    cond_type: attribute
+    resource_types:
+      - "aws_security_group"
+    attribute: "ingress.*.cidr_blocks"
+    operator: "contains"
+    value: "0.0.0.0/0"
+```

--- a/docs/3.Custom Policies/YAML Custom Policies.md
+++ b/docs/3.Custom Policies/YAML Custom Policies.md
@@ -41,6 +41,7 @@ The policy definition consists of:
 * **Logical Operator(s)** (optional)
 * **Filter**(optional)
 
+The top level object under `definition` must be a single object (not a list). It can be an attribute block, a connection block, or a logical operator (`and`, `or`, `not`).
 
 ## Types of Definition Blocks
 
@@ -49,6 +50,9 @@ The policy definition consists of:
 
 ### Using AND/OR Logic
 A policy definition may include multiple blocks (**Attribute**, **Connection state** or both), associated by **AND/OR** logic.
+
+### Using NOT Logic
+A policy definition may include any block (**Attribute**, **Connection state**, or **AND/OR**) underneath a `not` block to invert the statement.
 
 ## Attribute Blocks
 
@@ -190,9 +194,10 @@ definition:
 
 The Bridgecrew platform allows you to combine definition blocks using AND/OR operators.
 
-* The top-level logical operator is the first key below \"definition\" (and not an item in a collection). It defines the relationship of all of the definition blocks in the specific YAML policy definition.
+* The top-level logical operator is the first key below \"definition\" (and not an item in a collection). Most policies will start with an `and` or `or` key here, with multiple conditions nested within that.
 * Filter blocks apply (only) to the top-level and constitute an AND condition. For example, if you'd like to indicate a requirement for a Connection State between types of resources, but only within a certain subset of all of those resources.
 Every other logical operator applies within a collection. For example, you can use AND/OR logic in a collection of key-value pairs.
+* The value for the `and` or `or` key must be a list; each element of the list must be a valid definition on its own (i.e., a combination of attribute conditions, connection conditions, nested AND/OR, etc).
 
 ### Example
 
@@ -202,12 +207,49 @@ The logic in the policy definition shown below is:
 ```yaml
 #....
 defintion:
-           and:
-               - #filter block 1
-               - #block 2
-               - or:
-                   - #block 3
-                   - #block 4
+  and:
+  - #filter block 1
+  - #block 2
+  - or:
+    - #block 3
+    - #block 4
 ```
 
 [See all examples of Custom Policies in code](https://www.checkov.io/3.Custom%20Policies/Examples.html)
+
+## Using NOT Logic
+
+You can use `not` in the same places that you may use `and` and `or` to invert the nested condition definition. The value of the `not` element in the policy may be either a list containing exactly one element (which can also be nested more deeply), or any other type of block.
+
+### Example
+
+The definition below inverts the example in the previous section.
+
+```yaml
+#....
+defintion:
+  not:
+    and:
+    - #filter block 1
+    - #block 2
+    - or:
+      - #block 3
+      - #block 4
+```
+
+The following code is also valid (the child of `not` is a list of length 1):
+
+```yaml
+#....
+defintion:
+  not:
+  - and:
+    - #filter block 1
+    - #block 2
+    - or:
+      - #block 3
+      - #block 4
+```
+
+[See all examples of Custom Policies in code](https://www.checkov.io/3.Custom%20Policies/Examples.html)
+

--- a/docs/3.Custom Policies/YAML Custom Policies.md
+++ b/docs/3.Custom Policies/YAML Custom Policies.md
@@ -115,6 +115,39 @@ definition:
 | `value` (not relevant for operator: `exists`/`not_exists`) | string | User input.                                                                                                                                                                                                                                                                                              |
 
 
+### Evaluating list attributes
+
+You may use a wildcard (`*`) to evaluate all of the items within a list. You may use multiple wildcards to evaluated nested lists. If *any* item in the list matches the condition, then the condition passes.
+
+For example, consider the following resource:
+
+```
+resource "aws_security_group" "sg" {
+  ...
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    ...
+  }
+  ingress {
+    cidr_blocks = ["192.168.1.0/24"]
+    ...
+  }
+}
+```
+
+The following definition will return `true`, because one of the CIDR blocks contains `0.0.0.0/0`:
+
+```yaml
+cond_type: attribute
+resource_types:
+  - "aws_security_group"
+attribute: "ingress.*.cidr_blocks"
+operator: "contains"
+value: "0.0.0.0/0"
+```
+
+Note that switching the operator to `not_contains` will still result in the evaluation being `true`, because there is also an element that does *not* contain `0.0.0.0/0`. If you want to write a policy that fails if any CIDR block contains `0.0.0.0/0`, consider the `not` operator, described below.
+
 ## Connection State Block
 
 A Connection State Block indicates a type of resource that has or does not have a connection to another type of resource.

--- a/tests/terraform/graph/checks_infra/complex_solvers/not_solver/BucketsWithDevEnvAndPrivateACL.yaml
+++ b/tests/terraform/graph/checks_infra/complex_solvers/not_solver/BucketsWithDevEnvAndPrivateACL.yaml
@@ -1,0 +1,19 @@
+metadata:
+  id: "NotTest"
+scope:
+  provider: "AWS"
+definition:
+  not:
+    and:
+      - cond_type: "attribute"
+        resource_types:
+          - "aws_s3_bucket"
+        attribute: "tags.Environment"
+        operator: "equals"
+        value: "Dev"
+      - cond_type: "attribute"
+        resource_types:
+          - "aws_s3_bucket"
+        attribute: "acl"
+        operator: "equals"
+        value: "private"

--- a/tests/terraform/graph/checks_infra/complex_solvers/not_solver/NotWithNestedDict.yaml
+++ b/tests/terraform/graph/checks_infra/complex_solvers/not_solver/NotWithNestedDict.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "NotWithNestedDict"
+scope:
+  provider: "AWS"
+definition:
+  not:
+    cond_type: "attribute"
+    resource_types:
+      - "aws_s3_bucket"
+    attribute: "tags.Environment"
+    operator: "equals"
+    value: "Dev"

--- a/tests/terraform/graph/checks_infra/complex_solvers/not_solver/NotWithNestedList.yaml
+++ b/tests/terraform/graph/checks_infra/complex_solvers/not_solver/NotWithNestedList.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "NotWithNestedList"
+scope:
+  provider: "AWS"
+definition:
+  not:
+  - cond_type: "attribute"
+    resource_types:
+      - "aws_s3_bucket"
+    attribute: "tags.Environment"
+    operator: "equals"
+    value: "Dev"

--- a/tests/terraform/graph/checks_infra/complex_solvers/not_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/complex_solvers/not_solver/test_solver.py
@@ -1,0 +1,36 @@
+from tests.terraform.graph.checks_infra.test_base import TestBaseSolver
+import os
+TEST_DIRNAME = os.path.dirname(os.path.realpath(__file__))
+
+
+class TestNotQuery(TestBaseSolver):
+    def setUp(self):
+        self.checks_dir = TEST_DIRNAME
+        super(TestNotQuery, self).setUp()
+
+    def test_buckets_with_option_env_tag(self):
+        root_folder = '../../../resources/s3_bucket_2'
+        check_id = "NotTest"
+        should_fail = ['aws_s3_bucket.private']
+        should_pass = ['aws_s3_bucket.public', 'aws_s3_bucket.non_tag']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_simple_not_with_list(self):
+        root_folder = '../../../resources/s3_bucket_2'
+        check_id = "NotWithNestedList"
+        should_fail = ['aws_s3_bucket.private']
+        should_pass = ['aws_s3_bucket.public', 'aws_s3_bucket.non_tag']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_simple_not_with_dict(self):
+        root_folder = '../../../resources/s3_bucket_2'
+        check_id = "NotWithNestedDict"
+        should_fail = ['aws_s3_bucket.private']
+        should_pass = ['aws_s3_bucket.public', 'aws_s3_bucket.non_tag']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Adds `not` as a possible complex solver (can appear at the same place as `and` and `or`). It will invert the sub-solver. It requires exactly one sub-solver. It will accept a list, like `and` and `or` today, but requires it to have exactly 1 element.

Even though we have a `not_` variant of every operator, there is at least one case where this is insufficient to express any policy by applying DeMorgan's law. That is when you want to do operations over an array.

For example, given the following resource:

```
resource "aws_security_group" "sg" {
  ingress {
    cidr_blocks = ["0.0.0.0/0"]
  }
  ingress {
    cidr_blocks = ["192.168.1.0/24"]
  }
}
```

If you write a policy that says `ingress.*.cidr_blocks contains "0.0.0.0/0"`. it will evaluate to true. If you invert the operator to `ingress.*.cidr_blocks not_contains "0.0.0.0/0"`, it will also evaluate to true. In each case, there is one matching item in the wildcard array, so it passes. So, this `not` complex solver will allow you to properly pass a security group that does NOT contain 0.0.0.0 in any of its ingress rules.

I also made a tiny change to the parser to convert a sub-solver from a dict to a list of length 1. This allows you to specify either:

```
not:
  - cond_type: attribute
     ...
```

Or:
```
not:
  cond_type: attribute
  ...
```

The second is more intuitive for `not`. Doing it this way allows us to reuse all the other code related to complex solver types.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
