### PR TITLE
AKSLoggingEnabled BaseResourceValueCheck in case the Azure provider is v2 syntax

### DIFF
--- a/checkov/terraform/checks/resource/azure/AKSLoggingEnabled.py
+++ b/checkov/terraform/checks/resource/azure/AKSLoggingEnabled.py
@@ -11,7 +11,7 @@ class AKSLoggingEnabled(BaseResourceValueCheck):
         supported_resources = ['azurerm_kubernetes_cluster']
         categories = [CheckCategories.KUBERNETES]
         self.provider_version_2_path = "addon_profile/[0]/oms_agent/[0]/enabled"
-        self.provider_version_3_path = "oms_agent/[0]"
+        self.provider_version_3_path = "oms_agent/[0]/log_analytics_workspace_id"
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):

--- a/checkov/terraform/checks/resource/azure/AKSLoggingEnabled.py
+++ b/checkov/terraform/checks/resource/azure/AKSLoggingEnabled.py
@@ -1,28 +1,31 @@
 import dpath
 
 from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class AKSLoggingEnabled(BaseResourceCheck):
+class AKSLoggingEnabled(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure AKS logging to Azure Monitoring is Configured"
         id = "CKV_AZURE_4"
         supported_resources = ['azurerm_kubernetes_cluster']
         categories = [CheckCategories.KUBERNETES]
+        self.provider_version_2_path = "addon_profile/[0]/oms_agent/[0]/enabled"
+        self.provider_version_3_path = "oms_agent/[0]"
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        provider_version_2_path = "addon_profile/[0]/oms_agent/[0]/enabled"
-        provider_version_3_path = "oms_agent/[0]"
-        if dpath.search(conf, provider_version_2_path) and dpath.get(conf, provider_version_2_path)[0]:
-            self.evaluated_keys = [provider_version_2_path]
-            return CheckResult.PASSED
-        elif dpath.search(conf, provider_version_3_path):
-            self.evaluated_keys = [provider_version_3_path]
+        if dpath.search(conf, self.provider_version_2_path):
+            self.evaluated_keys = [self.provider_version_2_path]
+            return super().scan_resource_conf(conf)
+        elif dpath.search(conf, self.provider_version_3_path):
+            self.evaluated_keys = [self.provider_version_3_path]
             return CheckResult.PASSED
 
         return CheckResult.FAILED
+
+    def get_inspected_key(self) -> str:
+        return self.provider_version_2_path
 
 
 check = AKSLoggingEnabled()


### PR DESCRIPTION
Support AKSLoggingEnabled to use base resource value check in case the azure provider is version 2.x

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)


## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
