### PR TITLE
fix(terraform): Handle edge case for None attribute value in ContainsAttributeSolver

### DIFF
--- a/checkov/common/checks_infra/solvers/attribute_solvers/contains_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/contains_attribute_solver.py
@@ -13,6 +13,7 @@ class ContainsAttributeSolver(BaseAttributeSolver):
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:  # type:ignore[override]
         att = vertex.get(attribute, "{}")  # type:ignore[arg-type]  # due to attribute can be None
+        att = "{}" if att is None else att
         if isinstance(att, str):
             try:
                 att = json.loads(att.replace("'", '"'))

--- a/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/NetworkAclsIPs.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/NetworkAclsIPs.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "NetworkACL"
+scope:
+  provider: "Azure"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "azurerm_key_vault"
+  attribute: "network_acls.ip_rules"
+  operator: "contains"
+  value: "acme"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/test_solver.py
@@ -68,8 +68,6 @@ class TestContainsSolver(TestBaseSolver):
 
     def test_none_network_acl_ips(self):
         root_folder = '../../../resources/none_contains'
-        # this tests a specific condition related to wildcard expression evaluation and is not necessarily a full
-        # solver test
         check_id = "NetworkACL"
         should_pass = []
         should_fail = ['azurerm_key_vault.kv']

--- a/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/test_solver.py
@@ -65,3 +65,14 @@ class TestContainsSolver(TestBaseSolver):
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
         self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_none_network_acl_ips(self):
+        root_folder = '../../../resources/none_contains'
+        # this tests a specific condition related to wildcard expression evaluation and is not necessarily a full
+        # solver test
+        check_id = "NetworkACL"
+        should_pass = []
+        should_fail = ['azurerm_key_vault.kv']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)

--- a/tests/terraform/graph/resources/none_contains/main.tf
+++ b/tests/terraform/graph/resources/none_contains/main.tf
@@ -1,0 +1,20 @@
+variable "iterator" {}
+
+resource "azurerm_key_vault" "kv" {
+
+  dynamic "network_acls" {
+    for_each = []
+    content {
+      default_action             = "Deny"
+      bypass                     = "AzureServices"
+      ip_rules                   = null
+      virtual_network_subnet_ids = null
+    }
+  }
+
+  location            = ""
+  name                = ""
+  resource_group_name = ""
+  sku_name            = ""
+  tenant_id           = ""
+}

--- a/tests/terraform/graph/resources/none_contains/main.tf
+++ b/tests/terraform/graph/resources/none_contains/main.tf
@@ -6,7 +6,7 @@ resource "azurerm_key_vault" "kv" {
     for_each = []
     content {
       default_action             = "Deny"
-      bypass                     = "AzureServices"
+      bypass                     = ""
       ip_rules                   = null
       virtual_network_subnet_ids = null
     }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
In case where an attribute value is `null`, the `ContainsAttributeSolver` will attempt to find the value in a `None` attribute, raising an exception.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
