### PR TITLE
Do not populate BC ID on local graph checks

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -49,6 +49,7 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
                     resource_types = Registry._get_resource_types(converted_check['metadata'])
                     check = self.platform_policy_parser.parse_raw_check(converted_check, resources_types=resource_types)
                     check.severity = Severities[policy['severity']]
+                    check.bc_id = check.id
                     if check.frameworks:
                         for f in check.frameworks:
                             if f.lower() == "cloudformation":

--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -116,7 +116,6 @@ class NXGraphCheckParser(BaseGraphCheckParser):
         policy_definition = raw_check.get("definition", {})
         check = self._parse_raw_check(policy_definition, kwargs.get("resources_types"))
         check.id = raw_check.get("metadata", {}).get("id", "")
-        check.bc_id = raw_check.get("metadata", {}).get("id", "")
         check.name = raw_check.get("metadata", {}).get("name", "")
         check.category = raw_check.get("metadata", {}).get("category", "")
         check.frameworks = raw_check.get("metadata", {}).get("frameworks", [])

--- a/tests/common/checks/test_graph_check_loading.py
+++ b/tests/common/checks/test_graph_check_loading.py
@@ -16,6 +16,8 @@ class TestGraphChecks(unittest.TestCase):
         runner_filter = RunnerFilter()
         for check in registry.checks:
             self.assertFalse(runner_filter.is_external_check(check))
+            # The BC ID should not be populated with a CKV2 ID
+            self.assertIsNone(check.bc_id)
 
     def test_external_graph_check_load(self):
         runner = Runner()

--- a/tests/common/integration_features/test_custom_policies_integration.py
+++ b/tests/common/integration_features/test_custom_policies_integration.py
@@ -218,7 +218,9 @@ class TestCustomPoliciesIntegration(unittest.TestCase):
         k8s_registry = get_graph_checks_registry("kubernetes").checks
         self.assertEqual(1, len(custom_policies_integration.bc_cloned_checks))
         self.assertEqual('kpande_AZR_1648821862291', tf_registry[0].id, cfn_registry[0].id)
+        self.assertEqual('kpande_AZR_1648821862291', tf_registry[0].bc_id, cfn_registry[0].bc_id)
         self.assertEqual('kpande_kubernetes_1650378013211', k8s_registry[0].id)
+        self.assertEqual('kpande_kubernetes_1650378013211', k8s_registry[0].bc_id)
 
     def test_post_runner_with_cloned_checks(self):
         instance = BcPlatformIntegration()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fixes an issue where CKV2 checks were having the `bc_id` populated, which made them appear to be platform checks, even if they do not appear in the platform. This breaks the functionality where running with an API key should only include platform checks by default.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
