### PR TITLE
Fix running locally sca package scan if only some files succeeded

### DIFF
--- a/checkov/sca_package/scanner.py
+++ b/checkov/sca_package/scanner.py
@@ -69,11 +69,12 @@ class Scanner:
                     scan_results[idx] for idx, input_path in enumerate(input_paths)
                 ]
             else:
-                indices_to_fix: List[int] = []
                 input_paths_as_list: List[Path] = list(input_paths)  # create a list from a set ("Iterable")
-                for idx in range(len(input_paths_as_list)):
-                    if scan_results[idx]["packages"] is None:
-                        indices_to_fix.append(idx)
+                indices_to_fix: List[int] = [
+                    idx
+                    for idx in range(len(input_paths_as_list))
+                    if scan_results[idx]["packages"] is None
+                ]
                 new_scan_results = await asyncio.gather(*[
                     self.execute_twistcli_scan(input_paths_as_list[idx]) for idx in indices_to_fix
                 ])

--- a/checkov/sca_package/scanner.py
+++ b/checkov/sca_package/scanner.py
@@ -71,7 +71,7 @@ class Scanner:
             else:
                 indices_to_fix: List[int] = []
                 input_paths_as_list: List[Path] = list(input_paths)  # create a list from a set ("Iterable")
-                for idx, input_path in enumerate(input_paths_as_list):
+                for idx in range(len(input_paths_as_list)):
                     if scan_results[idx]["packages"] is None:
                         indices_to_fix.append(idx)
                 new_scan_results = await asyncio.gather(*[

--- a/checkov/sca_package/scanner.py
+++ b/checkov/sca_package/scanner.py
@@ -57,7 +57,7 @@ class Scanner:
         else:
             scan_results: List[Dict[str, Any]] = await asyncio.gather(*[self.run_scan(i) for i in input_paths])
 
-        if any(scan_result["vulnerabilities"] is None for scan_result in scan_results):
+        if any(scan_result["packages"] is None for scan_result in scan_results):
             image_scanner.setup_twistcli()
 
             if os.getenv("PYCHARM_HOSTED") == "1":
@@ -65,14 +65,14 @@ class Scanner:
                 # it avoids us from crashing, which happens when using multiprocessing via Pycharm's debug-mode
                 logging.warning("Running the scans in sequence for avoiding crashing when running via Pycharm")
                 scan_results = [
-                    await self.execute_twistcli_scan(input_path) if scan_results[idx]["vulnerabilities"] is None else
+                    await self.execute_twistcli_scan(input_path) if scan_results[idx]["packages"] is None else
                     scan_results[idx] for idx, input_path in enumerate(input_paths)
                 ]
             else:
                 indices_to_fix: List[int] = []
                 input_paths_as_list: List[Path] = list(input_paths)  # create a list from a set ("Iterable")
                 for idx, input_path in enumerate(input_paths_as_list):
-                    if scan_results[idx]["vulnerabilities"] is None:
+                    if scan_results[idx]["packages"] is None:
                         indices_to_fix.append(idx)
                 new_scan_results = await asyncio.gather(*[
                     self.execute_twistcli_scan(input_paths_as_list[idx]) for idx in indices_to_fix


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
It seems that if some files were scanned successfully and others were not, we failed to scan them locally because we tried to send asyncio a dict as a future. This fixes it

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
