### PR TITLE
Fix - TFPlan Crash - Terraform - K8s - Check - SeccompPSP

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/SeccompPSP.py
+++ b/checkov/terraform/checks/resource/kubernetes/SeccompPSP.py
@@ -18,12 +18,13 @@ class SeccompPSP(BaseResourceCheck):
                 metadata = conf["metadata"][0]
                 if metadata.get("annotations"):
                     annotations = metadata["annotations"][0]
-                    for annotation in annotations:
-                        annotation = ''.join(annotation.split())
-                        if annotation == "seccomp.security.alpha.kubernetes.io/defaultProfileName":
-                            my_value = str(annotations.get(annotation))
-                            if "docker/default" in my_value or "runtime/default" in my_value:
-                                return CheckResult.PASSED
+                    if annotations is not None:
+                        for annotation in annotations:
+                            annotation = ''.join(annotation.split())
+                            if annotation == "seccomp.security.alpha.kubernetes.io/defaultProfileName":
+                                my_value = str(annotations.get(annotation))
+                                if "docker/default" in my_value or "runtime/default" in my_value:
+                                    return CheckResult.PASSED
         return CheckResult.FAILED
 
 


### PR DESCRIPTION
## Description
Hello!

I've found an issue that only happens for Terraform Plan Scanning.

When you create a terraform kubernetes resource and you do not include `metadata.annotations` (because you don't want to add any annotations) then the tfplan unhelpfully represents this as existing with the `null` **value** instead of either not existing or being an empty map (`{}`). There might be a good reason that I just don't understand atm.
```
                  "metadata":[
                     {
                        "annotations":null,
                        "labels":null,
                        "name":"terraform-example"
                     }
                  ]
```
This causes checks to crash that try to read `annotations` if there is no explicit  `annotations` set only for TF Plan.


## Testing
I don't think there is a great way to consistently test for odd things like this at the moment. I don't think it's clear when / where terraform plan will add these null values in other contexts either but it's something to try to remember.

### Steps to reproduce
1. Install latest Version of Checkov
2. Terraform K8s PSP Resource In `main.tf`:
```
resource "kubernetes_pod_security_policy" "example" {
  metadata {
    name = "terraform-example"
  }
  spec {
    privileged                 = false
    allow_privilege_escalation = false

    volumes = [
      "configMap",
      "emptyDir",
      "projected",
      "secret",
      "downwardAPI",
      "persistentVolumeClaim",
    ]

    run_as_user {
      rule = "MustRunAsNonRoot"
    }

    se_linux {
      rule = "RunAsAny"
    }

    supplemental_groups {
      rule = "MustRunAs"
      range {
        min = 1
        max = 65535
      }
    }

    fs_group {
      rule = "MustRunAs"
      range {
        min = 1
        max = 65535
      }
    }

    read_only_root_filesystem = true
  }
}
```
3. Convert to `tfplan.json` and scan.
```
terraform init
terraform plan --out tfplan.binary
terraform show -json tfplan.binary > tfplan.json
checkov -f tfplan.json
```
4. Negative results:
```
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/site-packages/checkov/common/parallelizer/parallel_runner.py", line 37, in func_wrapper
    result = original_func(item)
  File "/usr/local/lib/python3.8/site-packages/checkov/common/runners/runner_registry.py", line 76, in _parallel_run
    return runner.run(
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/plan_runner.py", line 72, in run
    self.check_tf_definition(report, root_folder, runner_filter)
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/plan_runner.py", line 90, in check_tf_definition
    self.run_block(definition[block_type], None, full_file_path, root_folder, report, scanned_file,
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/plan_runner.py", line 110, in run_block
    results = registry.scan(scanned_file, entity, [], runner_filter)
  File "/usr/local/lib/python3.8/site-packages/checkov/common/checks/base_check_registry.py", line 124, in scan
    result = self.run_check(check, entity_configuration, entity_name, entity_type, scanned_file, skip_info)
  File "/usr/local/lib/python3.8/site-packages/checkov/common/checks/base_check_registry.py", line 138, in run_check
    result = check.run(
  File "/usr/local/lib/python3.8/site-packages/checkov/common/checks/base_check.py", line 75, in run
    check_result["result"] = self.scan_entity_conf(entity_configuration, entity_type)
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/checks/resource/base_resource_check.py", line 43, in scan_entity_conf
    return self.scan_resource_conf(conf)
  File "/usr/local/lib/python3.8/site-packages/checkov/terraform/checks/resource/kubernetes/SeccompPSP.py", line 21, in scan_resource_conf
    for annotation in annotations:
TypeError: 'NoneType' object is not iterable
```


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


## License
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**