### PR TITLE
Fix ssh source pat clone

### DIFF
--- a/checkov/terraform/module_loading/loaders/github_access_token_loader.py
+++ b/checkov/terraform/module_loading/loaders/github_access_token_loader.py
@@ -11,16 +11,20 @@ class GithubAccessTokenLoader(GenericGitLoader):
 
     def _is_matching_loader(self) -> bool:
         if self.token:
+            # if GITHUB_PAT is set and previous loaders failed, convert source (ssh or http or generic git)
+            # to use the token in generic format git::https://x-access-token:<token>@github.com/org/repo.git
             self.logger.debug("GITHUB_PAT found. Attempting to clone module using HTTP basic authentication.")
+            # if module_source = github.com/org/repo
             if self.module_source.startswith(self.module_source_prefix):
                 self.module_source = f"git::https://{self.username}:{self.token}@{self.module_source}"
                 return True
-            if self.module_source.startswith(self.module_source_prefix):
-                source = self.module_source.replace(":", "/")
-                self.module_source = f"git::https://{self.username}:{self.token}@{source}"
-                return True
+            # if module_source = git@github.com:org/repo.git
             if self.module_source.startswith(f"git::https://{self.module_source_prefix}"):
                 self.module_source = f"git::https://{self.username}:{self.token}@{self.module_source.split('git::https://')[1]}"
+                return True
+            # if module_source = git@github.com:org/repo.git
+            if self.module_source.startswith(f"git@{self.module_source_prefix}:"):
+                self.module_source = f"git::https://{self.username}:{self.token}@{self.module_source.split('git@')[1].replace(':', '/')}"
                 return True
 
         return False

--- a/checkov/terraform/module_loading/loaders/github_access_token_loader.py
+++ b/checkov/terraform/module_loading/loaders/github_access_token_loader.py
@@ -11,20 +11,24 @@ class GithubAccessTokenLoader(GenericGitLoader):
 
     def _is_matching_loader(self) -> bool:
         if self.token:
-            # if GITHUB_PAT is set and previous loaders failed, convert source (ssh or http or generic git)
+            # if GITHUB_PAT is set and previous loaders failed, convert source (github ssh or github http or generic git)
             # to use the token in generic format git::https://x-access-token:<token>@github.com/org/repo.git
             self.logger.debug("GITHUB_PAT found. Attempting to clone module using HTTP basic authentication.")
             # if module_source = github.com/org/repo
             if self.module_source.startswith(self.module_source_prefix):
                 self.module_source = f"git::https://{self.username}:{self.token}@{self.module_source}"
                 return True
-            # if module_source = git@github.com:org/repo.git
+            # if module_source = git::https://github.com/org/repo.git
             if self.module_source.startswith(f"git::https://{self.module_source_prefix}"):
                 self.module_source = f"git::https://{self.username}:{self.token}@{self.module_source.split('git::https://')[1]}"
                 return True
             # if module_source = git@github.com:org/repo.git
             if self.module_source.startswith(f"git@{self.module_source_prefix}:"):
                 self.module_source = f"git::https://{self.username}:{self.token}@{self.module_source.split('git@')[1].replace(':', '/')}"
+                return True
+            # if module_source = git::ssh://git@github.com/org/repo.git
+            if self.module_source.startswith(f"git::ssh://git@{self.module_source_prefix}"):
+                self.module_source = f"git::https://{self.username}:{self.token}@{self.module_source.split('git::ssh://git@')[1]}"
                 return True
 
         return False

--- a/checkov/terraform/module_loading/loaders/github_access_token_loader.py
+++ b/checkov/terraform/module_loading/loaders/github_access_token_loader.py
@@ -19,6 +19,9 @@ class GithubAccessTokenLoader(GenericGitLoader):
                 source = self.module_source.replace(":", "/")
                 self.module_source = f"git::https://{self.username}:{self.token}@{source}"
                 return True
+            if self.module_source.startswith(f"git::https://{self.module_source_prefix}"):
+                self.module_source = f"git::https://{self.username}:{self.token}@{self.module_source.split('git::https://')[1]}"
+                return True
 
         return False
 

--- a/tests/terraform/module_loading/test_registry.py
+++ b/tests/terraform/module_loading/test_registry.py
@@ -365,9 +365,33 @@ def test_load_local_path(git_getter, tmp_path: Path, source, expected_content_pa
             "github.com/kartikp10/terraform-aws-s3-bucket1/HEAD",
             "git::https://x-access-token:ghp_xxxxxxxxxxxxxxxxx@github.com/kartikp10/terraform-aws-s3-bucket1",
             "",
+        ),
+       ( 
+            "git::https://github.com/kartikp10/terraform-aws-s3-bucket1.git",
+            "github.com/kartikp10/terraform-aws-s3-bucket1/HEAD",
+            "https://x-access-token:ghp_xxxxxxxxxxxxxxxxx@github.com/kartikp10/terraform-aws-s3-bucket1.git",
+            "github.com/kartikp10/terraform-aws-s3-bucket1/HEAD",
+            "git::https://x-access-token:ghp_xxxxxxxxxxxxxxxxx@github.com/kartikp10/terraform-aws-s3-bucket1.git",
+            "",
+        ),
+       ( 
+           "git@github.com:kartikp10/terraform-aws-s3-bucket1.git",
+            "github.com/kartikp10/terraform-aws-s3-bucket1/HEAD",
+            "https://x-access-token:ghp_xxxxxxxxxxxxxxxxx@github.com/kartikp10/terraform-aws-s3-bucket1.git",
+            "github.com/kartikp10/terraform-aws-s3-bucket1/HEAD",
+            "git::https://x-access-token:ghp_xxxxxxxxxxxxxxxxx@github.com/kartikp10/terraform-aws-s3-bucket1.git",
+            "",
+        ),
+       ( 
+           "git::ssh://git@github.com/kartikp10/terraform-aws-s3-bucket1.git",
+            "github.com/kartikp10/terraform-aws-s3-bucket1/HEAD",
+            "https://x-access-token:ghp_xxxxxxxxxxxxxxxxx@github.com/kartikp10/terraform-aws-s3-bucket1.git",
+            "github.com/kartikp10/terraform-aws-s3-bucket1/HEAD",
+            "git::https://x-access-token:ghp_xxxxxxxxxxxxxxxxx@github.com/kartikp10/terraform-aws-s3-bucket1.git",
+            "",
         )
     ],
-    ids=["module"],
+    ids=["github_http_module", "generic_git_module", "ssh_github_module", "generic_ssh_module"],
 )
 @mock.patch.dict(os.environ, {"GITHUB_PAT": "ghp_xxxxxxxxxxxxxxxxx"})
 @mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

This PR modifies how a user needs to set up private module scanning while using Github modules. Github is a particular case here because of the unique format for module sources - https://www.terraform.io/language/modules/sources#github

Changes: 
- If checkov discovers a GITHUB_PAT, that token will be used for all modules that have a Github source (assuming previous loaders fail). 
- This will include generic format sources -> git::ssh, git::https and Github format sources -> github.com..., git@github.com... 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
