### PR TITLE
leverage K8_POSSIBLE_ENDINGS as file_extensions value

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,7 @@ max-line-length = 120
 # E501 doesn't work with black together
 ignore = E127,E128,E129,E203,E231,E302,E303,E305,E501,E731,W291,W292,W293,W503,W504,DUO107,DUO104,DUO130,DUO109,DUO116,B950
 select = C,E,F,W,B,B9,A
-extend-exclude = .github, .pytest_cache, bin/*, docs/*, kubernetes/*, venv/*, tests/*, flake8_plugins/*, checkov/cloudformation/*, checkov/common/*, checkov/dockerfile/*, checkov/kubernetes/*, checkov/sca_image/*, checkov/sca_package/*, checkov/secrets/*, checkov/serverless/*, checkov/terraform/*, checkov/example_runner/*, checkov/kustomize/*, checkov/helm/*
+extend-exclude = .github, .pytest_cache, bin/*, docs/*, kubernetes/*, venv/*, tests/*, flake8_plugins/*, checkov/cloudformation/*, checkov/common/*, checkov/dockerfile/*, checkov/sca_image/*, checkov/sca_package/*, checkov/secrets/*, checkov/serverless/*, checkov/terraform/*, checkov/example_runner/*, checkov/kustomize/*, checkov/helm/*
 
 [flake8:local-plugins]
 extension =

--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -22,8 +22,6 @@ from checkov.kubernetes.runner import Runner as k8_runner
 from checkov.runner_filter import RunnerFilter
 from checkov.common.parallelizer.parallel_runner import parallel_runner
 
-K8_POSSIBLE_ENDINGS = [".yaml", ".yml", ".json"]
-
 
 class K8sHelmRunner(k8_runner):
     def __init__(self, graph_class: Type[LocalGraph] = KubernetesLocalGraph,
@@ -194,7 +192,13 @@ class Runner(BaseRunner):
                 exc_info=True,
             )
 
-        self._parse_output(target_dir, o)
+        try:
+            self._parse_output(target_dir, o)
+        except Exception:
+            logging.info(
+                f"Error parsing output {chart_name} at dir: {chart_dir}. Working dir: {target_dir}.",
+                exc_info=True,
+            )
 
     def convert_helm_to_k8s(self, root_folder: str, files: list[str], runner_filter: RunnerFilter) -> list[tuple[Any, dict[str, Any]]]:
         self.root_folder = root_folder

--- a/checkov/kubernetes/checks/resource/base_rbac_check.py
+++ b/checkov/kubernetes/checks/resource/base_rbac_check.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from checkov.kubernetes.checks.resource.base_spec_check import BaseK8Check
 from checkov.common.models.enums import CheckCategories, CheckResult
 from typing import Dict, Any, List
@@ -13,8 +15,9 @@ class RbacOperation():
         resources=["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]) 
     Rules matching an apiGroup, verb and resource should be able to perform the operation.
     """
-    def __init__(self, apigroups: List[str], verbs: List[str],
-                 resources: List[str]):
+    __slots__ = ("apigroups", "resources", "verbs")
+
+    def __init__(self, apigroups: List[str], verbs: List[str], resources: List[str]):
         self.apigroups = apigroups
         self.verbs = verbs
         self.resources = resources
@@ -30,7 +33,7 @@ class BaseRbacK8sCheck(BaseK8Check):
         categories = [CheckCategories.KUBERNETES]
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities)
         # A role that grants *ALL* the RbacOperation in failing_operations fails this check
-        self.failing_operations: RbacOperation = []
+        self.failing_operations: list[RbacOperation] = []
 
     def scan_spec_conf(self, conf):
         rules = conf.get("rules")

--- a/checkov/kubernetes/kubernetes_utils.py
+++ b/checkov/kubernetes/kubernetes_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 from copy import deepcopy
@@ -14,7 +16,7 @@ from checkov.common.runners.base_runner import filter_ignored_paths
 from checkov.common.util.type_forcers import force_list
 from checkov.kubernetes.parser.parser import parse
 
-K8_POSSIBLE_ENDINGS = [".yaml", ".yml", ".json"]
+K8_POSSIBLE_ENDINGS = {".yaml", ".yml", ".json"}
 
 
 def get_folder_definitions(
@@ -93,12 +95,13 @@ def get_skipped_checks(entity_conf):
 
 
 def create_definitions(
-    root_folder: str,
-    files: Optional[List[str]] = None,
-    runner_filter: RunnerFilter = RunnerFilter(),
-) -> Tuple[Dict[str, DictNode], Dict[str, List[Tuple[int, str]]]]:
-    definitions = {}
-    definitions_raw = {}
+    root_folder: str | None,
+    files: list[str] | None = None,
+    runner_filter: RunnerFilter | None = None,
+) -> tuple[dict[str, DictNode], dict[str, list[tuple[int, str]]]]:
+    runner_filter = runner_filter or RunnerFilter()
+    definitions: dict[str, DictNode] = {}
+    definitions_raw: dict[str, list[tuple[int, str]]] = {}
     if files:
         definitions, definitions_raw = get_files_definitions(files)
 

--- a/flake8_plugins/flake8_class_attributes_plugin/tests/test_files/class_special_attributes_pass.py
+++ b/flake8_plugins/flake8_class_attributes_plugin/tests/test_files/class_special_attributes_pass.py
@@ -1,0 +1,9 @@
+class A:
+    __slots__ = ("some_attr")
+
+    @classmethod
+    def _get_favicon_path(cls, object_name: str):
+        pass
+
+    def get_tabs_info(self):
+        pass

--- a/flake8_plugins/flake8_class_attributes_plugin/tests/test_handler.py
+++ b/flake8_plugins/flake8_class_attributes_plugin/tests/test_handler.py
@@ -11,6 +11,11 @@ def test_file_with_class_const():
     assert len(errors) == 0
 
 
+def test_file_with_class_special_attributes():
+    errors = run_validator_for_test_file('class_special_attributes_pass.py')
+    assert len(errors) == 0
+
+
 def test_dataclass_skip():
     errors = run_validator_for_test_file('dataclass_skip.py')
     assert len(errors) == 0

--- a/tests/common/runner_registry/test_runner_registry.py
+++ b/tests/common/runner_registry/test_runner_registry.py
@@ -148,6 +148,13 @@ class TestRunnerRegistry(unittest.TestCase):
         runner_registry.filter_runners_for_files(['main.tf'])
         self.assertEqual(set(r.check_type for r in runner_registry.runners), {'secrets'})
 
+        runner_filter = RunnerFilter(framework=['all'], runners=checkov_runners)
+        runner_registry = RunnerRegistry(
+            banner, runner_filter, *DEFAULT_RUNNERS
+        )
+        runner_registry.filter_runners_for_files(['manifest.json'])
+        self.assertIn("kubernetes", set(r.check_type for r in runner_registry.runners))
+
 
 def test_non_compact_json_output(capsys):
     # given


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

- reused the `K8_POSSIBLE_ENDINGS` constant as `file_extensions` so JSON files are supported again
- enabled flake8 for K8s and adjusted out plugin to skip/pass `__slots__` as acceptable class attribute

Fixes #3150

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
