### PR TITLE
fix: Pass empty workflow name as metadata by default

### DIFF
--- a/checkov/common/runners/object_runner.py
+++ b/checkov/common/runners/object_runner.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 class GhaMetadata(TypedDict):
     triggers: set[str]
-    workflow_name: str | None
+    workflow_name: str
     jobs: dict[int, str]
 
 
@@ -47,7 +47,7 @@ class Runner(BaseRunner[None]):  # if a graph is added, Any needs to replaced
                 (definitions[file], definitions_raw[file]) = result
                 definition = result[0]
                 if self.check_type == CheckType.GITHUB_ACTIONS and isinstance(definition, dict):
-                    workflow_name = definition.get('name')
+                    workflow_name = definition.get('name', '')
                     triggers = self._get_triggers(definition)
                     jobs = self._get_jobs(definition)
                     self.map_file_path_to_gha_metadata_dict[file] = \

--- a/checkov/common/runners/object_runner.py
+++ b/checkov/common/runners/object_runner.py
@@ -133,7 +133,7 @@ class Runner(BaseRunner[None]):  # if a graph is added, Any needs to replaced
                         file_abs_path=os.path.abspath(file_path),
                         entity_tags=None,
                         severity=check.severity,
-                        job=self.map_file_path_to_gha_metadata_dict[file_path]["jobs"].get(end),
+                        job=self.map_file_path_to_gha_metadata_dict[file_path]["jobs"].get(end, ''),
                         triggers=self.map_file_path_to_gha_metadata_dict[file_path]["triggers"],
                         workflow_name=self.map_file_path_to_gha_metadata_dict[file_path]["workflow_name"]
                     )

--- a/tests/github_actions/test_runner.py
+++ b/tests/github_actions/test_runner.py
@@ -146,9 +146,9 @@ class TestRunnerValid(unittest.TestCase):
         )
 
         # then
-        assert report.failed_checks[0].job[0] == None
+        assert report.failed_checks[0].job[0] == ''
         assert report.failed_checks[0].triggers[0] == {'workflow_dispatch'}
-        assert report.failed_checks[0].workflow_name == None
+        assert report.failed_checks[0].workflow_name == ''
 
     def test_runner_on_list_typed_workflow_dispatch(self):
         # given


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally we encourage adding a scope to the prefix, which indicates the targeted framework, otherwise 'general' will be assumed.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Pass empty workflow name as metadata by default instead of None.

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
