### PR TITLE
Google compute instance and AWS provider credentials type assertion

### DIFF
--- a/checkov/terraform/checks/provider/aws/credentials.py
+++ b/checkov/terraform/checks/provider/aws/credentials.py
@@ -28,7 +28,7 @@ class AWSCredentials(BaseProviderCheck):
     def secret_found(self, conf: Dict[str, List[Any]], field: str, pattern: str) -> bool:
         if field in conf.keys():
             value = conf[field][0]
-            if re.match(pattern, value) is not None:
+            if isinstance(value, str) and re.match(pattern, value) is not None:
                 conf[f'{self.id}_secret_{field}'] = value
                 return True
         return False

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeBlockProjectSSH.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeBlockProjectSSH.py
@@ -13,7 +13,7 @@ class GoogleComputeBlockProjectSSH(BaseResourceValueCheck):
 
     def scan_resource_conf(self, conf) -> CheckResult:
         if ('source_instance_template' in conf.keys() and 'metadata' not in conf.keys()) or \
-                ('source_instance_template' in conf.keys() and 'block-project-ssh-keys' not in
+                ('source_instance_template' in conf.keys() and isinstance(conf['metadata'][0], dict) and 'block-project-ssh-keys' not in
                  conf['metadata'][0].keys()):
             # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
             # and block-project-ssh-keys is not present, then this check cannot PASS, since we don't know what the

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeInstanceOSLogin.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeInstanceOSLogin.py
@@ -14,7 +14,7 @@ class GoogleComputeInstanceOSLogin(BaseResourceNegativeValueCheck):
 
     def scan_resource_conf(self, conf) -> CheckResult:
         if ('source_instance_template' in conf.keys() and 'metadata' not in conf.keys()) or \
-                ('source_instance_template' in conf.keys() and 'enable-oslogin' not in
+                ('source_instance_template' in conf.keys() and isinstance(conf['metadata'][0], dict) and 'enable-oslogin' not in
                  conf['metadata'][0].keys()):
             # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
             # and enable-oslogin is not present, then this check cannot PASS, since we don't know what the

--- a/checkov/terraform/checks/resource/gcp/GoogleComputeSerialPorts.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleComputeSerialPorts.py
@@ -13,7 +13,7 @@ class GoogleComputeSerialPorts(BaseResourceNegativeValueCheck):
 
     def scan_resource_conf(self, conf) -> CheckResult:
         if ('source_instance_template' in conf.keys() and 'metadata' not in conf.keys()) or \
-                ('source_instance_template' in conf.keys() and 'serial-port-enable' not in
+                ('source_instance_template' in conf.keys() and isinstance(conf['metadata'][0], dict) and 'serial-port-enable' not in
                  conf['metadata'][0].keys()):
             # if the source_instance_template value is there (indicating a google_compute_instance_from_template),
             # and serial-port-enable is not present, then this check cannot PASS, since we don't know what the


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

- assert google_compute_instance metadata value is dict before accessing it
- assert provider access keys value is string before matching it to a regex

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)


## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
