### PR TITLE
handle invalid structure in LambdaEnvironmentEncryptionSettings

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentEncryptionSettings.py
+++ b/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentEncryptionSettings.py
@@ -17,7 +17,9 @@ class LambdaEnvironmentEncryptionSettings(BaseResourceCheck):
         if properties is not None:
             env = properties.get('Environment')
             if env is not None:
-                if env.get('Variables') and not properties.get('KmsKeyArn'):
+                if not isinstance(env, dict):
+                    return CheckResult.UNKNOWN
+                elif env.get('Variables') and not properties.get('KmsKeyArn'):
                     return CheckResult.FAILED
         return CheckResult.PASSED
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Handle scan failure due to invalid structure

Fixes # (issue)

https://redlock.atlassian.net/browse/BCE-7216


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
