### PR TITLE
ALICloud Check TLS cypher policy is secure

### DIFF
--- a/checkov/terraform/checks/resource/alicloud/TLSPoliciesAreSecure.py
+++ b/checkov/terraform/checks/resource/alicloud/TLSPoliciesAreSecure.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+
+
+class TLSPoliciesAreSecure(BaseResourceNegativeValueCheck):
+    def __init__(self):
+        name = "Alibaba Cloud Cypher Policy are secure"
+        id = "CKV_ALI_33"
+        supported_resources = ['alicloud_slb_tls_cipher_policy']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'tls_versions'
+
+    def get_forbidden_values(self):
+        return ["TLSv1.1", "TLSv1.0"]
+
+
+check = TLSPoliciesAreSecure()

--- a/checkov/terraform/checks/resource/base_resource_negative_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_negative_value_check.py
@@ -47,6 +47,11 @@ class BaseResourceNegativeValueCheck(BaseResourceCheck):
             if get_referenced_vertices_in_value(value=value, aliases={}, resources_types=[]):
                 # we don't provide resources_types as we want to stay provider agnostic
                 return CheckResult.UNKNOWN
+            #value can still be a list
+            if isinstance(value, list):
+                for val in value:
+                    if val in bad_values:
+                        return CheckResult.FAILED
             if value in bad_values or ANY_VALUE in bad_values:
                 return CheckResult.FAILED
             else:

--- a/tests/terraform/checks/resource/alicloud/example_TLSPoliciesAreSecure/main.tf
+++ b/tests/terraform/checks/resource/alicloud/example_TLSPoliciesAreSecure/main.tf
@@ -1,0 +1,11 @@
+resource "alicloud_slb_tls_cipher_policy" "fail" {
+  tls_cipher_policy_name = "itsbaditsdverybad"
+  tls_versions           = ["TLSv1.1","TLSv1.2"]
+  ciphers                = ["AES256-SHA","AES256-SHA256", "AES128-GCM-SHA256"]
+}
+
+resource "alicloud_slb_tls_cipher_policy" "pass" {
+  tls_cipher_policy_name = "itsfine"
+  tls_versions           = ["TLSv1.2"]
+  ciphers                = ["AES256-SHA","AES256-SHA256", "AES128-GCM-SHA256"]
+}

--- a/tests/terraform/checks/resource/alicloud/test_TLSPoliciesAreSecure.py
+++ b/tests/terraform/checks/resource/alicloud/test_TLSPoliciesAreSecure.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.alicloud.TLSPoliciesAreSecure import check
+
+
+class TestTLSPoliciesAreSecure(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_TLSPoliciesAreSecure")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'alicloud_slb_tls_cipher_policy.pass',
+        }
+        failing_resources = {
+            'alicloud_slb_tls_cipher_policy.fail',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Checking that cypher policies cant include legacy schemes.
Had to update the base class as it didn't compare list to list.
