### PR TITLE
use severity enum for cloned policy

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -44,6 +44,7 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
                     converted_check = self._convert_raw_check(policy)
                     source_incident_id = policy.get('sourceIncidentId')
                     if source_incident_id:
+                        policy['severity'] = Severities[policy['severity']]
                         self.bc_cloned_checks[source_incident_id].append(policy)
                         continue
                     resource_types = Registry._get_resource_types(converted_check['metadata'])
@@ -98,7 +99,7 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
                 new_record.check_id = cloned_policy['id']
                 new_record.bc_check_id = cloned_policy['id']
                 new_record.guideline = cloned_policy['guideline']
-                new_record.severity = Severities[cloned_policy['severity']]
+                new_record.severity = cloned_policy['severity']
                 new_record.check_name = cloned_policy['title']
                 records.append(new_record)
         return records

--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -98,7 +98,7 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
                 new_record.check_id = cloned_policy['id']
                 new_record.bc_check_id = cloned_policy['id']
                 new_record.guideline = cloned_policy['guideline']
-                new_record.severity = cloned_policy['severity']
+                new_record.severity = Severities[cloned_policy['severity']]
                 new_record.check_name = cloned_policy['title']
                 records.append(new_record)
         return records


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fixes an issue where cloned OOTB policies had a severity value of type string, instead of the Severities dataclass, causing a property error later on.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
