### PR TITLE
Make `CKV_AZURE_4` check work for AzureRM 3.0 syntax to fix #3159

### DIFF
--- a/checkov/terraform/checks/resource/azure/AKSLoggingEnabled.py
+++ b/checkov/terraform/checks/resource/azure/AKSLoggingEnabled.py
@@ -1,8 +1,10 @@
-from checkov.common.models.enums import CheckCategories
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+import dpath
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
 
 
-class AKSLoggingEnabled(BaseResourceValueCheck):
+class AKSLoggingEnabled(BaseResourceCheck):
     def __init__(self):
         name = "Ensure AKS logging to Azure Monitoring is Configured"
         id = "CKV_AZURE_4"
@@ -10,8 +12,15 @@ class AKSLoggingEnabled(BaseResourceValueCheck):
         categories = [CheckCategories.KUBERNETES]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return "addon_profile/[0]/oms_agent/[0]/enabled"
+    def scan_resource_conf(self, conf):
+        two_point_o_path = "addon_profile/[0]/oms_agent/[0]/enabled"
+        three_point_o_path = "oms_agent/[0]"
+        if dpath.search(conf, two_point_o_path) and dpath.get(conf, two_point_o_path)[0]:
+            return CheckResult.PASSED
+        elif dpath.search(conf, three_point_o_path):
+            return CheckResult.PASSED
+
+        return CheckResult.FAILED
 
 
 check = AKSLoggingEnabled()

--- a/tests/terraform/checks/resource/azure/test_AKSLoggingEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_AKSLoggingEnabled.py
@@ -26,6 +26,25 @@ class TestAKSLoggingEnabled(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_success(self):
+        resource_conf = {'name': ['example-aks1'], 'location': ['${azurerm_resource_group.example.location}'],
+                         'resource_group_name': ['${azurerm_resource_group.example.name}'], 'dns_prefix': ['exampleaks1'],
+                         'default_node_pool': [{'name': ['default'], 'node_count': [1], 'vm_size': ['Standard_D2_v2']}],
+                         'identity': [{'type': ['SystemAssigned']}], 'agent_pool_profile': [{}], 'service_principal': [{}],
+                         'tags': [{'Environment': 'Production'}],
+                         'addon_profile': [{'oms_agent': [{'enabled': [True], 'log_analytics_workspace_id': ['']}]}]}
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_new_syntax(self):
+        resource_conf = {'name': ['example-aks1'], 'location': ['${azurerm_resource_group.example.location}'],
+                         'resource_group_name': ['${azurerm_resource_group.example.name}'], 'dns_prefix': ['exampleaks1'],
+                         'default_node_pool': [{'name': ['default'], 'node_count': [1], 'vm_size': ['Standard_D2_v2']}],
+                         'identity': [{'type': ['SystemAssigned']}], 'agent_pool_profile': [{}], 'service_principal': [{}],
+                         'tags': [{'Environment': 'Production'}],
+                         'oms_agent': [{'log_analytics_workspace_id': 'mock_workspace_id'}]}
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

This patch modifies `AKSLoggingEnabled.py` file to support AzureRM 3.0 syntax.

Fixes #3159


## New/Edited policies (Delete if not relevant)

`CKV_AZURE_4`

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

Change `CKV_AZURE_4` class type to `BaseResrouceCheck`, add extra check logic for `oms_agent` block's presence.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
