### PR TITLE
using request_wrapper in [image_scanner](get_scan_results_from_cache)

### DIFF
--- a/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
@@ -12,12 +12,11 @@ import json
 import os
 import time
 
-import requests
-
 from checkov.common.bridgecrew.vulnerability_scanning.integrations.docker_image_scanning import \
     docker_image_scanning_integration
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.util.file_utils import decompress_file_gzip_base64
+from checkov.common.util.http_utils import request_wrapper
 from checkov.common.bridgecrew.platform_key import bridgecrew_dir
 
 TWISTCLI_FILE_NAME = 'twistcli'
@@ -118,11 +117,10 @@ class ImageScanner:
     @staticmethod
     def get_scan_results_from_cache(image_id: str) -> Dict[str, Any]:
         image_id_encode = quote_plus(image_id)
-        response = requests.request(
+        response = request_wrapper(
             "GET", f"{bc_integration.api_url}/api/v1/vulnerabilities/scan-results/{image_id_encode}",
-            headers=bc_integration.get_default_headers("GET")
+            headers=bc_integration.get_default_headers("GET"), should_call_raise_for_status=True
         )
-        response.raise_for_status()
         response_json = response.json()
         output_type = response_json["outputType"]
 

--- a/checkov/common/bridgecrew/vulnerability_scanning/integrations/twistcli.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/integrations/twistcli.py
@@ -36,10 +36,6 @@ class TwistcliIntegration(ABC):
                                    headers=bc_integration.get_default_headers("GET"),
                                    should_call_raise_for_status=True)
 
-        if not response:
-            logging.error("twistcli could not be downloaded")
-            return
-
         cli_file_name_path.write_bytes(response.content)
         cli_file_name_path.chmod(cli_file_name_path.stat().st_mode | stat.S_IEXEC)
         logging.debug("twistcli downloaded and has execute permission")

--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -105,7 +105,7 @@ def request_wrapper(
     # 'ConnectionError' instances that appeared:
     # * 'Connection aborted.', ConnectionResetError(104, 'Connection reset by peer').
     # * 'Connection aborted.', OSError(107, 'Socket not connected').
-    # 'ConnectionError' instances that appeared:
+    # 'HTTPError' instances that appeared:
     # * 403 Client Error: Forbidden for url.
     # * 504 Server Error: Gateway Time-out for url.
 

--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -99,7 +99,7 @@ def request_wrapper(
     data: Any | None = None,
     json: dict[str, Any] | None = None,
     should_call_raise_for_status: bool = False
-) -> Response | None:
+) -> Response:
     # using of "retry" mechanism for 'requests.request' due to unpredictable 'ConnectionError' and 'HttpError'
     # instances that appears from time to time.
     # 'ConnectionError' instances that appeared:
@@ -131,5 +131,6 @@ def request_wrapper(
                 time.sleep(sleep_between_request_tries * (i + 1))
                 continue
             raise http_error
-
-    return None
+    else:
+        raise Exception("Unexpected behavior: the method \'request_wrapper\' should be terminated inside the above for-"
+                        "loop")


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
using request_wrapper in [image_scanner](get_scan_results_from_cache)
the request_wrapper basically perform the method 'requests.request' and adding retries if possible and required

Fixes # (issue) 
fixing unexpected connection issues when performing http-requests by adding retry mechanims

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
