### PR TITLE
Fix SNSTopicPolicyAnyPrincipal check

### DIFF
--- a/checkov/terraform/checks/resource/aws/SNSTopicPolicyAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/SNSTopicPolicyAnyPrincipal.py
@@ -20,9 +20,12 @@ class SNSTopicPolicyAnyPrincipal(BaseResourceCheck):
         conf_policy = conf.get("policy")
         if conf_policy:
             if isinstance(conf_policy[0], dict):
-                policy = Policy(conf["policy"][0])
-                if policy.is_internet_accessible():
-                    return CheckResult.FAILED
+                try:
+                    policy = Policy(conf["policy"][0])
+                    if policy.is_internet_accessible():
+                        return CheckResult.FAILED
+                except AttributeError:
+                    return CheckResult.UNKNOWN
             else:
                 return CheckResult.UNKNOWN
         return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/aws/SNSTopicPolicyAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/SNSTopicPolicyAnyPrincipal.py
@@ -24,7 +24,7 @@ class SNSTopicPolicyAnyPrincipal(BaseResourceCheck):
                 condition_values = policy.get('Statement', [{}])[0].get('Condition', {}).values()
                 if condition_values and not any(isinstance(condition, dict) for condition in condition_values):
                     return CheckResult.UNKNOWN
-                policy = Policy(conf["policy"][0])
+                policy = Policy(policy)
                 if policy.is_internet_accessible():
                     return CheckResult.FAILED
             else:

--- a/checkov/terraform/checks/resource/aws/SNSTopicPolicyAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/SNSTopicPolicyAnyPrincipal.py
@@ -20,12 +20,13 @@ class SNSTopicPolicyAnyPrincipal(BaseResourceCheck):
         conf_policy = conf.get("policy")
         if conf_policy:
             if isinstance(conf_policy[0], dict):
-                try:
-                    policy = Policy(conf["policy"][0])
-                    if policy.is_internet_accessible():
-                        return CheckResult.FAILED
-                except AttributeError:
+                policy = conf_policy[0]
+                condition_values = policy.get('Statement', [{}])[0].get('Condition', {}).values()
+                if condition_values and not any(isinstance(condition, dict) for condition in condition_values):
                     return CheckResult.UNKNOWN
+                policy = Policy(conf["policy"][0])
+                if policy.is_internet_accessible():
+                    return CheckResult.FAILED
             else:
                 return CheckResult.UNKNOWN
         return CheckResult.PASSED

--- a/tests/terraform/checks/resource/aws/example_SNSTopicPolicyAnyPrincipal/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SNSTopicPolicyAnyPrincipal/main.tf
@@ -27,7 +27,7 @@ resource "aws_sns_topic_policy" "sns_tp1" {
 POLICY
 }
 
-# pass
+# should return as unknown dou to condition parsing error.
 resource "aws_sns_topic_policy" "sns_tp_unknown" {
   arn = aws_sns_topic.test.arn
 

--- a/tests/terraform/checks/resource/aws/example_SNSTopicPolicyAnyPrincipal/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SNSTopicPolicyAnyPrincipal/main.tf
@@ -27,6 +27,37 @@ resource "aws_sns_topic_policy" "sns_tp1" {
 POLICY
 }
 
+# pass
+resource "aws_sns_topic_policy" "sns_tp_unknown" {
+  arn = aws_sns_topic.test.arn
+
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[
+       {
+          "Principal": "*",
+          "Effect": "Deny",
+          "Action": [
+            "SNS:Subscribe",
+            "SNS:SetTopicAttributes",
+            "SNS:RemovePermission",
+            "SNS:Receive",
+            "SNS:Publish",
+            "SNS:ListSubscriptionsByTopic",
+            "SNS:GetTopicAttributes",
+            "SNS:DeleteTopic",
+            "SNS:AddPermission",
+          ],
+          "Resource": "${aws_sns_topic.test.arn}",
+          "Condition": {'StringEquals': 'AWS:SourceOwner'}
+       }
+    ]
+}
+POLICY
+}
+
+
 # fail
 resource "aws_sns_topic_policy" "sns_tp2" {
   arn = aws_sns_topic.test.arn


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fixed an issue where `SNSTopicPolicyAnyPrincipal` check failed on - 
`AttributeError: 'str' object has no attribute 'items'`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
