### PR TITLE
add more explicit API key format validation

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -54,6 +54,7 @@ SLEEP_SECONDS = 1
 
 EMAIL_PATTERN = re.compile(r"[^@]+@[^@]+\.[^@]+")
 UUID_V4_PATTERN = re.compile(r"^[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}$")
+# found at https://regexland.com/base64/
 BASE64_PATTERN = re.compile(r"^(?:[A-Za-z\d+/]{4})*(?:[A-Za-z\d+/]{3}=|[A-Za-z\d+/]{2}==)?$")
 
 ACCOUNT_CREATION_TIME = 180  # in seconds

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -54,6 +54,7 @@ SLEEP_SECONDS = 1
 
 EMAIL_PATTERN = re.compile(r"[^@]+@[^@]+\.[^@]+")
 UUID_V4_PATTERN = re.compile(r"^[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}$")
+BASE64_PATTERN = re.compile(r"^(?:[A-Za-z\d+/]{4})*(?:[A-Za-z\d+/]{3}=|[A-Za-z\d+/]{2}==)?$")
 
 ACCOUNT_CREATION_TIME = 180  # in seconds
 
@@ -122,6 +123,17 @@ class BcPlatformIntegration:
 
     def is_prisma_integration(self) -> bool:
         return self.bc_api_key and not self.is_bc_token(self.bc_api_key)
+
+    @staticmethod
+    def is_token_valid(token: str) -> bool:
+        parts = token.split('::')
+        if len(parts) == 1:
+            return BcPlatformIntegration.is_bc_token(token)
+        elif len(parts) == 2:
+            # A Prisma access key is a UUID, same as a BC API key
+            return BcPlatformIntegration.is_bc_token(parts[0]) and parts[1] and BASE64_PATTERN.match(parts[1]) is not None
+        else:
+            return False
 
     @staticmethod
     def is_bc_token(token: str) -> TypeGuard[str]:

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -128,9 +128,10 @@ class BcPlatformIntegration:
     @staticmethod
     def is_token_valid(token: str) -> bool:
         parts = token.split('::')
-        if len(parts) == 1:
+        parts_len = len(parts)
+        if parts_len == 1:
             return BcPlatformIntegration.is_bc_token(token)
-        elif len(parts) == 2:
+        elif parts_len == 2:
             # A Prisma access key is a UUID, same as a BC API key
             return BcPlatformIntegration.is_bc_token(parts[0]) and parts[1] and BASE64_PATTERN.match(parts[1]) is not None
         else:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -167,6 +167,11 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
     elif config.bc_api_key:
         logger.debug(f'Using API key ending with {config.bc_api_key[-8:]}')
 
+        if not bc_integration.is_token_valid(config.bc_api_key):
+            raise Exception(f'The provided API key does not appear to be a valid Bridgecrew API key or Prisma Cloud '
+                            f'access key and secret key. For Prisma, the value must be in the form '
+                            f'ACCESS_KEY::SECRET_KEY')
+
         if config.repo_id is None and not config.list:
             # if you are only listing policies, then the API key will be used to fetch policies, but that's it,
             # so the repo is not required

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -168,11 +168,11 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
         logger.debug(f'Using API key ending with {config.bc_api_key[-8:]}')
 
         if not bc_integration.is_token_valid(config.bc_api_key):
