### PR TITLE
normalize the language name gem to be ruby

### DIFF
--- a/checkov/common/sca/commons.py
+++ b/checkov/common/sca/commons.py
@@ -3,6 +3,9 @@ from checkov.common.output.common import ImageDetails
 
 UNFIXABLE_VERSION = "N/A"
 
+TWISTCLI_TO_CHECKOV_LANG_NORMALIZATION = {
+    "gem": "ruby"
+}
 
 def get_file_path_for_record(rootless_file_path: str) -> str:
     return f"/{rootless_file_path}"
@@ -21,3 +24,11 @@ def get_package_type(package_name: str, package_version: str, image_details: Ima
         return str(image_details.package_types.get(f"{package_name}@{package_version}", ""))
     else:
         return ""
+
+
+def normalize_twistcli_language(language: str) -> str:
+    """
+    part of the language names that are returned by twistcli may be a little differ from those we use in checkov.
+    this function's goal is to normalize them
+    """
+    return TWISTCLI_TO_CHECKOV_LANG_NORMALIZATION.get(language, language)

--- a/checkov/common/sca/output.py
+++ b/checkov/common/sca/output.py
@@ -21,6 +21,7 @@ from checkov.common.sca.commons import (
     get_package_alias,
     UNFIXABLE_VERSION,
     get_package_type,
+    normalize_twistcli_language,
 )
 from checkov.common.util.http_utils import request_wrapper
 from checkov.runner_filter import RunnerFilter
@@ -273,11 +274,16 @@ def parse_vulns_to_records(
             )
 
 
-def get_license_statuses(packages: list[dict[str, Any]]) -> list[_LicenseStatus]:
-    requests_input = [
-        {"name": package.get("name", ""), "version": package.get("version", ""), "lang": package.get("type", "")}
+def _get_request_input(packages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {"name": package.get("name", ""), "version": package.get("version", ""),
+         "lang": normalize_twistcli_language(package.get("type", ""))}
         for package in packages
     ]
+
+
+def get_license_statuses(packages: list[dict[str, Any]]) -> list[_LicenseStatus]:
+    requests_input = _get_request_input(packages)
     if not requests_input:
         return []
     try:

--- a/tests/common/sca/test_commons.py
+++ b/tests/common/sca/test_commons.py
@@ -1,0 +1,21 @@
+from checkov.common.sca.commons import normalize_twistcli_language
+
+
+def test_normalize_twistcli_language_for_gem():
+    assert normalize_twistcli_language("gem") == "ruby"
+
+
+def test_normalize_twistcli_language_for_ruby():
+    assert normalize_twistcli_language("ruby") == "ruby"
+
+
+def test_normalize_twistcli_language_for_empty():
+    assert normalize_twistcli_language("") == ""
+
+
+def test_normalize_twistcli_language_for_invalid():
+    assert normalize_twistcli_language("bbb") == "bbb"
+
+
+def test_normalize_twistcli_language_for_python():
+    assert normalize_twistcli_language("python") == "python"

--- a/tests/common/sca/test_output.py
+++ b/tests/common/sca/test_output.py
@@ -3,7 +3,28 @@ from unittest import mock
 
 import responses
 
-from checkov.common.sca.output import get_license_statuses
+from checkov.common.sca.output import get_license_statuses, _get_request_input
+
+
+def test_get_request_input():
+    packages_input = [
+        {"name": "docutils", "version": "0.15.2", "type": "python"},
+        {"name": "github.com/apparentlymart/go-textseg/v12", "version": "v12.0.0", "lang": "go"},
+        {"name": "ruby_package", "version": "9.9.9", "type": "ruby"},
+        {"name": "ruby_package2", "version": "8.8.8", "type": "gem"},
+        {"name": "empty_type_package", "version": "8.8.8", "type": ""},
+        {"name": "invalid_type_package", "version": "8.8.8", "type": "bbbbb"}
+    ]
+    request_input = _get_request_input(packages_input)
+
+    assert request_input == [
+        {'name': 'docutils', 'version': '0.15.2', 'lang': 'python'},
+        {'name': 'github.com/apparentlymart/go-textseg/v12', 'version': 'v12.0.0', 'lang': ''},
+        {'name': 'ruby_package', 'version': '9.9.9', 'lang': 'ruby'},
+        {'name': 'ruby_package2', 'version': '8.8.8', 'lang': 'ruby'},
+        {'name': 'empty_type_package', 'version': '8.8.8', 'lang': ''},
+        {'name': 'invalid_type_package', 'version': '8.8.8', 'lang': 'bbbbb'}
+    ]
 
 
 @responses.activate


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
* normalize the language name gem to be ruby before performing API call to the platform. as it is what platform expect

## Description
* testing the normalization
* testing the full request input

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
