### PR TITLE
new AWS resources new CMK checks

### DIFF
--- a/checkov/terraform/checks/resource/aws/AppFlowConnectorProfileUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/AppFlowConnectorProfileUsesCMK.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.consts import ANY_VALUE
+
+
+class AppFlowConnectorProfileUsesCMK(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure App Flow connector profile uses CMK"
+        id = "CKV_AWS_264"
+        supported_resources = ['aws_appflow_connector_profile']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'kms_arn'
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = AppFlowConnectorProfileUsesCMK()

--- a/checkov/terraform/checks/resource/aws/AppFlowUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/AppFlowUsesCMK.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.consts import ANY_VALUE
+
+
+class AppFlowUsesCMK(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure App Flow flow uses CMK"
+        id = "CKV_AWS_263"
+        supported_resources = ['aws_appflow_flow']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'kms_arn'
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = AppFlowUsesCMK()

--- a/checkov/terraform/checks/resource/aws/DBSnapshotCopyUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/DBSnapshotCopyUsesCMK.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.consts import ANY_VALUE
+
+
+class BDSnapshotCopyUsesCMK(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure App Flow connector profile uses CMK"
+        id = "CKV_AWS_264"
+        supported_resources = ['aws_db_snapshot_copy']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'kms_key_id'
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = BDSnapshotCopyUsesCMK()

--- a/checkov/terraform/checks/resource/aws/DBSnapshotCopyUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/DBSnapshotCopyUsesCMK.py
@@ -6,7 +6,7 @@ from checkov.common.models.consts import ANY_VALUE
 class BDSnapshotCopyUsesCMK(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure App Flow connector profile uses CMK"
-        id = "CKV_AWS_264"
+        id = "CKV_AWS_266"
         supported_resources = ['aws_db_snapshot_copy']
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/checkov/terraform/checks/resource/aws/KendraIndexSSEUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/KendraIndexSSEUsesCMK.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.consts import ANY_VALUE
+
+
+class KendraIndexSSEUsesCMK(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Kendra index Server side encryption uses CMK"
+        id = "CKV_AWS_262"
+        supported_resources = ['aws_kendra_index']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'server_side_encryption_configuration/[0]/kms_key_id'
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = KendraIndexSSEUsesCMK()

--- a/checkov/terraform/checks/resource/aws/KeyspacesTableUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/KeyspacesTableUsesCMK.py
@@ -1,0 +1,25 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class KeyspacesTableUsesCMK(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure Keyspaces Table uses CMK"
+        id = "CKV_AWS_265"
+        supported_resources = ['aws_keyspaces_table']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf) -> CheckResult:
+        if conf.get("encryption_specification") and isinstance(conf.get("encryption_specification"), list):
+            encrypt = conf.get("encryption_specification")[0]
+            if encrypt.get("kms_key_identifier") and isinstance(encrypt.get("kms_key_identifier"), list):
+                if encrypt.get("type") == ["CUSTOMER_MANAGED_KEY"]:
+                    return CheckResult.PASSED
+                self.evaluated_keys = ["encryption_specification/[0]/type"]
+            self.evaluated_keys = ["encryption_specification/[0]/kms_key_identifier"]
+        self.evaluated_keys = ["encryption_specification"]
+        return CheckResult.FAILED
+
+
+check = KeyspacesTableUsesCMK()

--- a/tests/terraform/checks/resource/aws/example_AppFlowConnectorProfileUsesCMK/main.tf
+++ b/tests/terraform/checks/resource/aws/example_AppFlowConnectorProfileUsesCMK/main.tf
@@ -1,0 +1,49 @@
+resource "aws_appflow_connector_profile" "fail" {
+  name            = "example_profile"
+  connector_type  = "Redshift"
+  connection_mode = "Public"
+
+  connector_profile_config {
+
+    connector_profile_credentials {
+      redshift {
+        password = aws_redshift_cluster.example.master_password
+        username = aws_redshift_cluster.example.master_username
+      }
+    }
+
+    connector_profile_properties {
+      redshift {
+        bucket_name  = aws_s3_bucket.example.name
+        database_url = "jdbc:redshift://${aws_redshift_cluster.example.endpoint}/${aws_redshift_cluster.example.database_name}"
+        role_arn     = aws_iam_role.example.arn
+      }
+    }
+  }
+}
+
+resource "aws_appflow_connector_profile" "pass" {
+  name            = "example_profile"
+  connector_type  = "Redshift"
+  connection_mode = "Public"
+  kms_arn = aws_kms_key.example.arn
+
+
+  connector_profile_config {
+
+    connector_profile_credentials {
+      redshift {
+        password = aws_redshift_cluster.example.master_password
+        username = aws_redshift_cluster.example.master_username
+      }
+    }
+
+    connector_profile_properties {
+      redshift {
+        bucket_name  = aws_s3_bucket.example.name
+        database_url = "jdbc:redshift://${aws_redshift_cluster.example.endpoint}/${aws_redshift_cluster.example.database_name}"
+        role_arn     = aws_iam_role.example.arn
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/aws/example_AppFlowUsesCMK/main.tf
+++ b/tests/terraform/checks/resource/aws/example_AppFlowUsesCMK/main.tf
@@ -1,0 +1,87 @@
+resource "aws_appflow_flow" "fail" {
+  name = "example"
+
+  source_flow_config {
+    connector_type = "S3"
+    source_connector_properties {
+      s3 {
+        bucket_name   = aws_s3_bucket_policy.example_source.bucket
+        bucket_prefix = "example"
+      }
+    }
+  }
+
+  destination_flow_config {
+    connector_type = "S3"
+    destination_connector_properties {
+      s3 {
+        bucket_name = aws_s3_bucket_policy.example_destination.bucket
+
+        s3_output_format_config {
+          prefix_config {
+            prefix_type = "PATH"
+          }
+        }
+      }
+    }
+  }
+
+  task {
+    source_fields     = ["exampleField"]
+    destination_field = "exampleField"
+    task_type         = "Map"
+
+    connector_operator {
+      s3 = "NO_OP"
+    }
+  }
+
+  trigger_config {
+    trigger_type = "OnDemand"
+  }
+}
+
+resource "aws_appflow_flow" "pass" {
+  name = "example"
+
+  source_flow_config {
+    connector_type = "S3"
+    source_connector_properties {
+      s3 {
+        bucket_name   = aws_s3_bucket_policy.example_source.bucket
+        bucket_prefix = "example"
+      }
+    }
+  }
+
+  destination_flow_config {
+    connector_type = "S3"
+    destination_connector_properties {
+      s3 {
+        bucket_name = aws_s3_bucket_policy.example_destination.bucket
+
+        s3_output_format_config {
+          prefix_config {
+            prefix_type = "PATH"
+          }
+        }
+      }
+    }
+  }
+
+  task {
+    source_fields     = ["exampleField"]
+    destination_field = "exampleField"
+    task_type         = "Map"
+
+    connector_operator {
+      s3 = "NO_OP"
+    }
+  }
+
+  kms_arn = aws_kms_key.example.arn
+
+  trigger_config {
+    trigger_type = "OnDemand"
+  }
+}

--- a/tests/terraform/checks/resource/aws/example_DBSnapshotCopyUsesCMK/main.tf
+++ b/tests/terraform/checks/resource/aws/example_DBSnapshotCopyUsesCMK/main.tf
@@ -1,0 +1,10 @@
+resource "aws_db_snapshot_copy" "fail" {
+  source_db_snapshot_identifier = aws_db_snapshot.example.db_snapshot_arn
+  target_db_snapshot_identifier = "testsnapshot1234-copy"
+}
+
+resource "aws_db_snapshot_copy" "pass" {
+  source_db_snapshot_identifier = aws_db_snapshot.example.db_snapshot_arn
+  target_db_snapshot_identifier = "testsnapshot1234-copy"
+  kms_key_id= aws_kms_key.example.id
+}

--- a/tests/terraform/checks/resource/aws/example_KendraIndexSSEUsesCMK/main.tf
+++ b/tests/terraform/checks/resource/aws/example_KendraIndexSSEUsesCMK/main.tf
@@ -1,0 +1,19 @@
+resource "aws_kendra_index" "fail" {
+  name        = "example"
+  description = "example"
+  edition     = "DEVELOPER_EDITION"
+  role_arn    = aws_iam_role.this.arn
+
+  tags = {
+    "Key1" = "Value1"
+  }
+}
+
+resource "aws_kendra_index" "pass" {
+  name     = "example"
+  role_arn = aws_iam_role.this.arn
+
+  server_side_encryption_configuration {
+    kms_key_id = data.aws_kms_key.this.arn
+  }
+}

--- a/tests/terraform/checks/resource/aws/example_KeyspacesTableUsesCMK/main.tf
+++ b/tests/terraform/checks/resource/aws/example_KeyspacesTableUsesCMK/main.tf
@@ -1,0 +1,78 @@
+resource "aws_keyspaces_table" "fail" {
+  keyspace_name = aws_keyspaces_keyspace.example.name
+  table_name    = "my_table"
+
+  schema_definition {
+    column {
+      name = "Message"
+      type = "ASCII"
+    }
+
+    partition_key {
+      name = "Message"
+    }
+  }
+}
+
+resource "aws_keyspaces_table" "fail2" {
+  keyspace_name = aws_keyspaces_keyspace.example.name
+  table_name    = "my_table"
+
+  schema_definition {
+    column {
+      name = "Message"
+      type = "ASCII"
+    }
+
+    partition_key {
+      name = "Message"
+    }
+  }
+  encryption_specification {
+    type="AWS_OWNED_KMS_KEY"
+  }
+
+}
+
+
+resource "aws_keyspaces_table" "fail3" {
+  keyspace_name = aws_keyspaces_keyspace.example.name
+  table_name    = "my_table"
+
+  schema_definition {
+    column {
+      name = "Message"
+      type = "ASCII"
+    }
+
+    partition_key {
+      name = "Message"
+    }
+  }
+  encryption_specification {
+    kms_key_identifier=aws_kms_key.example.arn
+    type="AWS_OWNED_KMS_KEY"
+  }
+
+}
+
+resource "aws_keyspaces_table" "pass" {
+  keyspace_name = aws_keyspaces_keyspace.example.name
+  table_name    = "my_table"
+
+  schema_definition {
+    column {
+      name = "Message"
+      type = "ASCII"
+    }
+
+    partition_key {
+      name = "Message"
+    }
+  }
+  encryption_specification {
+    kms_key_identifier=aws_kms_key.example.arn
+    type="CUSTOMER_MANAGED_KEY"
+  }
+
+}

--- a/tests/terraform/checks/resource/aws/test_AppFlowConnectorProfileUsesCMK.py
+++ b/tests/terraform/checks/resource/aws/test_AppFlowConnectorProfileUsesCMK.py
@@ -1,0 +1,43 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.AppFlowConnectorProfileUsesCMK import check
+from checkov.terraform.runner import Runner
+
+
+class TestAppFlowConnectorProfileUsesCMK(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_AppFlowConnectorProfileUsesCMK"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_appflow_connector_profile.pass",
+        }
+
+        failing_resources = {
+            "aws_appflow_connector_profile.fail",
+        }
+
+        skipped_resources = {}
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_AppFlowUsesCMK.py
+++ b/tests/terraform/checks/resource/aws/test_AppFlowUsesCMK.py
@@ -1,0 +1,43 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.AppFlowUsesCMK import check
+from checkov.terraform.runner import Runner
+
+
+class TestAppFlowUsesCMK(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_AppFlowUsesCMK"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_appflow_flow.pass",
+        }
+
+        failing_resources = {
+            "aws_appflow_flow.fail",
+        }
+
+        skipped_resources = {}
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_DBSnapshotCopyUsesCMK.py
+++ b/tests/terraform/checks/resource/aws/test_DBSnapshotCopyUsesCMK.py
@@ -1,0 +1,43 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.DBSnapshotCopyUsesCMK import check
+from checkov.terraform.runner import Runner
+
+
+class TestDBSnapshotCopyUsesCMK(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_DBSnapshotCopyUsesCMK"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_db_snapshot_copy.pass",
+        }
+
+        failing_resources = {
+            "aws_db_snapshot_copy.fail",
+        }
+
+        skipped_resources = {}
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_KendraIndexSSEUsesCMK.py
+++ b/tests/terraform/checks/resource/aws/test_KendraIndexSSEUsesCMK.py
@@ -1,0 +1,43 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.KendraIndexSSEUsesCMK import check
+from checkov.terraform.runner import Runner
+
+
+class TestKendraIndexSSEUsesCMK(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_KendraIndexSSEUsesCMK"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_kendra_index.pass",
+        }
+
+        failing_resources = {
+            "aws_kendra_index.fail",
+        }
+
+        skipped_resources = {}
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_KeyspacesTableUsesCMK.py
+++ b/tests/terraform/checks/resource/aws/test_KeyspacesTableUsesCMK.py
@@ -1,0 +1,45 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.KeyspacesTableUsesCMK import check
+from checkov.terraform.runner import Runner
+
+
+class TestKeyspacesTableUsesCMK(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_KeyspacesTableUsesCMK"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_keyspaces_table.pass",
+        }
+
+        failing_resources = {
+            "aws_keyspaces_table.fail",
+            "aws_keyspaces_table.fail2",
+            "aws_keyspaces_table.fail3",
+        }
+
+        skipped_resources = {}
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A number of new AWS resources have been published, a few can use CMKs. these checks ensure that you do.

New checks for:
262 aws_kendra_index (#24920) -encryption block 
263 aws_appflow_flow (#24017) -customer managed kms key 
264 aws_appflow_connector_profile (#23892)  -customer managed kms key
265 aws_keyspaces_table (#24351) encryption_specification and CMK
266 aws_db_snapshot_copy (#9886) kms key id is set