### PR TITLE
feat(general): Add severities to IaC components in CycloneDX report

### DIFF
--- a/checkov/common/output/cyclonedx.py
+++ b/checkov/common/output/cyclonedx.py
@@ -279,6 +279,11 @@ class CycloneDX:
           <source>
             <name>checkov</name>
           </source>
+          <ratings>
+            <rating>
+              <severity>medium</severity>
+            </rating>
+          </ratings>
           <description>Resource: aws_s3_bucket.example. Ensure all data stored in the S3 bucket have versioning enabled</description>
           <advisories>
             <advisory>
@@ -297,9 +302,18 @@ class CycloneDX:
         if resource.guideline:
             advisories = [VulnerabilityAdvisory(url=XsUri(resource.guideline))]
 
+        severity = VulnerabilitySeverity.UNKNOWN
+        if resource.severity:
+            severity = BC_SEVERITY_TO_CYCLONEDX_LEVEL.get(resource.severity.name, VulnerabilitySeverity.UNKNOWN)
+
         vulnerability = Vulnerability(
             id=resource.check_id,
             source=VulnerabilitySource(name="checkov"),
+            ratings=[
+                VulnerabilityRating(
+                    severity=severity,
+                )
+            ],
             description=f"Resource: {resource.resource}. {resource.check_name}",
             affects_targets=[BomTarget(ref=component.bom_ref.value)],
             advisories=advisories,


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally we encourage adding a scope to the prefix, which indicates the targeted framework, otherwise 'general' will be assumed.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added missing severities for IaC vulnerabilities to CycloneDX report

ex.
```xml
<vulnerability bom-ref="bb3ac62a-7cdb-4975-8577-014296801f08">
    <id>CKV_AWS_21</id>
    <source>
        <name>checkov</name>
    </source>
    <ratings>
        <rating>
            <severity>medium</severity>
        </rating>
    </ratings>
    <description>Resource: aws_s3_bucket.example. Ensure all data stored in the S3 bucket have versioning
        enabled
    </description>
    <advisories>
        <advisory>
            <url>https://docs.bridgecrew.io/docs/s3_16-enable-versioning</url>
        </advisory>
    </advisories>
    <affects>
        <target>
            <ref>
                pkg:terraform/cli_repo/main.tf/aws_s3_bucket.example@sha1:9f0061d10bf92fcfc8c2321860ceac816fb9b76d
            </ref>
        </target>
    </affects>
</vulnerability>
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
