### PR TITLE
use urllib3 for fixes integration

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
@@ -91,15 +91,15 @@ class FixesIntegration(BaseIntegrationFeature):
             {"Authorization": self.bc_integration.get_auth_token()}
         )
 
-        response = requests.request('POST', self.fixes_url, headers=headers, json=payload)
+        request = self.bc_integration.http.request("POST", self.fixes_url, headers=headers, body=json.dumps(payload))
 
-        if response.status_code != 200:
-            error_message = extract_error_message(response)
-            raise Exception(f'Get fixes request failed with response code {response.status_code}: {error_message}')
+        if request.status != 200:
+            error_message = extract_error_message(request)
+            raise Exception(f'Get fixes request failed with response code {request.status}: {error_message}')
 
-        logging.debug(f'Response from fixes API: {response.content}')
+        logging.debug(f'Response from fixes API: {request.data}')
 
-        fixes = json.loads(response.content) if response.content else None
+        fixes = json.loads(request.data) if request.data else None
         if not fixes or type(fixes) != list:
             logging.warning(f'Unexpected fixes API response for file {filename}; skipping fixes for this file')
             return None

--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -7,6 +7,8 @@ import time
 import os
 from typing import Any, TYPE_CHECKING, cast
 
+from urllib3.response import HTTPResponse
+
 from checkov.common.bridgecrew.bc_source import SourceType
 from checkov.common.util.consts import DEV_API_GET_HEADERS, DEV_API_POST_HEADERS, PRISMA_API_GET_HEADERS, \
     PRISMA_PLATFORM, BRIDGECREW_PLATFORM
@@ -39,12 +41,14 @@ def get_auth_error_message(status: int, is_prisma: bool, is_s3_upload: bool) -> 
     return error_message
 
 
-def extract_error_message(response: requests.Response) -> str:
-    if response.content:
+def extract_error_message(response: requests.Response | HTTPResponse) -> str:
+    if (isinstance(response, requests.Response) and response.content) or (isinstance(response, HTTPResponse) and response.data):
         try:
-            content = json.loads(response.content)
+            content = json.loads(response.content if isinstance(response, requests.Response) else response.data)
             if 'message' in content:
                 return cast(str, content['message'])
+            elif 'Message' in content:
+                return cast(str, content['Message'])
         except Exception:
             logging.debug(f'Failed to parse the response content: {response.content.decode()}')
 

--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -5,7 +5,7 @@ import requests
 import logging
 import time
 import os
-from typing import Any, TYPE_CHECKING, cast
+from typing import Any, TYPE_CHECKING, cast, Optional
 
 from urllib3.response import HTTPResponse
 
@@ -41,16 +41,17 @@ def get_auth_error_message(status: int, is_prisma: bool, is_s3_upload: bool) -> 
     return error_message
 
 
-def extract_error_message(response: requests.Response | HTTPResponse) -> str:
+def extract_error_message(response: requests.Response | HTTPResponse) -> Optional[str]:
     if (isinstance(response, requests.Response) and response.content) or (isinstance(response, HTTPResponse) and response.data):
+        raw = response.content if isinstance(response, requests.Response) else response.data
         try:
-            content = json.loads(response.content if isinstance(response, requests.Response) else response.data)
+            content = json.loads(raw)
             if 'message' in content:
                 return cast(str, content['message'])
             elif 'Message' in content:
                 return cast(str, content['Message'])
         except Exception:
-            logging.debug(f'Failed to parse the response content: {response.content.decode()}')
+            logging.debug(f'Failed to parse the response content: {raw.decode()}')
 
     return response.reason
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Changes the fixes integration logic to use urllib3 instead of requests, so that SSL is properly handled.


## Checklist:

- [X ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
