### PR TITLE
feat: support injection of custom plugins

### DIFF
--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -181,7 +181,7 @@ class Runner(BaseRunner[None]):
             secrets_duplication: dict[str, bool] = {}
             for _, secret in secrets:
                 if hasattr(secret, 'check_id'):
-                    check_id = secret.check_id
+                    check_id = secret.check_id      # type: ignore
                 else:
                     check_id = SECRET_TYPE_TO_ID.get(secret.type)
                 if not check_id:

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -127,10 +127,10 @@ class Runner(BaseRunner[None]):
                     'limit': ENTROPY_KEYWORD_LIMIT
                 }
             ]
-        custom_plugins = os.getenv("CHECKOV_CUSTOM_DETECTOR_PLUGINS", None)
+        custom_plugins = os.getenv("CHECKOV_CUSTOM_DETECTOR_PLUGINS_PATH", None)
         logging.info(f"Custom detector flag set to {custom_plugins}")
         if custom_plugins:
-            detector_path = f"/tmp/plugins/platform_regex_detector.py"
+            detector_path = f"{custom_plugins}/platform_regex_detector.py"
             file_exists = exists(detector_path)
             if file_exists:
                 logging.info(f"Custom detector found at {detector_path}. Loading...")

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -81,7 +81,8 @@ class Runner(BaseRunner[None]):
         runner_filter = runner_filter or RunnerFilter()
         current_dir = Path(__file__).parent
         secrets = SecretsCollection()
-        plugins_used = [
+        plugins_used = \
+            [
                 {
                     'name': 'AWSKeyDetector'
                 },

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -128,15 +128,14 @@ class Runner(BaseRunner[None]):
                     'limit': ENTROPY_KEYWORD_LIMIT
                 }
             ]
-        custom_plugins = os.getenv("CHECKOV_CUSTOM_DETECTOR_PLUGINS_PATH", None)
+        custom_plugins = os.getenv("CHECKOV_CUSTOM_DETECTOR_PLUGINS_PATH")
         logging.info(f"Custom detector flag set to {custom_plugins}")
         if custom_plugins:
-            detector_path = f"{custom_plugins}/platform_regex_detector.py"
-            file_exists = exists(detector_path)
-            if file_exists:
+            detector_path = f"{custom_plugins}/custom_regex_detector.py"
+            if exists(detector_path):
                 logging.info(f"Custom detector found at {detector_path}. Loading...")
                 plugins_used.append({
-                    'name': 'PlatformRegexDetector',
+                    'name': 'CustomRegexDetector',
                     'path': f'file://{detector_path}'
                 })
             else:
@@ -257,6 +256,7 @@ class Runner(BaseRunner[None]):
         try:
             start_time = datetime.datetime.now()
             file_results = [*scan.scan_file(full_file_path)]
+            logging.info(f'file {full_file_path} results {file_results}')
             end_time = datetime.datetime.now()
             run_time = end_time - start_time
             if run_time > datetime.timedelta(seconds=10):


### PR DESCRIPTION
This PR adds support for injecting custom plugins from the outside. This is part of secret detection capability.
Checkov reads the detector from file and loads it together with its own internal detectors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
