### PR TITLE
fix(general): Fix file paths in k8s and bicep

### DIFF
--- a/checkov/bicep/runner.py
+++ b/checkov/bicep/runner.py
@@ -222,7 +222,7 @@ class Runner(BaseRunner[BicepGraphManager]):
                     check_name=check.name,
                     check_result=clean_check_result,
                     code_block=file_code_lines[start_line - 1 : end_line],
-                    file_path=str(clean_file_path(entity_file_path)),
+                    file_path=self.extract_file_path_from_abs_path(clean_file_path(entity_file_path)),
                     file_line_range=[start_line, end_line],
                     resource=entity.get(CustomAttributes.ID),
                     check_class=check.__class__.__module__,

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -345,7 +345,7 @@ class RunnerRegistry:
     def print_iac_bom_reports(self, output_path: str,
                               scan_reports: list[Report],
                               output_types: list[str],
-                              account_id: str | None = None) -> dict[str, str]:
+                              account_id: str) -> dict[str, str]:
 
         output_files = {
             'cyclonedx': 'results_cyclonedx.xml',
@@ -462,8 +462,8 @@ class RunnerRegistry:
                     result_dict["connected_node"] = None
 
     @staticmethod
-    def extract_git_info_from_account_id(account_id: str | None) -> tuple[str, str]:
-        if account_id and '/' in account_id:
+    def extract_git_info_from_account_id(account_id: str) -> tuple[str, str]:
+        if '/' in account_id:
             account_id_list = account_id.split('/')
             git_org = '/'.join(account_id_list[0:-1])
             git_repository = account_id_list[-1]

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -195,7 +195,7 @@ class Runner(BaseRunner):
                     check_name=check.name,
                     check_result=check_result,
                     code_block=entity_context.get("code_lines"),
-                    file_path=entity_file_path,
+                    file_path=f"/{os.path.relpath(entity_file_abs_path, root_folder)}",
                     file_line_range=[entity_context.get("start_line"), entity_context.get("end_line")],
                     resource=entity.get(CustomAttributes.ID),
                     evaluations={},

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -195,7 +195,7 @@ class Runner(BaseRunner):
                     check_name=check.name,
                     check_result=check_result,
                     code_block=entity_context.get("code_lines"),
-                    file_path=f"/{os.path.relpath(entity_file_abs_path, root_folder)}",
+                    file_path=get_relative_file_path(entity_file_abs_path, root_folder),
                     file_line_range=[entity_context.get("start_line"), entity_context.get("end_line")],
                     resource=entity.get(CustomAttributes.ID),
                     evaluations={},
@@ -207,6 +207,9 @@ class Runner(BaseRunner):
                 report.add_record(record=record)
         return report
 
+
+def get_relative_file_path(file_abs_path: str, root_folder: str) -> str:
+    return f"/{os.path.relpath(file_abs_path, root_folder)}"
 
 def _get_entity_abs_path(root_folder: str | None, entity_file_path: str) -> str:
     if entity_file_path[0] == '/' and (root_folder and not entity_file_path.startswith(root_folder)):

--- a/tests/common/output/test_bom_report.py
+++ b/tests/common/output/test_bom_report.py
@@ -27,7 +27,10 @@ class TestBomOutput:
         reports = runner_registry.run(root_folder=test_files_dir)
 
         with patch('sys.stdout', new=io.StringIO()) as captured_output:
-            runner_registry.print_iac_bom_reports(output_path=str(tmp_path), scan_reports=reports, output_types=['csv'])
+            runner_registry.print_iac_bom_reports(output_path=str(tmp_path),
+                                                  scan_reports=reports,
+                                                  output_types=['csv'],
+                                                  account_id="org/name")
         output = captured_output.getvalue()
         assert 'Persisting SBOM to' in output
         iac_file_path = tmp_path / 'results_iac.csv'
@@ -276,7 +279,8 @@ class TestBomOutput:
 
         result_files_list = runner_registry.print_iac_bom_reports(output_path=str(output_path),
                                                                   scan_reports=reports,
-                                                                  output_types=output_types)
+                                                                  output_types=output_types,
+                                                                  account_id="org/name")
 
         assert len(result_files_list) == len(output_types)
         for result_file in result_files_list.values():


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Files paths for k8s and bicep included absolute path instead of relative path pointing to resources. This PR strips the root folder and leaving only relative paths to the resources.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
