### PR TITLE
Fix json parser end line

### DIFF
--- a/checkov/common/parsers/json/decoder.py
+++ b/checkov/common/parsers/json/decoder.py
@@ -200,6 +200,8 @@ def get_beg_end_mark(s: str, start: int, end: int, indexes: list[int]) -> tuple[
 
     offset = 1 if len(indexes) > 1 else 0
     end_lineno = count_occurrences(indexes, end) - offset
+    if s[end] not in WHITESPACE_STR:
+        end_lineno += 1
     end_colno = end - largest_less_than(indexes, end_lineno, end)
     end_mark = Mark(end_lineno, end_colno)
 

--- a/tests/common/parsers/json/resources/file1.json
+++ b/tests/common/parsers/json/resources/file1.json
@@ -1,0 +1,33 @@
+{
+	"Resources": {
+		"S3Bucket": {
+			"Type": "AWS::S3::Bucket",
+			"Properties": {
+				"AccessControl": "PublicRead",
+				"BucketName": "public-bucket-achia",
+				"MetricsConfigurations": [
+					{
+						"Id": "EntireBucket"
+					}
+				],
+				"WebsiteConfiguration": {
+					"IndexDocument": "index.html",
+					"ErrorDocument": "error.html",
+					"RoutingRules": [
+						{
+							"RoutingRuleCondition": {
+								"HttpErrorCodeReturnedEquals": "404",
+								"KeyPrefixEquals": "out1/"
+							},
+							"RedirectRule": {
+								"HostName": "ec2-11-22-333-44.compute-1.amazonaws.com",
+								"ReplaceKeyPrefixWith": "report-404/"
+							}
+						}
+					]
+				}
+			},
+			"DeletionPolicy": "Retain"
+		}
+	}
+}

--- a/tests/common/parsers/json/test_json_parser.py
+++ b/tests/common/parsers/json/test_json_parser.py
@@ -2,7 +2,6 @@ import os
 import unittest
 from checkov.common.parsers.json import parse
 
-
 current_dir = os.path.dirname(os.path.realpath(__file__))
 
 

--- a/tests/common/parsers/json/test_json_parser.py
+++ b/tests/common/parsers/json/test_json_parser.py
@@ -1,0 +1,24 @@
+import os
+import unittest
+from checkov.common.parsers.json import parse
+
+current_dir = os.path.dirname(os.path.realpath(__file__))
+
+
+class TestJsonParser(unittest.TestCase):
+    def test_json_parser_lines(self):
+        test_file = current_dir + "/resources/file1.json"
+        cfn_dict, cfn_str = parse(test_file)
+
+        resources = cfn_dict.get('Resources')
+        bucket = resources.get('S3Bucket')
+        properties = bucket.get('Properties')
+
+        assert resources.start_mark.line == 5
+        assert resources.end_mark.line == 31
+
+        assert bucket.start_mark.line == 3
+        assert bucket.end_mark.line == 30
+
+        assert properties.start_mark.line == 5
+        assert properties.end_mark.line == 28

--- a/tests/common/parsers/json/test_json_parser.py
+++ b/tests/common/parsers/json/test_json_parser.py
@@ -14,7 +14,7 @@ class TestJsonParser(unittest.TestCase):
         bucket = resources.get('S3Bucket')
         properties = bucket.get('Properties')
 
-        assert resources.start_mark.line == 5
+        assert resources.start_mark.line == 2
         assert resources.end_mark.line == 31
 
         assert bucket.start_mark.line == 3

--- a/tests/common/parsers/json/test_json_parser.py
+++ b/tests/common/parsers/json/test_json_parser.py
@@ -8,7 +8,7 @@ current_dir = os.path.dirname(os.path.realpath(__file__))
 class TestJsonParser(unittest.TestCase):
     def test_json_parser_lines(self):
         test_file = current_dir + "/resources/file1.json"
-        cfn_dict, cfn_str = parse(test_file)
+        cfn_dict, _ = parse(test_file)
 
         resources = cfn_dict.get('Resources')
         bucket = resources.get('S3Bucket')

--- a/tests/common/parsers/json/test_json_parser.py
+++ b/tests/common/parsers/json/test_json_parser.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from checkov.common.parsers.json import parse
 
+
 current_dir = os.path.dirname(os.path.realpath(__file__))
 
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
In some cases the end_mark line of json object was wrong.
This should fix it

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
