### PR TITLE
limit pyston to Intel CPU and upper cap cyclonedx for now

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -68,7 +68,7 @@ policyuniverse = "*"
 typing-extensions = "*"
 importlib-metadata = ">=0.12"
 cachetools = "*"
-cyclonedx-python-lib = ">=2.4.0"
+cyclonedx-python-lib = ">=2.4.0,<3.0.0"
 click = ">=8.0.0"
 aiohttp = "*"
 aiodns = "*"
@@ -78,8 +78,8 @@ jsonschema = "~=3.0"
 prettytable = ">=3.0.0"
 pycep-parser = "==0.3.7"
 charset-normalizer = "*"
-pyston_lite_autoload = {version = "==2.3.4.1", markers="python_version == '3.8' and (sys_platform=='linux' or sys_platform=='darwin')"}
-pyston-lite = {version = "==2.3.4.1", markers="python_version == '3.8' and (sys_platform=='linux' or sys_platform=='darwin')"}
+pyston_lite_autoload = {version = "==2.3.4.1", markers="python_version == '3.8' and (sys_platform=='linux' or sys_platform=='darwin') and platform_machine == 'x86_64'"}
+pyston-lite = {version = "==2.3.4.1", markers="python_version == '3.8' and (sys_platform=='linux' or sys_platform=='darwin') and platform_machine == 'x86_64'"}
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c259c4646ba6564605635750fab6f2ceb733321cc20a599b82873ab0ecbd3939"
+            "sha256": "465301fe65eb7147baf900ffe92133227be17931642a58773ae1af6e4da0eb72"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -168,19 +168,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:2ca999b621ab5fb7442f86e783440ec0e292a86c48782ee09e526c325902ecf1",
-                "sha256:ac1a4a9070101f42062461d8e829dd97f77b6e091bcc8cddee577739b28d39bb"
+                "sha256:5c775dcb12ca5d6be3f5aa3c49d77783faa64eb30fd3f4af93ff116bb42f9ffb",
+                "sha256:5d9bcc355cf6edd7f3849fedac4252e12a0aa2b436cdbc0d4371b16a0f852a30"
             ],
             "index": "pypi",
