### PR TITLE
adding the license also for packages without cves

### DIFF
--- a/checkov/sca_package/runner.py
+++ b/checkov/sca_package/runner.py
@@ -189,6 +189,7 @@ class Runner(BaseRunner):
                         vulnerability_details={
                             "package_name": package["name"],
                             "package_version": package["version"],
+                            "licenses": ', '.join(licenses_per_package_map[get_package_alias(package["name"], package["version"])]) or 'Unknown',
                         }
                     )
                 )

--- a/tests/sca_package/conftest.py
+++ b/tests/sca_package/conftest.py
@@ -382,6 +382,14 @@ def scan_result() -> List[Dict[str, Any]]:
                     "license": "DUMMY_OTHER_LICENSE",  # not a real license. it is just for test a package with 2 licenses
                     "status": "OPEN",
                     "policy": "BC_LIC_1"
+                },
+                {
+                    "packageName": "requests",
+                    "packageVersion": "2.26.0",
+                    "packageLang": "python",
+                    "license": "OSI_APACHE",
+                    "status": "COMPLIANT",
+                    "policy": "BC_LIC_1"
                 }
             ],
         },

--- a/tests/sca_package/test_runner.py
+++ b/tests/sca_package/test_runner.py
@@ -31,9 +31,10 @@ def test_run(mocker: MockerFixture, scan_result):
         "path/to/go.sum.golang.org/x/crypto",
         "path/to/requirements.txt.django",
         "path/to/requirements.txt.flask",
+        "path/to/requirements.txt.requests",
         "path/to/sub/requirements.txt.requests",
     }
-    assert len(report.passed_checks) == 3
+    assert len(report.passed_checks) == 4
     assert len(report.failed_checks) == 9
     assert len(report.skipped_checks) == 0
     assert len(report.parsing_errors) == 0
@@ -72,6 +73,11 @@ def test_run(mocker: MockerFixture, scan_result):
     assert "licenses" in cve_record_with_2_license.vulnerability_details
     assert cve_record_with_2_license.vulnerability_details["licenses"] == "OSI_APACHE, DUMMY_OTHER_LICENSE"
 
+    extra_resource = next((c for c in report.extra_resources if c.resource == "path/to/requirements.txt.requests"), None)
+    assert extra_resource is not None
+    assert "licenses" in extra_resource.vulnerability_details
+    assert extra_resource.vulnerability_details["licenses"] == "OSI_APACHE"
+
 
 def test_run_with_empty_scan_result(mocker: MockerFixture):
     # given
@@ -106,9 +112,10 @@ def test_run_with_skip(mocker: MockerFixture, scan_result):
         "path/to/go.sum.golang.org/x/crypto",
         "path/to/requirements.txt.django",
         "path/to/requirements.txt.flask",
+        "path/to/requirements.txt.requests",
         "path/to/sub/requirements.txt.requests",
     }
-    assert len(report.passed_checks) == 3
+    assert len(report.passed_checks) == 4
     assert len(report.failed_checks) == 8
     assert len(report.skipped_checks) == 1
     assert len(report.parsing_errors) == 0

--- a/tests/sca_package/test_runner.py
+++ b/tests/sca_package/test_runner.py
@@ -63,6 +63,8 @@ def test_run(mocker: MockerFixture, scan_result):
         packaging_version.parse("v0.0.0-20201216223049-8b5274cf687f"),
     ]
 
+    # making sure cve-records have licenses (the one belongs to the associated package) - this data will be printed
+    # as part of the BON report.
     cve_record_with_license = next((c for c in report.failed_checks if c.resource == "path/to/requirements.txt.django" and c.check_name == "SCA package scan"), None)
     assert cve_record_with_license is not None
     assert "licenses" in cve_record_with_license.vulnerability_details
@@ -73,6 +75,8 @@ def test_run(mocker: MockerFixture, scan_result):
     assert "licenses" in cve_record_with_2_license.vulnerability_details
     assert cve_record_with_2_license.vulnerability_details["licenses"] == "OSI_APACHE, DUMMY_OTHER_LICENSE"
 
+    # making sure extra-resources (a scanned packages without cves) also have licenses - this data will be printed
+    # as part of the BON report.
     extra_resource = next((c for c in report.extra_resources if c.resource == "path/to/requirements.txt.requests"), None)
     assert extra_resource is not None
     assert "licenses" in extra_resource.vulnerability_details


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
* adding the license also for packages without cves
* testing the licenses are added to extra_resource in the sca-package runner

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
