### PR TITLE
Safely accessing type of kustomize file

### DIFF
--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -169,8 +169,8 @@ class Runner(BaseRunner):
         # We need parse some of the Kustomization.yaml files to work out which
         # This is so we can provide "Environment" information back to the user as part of the checked resource name/description.
         # TODO: We could also add a --kustomize-environment option so we only scan certain overlay names (prod, test etc) useful in CI.
-        yaml_path = os.path.join(parseKustomizationData,"kustomization.yaml")
-        yml_path = os.path.join(parseKustomizationData,"kustomization.yml")
+        yaml_path = os.path.join(parseKustomizationData, "kustomization.yaml")
+        yml_path = os.path.join(parseKustomizationData, "kustomization.yml")
         if os.path.isfile(yml_path):
             kustomization_path = yml_path
         elif os.path.isfile(yaml_path):
@@ -333,13 +333,13 @@ class Runner(BaseRunner):
         proc = subprocess.Popen([templateRendererCommand, templateRenderCommandOptions, filePath], stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # nosec
         output, _ = proc.communicate()
         logging.info(
-            f"Ran kubectl to build Kustomize output. DIR: {filePath}. TYPE: {kustomizeProcessedFolderAndMeta[filePath]['type']}.")
+            f"Ran kubectl to build Kustomize output. DIR: {filePath}. TYPE: {kustomizeProcessedFolderAndMeta[filePath].get('type')}.")
         return output
 
     @staticmethod
     def _get_env_or_base_path_prefix(filePath, kustomizeProcessedFolderAndMeta) -> str:
         env_or_base_path_prefix = None
-        if kustomizeProcessedFolderAndMeta[filePath]['type'] == "overlay":
+        if kustomizeProcessedFolderAndMeta[filePath].get('type') == "overlay":
             if 'calculated_bases' not in kustomizeProcessedFolderAndMeta[filePath]:
                 logging.debug(f"Kustomize: Overlay with unknown base. User may have specified overlay dir directly. {filePath}")
                 env_or_base_path_prefix = ""
@@ -348,7 +348,7 @@ class Runner(BaseRunner):
                 mostSignificantBasePath = "/" + basePathParents._parts[-3] + "/" + basePathParents._parts[-2] + "/" + basePathParents._parts[-1]
                 env_or_base_path_prefix = f"{mostSignificantBasePath}/{kustomizeProcessedFolderAndMeta[filePath]['overlay_name']}"
 
-        if kustomizeProcessedFolderAndMeta[filePath]['type'] == "base":
+        if kustomizeProcessedFolderAndMeta[filePath].get('type') == "base":
             # Validated base last three parents as a path
             basePathParents = pathlib.Path(kustomizeProcessedFolderAndMeta[filePath]['filePath']).parents
             mostSignificantBasePath = "/" + basePathParents._parts[-4] + "/" + basePathParents._parts[-3] + "/" + basePathParents._parts[-2]
@@ -358,7 +358,7 @@ class Runner(BaseRunner):
 
     @staticmethod
     def _run_kustomize_parser(filePath, sharedKustomizeFileMappings, kustomizeProcessedFolderAndMeta, templateRendererCommand, target_folder_path):
-        logging.debug(f"Kustomization at {filePath} likley a {kustomizeProcessedFolderAndMeta[filePath]['type']}")
+        logging.debug(f"Kustomization at {filePath} likley a {kustomizeProcessedFolderAndMeta[filePath].get('type')}")
         try:
             output = Runner._get_kubectl_output(filePath, templateRendererCommand, kustomizeProcessedFolderAndMeta)
         except Exception:

--- a/tests/kustomize/runner/resources/no_type/kustomization.yaml
+++ b/tests/kustomize/runner/resources/no_type/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+secretGenerator:
+- literals:
+  - db-password=12345
+  name: sl-demo-app
+  type: Opaque
+
+images:
+- name: foo/bar
+  newName: foo/bar
+  newTag: 3.4.5

--- a/tests/kustomize/test_runner.py
+++ b/tests/kustomize/test_runner.py
@@ -2,9 +2,6 @@ import os
 import unittest
 from pathlib import Path
 
-# from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as metadata_integration
-#
-# from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.bridgecrew.severities import Severities, BcSeverities
 from checkov.runner_filter import RunnerFilter

--- a/tests/kustomize/test_runner.py
+++ b/tests/kustomize/test_runner.py
@@ -47,7 +47,7 @@ class TestRunnerValid(unittest.TestCase):
         runner.templateRendererCommandOptions = "build"
         checks_allowlist = ['CKV_K8S_37']
         report = runner.run(root_folder=dir_rel_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='kustomize', checks=checks_allowlist))
+                            runner_filter=RunnerFilter(framework=['kustomize'], checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
         self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
@@ -72,7 +72,7 @@ class TestRunnerValid(unittest.TestCase):
         runner.templateRendererCommandOptions = "build"
         checks_allowlist = ['CKV_K8S_37']
         report = runner.run(root_folder=dir_rel_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='kustomize', checks=checks_allowlist))
+                            runner_filter=RunnerFilter(framework=['kustomize'], checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
         self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
@@ -97,14 +97,34 @@ class TestRunnerValid(unittest.TestCase):
         runner.templateRendererCommandOptions = "build"
         checks_allowlist = ['CKV_K8S_37']
         report = runner.run(root_folder=dir_rel_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='kustomize', checks=checks_allowlist))
+                            runner_filter=RunnerFilter(framework=['kustomize'], checks=checks_allowlist))
 
         all_checks = report.failed_checks + report.passed_checks
         self.assertGreater(len(all_checks), 0)  # ensure that the assertions below are going to do something
         for record in all_checks:
             # Kustomize deals with absolute paths
             # self.assertEqual(record.repo_file_path in record.file_path)
-            self.assertIn(record.repo_file_path, record.file_path)
+            self.assertIn(record.repo_file_path, record.file_path)\
+    
+    @unittest.skipIf(os.name == "nt", "Skipping Kustomize test for windows OS.")
+    def test_no_file_type_exists(self):
+        # test whether the record's repo_file_path is correct, relative to the CWD (with a / at the start).
+
+        # this is just constructing the scan dir as normal
+        scan_dir_path = Path(__file__).parent / "runner/resources/no_type"
+
+
+        # this is the relative path to the directory to scan (what would actually get passed to the -d arg)
+        dir_rel_path = os.path.relpath(scan_dir_path).replace('\\', '/')
+
+        runner = Runner()
+        runner.templateRendererCommand = "kustomize"
+        runner.templateRendererCommandOptions = "build"
+        report = runner.run(root_folder=dir_rel_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework=['kustomize']))
+
+        all_checks = report.failed_checks + report.passed_checks
+        self.assertEqual(len(all_checks), 0)  # we should no get any results
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
Fixing an issue where kustomize runner fails to run when a file type is not determined.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
