### PR TITLE
fix(bicep): only scan files, not folders

### DIFF
--- a/checkov/bicep/utils.py
+++ b/checkov/bicep/utils.py
@@ -24,7 +24,7 @@ def get_scannable_file_paths(root_folder: str | Path | None = None, files: list[
 
     if root_folder:
         root_path = Path(root_folder)
-        file_paths = {file_path for file_path in root_path.rglob("*.bicep")}
+        file_paths = {file_path for file_path in root_path.rglob("*.bicep") if file_path.is_file()}
     if files:
         for file in files:
             if file.endswith(".bicep"):

--- a/tests/bicep/test_utils.py
+++ b/tests/bicep/test_utils.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from checkov.bicep.utils import get_scannable_file_paths
+
+
+def test_get_scannable_file_paths(tmp_path: Path):
+    # given
+    (tmp_path / "storage.json").touch()
+    (tmp_path / "storage.bicep").touch()
+
+    (tmp_path / ".bicep").mkdir()
+    (tmp_path / ".bicep/main.bicep").touch()
+
+    # when
+    file_paths = get_scannable_file_paths(root_folder=tmp_path)
+
+    # then
+    assert file_paths == {
+        tmp_path / "storage.bicep",
+        tmp_path / ".bicep/main.bicep",
+    }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally we encourage adding a scope to the prefix, which indicates the targeted framework, otherwise 'general' will be assumed.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- there was a weird issue with a folder named `.bicep` which blows up during the parsing of the files

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