-            raise Exception(f'The provided API key does not appear to be a valid Bridgecrew API key or Prisma Cloud '
-                            f'access key and secret key. For Prisma, the value must be in the form '
-                            f'ACCESS_KEY::SECRET_KEY. For Bridgecrew, make sure to copy the token value from when you '
-                            f'created it, not the token ID visible later on. If you are using environment variables, '
-                            f'make sure they are properly set and exported.')
+            raise Exception('The provided API key does not appear to be a valid Bridgecrew API key or Prisma Cloud '
+                            'access key and secret key. For Prisma, the value must be in the form '
+                            'ACCESS_KEY::SECRET_KEY. For Bridgecrew, make sure to copy the token value from when you '
+                            'created it, not the token ID visible later on. If you are using environment variables, '
+                            'make sure they are properly set and exported.')
 
         if config.repo_id is None and not config.list:
             # if you are only listing policies, then the API key will be used to fetch policies, but that's it,

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -170,7 +170,9 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
         if not bc_integration.is_token_valid(config.bc_api_key):
             raise Exception(f'The provided API key does not appear to be a valid Bridgecrew API key or Prisma Cloud '
                             f'access key and secret key. For Prisma, the value must be in the form '
-                            f'ACCESS_KEY::SECRET_KEY')
+                            f'ACCESS_KEY::SECRET_KEY. For Bridgecrew, make sure to copy the token value from when you '
+                            f'created it, not the token ID visible later on. If you are using environment variables, '
+                            f'make sure they are properly set and exported.')
 
         if config.repo_id is None and not config.list:
             # if you are only listing policies, then the API key will be used to fetch policies, but that's it,

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -1,5 +1,8 @@
+import base64
 import os
+import random
 import unittest
+import uuid
 from unittest import mock
 from checkov.common.bridgecrew.bc_source import get_source_type
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import \
@@ -15,6 +18,45 @@ class TestBCApiUrl(unittest.TestCase):
     def test_overriding_bc_api_url(self):
         instance = BcPlatformIntegration()
         self.assertEqual(instance.api_url, "foo")
+
+    @staticmethod
+    def get_random_string():
+        len = random.randrange(5, 50)
+        chars = []
+        for i in range(0, len):
+            chars.append(chr(random.randrange(32, 127)))
+        return ''.join(chars)
+
+    def test_is_token_valid(self):
+        uuids = []
+        for i in range(0, 1000):
+            uuids.append(str(uuid.uuid4()))
+
+        # validate BC API keys
+        for u in uuids:
+            self.assertTrue(BcPlatformIntegration.is_token_valid(u))
+
+        # generate Prisma access keys, which are UUIDs (just reuse the ones from above),
+        # and secret keys, which are b64 encoded strings
+        for i in range(0, len(uuids)):
+            string_to_encode = self.get_random_string()
+            encoded = base64.b64encode(bytes(string_to_encode, 'utf-8'))
+            uuids[i] = uuids[i] + '::' + encoded.decode('utf-8')
+
+        for u in uuids:
+            self.assertTrue(BcPlatformIntegration.is_token_valid(u))
+
+        uuid_str = str(uuid.uuid4())
+        b64_str = base64.b64encode(bytes(self.get_random_string(), 'utf-8')).decode('utf-8')
+        self.assertFalse(BcPlatformIntegration.is_token_valid(f'{uuid_str}{b64_str}'))
+        self.assertFalse(BcPlatformIntegration.is_token_valid(f'{uuid_str}:{b64_str}'))
+        self.assertFalse(BcPlatformIntegration.is_token_valid(f'{uuid_str}:::{b64_str}'))
+        self.assertFalse(BcPlatformIntegration.is_token_valid(f'{uuid_str}::'))
+        self.assertFalse(BcPlatformIntegration.is_token_valid(f'::{b64_str}'))
+        self.assertFalse(BcPlatformIntegration.is_token_valid(''))
+        self.assertFalse(BcPlatformIntegration.is_token_valid('1234::56789'))
+        self.assertFalse(BcPlatformIntegration.is_token_valid(f'{uuid_str}::56789'))
+        self.assertFalse(BcPlatformIntegration.is_token_valid(f'1234::{b64_str}'))
 
     def test_overriding_pc_api_url(self):
         instance = BcPlatformIntegration()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Addresses an issue that is uncommon but frustrating for everyone (user and support) when it happens - an API key that is malformed, either because of a fatfinger issue or an issue with CI/CD variables. We have some basic validation today, but this takes it up a level or two.

BC API keys are UUIDv4s.

Prisma access keys are also UUIDv4s, and secret keys are base64 encoded strings.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
