### PR TITLE
change check ID CKV_AWS_62 to CKV_AWS_1

### DIFF
--- a/checkov/terraform/checks/resource/aws/IAMAdminPolicyDocument.py
+++ b/checkov/terraform/checks/resource/aws/IAMAdminPolicyDocument.py
@@ -8,7 +8,7 @@ class IAMAdminPolicyDocument(BaseResourceCheck):
 
     def __init__(self):
         name = "Ensure IAM policies that allow full \"*-*\" administrative privileges are not created"
-        id = "CKV_AWS_62"
+        id = "CKV_AWS_1"
         supported_resources = ['aws_iam_role_policy', 'aws_iam_user_policy', 'aws_iam_group_policy', 'aws_iam_policy','aws_ssoadmin_permission_set_inline_policy']
         categories = [CheckCategories.IAM]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -197,6 +197,7 @@ class TestRunnerValid(unittest.TestCase):
         unique_checks = {}
         bad_checks = []
         for registry in list(runner.block_type_registries.values()):
+            unique_checks = {}
             checks = [check for entity_type in list(registry.checks.values()) for check in entity_type]
             for check in checks:
                 if check.id not in unique_checks:
@@ -244,6 +245,9 @@ class TestRunnerValid(unittest.TestCase):
                 continue
             if f'CKV_AWS_{i}' == 'CKV_AWS_52':
                 # CKV_AWS_52 was deleted since it cannot be toggled in terraform.
+                continue
+            if f'CKV_AWS_{i}' == 'CKV_AWS_62':
+                # CKV_AWS_62 has now the same ID as the data block version CKV_AWS_1.
                 continue
             self.assertIn(f'CKV_AWS_{i}', aws_checks, msg=f'The new AWS violation should have the ID "CKV_AWS_{i}"')
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

- change check ID CKV_AWS_62 to CKV_AWS_1
- also adjusted the collision test to allow the same check ID to be used in different check registries 🙂 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
