### PR TITLE
fix: fix git info extraction from account_id in bom report

### DIFF
--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -368,10 +368,7 @@ class RunnerRegistry:
             csv_sbom_report = CSVSBOM()
             for report in scan_reports:
                 if not report.is_empty():
-                    if account_id:
-                        git_org, git_repository = account_id.split('/')
-                    else:
-                        git_org, git_repository = "", ""
+                    git_org, git_repository = self.extract_git_info_from_account_id(account_id)
                     csv_sbom_report.add_report(report=report, git_org=git_org, git_repository=git_repository)
             csv_sbom_report.persist_report_iac(file_name=output_files['csv'], output_path=output_path)
 
@@ -463,3 +460,17 @@ class RunnerRegistry:
                 for result_dict in result:
                     result_dict["code_block"] = None
                     result_dict["connected_node"] = None
+
+    @staticmethod
+    def extract_git_info_from_account_id(account_id: str) -> tuple[str, str]:
+        if account_id:
+            try:
+                account_id_list = account_id.split('/')
+                git_org = '/'.join(account_id_list[0:-1])
+                git_repository = account_id_list[-1]
+            except Exception:
+                git_org, git_repository = "", ""
+        else:
+            git_org, git_repository = "", ""
+
+        return git_org, git_repository

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -462,7 +462,7 @@ class RunnerRegistry:
                     result_dict["connected_node"] = None
 
     @staticmethod
-    def extract_git_info_from_account_id(account_id: str) -> tuple[str, str]:
+    def extract_git_info_from_account_id(account_id: str | None) -> tuple[str, str]:
         if account_id:
             try:
                 account_id_list = account_id.split('/')

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -463,13 +463,10 @@ class RunnerRegistry:
 
     @staticmethod
     def extract_git_info_from_account_id(account_id: str | None) -> tuple[str, str]:
-        if account_id:
-            try:
-                account_id_list = account_id.split('/')
-                git_org = '/'.join(account_id_list[0:-1])
-                git_repository = account_id_list[-1]
-            except Exception:
-                git_org, git_repository = "", ""
+        if account_id and '/' in account_id:
+            account_id_list = account_id.split('/')
+            git_org = '/'.join(account_id_list[0:-1])
+            git_repository = account_id_list[-1]
         else:
             git_org, git_repository = "", ""
 

--- a/tests/common/runner_registry/test_runner_registry.py
+++ b/tests/common/runner_registry/test_runner_registry.py
@@ -209,6 +209,28 @@ class TestRunnerRegistry(unittest.TestCase):
         for runner in checkov_runners:
             self.assertIn(runner, CodeCategoryMapping)
 
+    def test_extract_git_info_from_account_id(self):
+        account_id = "owner/name"
+        expected_git_org = "owner"
+        expected_git_repo = "name"
+        result_git_org, result_git_repo = RunnerRegistry.extract_git_info_from_account_id(account_id)
+        self.assertEqual(expected_git_repo, result_git_repo)
+        self.assertEqual(expected_git_org, result_git_org)
+
+        account_id = "owner/with/slash/separator/name"
+        expected_git_org = "owner/with/slash/separator"
+        expected_git_repo = "name"
+        result_git_org, result_git_repo = RunnerRegistry.extract_git_info_from_account_id(account_id)
+        self.assertEqual(expected_git_repo, result_git_repo)
+        self.assertEqual(expected_git_org, result_git_org)
+
+        account_id = ""
+        expected_git_org = ""
+        expected_git_repo = ""
+        result_git_org, result_git_repo = RunnerRegistry.extract_git_info_from_account_id(account_id)
+        self.assertEqual(expected_git_repo, result_git_repo)
+        self.assertEqual(expected_git_org, result_git_org)
+
 
 def test_non_compact_json_output(capsys):
     # given

--- a/tests/common/runner_registry/test_runner_registry.py
+++ b/tests/common/runner_registry/test_runner_registry.py
@@ -224,6 +224,13 @@ class TestRunnerRegistry(unittest.TestCase):
         self.assertEqual(expected_git_repo, result_git_repo)
         self.assertEqual(expected_git_org, result_git_org)
 
+        account_id = "name"
+        expected_git_org = ""
+        expected_git_repo = ""
+        result_git_org, result_git_repo = RunnerRegistry.extract_git_info_from_account_id(account_id)
+        self.assertEqual(expected_git_repo, result_git_repo)
+        self.assertEqual(expected_git_org, result_git_org)
+
         account_id = ""
         expected_git_org = ""
         expected_git_repo = ""


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

CSV BOM report uses account id for ```git_org``` and ```git_repository``` in columns. Some account ids appear to have multiple slashes, which breaks the ```split```  outcome. This fix handle multiple slashes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
