### PR TITLE
return csv format as string

### DIFF
--- a/checkov/common/output/csv.py
+++ b/checkov/common/output/csv.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 date_now = f'{datetime.now().strftime("%Y%m%d-%H%M%S")}'
 FILE_NAME_OSS_PACKAGES = f"{date_now}_oss_packages.csv"
-HEADER_OSS_PACKAGES : list[str] = [
+HEADER_OSS_PACKAGES = [
     "Package",
     "Version",
     "Path",

--- a/checkov/common/output/csv.py
+++ b/checkov/common/output/csv.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 date_now = f'{datetime.now().strftime("%Y%m%d-%H%M%S")}'
 FILE_NAME_OSS_PACKAGES = f"{date_now}_oss_packages.csv"
-HEADER_OSS_PACKAGES = [
+HEADER_OSS_PACKAGES : list[str] = [
     "Package",
     "Version",
     "Path",
@@ -163,3 +163,18 @@ class CSVSBOM:
                 writer = csv.writer(f)
                 writer.writerow(header)
                 writer.writerow([CTA_NO_API_KEY])
+
+    def get_csv_output_oss_packages(self) -> str:
+        # header
+        csv_output = ','.join(HEADER_OSS_PACKAGES) + '\n'
+
+        for row in self.package_rows:
+            for header in HEADER_OSS_PACKAGES:
+                field = row[header] if row[header] else ''
+                if header == 'Package':
+                    csv_output += f'{field}'
+                else:
+                    csv_output += f',{field}'
+            csv_output += '\n'
+
+        return csv_output

--- a/tests/common/output/test_bom_report.py
+++ b/tests/common/output/test_bom_report.py
@@ -88,9 +88,12 @@ class TestBomOutput:
         # then
         output_file_path = tmp_path / file_name
         csv_output = output_file_path.read_text()
-
-        assert csv_output == (
+        csv_output_str = csv_sbom_report.get_csv_output_oss_packages()
+        expected_csv = (
             "Package,Version,Path,git org,git repository,Vulnerability,Severity,License\n"
             "flask,0.6,/requirements.txt,acme,bridgecrewio/example,CVE-2019-1010083,HIGH,\n"
             "requests,,/requirements.txt,acme,bridgecrewio/example,,,\n"
         )
+
+        assert csv_output == expected_csv
+        assert csv_output_str == expected_csv


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

Added function that returns csv format as string.

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)


## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
