### PR TITLE
Fix typo in copy-pastable code examples

### DIFF
--- a/docs/3.Custom Policies/YAML Custom Policies.md
+++ b/docs/3.Custom Policies/YAML Custom Policies.md
@@ -245,7 +245,7 @@ The logic in the policy definition shown below is:
 
 ```yaml
 #....
-defintion:
+definition:
   and:
   - #filter block 1
   - #block 2
@@ -266,7 +266,7 @@ The definition below inverts the example in the previous section.
 
 ```yaml
 #....
-defintion:
+definition:
   not:
     and:
     - #filter block 1
@@ -280,7 +280,7 @@ The following code is also valid (the child of `not` is a list of length 1):
 
 ```yaml
 #....
-defintion:
+definition:
   not:
   - and:
     - #filter block 1


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fix a typo in code examples.

## Checklist:

- [x] I have made corresponding changes to the documentation
