### PR TITLE
fix(sca): Revert - Remove commas between licenses in CSV reports (#3391)

### DIFF
--- a/checkov/common/output/csv.py
+++ b/checkov/common/output/csv.py
@@ -84,7 +84,7 @@ class CSVSBOM:
                 "Git Repository": git_repository,
                 "Vulnerability": resource.vulnerability_details.get("id"),
                 "Severity": severity,
-                "Licenses": resource.vulnerability_details.get("licenses", "Unknown").replace(",", ""),
+                "Licenses": resource.vulnerability_details.get("licenses"),
             }
         )
 

--- a/tests/common/output/test_bom_report.py
+++ b/tests/common/output/test_bom_report.py
@@ -233,7 +233,7 @@ class TestBomOutput:
             vulnerability_details={
                 "package_name": "requests",
                 "package_version": "",
-                "licenses": "MIT Apache"
+                "licenses": "MIT, Apache"
             }
         )
 
@@ -251,7 +251,7 @@ class TestBomOutput:
         expected_csv = (
             "Package,Version,Path,Git Org,Git Repository,Vulnerability,Severity,Licenses\n"
             "flask,0.6,/requirements.txt,acme,bridgecrewio/example,CVE-2019-1010083,HIGH,MIT\n"
-            "requests,,/requirements.txt,acme,bridgecrewio/example,,,MIT Apache\n"
+            "requests,,/requirements.txt,acme,bridgecrewio/example,,,\"MIT, Apache\"\n"
         )
 
         assert csv_output == expected_csv
@@ -259,7 +259,7 @@ class TestBomOutput:
         expected_csv = (
             "Package,Version,Path,Git Org,Git Repository,Vulnerability,Severity,Licenses\n"
             "flask,0.6,/requirements.txt,acme,bridgecrewio/example,CVE-2019-1010083,HIGH,\"MIT\"\n"
-            "requests,,/requirements.txt,acme,bridgecrewio/example,,,\"MIT Apache\"\n"
+            "requests,,/requirements.txt,acme,bridgecrewio/example,,,\"MIT, Apache\"\n"
         )
 
         assert csv_output_str == expected_csv


### PR DESCRIPTION
This reverts commit 8c48003ae8aa2bbc48d1e5992db883b186478ce4.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - feat:  to indicate new features or checks
    - fix:   to indicate a bugfix or handling of edge cases of existing checks
    - break: to indicate a breaking change
    - docs:  to indicate an update to our documentation
    - chore: to indicate adjustments to workflow files or dependency updates
    Addtionally we encourage adding a scope to the prefix, which indicates the targeted framework, otherwise 'general' will be assumed.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- nothing to add 😄 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
