### PR TITLE
change github org schema and add UT

### DIFF
--- a/checkov/github/schemas/org_security.py
+++ b/checkov/github/schemas/org_security.py
@@ -31,12 +31,19 @@ class OrgSecuritySchema(VCSSchema):
                                     "type": "boolean"
                                 },
                                 "samlIdentityProvider": {
-                                    "type": "object",
-                                    "properties": {
-                                        "ssoUrl": {
-                                            "type": "string"
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "ssoUrl": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
                                         }
-                                    }
+                                    ]
                                 }
                             },
                             "required": [

--- a/tests/github/test_dal.py
+++ b/tests/github/test_dal.py
@@ -1,0 +1,28 @@
+import os
+from unittest import mock
+
+from pytest_mock import MockerFixture
+
+from checkov.github.dal import Github
+
+
+@mock.patch.dict(os.environ, {"GITHUB_ORG": "simpleOrg"}, clear=True)
+def test_org_security(mocker: MockerFixture):
+    dal = Github()
+    mock_data = {
+        "data": {
+            "organization": {
+                "name": "Bridgecrew",
+                "login": "Bridgecrew-dev",
+                "description": "",
+                "ipAllowListEnabledSetting": "DISABLED",
+                "ipAllowListForInstalledAppsEnabledSetting": "DISABLED",
+                "requiresTwoFactorAuthentication": False,
+                "samlIdentityProvider": None
+            }
+        }
+    }
+    graphql_mock = mocker.MagicMock(return_value=mock_data)
+    mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request_graphql", graphql_mock)
+    result = dal.get_organization_security()
+    assert result

--- a/tests/github/test_dal.py
+++ b/tests/github/test_dal.py
@@ -22,7 +22,6 @@ def test_org_security(mocker: MockerFixture):
             }
         }
     }
-    graphql_mock = mocker.MagicMock(return_value=mock_data)
-    mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request_graphql", graphql_mock)
+    mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request_graphql", return_value=mock_data)
     result = dal.get_organization_security()
     assert result


### PR DESCRIPTION

This PR fixes an issue with checkov github VCS flow.
Github graphql API can return null for some objects (unless they are explicitly defined as non null).
samlIdentityProvider can be null, but since our schema does not take it into account, it fails json validation and ignores the organization. This silent ignore causes this issue to remain hidden.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
