### PR TITLE
fix exporting csv results with output-file-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Checkov also powers [**Bridgecrew**](https://bridgecrew.io/?utm_source=github&ut
  * Evaluates [Terraform Provider](https://registry.terraform.io/browse/providers) settings to regulate the creation, management, and updates of IaaS, PaaS or SaaS managed through Terraform.
  * Policies support evaluation of [variables](docs/2.Basics/Handling%20Variables.md) to their optional default value.
  * Supports in-line [suppression](docs/2.Basics/Suppressing%20and%20Skipping%20Policies.md) of accepted risks or false-positives to reduce recurring scan failures. Also supports global skip from using CLI.
- * [Output](docs/2.Basics/Reviewing%20Scan%20Results.md) currently available as CLI, [CycloneDX](https://cyclonedx.org), JSON, JUnit XML, SARIF and github markdown and link to remediation [guides](https://docs.bridgecrew.io/docs/aws-policy-index).
+ * [Output](docs/2.Basics/Reviewing%20Scan%20Results.md) currently available as CLI, [CycloneDX](https://cyclonedx.org), JSON, JUnit XML, CSV, SARIF and github markdown and link to remediation [guides](https://docs.bridgecrew.io/docs/aws-policy-index).
  
 ## Screenshots
 

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -237,10 +237,13 @@ class RunnerRegistry:
             csv_sbom_report.persist_report(is_api_key)
 
         # Save output to file
-        file_names = {'cli': 'results_cli.txt', 'github_failed_only': 'results_github_failed_only.txt',
+        file_names = {'cli': 'results_cli.txt',
+                      'github_failed_only': 'results_github_failed_only.txt',
                       'sarif': 'results_sarif.sarif',
-                      'json': 'results_json.json', 'junitxml': 'results_junitxml.xml',
-                      'cyclonedx': 'results_cyclonedx.xml'}
+                      'json': 'results_json.json',
+                      'junitxml': 'results_junitxml.xml',
+                      'cyclonedx': 'results_cyclonedx.xml',
+                      'csv': 'results_csv.csv'}
         if config.output_file_path:
             for output in config.output:
                 self.save_output_to_file(file_name=f'{config.output_file_path}/{file_names[output]}',


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fixed exception when running scans with csv output and output-file-path flag
e.g:
checkov -d .   -o csv --output-file-path /tmp

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