-            "version": "==1.24.30"
+            "version": "==1.24.34"
         },
         "botocore": {
             "hashes": [
-                "sha256:35897569bf5f80b935f7381f6b0d1580ee0f6a94e3c568faca9ce6603391c829",
-                "sha256:953b9b4c0033280b2229e6e9c5de3ad2e56b887aec02c85680a2156842212092"
+                "sha256:0d824a5315f5f5c3bea53c14107a69695ef43190edf647f1281bac8f172ca77c",
+                "sha256:9c695d47f1f1212f3e306e51f7bacdf67e58055194ddcf7d8296660b124cf135"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.27.30"
+            "version": "==1.27.34"
         },
         "cached-property": {
             "hashes": [
@@ -539,11 +539,11 @@
         },
         "markdown": {
             "hashes": [
-                "sha256:03078d25ed76dd9d2a803e5708ddb1c4ec3a5ed7654bc882e032364f09c184d5",
-                "sha256:e90f851d4b0f788ee2e9c352205d8a592fd0c713ca6b934f87b81bc14d24dab7"
+                "sha256:08fb8465cffd03d10b9dd34a5c3fea908e20391a2a90b88d66362cb05beed186",
+                "sha256:3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.4"
+            "version": "==3.4.1"
         },
         "markupsafe": {
             "hashes": [
@@ -689,11 +689,11 @@
         },
         "policy-sentry": {
             "hashes": [
-                "sha256:5358f388ba7ff682a337f0a80a9cb7fb1ee981b6f46ad1c446132c017ac5ede4",
-                "sha256:75137fc7e1311bc24836855dce7caa40548f3f81a72045bb6731d55f48de644a"
+                "sha256:1f0a96a070933cf90510c76823cadfa8852c9d6b95a2dbf53b96acfb4b49ed80",
+                "sha256:de0d9a8f74a564a7c010baa5add8d5ff97d496c0cef01af1726e1d67a581aa46"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.12.3"
+            "version": "==0.12.4"
         },
         "policyuniverse": {
             "hashes": [
@@ -798,7 +798,7 @@
             "version": "==0.18.1"
         },
         "pyston-lite": {
-            "markers": "python_version == '3.8' and (sys_platform=='linux' or sys_platform=='darwin')",
+            "markers": "python_version == '3.8' and (sys_platform=='linux' or sys_platform=='darwin') and platform_machine == 'x86_64'",
             "version": "==2.3.4.1"
         },
         "pyston-lite-autoload": {
@@ -806,7 +806,7 @@
                 "sha256:c231317e56a40e9d9b1b9f2ac3627845953fb8e92f49c1ce40d4d616dbacdaf6",
                 "sha256:d2b74f4a1e34ef84ac1974f1eb84133e57171d2f96e96bd0cab574ae1d5fdbcf"
             ],
-            "markers": "python_version == '3.8' and (sys_platform == 'linux' or sys_platform == 'darwin')",
+            "markers": "python_version == '3.8' and (sys_platform == 'linux' or sys_platform == 'darwin') and platform_machine == 'x86_64'",
             "version": "==2.3.4.1"
         },
         "python-dateutil": {
@@ -1510,11 +1510,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:0dca2ea3e4381c435ef9c33ba100a78a9b40c0bab11189c7cf121f75815efeaa",
-                "sha256:3d11b16f3fe19f52039fb7e39c9c884b21cb1b586988114fbe42671f03de3e82"
+                "sha256:a3d4c096b384d50d5e6dc5bc8b9bc44f1f61cefebd750a7b3e9f939b53fb214d",
+                "sha256:feaa9db2dc0ce333b453ce171c0cf1247bbfde2c55fc6bb785022d411a1b78b5"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.1"
+            "version": "==2.5.2"
         },
         "idna": {
             "hashes": [
@@ -1637,32 +1637,32 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:006be38474216b833eca29ff6b73e143386f352e10e9c2fbe76aa8549e5554f5",
-                "sha256:03c6cc893e7563e7b2949b969e63f02c000b32502a1b4d1314cabe391aa87d66",
-                "sha256:0e9f70df36405c25cc530a86eeda1e0867863d9471fe76d1273c783df3d35c2e",
-                "sha256:1ece702f29270ec6af25db8cf6185c04c02311c6bb21a69f423d40e527b75c56",
-                "sha256:3e09f1f983a71d0672bbc97ae33ee3709d10c779beb613febc36805a6e28bb4e",
-                "sha256:439c726a3b3da7ca84a0199a8ab444cd8896d95012c4a6c4a0d808e3147abf5d",
-                "sha256:5a0b53747f713f490affdceef835d8f0cb7285187a6a44c33821b6d1f46ed813",
-                "sha256:5f1332964963d4832a94bebc10f13d3279be3ce8f6c64da563d6ee6e2eeda932",
-                "sha256:63e85a03770ebf403291ec50097954cc5caf2a9205c888ce3a61bd3f82e17569",
-                "sha256:64759a273d590040a592e0f4186539858c948302c653c2eac840c7a3cd29e51b",
-                "sha256:697540876638ce349b01b6786bc6094ccdaba88af446a9abb967293ce6eaa2b0",
-                "sha256:9940e6916ed9371809b35b2154baf1f684acba935cd09928952310fbddaba648",
-                "sha256:9f5f5a74085d9a81a1f9c78081d60a0040c3efb3f28e5c9912b900adf59a16e6",
-                "sha256:a5ea0875a049de1b63b972456542f04643daf320d27dc592d7c3d9cd5d9bf950",
-                "sha256:b117650592e1782819829605a193360a08aa99f1fc23d1d71e1a75a142dc7e15",
-                "sha256:b24be97351084b11582fef18d79004b3e4db572219deee0212078f7cf6352723",
-                "sha256:b88f784e9e35dcaa075519096dc947a388319cb86811b6af621e3523980f1c8a",
-                "sha256:bdd5ca340beffb8c44cb9dc26697628d1b88c6bddf5c2f6eb308c46f269bb6f3",
-                "sha256:d5aaf1edaa7692490f72bdb9fbd941fbf2e201713523bdb3f4038be0af8846c6",
-                "sha256:e999229b9f3198c0c880d5e269f9f8129c8862451ce53a011326cad38b9ccd24",
-                "sha256:f4a21d01fc0ba4e31d82f0fff195682e29f9401a8bdb7173891070eb260aeb3b",
-                "sha256:f4b794db44168a4fc886e3450201365c9526a522c46ba089b55e1f11c163750d",
-                "sha256:f730d56cb924d371c26b8eaddeea3cc07d78ff51c521c6d04899ac6904b75492"
+                "sha256:02ef476f6dcb86e6f502ae39a16b93285fef97e7f1ff22932b657d1ef1f28655",
+                "sha256:0d054ef16b071149917085f51f89555a576e2618d5d9dd70bd6eea6410af3ac9",
+                "sha256:19830b7dba7d5356d3e26e2427a2ec91c994cd92d983142cbd025ebe81d69cf3",
+                "sha256:1f7656b69974a6933e987ee8ffb951d836272d6c0f81d727f1d0e2696074d9e6",
+                "sha256:23488a14a83bca6e54402c2e6435467a4138785df93ec85aeff64c6170077fb0",
+                "sha256:23c7ff43fff4b0df93a186581885c8512bc50fc4d4910e0f838e35d6bb6b5e58",
+                "sha256:25c5750ba5609a0c7550b73a33deb314ecfb559c350bb050b655505e8aed4103",
+                "sha256:2ad53cf9c3adc43cf3bea0a7d01a2f2e86db9fe7596dfecb4496a5dda63cbb09",
+                "sha256:3fa7a477b9900be9b7dd4bab30a12759e5abe9586574ceb944bc29cddf8f0417",
+                "sha256:40b0f21484238269ae6a57200c807d80debc6459d444c0489a102d7c6a75fa56",
+                "sha256:4b21e5b1a70dfb972490035128f305c39bc4bc253f34e96a4adf9127cf943eb2",
+                "sha256:5a361d92635ad4ada1b1b2d3630fc2f53f2127d51cf2def9db83cba32e47c856",
+                "sha256:77a514ea15d3007d33a9e2157b0ba9c267496acf12a7f2b9b9f8446337aac5b0",
+                "sha256:855048b6feb6dfe09d3353466004490b1872887150c5bb5caad7838b57328cc8",
+                "sha256:9796a2ba7b4b538649caa5cecd398d873f4022ed2333ffde58eaf604c4d2cb27",
+                "sha256:98e02d56ebe93981c41211c05adb630d1d26c14195d04d95e49cd97dbc046dc5",
+                "sha256:b793b899f7cf563b1e7044a5c97361196b938e92f0a4343a5d27966a53d2ec71",
+                "sha256:d1ea5d12c8e2d266b5fb8c7a5d2e9c0219fedfeb493b7ed60cd350322384ac27",
+                "sha256:d2022bfadb7a5c2ef410d6a7c9763188afdb7f3533f22a0a32be10d571ee4bbe",
+                "sha256:d3348e7eb2eea2472db611486846742d5d52d1290576de99d59edeb7cd4a42ca",
+                "sha256:d744f72eb39f69312bc6c2abf8ff6656973120e2eb3f3ec4f758ed47e414a4bf",
+                "sha256:ef943c72a786b0f8d90fd76e9b39ce81fb7171172daf84bf43eaf937e9f220a9",
+                "sha256:f2899a3cbd394da157194f913a931edfd4be5f274a88041c9dc2d9cdcb1c315c"
             ],
             "index": "pypi",
-            "version": "==0.961"
+            "version": "==0.971"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1977,11 +1977,11 @@
         },
         "types-jmespath": {
             "hashes": [
-                "sha256:6ca36ad673ea73356c818e8fc5a1105dfebdbe28f59d6fd9cbb40158083ab5f5",
-                "sha256:72ed5da2c9ff72369a7c5eb984b6d29d222d68838b58e399ee675c4f634bd515"
+                "sha256:18c1cf8e7444f663155a765c0bc4c242ed30f50581a9dec711769e8ad20c262f",
+                "sha256:d21eb5858a998ef09e9bd82ba30d27c7c74de565c0d7235295473cd27bec1bfe"
             ],
             "index": "pypi",
-            "version": "==1.0.1"
+            "version": "==1.0.2"
         },
         "types-jsonschema": {
             "hashes": [
@@ -2001,11 +2001,11 @@
         },
         "types-requests": {
             "hashes": [
-                "sha256:acd8ed78509d27bdf04cddcc05f7066dfde4d30dd7dba67b808cdb1141d62ffe",
-                "sha256:b097692e124001f0ed5e4490245bb090f5e8e929819972f9ace84f9c3e146e8c"
+                "sha256:66f0e427708588d4dac2f365a0b2c1ad8f31780429fd8ad193fec93139b22112",
+                "sha256:fb9ea69311766967f9e91861211ec7449f6484025b766ea709689c0dbb29d7ba"
             ],
             "index": "pypi",
-            "version": "==2.28.1"
+            "version": "==2.28.3"
         },
         "types-tabulate": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "policyuniverse",
         "typing-extensions>=4.1.0",
         "cachetools",
-        "cyclonedx-python-lib>=2.4.0",
+        "cyclonedx-python-lib>=2.4.0,<3.0.0",
         "click>=8.0.0",
         "aiohttp",
         "aiodns",
@@ -68,8 +68,8 @@ setup(
         "prettytable>=3.0.0",
         "pycep-parser==0.3.7",
         "charset-normalizer",
-        "pyston_lite_autoload==2.3.4.1; python_version=='3.8' and (sys_platform=='linux' or sys_platform=='darwin')",
-        "pyston-lite==2.3.4.1; python_version=='3.8' and (sys_platform=='linux' or sys_platform=='darwin')"
+        "pyston_lite_autoload==2.3.4.1; python_version=='3.8' and (sys_platform=='linux' or sys_platform=='darwin') and platform_machine == 'x86_64'",
+        "pyston-lite==2.3.4.1; python_version=='3.8' and (sys_platform=='linux' or sys_platform=='darwin') and platform_machine == 'x86_64'"
     ],
     license="Apache License 2.0",
     name="checkov",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

- it looks like pyston-lite doesn't play nice with Mac M1, so I limited to Intel CPUs
- also upper caped CycloneDX lib to properly test v3, when it comes out

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
