### PR TITLE
fail license and cache requests silently

### DIFF
--- a/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
@@ -117,27 +117,33 @@ class ImageScanner:
     @staticmethod
     def get_scan_results_from_cache(image_id: str) -> Dict[str, Any]:
         image_id_encode = quote_plus(image_id)
-        response = request_wrapper(
-            "GET", f"{bc_integration.api_url}/api/v1/vulnerabilities/scan-results/{image_id_encode}",
-            headers=bc_integration.get_default_headers("GET"), should_call_raise_for_status=True
-        )
-        response_json = response.json()
-        output_type = response_json["outputType"]
 
-        logging.info(f"{output_type} returned from cache")
-
-        if output_type == "Error":
-            logging.error(response_json["outputData"])
-            return {}
-
-        elif output_type == "Result":
-            result: dict[str, Any] = json.loads(
-                decompress_file_gzip_base64(
-                    response_json["outputData"]
-                )
+        try:
+            response = request_wrapper(
+                "GET", f"{bc_integration.api_url}/api/v1/vulnerabilities/scan-results/{image_id_encode}",
+                headers=bc_integration.get_default_headers("GET"), should_call_raise_for_status=True
             )
-            return result
-        logging.info(f"Got an empty result for image={image_id}")
+            response_json = response.json()
+            output_type = response_json["outputType"]
+
+            logging.info(f"{output_type} returned from cache")
+
+            if output_type == "Error":
+                logging.error(response_json["outputData"])
+                return {}
+
+            elif output_type == "Result":
+                result: dict[str, Any] = json.loads(
+                    decompress_file_gzip_base64(
+                        response_json["outputData"]
+                    )
+                )
+                return result
+
+            logging.info(f"Got an empty result for image={image_id}")
+        except Exception:
+            logging.info("Failed to retrieve image cache result", exc_info=True)
+
         return {}
 
     def should_download(self) -> bool:

--- a/checkov/common/sca/output.py
+++ b/checkov/common/sca/output.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
@@ -299,9 +300,11 @@ def get_license_statuses(packages: list[dict[str, Any]]) -> list[_LicenseStatus]
             for license_violation in response_json.get("violations", [])
         ]
         return license_statuses
-    except Exception as e:
+    except Exception:
         error_message = (
             "failing when trying to get licenses-violations. it is apparently some unexpected "
             "connection issue. please try later. in case it keep happening. please report."
         )
-        raise Exception(error_message) from e
+        logging.info(error_message, exc_info=True)
+
+    return []

--- a/tests/common/sca/test_output.py
+++ b/tests/common/sca/test_output.py
@@ -1,3 +1,6 @@
+import os
+from unittest import mock
+
 import responses
 
 from checkov.common.sca.output import get_license_statuses
@@ -54,3 +57,26 @@ def test_licenses_status(mock_bc_integration):
             "status": "COMPLIANT",
         },
     ]
+
+
+@mock.patch.dict(os.environ, {"REQUEST_MAX_TRIES": "1", "SLEEP_BETWEEN_REQUEST_TRIES": "0.01"})
+@responses.activate
+def test_licenses_status_on_failure(mock_bc_integration):
+    # given
+    packages_input = [
+        {"name": "docutils", "version": "0.15.2", "lang": "python"},
+        {"name": "github.com/apparentlymart/go-textseg/v12", "version": "v12.0.0", "lang": "go"}
+    ]
+
+    responses.add(
+        method=responses.POST,
+        url=mock_bc_integration.bc_api_url + "/api/v1/vulnerabilities/packages/get-licenses-violations",
+        status=500
+    )
+
+    # when
+    # we expect no failure here, in case of a http/connection error
+    license_statuses = get_license_statuses(packages_input)
+
+    # then
+    assert len(license_statuses) == 0

--- a/tests/sca_image/test_runner.py
+++ b/tests/sca_image/test_runner.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.parse import quote_plus
 import responses
-import os
 from unittest import mock
 
 from checkov.common.bridgecrew.check_type import CheckType
@@ -125,30 +124,6 @@ def test_runner_honors_enforcement_rules(mock_bc_integration, image_name, cached
     assert summary["failed"] == 0
     assert summary["skipped"] == 5
     assert summary["parsing_errors"] == 0
-
-
-@mock.patch.dict(os.environ, {"REQUEST_MAX_TRIES": "1", "SLEEP_BETWEEN_REQUEST_TRIES": "0.01"})
-@responses.activate
-def test_licenses_status_on_failure(mock_bc_integration):
-    packages_input = [
-        {"name": "docutils", "version": "0.15.2", "lang": "python"},
-        {"name": "github.com/apparentlymart/go-textseg/v12", "version": "v12.0.0", "lang": "go"}
-    ]
-
-    # given
-    responses.add(
-        method=responses.POST,
-        url=mock_bc_integration.bc_api_url + "/api/v1/vulnerabilities/packages/get-licenses-violations",
-        status=500
-    )
-
-    image_runner = Runner()
-    try:
-        # we expect to have failure here, in case the of http/connection error
-        image_runner.get_license_statuses(packages_input)
-        assert False
-    except:
-        assert True
 
 
 @mock.patch('checkov.sca_image.runner.Runner.scan', mock_scan)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

- instead of raising an exception while trying to interact with our backend for cache hits and licenses, just log it 🙂 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
