### PR TITLE
fix: add missing csv bom report fields

### DIFF
--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -345,7 +345,7 @@ class RunnerRegistry:
     def print_iac_bom_reports(self, output_path: str,
                               scan_reports: list[Report],
                               output_types: list[str],
-                              account_id: str | None = None) -> dict[str, str]:
+                              account_id: str | None = None) -> dict[str, str]: # type:ignore[union-attr]  # None will be removed after method calling print_iac_bom_reports will be removed
 
         output_files = {
             'cyclonedx': 'results_cyclonedx.xml',

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -368,7 +368,10 @@ class RunnerRegistry:
             csv_sbom_report = CSVSBOM()
             for report in scan_reports:
                 if not report.is_empty():
-                    git_org, git_repository = account_id.split('/')
+                    if account_id:
+                        git_org, git_repository = account_id.split('/')
+                    else:
+                        git_org, git_repository = "", ""
                     csv_sbom_report.add_report(report=report, git_org=git_org, git_repository=git_repository)
             csv_sbom_report.persist_report_iac(file_name=output_files['csv'], output_path=output_path)
 

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -345,7 +345,7 @@ class RunnerRegistry:
     def print_iac_bom_reports(self, output_path: str,
                               scan_reports: list[Report],
                               output_types: list[str],
-                              account_id: str = None) -> dict[str, str]:
+                              account_id: str | None = None) -> dict[str, str]:
 
         output_files = {
             'cyclonedx': 'results_cyclonedx.xml',

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -344,7 +344,8 @@ class RunnerRegistry:
 
     def print_iac_bom_reports(self, output_path: str,
                               scan_reports: list[Report],
-                              output_types: list[str]) -> dict[str, str]:
+                              output_types: list[str],
+                              account_id: str = None) -> dict[str, str]:
 
         output_files = {
             'cyclonedx': 'results_cyclonedx.xml',
@@ -367,7 +368,8 @@ class RunnerRegistry:
             csv_sbom_report = CSVSBOM()
             for report in scan_reports:
                 if not report.is_empty():
-                    csv_sbom_report.add_report(report=report, git_org="", git_repository="")
+                    git_org, git_repository = account_id.split('/')
+                    csv_sbom_report.add_report(report=report, git_org=git_org, git_repository=git_repository)
             csv_sbom_report.persist_report_iac(file_name=output_files['csv'], output_path=output_path)
 
         return {key: os.path.join(output_path, value) for key, value in output_files.items()}

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -345,7 +345,7 @@ class RunnerRegistry:
     def print_iac_bom_reports(self, output_path: str,
                               scan_reports: list[Report],
                               output_types: list[str],
-                              account_id: str | None = None) -> dict[str, str]: # type:ignore[union-attr]  # None will be removed after method calling print_iac_bom_reports will be removed
+                              account_id: str | None = None) -> dict[str, str]:  # type:ignore[union-attr]  # None will be removed after method calling print_iac_bom_reports will be removed
 
         output_files = {
             'cyclonedx': 'results_cyclonedx.xml',

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -345,7 +345,7 @@ class RunnerRegistry:
     def print_iac_bom_reports(self, output_path: str,
                               scan_reports: list[Report],
                               output_types: list[str],
-                              account_id: str | None = None) -> dict[str, str]:  # type:ignore[union-attr]  # None will be removed after method calling print_iac_bom_reports will be removed
+                              account_id: str | None = None) -> dict[str, str]:
 
         output_files = {
             'cyclonedx': 'results_cyclonedx.xml',


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

CSV BOM report is missing ```git_org``` and ```git_repository``` fields, this PR adds those to the report

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

