### PR TITLE
add check if env var is set on conf with null value

### DIFF
--- a/checkov/github_actions/checks/job/AllowUnsecureCommandsOnJob.py
+++ b/checkov/github_actions/checks/job/AllowUnsecureCommandsOnJob.py
@@ -20,7 +20,7 @@ class AllowUnsecureCommandsOnJob(BaseGithubActionsCheck):
     def scan_entity_conf(self, conf: Dict[str, Any]) -> Tuple[CheckResult, Dict[str, Any]]:
         if not isinstance(conf, dict):
             return CheckResult.UNKNOWN, conf
-        if "env" not in conf:
+        if "env" not in conf or not conf["env"]:
             return CheckResult.PASSED, conf
         env_variables = conf.get("env", {})
         if env_variables.get("ACTIONS_ALLOW_UNSECURE_COMMANDS", False):


### PR DESCRIPTION

## Description

This PR fixes an issue with checkov AllowUnsecureCommandsOnJob check. Conf objects can be set with null env, which crashes on access. This fix will prevent that access.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
