### PR TITLE
Fix AllowUnsecureCommandsOnJob check GHA

### DIFF
--- a/checkov/github_actions/checks/job/AllowUnsecureCommandsOnJob.py
+++ b/checkov/github_actions/checks/job/AllowUnsecureCommandsOnJob.py
@@ -23,7 +23,7 @@ class AllowUnsecureCommandsOnJob(BaseGithubActionsCheck):
         if "env" not in conf or not conf["env"]:
             return CheckResult.PASSED, conf
         env_variables = conf.get("env", {})
-        if env_variables.get("ACTIONS_ALLOW_UNSECURE_COMMANDS", False):
+        if isinstance(env_variables, dict) and env_variables.get("ACTIONS_ALLOW_UNSECURE_COMMANDS", False):
             return CheckResult.FAILED, conf
         return CheckResult.PASSED, conf
 

--- a/checkov/github_actions/checks/job/AllowUnsecureCommandsOnJob.py
+++ b/checkov/github_actions/checks/job/AllowUnsecureCommandsOnJob.py
@@ -23,7 +23,10 @@ class AllowUnsecureCommandsOnJob(BaseGithubActionsCheck):
         if "env" not in conf or not conf["env"]:
             return CheckResult.PASSED, conf
         env_variables = conf.get("env", {})
-        if isinstance(env_variables, dict) and env_variables.get("ACTIONS_ALLOW_UNSECURE_COMMANDS", False):
+
+        if not isinstance(env_variables, dict):
+            return CheckResult.UNKNOWN, conf
+        if env_variables.get("ACTIONS_ALLOW_UNSECURE_COMMANDS", False):
             return CheckResult.FAILED, conf
         return CheckResult.PASSED, conf
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

`env` keyword can also be specified as such

```
env: ${{ matrix.config.env }}
```

which breaks the check since it's parsed as a string


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
