### PR TITLE
fix: avoid flattening single-item-list vertex values if the attribute…

### DIFF
--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -36,7 +36,9 @@ from checkov.common.checks_infra.solvers import (
     SubsetAttributeSolver,
     NotSubsetAttributeSolver,
     IsEmptyAttributeSolver,
-    IsNotEmptyAttributeSolver
+    IsNotEmptyAttributeSolver,
+    LengthEqualsAttributeSolver,
+    LengthNotEqualsAttributeSolver
 )
 from checkov.common.checks_infra.solvers.connections_solvers.connection_one_exists_solver import \
     ConnectionOneExistsSolver
@@ -80,6 +82,8 @@ operators_to_attributes_solver_classes: dict[str, Type[BaseAttributeSolver]] = {
     "jsonpath_not_exists": JsonpathNotExistsAttributeSolver,
     "is_empty": IsEmptyAttributeSolver,
     "is_not_empty": IsNotEmptyAttributeSolver,
+    "length_equals": LengthEqualsAttributeSolver,
+    "length_not_equals": LengthNotEqualsAttributeSolver,
 }
 
 operators_to_complex_solver_classes: dict[str, Type[BaseComplexSolver]] = {

--- a/checkov/common/checks_infra/solvers/attribute_solvers/__init__.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/__init__.py
@@ -24,3 +24,5 @@ from checkov.common.checks_infra.solvers.attribute_solvers.subset_attribute_solv
 from checkov.common.checks_infra.solvers.attribute_solvers.not_subset_attribute_solver import NotSubsetAttributeSolver  # noqa
 from checkov.common.checks_infra.solvers.attribute_solvers.is_empty_attribute_solver import IsEmptyAttributeSolver  # noqa
 from checkov.common.checks_infra.solvers.attribute_solvers.is_not_empty_attribute_solver import IsNotEmptyAttributeSolver  # noqa
+from checkov.common.checks_infra.solvers.attribute_solvers.length_equals_attribute_solver import LengthEqualsAttributeSolver  # noqa
+from checkov.common.checks_infra.solvers.attribute_solvers.length_not_equals_attribute_solver import LengthNotEqualsAttributeSolver  # noqa

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_equals_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_equals_attribute_solver.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Any, Dict
 from collections.abc import Sized
 from checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver import BaseAttributeSolver
 from checkov.common.graph.checks_infra.enums import Operators
-from checkov.common.util.type_forcers import force_integer
+from checkov.common.util.type_forcers import force_int
 
 
 class LengthEqualsAttributeSolver(BaseAttributeSolver):
@@ -22,6 +22,6 @@ class LengthEqualsAttributeSolver(BaseAttributeSolver):
             return True
 
         if isinstance(attr, Sized):
-            return len(attr) == force_integer(self.value)
+            return len(attr) == force_int(self.value)
 
         return False

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_equals_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_equals_attribute_solver.py
@@ -1,0 +1,27 @@
+from typing import List, Optional, Any, Dict
+from collections.abc import Sized
+from checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver import BaseAttributeSolver
+from checkov.common.graph.checks_infra.enums import Operators
+from checkov.common.util.type_forcers import force_integer
+
+
+class LengthEqualsAttributeSolver(BaseAttributeSolver):
+    operator = Operators.LENGTH_EQUALS
+
+    def __init__(self, resource_types: List[str], attribute: Optional[str], value: Any) -> None:
+        super().__init__(resource_types=resource_types, attribute=attribute, value=value)
+
+    def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
+        if vertex.get(attribute) is None:  # type:ignore[arg-type]  # due to attribute can be None
+            return False
+
+        attr = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
+        # if this value contains an underendered variable, then we cannot evaluate the check,
+        # so return True (since we cannot return UNKNOWN)
+        if self._is_variable_dependant(attr, vertex['source_']):
+            return True
+
+        if isinstance(attr, Sized):
+            return len(attr) == force_integer(self.value)
+
+        return False

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_not_equals_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_not_equals_attribute_solver.py
@@ -1,0 +1,14 @@
+from typing import List, Optional, Any, Dict
+
+from .length_equals_attribute_solver import LengthEqualsAttributeSolver
+from checkov.common.graph.checks_infra.enums import Operators
+
+
+class LengthNotEqualsAttributeSolver(LengthEqualsAttributeSolver):
+    operator = Operators.LENGTH_NOT_EQUALS
+
+    def __init__(self, resource_types: List[str], attribute: Optional[str], value: Any) -> None:
+        super().__init__(resource_types=resource_types, attribute=attribute, value=value)
+
+    def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
+        return not super()._get_operation(vertex, attribute)

--- a/checkov/common/graph/checks_infra/enums.py
+++ b/checkov/common/graph/checks_infra/enums.py
@@ -52,3 +52,5 @@ class Operators:
     JSONPATH_NOT_EXISTS = 'jsonpath_not_exists'
     IS_EMPTY = 'is_empty'
     IS_NOT_EMPTY = 'is_not_empty'
+    LENGTH_EQUALS = 'length_equals'
+    LENGTH_NOT_EQUALS = 'length_not_equals'

--- a/checkov/common/graph/graph_builder/graph_components/blocks.py
+++ b/checkov/common/graph/graph_builder/graph_components/blocks.py
@@ -106,7 +106,8 @@ class Block:
         for attribute_key in list(self.attributes.keys()):
             attribute_value = self.attributes[attribute_key]
             if isinstance(attribute_value, list) and len(attribute_value) == 1:
-                attribute_value = attribute_value[0]
+                if '.' not in attribute_key:
+                    attribute_value = attribute_value[0]
             # needs to be checked before adding anything to 'base_attributes'
             if attribute_key == "self":
                 base_attributes["self_"] = attribute_value

--- a/checkov/common/util/type_forcers.py
+++ b/checkov/common/util/type_forcers.py
@@ -44,15 +44,6 @@ def force_float(var: Any) -> float | None:
         return None
 
 
-def force_integer(var: Any) -> int | None:
-    try:
-        if not isinstance(var, int):
-            return int(var)
-        return var
-    except Exception:
-        return None
-
-
 def convert_str_to_bool(bool_str: bool | str) -> bool | str:
     if bool_str in ["true", '"true"', "True", '"True"']:
         return True

--- a/checkov/common/util/type_forcers.py
+++ b/checkov/common/util/type_forcers.py
@@ -44,6 +44,15 @@ def force_float(var: Any) -> float | None:
         return None
 
 
+def force_integer(var: Any) -> int | None:
+    try:
+        if not isinstance(var, int):
+            return int(var)
+        return var
+    except Exception:
+        return None
+
+
 def convert_str_to_bool(bool_str: bool | str) -> bool | str:
     if bool_str in ["true", '"true"', "True", '"True"']:
         return True

--- a/docs/3.Custom Policies/YAML Custom Policies.md
+++ b/docs/3.Custom Policies/YAML Custom Policies.md
@@ -100,11 +100,13 @@ definition:
 | Subset                | `subset`                |
 | Not Subset            | `not_subset`            |
 | Json Path Equals      | `jsonpath_equals`       |
-| Json Path Not Equals      | `jsonpath_not_equals`       |
+| Json Path Not Equals  | `jsonpath_not_equals`   |
 | Json Path Exists      | `jsonpath_exists`       |
-| Json Path Not Exists      | `jsonpath_not_exists`       |
+| Json Path Not Exists  | `jsonpath_not_exists`   |
 | Is Empty              | `is_empty`              |
 | Is Not Empty          | `is_not_empty`          |
+| Length Equals         | `length_equals`         |
+| Length Not Equals     | `length_equals`         |
 
 ### Attribute Condition: Keys and Values
 
@@ -113,7 +115,7 @@ definition:
 | `cond_type` | string | Must be `attribute`                                                                                                                                                                                                                                                                                      |
 | `resource_type` | collection of strings | Use either `all` or `[resource types from list]`                                                                                                                                                                                                                                                         |
 | `attribute` | string | Attribute of defined resource types. For example, `automated_snapshot_retention_period`                                                                                                                                                                                                                  |
-| `operator` | string | - `equals`, `not_equals`, `regex_match`, `not_regex_match`, `exists`, `not exists`, `any`, `contains`, `not_contains`, `within`, `starting_with`, `not_starting_with`, `ending_with`, `not_ending_with`, `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `jsonpath_equals`, `jsonpath_not_equals`, `jsonpath_exists`, `jsonpath_not_exists`, `is_empty`, `is_not_empty` |
+| `operator` | string | - `equals`, `not_equals`, `regex_match`, `not_regex_match`, `exists`, `not exists`, `any`, `contains`, `not_contains`, `within`, `starting_with`, `not_starting_with`, `ending_with`, `not_ending_with`, `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `jsonpath_equals`, `jsonpath_not_equals`, `jsonpath_exists`, `jsonpath_not_exists`, `is_empty`, `is_not_empty`, `length_equals`, `length_not_equals` |
 | `value` (not relevant for operator: `exists`/`not_exists`) | string | User input.                                                                                                                                                                                                                                                                                              |
 
 

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/ArrayLengthEquals.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/ArrayLengthEquals.yaml
@@ -1,0 +1,9 @@
+metadata:
+  id: "ArrayLengthEquals"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - aws_security_group
+  attribute: egress.cidr_blocks
+  operator: length_equals
+  value: 2

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/StringLengthEquals.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/StringLengthEquals.yaml
@@ -1,0 +1,9 @@
+metadata:
+  id: "StringLengthEquals"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - aws_security_group
+  attribute: description
+  operator: length_equals
+  value: "16"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/main.tf
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/main.tf
@@ -1,0 +1,43 @@
+resource "aws_security_group" "sg1" {
+  description = "sg1"
+
+  egress {
+    description = "Self Reference"
+    cidr_blocks = ["0.0.0.0/0", "25.0.9.19/92"]
+    from_port   = "0"
+    protocol    = "-1"
+    self        = "false"
+    to_port     = "0"
+  }
+
+  ingress {
+    description     = "Access to Bastion Host Security Group"
+    from_port       = "5432"
+    protocol        = "tcp"
+    security_groups = ["sg-id-0"]
+    self            = "false"
+    to_port         = "8182"
+  }
+}
+
+resource "aws_security_group" "sg2" {
+  description = "security_group_2"
+
+  egress {
+    description = "Self Reference"
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = "0"
+    protocol    = "-1"
+    self        = "false"
+    to_port     = "0"
+  }
+
+  ingress {
+    description     = "Access to Bastion Host Security Group"
+    from_port       = "5432"
+    protocol        = "tcp"
+    security_groups = ["sg-id-0"]
+    self            = "false"
+    to_port         = "1234"
+  }
+}

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/test_solver.py
@@ -1,0 +1,33 @@
+import os
+
+from tests.terraform.graph.checks_infra.test_base import TestBaseSolver
+
+TEST_DIRNAME = os.path.dirname(os.path.realpath(__file__))
+
+
+class TestLengthEquals(TestBaseSolver):
+    def setUp(self):
+        self.checks_dir = TEST_DIRNAME
+        super(TestLengthEquals, self).setUp()
+
+    def test_array_length_equals(self):
+        # this is just a basic check to make sure the operator works
+        # we'll check all the other combinations more directly (because coming up with all the policy combos is painful)
+        root_folder = './'
+        check_id = "ArrayLengthEquals"
+        should_pass = ['aws_security_group.sg1']
+        should_fail = ['aws_security_group.sg2']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_string_length_equals(self):
+        # this is just a basic check to make sure the operator works
+        # we'll check all the other combinations more directly (because coming up with all the policy combos is painful)
+        root_folder = './'
+        check_id = "StringLengthEquals"
+        should_pass = ['aws_security_group.sg2']
+        should_fail = ['aws_security_group.sg1']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/ArrayLengthNotEquals.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/ArrayLengthNotEquals.yaml
@@ -1,0 +1,9 @@
+metadata:
+  id: "ArrayLengthNotEquals"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - aws_security_group
+  attribute: egress.cidr_blocks
+  operator: length_not_equals
+  value: 2

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/StringLengthNotEquals.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/StringLengthNotEquals.yaml
@@ -1,0 +1,9 @@
+metadata:
+  id: "StringLengthNotEquals"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - aws_security_group
+  attribute: description
+  operator: length_not_equals
+  value: "16"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/main.tf
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/main.tf
@@ -1,0 +1,43 @@
+resource "aws_security_group" "sg1" {
+  description = "sg1"
+
+  egress {
+    description = "Self Reference"
+    cidr_blocks = ["0.0.0.0/0", "25.0.9.19/92"]
+    from_port   = "0"
+    protocol    = "-1"
+    self        = "false"
+    to_port     = "0"
+  }
+
+  ingress {
+    description     = "Access to Bastion Host Security Group"
+    from_port       = "5432"
+    protocol        = "tcp"
+    security_groups = ["sg-id-0"]
+    self            = "false"
+    to_port         = "8182"
+  }
+}
+
+resource "aws_security_group" "sg2" {
+  description = "security_group_2"
+
+  egress {
+    description = "Self Reference"
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = "0"
+    protocol    = "-1"
+    self        = "false"
+    to_port     = "0"
+  }
+
+  ingress {
+    description     = "Access to Bastion Host Security Group"
+    from_port       = "5432"
+    protocol        = "tcp"
+    security_groups = ["sg-id-0"]
+    self            = "false"
+    to_port         = "1234"
+  }
+}

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/test_solver.py
@@ -1,0 +1,33 @@
+import os
+
+from tests.terraform.graph.checks_infra.test_base import TestBaseSolver
+
+TEST_DIRNAME = os.path.dirname(os.path.realpath(__file__))
+
+
+class TestLengthNotEquals(TestBaseSolver):
+    def setUp(self):
+        self.checks_dir = TEST_DIRNAME
+        super(TestLengthNotEquals, self).setUp()
+
+    def test_array_length_not_equals(self):
+        # this is just a basic check to make sure the operator works
+        # we'll check all the other combinations more directly (because coming up with all the policy combos is painful)
+        root_folder = './'
+        check_id = "ArrayLengthNotEquals"
+        should_pass = ['aws_security_group.sg2']
+        should_fail = ['aws_security_group.sg1']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_string_length_not_equals(self):
+        # this is just a basic check to make sure the operator works
+        # we'll check all the other combinations more directly (because coming up with all the policy combos is painful)
+        root_folder = './'
+        check_id = "StringLengthNotEquals"
+        should_pass = ['aws_security_group.sg1']
+        should_fail = ['aws_security_group.sg2']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

1. Fixed vertex attribute values serializiation on graph creation  - verteices with single-item values would be flattned, for instance:
```
 cidr_blocks: ["0.0.0.0/0"]
```

becomes:
```
cidr_blocks: "0.0.0.0/0"
```

On graph creations, fixed this to only apply to attributes without a '.' notation.

2. Added two attribute solvers `length_equals` and `length_not_equals`

Fixes # (issue)


## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
