### PR TITLE
fix(terraform): do not evaluate OCI policy statements

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/renderer.py
+++ b/checkov/terraform/graph_builder/variable_rendering/renderer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import re
@@ -26,7 +28,7 @@ if TYPE_CHECKING:
     from checkov.terraform.graph_builder.local_graph import TerraformLocalGraph
 
 ATTRIBUTES_NO_EVAL = ["template_body", "template"]
-VAR_TYPE_DEFAULT_VALUES = {
+VAR_TYPE_DEFAULT_VALUES: dict[str, list[Any] | dict[str, Any]] = {
     'list': [],
     'map': {}
 }
@@ -137,7 +139,7 @@ class TerraformVariableRenderer(VariableRenderer):
             if value is not None:
                 return value
 
-        if attributes.get(CustomAttributes.BLOCK_TYPE) in [BlockType.VARIABLE, BlockType.TF_VARIABLE]:
+        if attributes.get(CustomAttributes.BLOCK_TYPE) in (BlockType.VARIABLE, BlockType.TF_VARIABLE):
             var_type = attributes.get('type')
             default_val = attributes.get("default")
             if default_val is None:
@@ -152,8 +154,8 @@ class TerraformVariableRenderer(VariableRenderer):
         return None
 
     @staticmethod
-    def get_default_placeholder_value(var_type):
-        if not var_type or type(var_type) != str:
+    def get_default_placeholder_value(var_type: Any) -> list[Any] | dict[str, Any] | None:
+        if not var_type or not isinstance(var_type, str):
             return None
         match = TYPE_REGEX.match(var_type)
         return VAR_TYPE_DEFAULT_VALUES.get(match.group(2)) if match else None
@@ -267,7 +269,7 @@ class TerraformVariableRenderer(VariableRenderer):
                 for inner_val in lst_curr_val:
                     if (
                         isinstance(inner_val, str)
-                        and not any(c in inner_val for c in ["{", "}", "[", "]", "="])
+                        and not any(c in inner_val for c in ("{", "}", "[", "]", "="))
                         or attribute in ATTRIBUTES_NO_EVAL
                     ):
                         evaluated_lst.append(inner_val)

--- a/checkov/terraform/graph_builder/variable_rendering/renderer.py
+++ b/checkov/terraform/graph_builder/variable_rendering/renderer.py
@@ -27,7 +27,6 @@ from checkov.terraform.graph_builder.variable_rendering.evaluate_terraform impor
 if TYPE_CHECKING:
     from checkov.terraform.graph_builder.local_graph import TerraformLocalGraph
 
-ATTRIBUTES_NO_EVAL = ["template_body", "template"]
 VAR_TYPE_DEFAULT_VALUES: dict[str, list[Any] | dict[str, Any]] = {
     'list': [],
     'map': {}
@@ -46,7 +45,6 @@ class TerraformVariableRenderer(VariableRenderer):
         if os.environ.get("CKV_TERRAFORM_PROVIDER") == "OCI":
             # OCI policy statements have a special syntax and should not be evaluated.
             self.attributes_no_eval.add("statements")
-
 
     def evaluate_vertex_attribute_from_edge(self, edge_list: List[Edge]) -> None:
         multiple_edges = len(edge_list) > 1

--- a/tests/terraform/graph/graph_builder/test_oci_policy.py
+++ b/tests/terraform/graph/graph_builder/test_oci_policy.py
@@ -1,0 +1,40 @@
+"""Test if OCI policy statements are evaluated correctly."""
+
+import os
+from pathlib import Path
+from unittest import mock
+
+from checkov.common.graph.db_connectors.networkx.networkx_db_connector import NetworkxConnector
+from checkov.terraform.graph_manager import TerraformGraphManager
+
+@mock.patch.dict(os.environ, {"CKV_TERRAFORM_PROVIDER": "OCI"})
+def test_oci_policy_statements_with_provider_env_var():
+    # given
+    resources_dir = Path(__file__).parent.parent / "resources/oci_policies"
+    graph_manager = TerraformGraphManager(db_connector=NetworkxConnector())
+
+    # when
+    local_graph, _ = graph_manager.build_graph_from_source_directory(
+        source_dir=str(resources_dir), render_variables=True
+    )
+
+    # then
+    statements = local_graph.vertices[0].config["oci_identity_policy"]["example"]["statements"][0]
+    assert statements == [
+        "allow group group-admin-001 to use groups in tenancy where target.group.name != 'Administrators'"
+    ]
+
+
+def test_oci_policy_statements_without_provider_env_var():
+    # given
+    resources_dir = Path(__file__).parent.parent / "resources/oci_policies"
+    graph_manager = TerraformGraphManager(db_connector=NetworkxConnector())
+
+    # when
+    local_graph, _ = graph_manager.build_graph_from_source_directory(str(resources_dir), render_variables=True)
+
+    # then
+    statements = local_graph.vertices[0].config["oci_identity_policy"]["example"]["statements"][0]
+    # If CKV_TERRAFORM_PROVIDER is not set to "OCI", Checkov wrongly evaluates this policy statement.
+    # Remove this assertion when Checkov can handle OCI policy statement evaluation.
+    assert statements == ["True"]

--- a/tests/terraform/graph/graph_builder/test_oci_policy.py
+++ b/tests/terraform/graph/graph_builder/test_oci_policy.py
@@ -1,13 +1,11 @@
 """Test if OCI policy statements are evaluated correctly."""
 
-import os
 from pathlib import Path
 from unittest import mock
 
 from checkov.common.graph.db_connectors.networkx.networkx_db_connector import NetworkxConnector
 from checkov.terraform.graph_manager import TerraformGraphManager
 
-@mock.patch.dict(os.environ, {"CKV_TERRAFORM_PROVIDER": "OCI"})
 def test_oci_policy_statements_with_provider_env_var():
     # given
     resources_dir = Path(__file__).parent.parent / "resources/oci_policies"
@@ -23,18 +21,3 @@ def test_oci_policy_statements_with_provider_env_var():
     assert statements == [
         "allow group group-admin-001 to use groups in tenancy where target.group.name != 'Administrators'"
     ]
-
-
-def test_oci_policy_statements_without_provider_env_var():
-    # given
-    resources_dir = Path(__file__).parent.parent / "resources/oci_policies"
-    graph_manager = TerraformGraphManager(db_connector=NetworkxConnector())
-
-    # when
-    local_graph, _ = graph_manager.build_graph_from_source_directory(str(resources_dir), render_variables=True)
-
-    # then
-    statements = local_graph.vertices[0].config["oci_identity_policy"]["example"]["statements"][0]
-    # If CKV_TERRAFORM_PROVIDER is not set to "OCI", Checkov wrongly evaluates this policy statement.
-    # Remove this assertion when Checkov can handle OCI policy statement evaluation.
-    assert statements == ["True"]

--- a/tests/terraform/graph/resources/oci_policies/main.tf
+++ b/tests/terraform/graph/resources/oci_policies/main.tf
@@ -1,0 +1,4 @@
+resource "oci_identity_policy" "example" {
+    compartment_id = var.tenancy_id
+    statements = ["allow group group-admin-001 to use groups in tenancy where target.group.name != 'Administrators'"]
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally we encourage adding a scope to the prefix, which indicates the targeted framework, otherwise 'general' will be assumed.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Checkov currently evaluates the `statements` attributes of a Terraform resource, which contain IAM policies. However, the syntax of the policies differ for different providers, which results in unexpected evaluations. Oracle Cloud Infrastructure uses a [special syntax](https://docs.oracle.com/en-us/iaas/Content/Identity/Concepts/policysyntax.htm) for the policy statements, but Checkov seems to try to evaluate it as a JSON object. 

Here is a solution which prevents evaluating the `statements` attributes when the provider is set to `OCI` through an environment variable.

Closes https://github.com/bridgecrewio/checkov/issues/3412
