### PR TITLE
Update --client-ca-file in KubeletClientCa check (CKV_K8S_140)

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/ApiServerEtcdCaFile.py
+++ b/checkov/kubernetes/checks/resource/k8s/ApiServerEtcdCaFile.py
@@ -8,7 +8,7 @@ from checkov.kubernetes.checks.resource.k8s.k8s_check_utils import extract_comma
 class ApiServerEtcdCaFile(BaseK8sContainerCheck):
     def __init__(self) -> None:
         id = "CKV_K8S_102"
-        name = "Ensure that the --etcd-ca-file argument is set as appropriate"
+        name = "Ensure that the --etcd-cafile argument is set as appropriate"
         super().__init__(name=name, id=id)
 
     def scan_container_conf(self, metadata: Dict[str, Any], conf: Dict[str, Any]) -> CheckResult:
@@ -16,7 +16,7 @@ class ApiServerEtcdCaFile(BaseK8sContainerCheck):
         keys, values = extract_commands(conf)
 
         if "kube-apiserver" in keys:
-            if "--etcd-ca-file" not in keys:
+            if "--etcd-cafile" not in keys:
                 return CheckResult.FAILED
 
         return CheckResult.PASSED

--- a/checkov/kubernetes/checks/resource/k8s/KubeletClientCa.py
+++ b/checkov/kubernetes/checks/resource/k8s/KubeletClientCa.py
@@ -13,16 +13,14 @@ class KubeletClientCa(BaseK8sContainerCheck):
 
     def scan_container_conf(self, metadata: Dict[str, Any], conf: Dict[str, Any]) -> CheckResult:
         self.evaluated_container_keys = ["command"]
-        if conf.get("command"):
+        if conf.get("command") is not None:
             if "kubelet" in conf["command"]:
+                hasClientCaFile = False
                 for command in conf["command"]:
-                    if command.startswith("--root-ca-file"):
-                        file_name = command.split("=")[1]
-                        extension = file_name.split(".")[1]
-                        if extension == "pem":
-                            return CheckResult.PASSED
-                        else:
-                            return CheckResult.FAILED
+                    if command.startswith("--client-ca-file"):
+                        if len(command.split("=")) == 2:
+                            hasClientCaFile = True
+                return CheckResult.PASSED if hasClientCaFile else CheckResult.FAILED
 
         return CheckResult.PASSED
 

--- a/tests/kubernetes/checks/example_ApiServerEtcdCaFile/example_ApiServerEtcdCaFile-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerEtcdCaFile/example_ApiServerEtcdCaFile-PASSED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    - --etcd-ca-file=ca.file
+    - --etcd-cafile=ca.file
     image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
     livenessProbe:
       failureThreshold: 8

--- a/tests/kubernetes/checks/example_KubeletClientCa/KubeletClientCa-FAILED.yaml
+++ b/tests/kubernetes/checks/example_KubeletClientCa/KubeletClientCa-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kubelet
-    - --root-ca-file=test.key
+    - --root-ca-file=test.pem
     image: gcr.io/google_containers/kubelet-amd64:v1.6.0
     livenessProbe:
       failureThreshold: 8

--- a/tests/kubernetes/checks/example_KubeletClientCa/KubeletClientCa-PASSED.yaml
+++ b/tests/kubernetes/checks/example_KubeletClientCa/KubeletClientCa-PASSED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kubelet
-    - --root-ca-file=test.pem
+    - --client-ca-file=/path/to/ca
     image: gcr.io/google_containers/kubelet-amd64:v1.6.0
     livenessProbe:
       failureThreshold: 8


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

- The parameter `--client-ca-file` in the KubeletClientCa.py is not checked, instead `--root-ca-file` is checked. So raising a PR with the correct parameter.

- Kubernetes Check # `CKV_K8S_102`

Fixes # (issue)
- `--root-ca-file` to `--client-ca-file`
- Also, updated the examples.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
