### PR TITLE
Catch UnicodeDecodeError exception when trying to parse helm chart

### DIFF
--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -79,7 +79,7 @@ class Runner(BaseRunner):
         with open(f"{chart_path}/Chart.yaml", 'r') as chartyaml:
             try:
                 chart_meta = yaml.safe_load(chartyaml)
-            except yaml.YAMLError:
+            except (yaml.YAMLError, UnicodeDecodeError):
                 logging.info(f"Failed to load chart metadata from {chart_path}/Chart.yaml.", exc_info=True)
                 return None
         return chart_meta


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Catch UnicodeDecodeError exception when trying to parse helm chart


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
