### PR TITLE
Update --etcd-cafile in ApiServerEtcdCaFile check (CKV_K8S_108)

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/ApiServerEtcdCaFile.py
+++ b/checkov/kubernetes/checks/resource/k8s/ApiServerEtcdCaFile.py
@@ -8,7 +8,7 @@ from checkov.kubernetes.checks.resource.k8s.k8s_check_utils import extract_comma
 class ApiServerEtcdCaFile(BaseK8sContainerCheck):
     def __init__(self) -> None:
         id = "CKV_K8S_102"
-        name = "Ensure that the --etcd-ca-file argument is set as appropriate"
+        name = "Ensure that the --etcd-cafile argument is set as appropriate"
         super().__init__(name=name, id=id)
 
     def scan_container_conf(self, metadata: Dict[str, Any], conf: Dict[str, Any]) -> CheckResult:
@@ -16,7 +16,7 @@ class ApiServerEtcdCaFile(BaseK8sContainerCheck):
         keys, values = extract_commands(conf)
 
         if "kube-apiserver" in keys:
-            if "--etcd-ca-file" not in keys:
+            if "--etcd-cafile" not in keys:
                 return CheckResult.FAILED
 
         return CheckResult.PASSED

--- a/tests/kubernetes/checks/example_ApiServerEtcdCaFile/example_ApiServerEtcdCaFile-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerEtcdCaFile/example_ApiServerEtcdCaFile-PASSED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    - --etcd-ca-file=ca.file
+    - --etcd-cafile=ca.file
     image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
     livenessProbe:
       failureThreshold: 8


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

- The parameter `--etcd-cafile` in the `ApiServerEtcdCaFile.py` has an extra hyphen. So raising a PR with the correct parameter.

- Kubernetes Check #  `CKV_K8S_108`

## Fixes

-   `--etcd-ca-file` to `--etcd-cafile`

## References

- [kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
