### PR TITLE
Handle non-list ipv4_enabled in check GoogleCloudSqlServerNoPublicIP

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleCloudSqlServerNoPublicIP.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudSqlServerNoPublicIP.py
@@ -22,7 +22,9 @@ class GoogleCloudSqlServerNoPublicIP(BaseResourceCheck):
         if 'settings' in conf.keys() and 'ip_configuration' in conf['settings'][0] and \
                 'ipv4_enabled' in conf['settings'][0]['ip_configuration'][0]:
             ipconfiguration = conf['settings'][0]['ip_configuration'][0]
-            if ipconfiguration['ipv4_enabled'][0]:
+            ipv4_enabled = ipconfiguration['ipv4_enabled']
+            ipv4_enabled = ipv4_enabled[0] if isinstance(ipv4_enabled, list) else ipv4_enabled
+            if ipv4_enabled:
                 self.evaluated_keys = ['database_version/[0]/SQLSERVER',
                                        'settings/[0]/ip_configuration/[0]/ipv4_enabled']
                 return CheckResult.FAILED

--- a/tests/terraform/checks/resource/gcp/example_CloudSQLServerNoPublicIP/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_CloudSQLServerNoPublicIP/main.tf
@@ -172,3 +172,57 @@ resource "google_sql_database_instance" "pass4" {
     availability_type = "ZONAL"
   }
 }
+
+resource "google_sql_database_instance" "fail_not_list" {
+  database_version = "SQLSERVER_2017_STANDARD"
+  name             = "general-sqlserver12"
+  project          = "gcp-bridgecrew-deployment"
+  region           = "us-central1"
+
+  settings {
+    activation_policy = "ALWAYS"
+    availability_type = "ZONAL"
+
+    backup_configuration {
+      binary_log_enabled             = false
+      enabled                        = true
+      location                       = "us"
+      point_in_time_recovery_enabled = false
+      start_time                     = "00:00"
+    }
+
+
+    database_flags {
+      name  = "cross db ownership chaining"
+      value = "off"
+    }
+
+    database_flags {
+      name  = "contained database authentication"
+      value = "off"
+    }
+
+    disk_autoresize = true
+    disk_size       = "20"
+    disk_type       = "PD_SSD"
+
+    ip_configuration = {
+      ipv4_enabled    = true
+      private_network = "projects/gcp-bridgecrew-deployment/global/networks/default"
+      require_ssl     = "false"
+    }
+
+    location_preference {
+      zone = "us-central1-a"
+    }
+
+    maintenance_window {
+      day  = "1"
+      hour = "0"
+    }
+
+    pricing_plan = "PER_USE"
+
+    tier = "db-custom-1-4096"
+  }
+}

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlServerNoPublicIP.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlServerNoPublicIP.py
@@ -26,13 +26,14 @@ class TestGoogleCloudSqlServerNoPublicIP(unittest.TestCase):
 
         failing_resources = {
             "google_sql_database_instance.fail",
+            "google_sql_database_instance.fail_not_list",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
         self.assertEqual(summary["passed"], 4)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Handled an edge case where the `ipv4_enabled` attributes is not parsed in a list, and causes the run to get an exceotion.


## New/Edited policies (Delete if not relevant)
`terraform/CKV_GCP_60`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
