### PR TITLE
Pass correct GHA resource id through image details

### DIFF
--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -9,7 +9,8 @@ import docker
 
 
 class Image:
-    def __init__(self, file_path: str, name: str, start_line: int, end_line: int) -> None:
+    def __init__(self, file_path: str, name: str, start_line: int, end_line: int,
+                 related_resource_id: str | None = None) -> None:
         """
 
         :param file_path: example: 'checkov/integration_tests/example_workflow_file/.github/workflows/vulnerable_container.yaml'
@@ -22,6 +23,7 @@ class Image:
         self.start_line = start_line
         self.name = name
         self.file_path = file_path
+        self.related_resource_id = related_resource_id
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, self.__class__):

--- a/checkov/github_actions/runner.py
+++ b/checkov/github_actions/runner.py
@@ -60,6 +60,21 @@ class Runner(YamlRunner, ImageReferencer):
             new_key = f'jobs.{job_name}.steps.{step_name}'
         return new_key
 
+    @staticmethod
+    def generate_resource_key(definition: dict[str, Any], start_line: int, end_line: int) -> str:
+        """
+        Generate resource key without the previous format of key (needed in get_resource)
+        """
+        jobs_dict: dict[str, Any] = definition.get("jobs", {})
+        for job_name, job in jobs_dict.items():
+            if not isinstance(job, dict):
+                continue
+
+            if job[START_LINE] <= start_line <= end_line <= job[END_LINE]:
+                return f'jobs.{job_name}'
+
+        return ''
+
     def get_images(self, file_path: str) -> set[Image]:
         """
         Get container images mentioned in a file
@@ -113,6 +128,7 @@ class Runner(YamlRunner, ImageReferencer):
                         name=image,
                         start_line=start_line,
                         end_line=end_line,
+                        related_resource_id=Runner.generate_resource_key(workflow, start_line, end_line)
                     )
                     images.add(image_obj)
 

--- a/tests/github_actions/test_runner_resource_names.py
+++ b/tests/github_actions/test_runner_resource_names.py
@@ -42,3 +42,36 @@ def test_get_resource(key, expected_key, definition):
     new_key = runner.get_resource("", key, [], definition)
 
     assert new_key == expected_key
+
+
+@pytest.mark.parametrize(
+    "start_line,end_line,expected_key",
+    [
+        (9, 17, "jobs.container-test-job"),
+        (24, 30, "jobs.second_job"),
+        (35, 40, "")
+    ],
+)
+def test_generate_resource_key(start_line, end_line, expected_key, definition):
+    runner = Runner()
+
+    key = runner.generate_resource_key(definition, start_line, end_line)
+
+    assert key == expected_key
+
+
+@pytest.mark.parametrize(
+    "start_line,end_line,old_key_format,expected_key",
+    [
+        (9, 17, 'jobs.container-test-job.CKV_GHA_3[7:23]', "jobs.container-test-job"),
+        (24, 30, "jobs.second_job.CKV_GHA_3[24:30]", "jobs.second_job")
+    ],
+)
+def test_generate_resource_key_generates_same_key_as_get_resource(start_line, end_line, old_key_format, expected_key, definition):
+    runner = Runner()
+
+    key1 = runner.get_resource("", old_key_format, [], definition)
+    key2 = runner.generate_resource_key(definition, start_line, end_line)
+
+    assert key1 == key2 == expected_key
+


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
Adding correct GHA resource id to Image class

added uts to test that the resource id generated is identical to the resource id generated while running through the checks.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
