### PR TITLE
platform(general): add INFO severity ahead of platform changes

### DIFF
--- a/checkov/common/bridgecrew/severities.py
+++ b/checkov/common/bridgecrew/severities.py
@@ -13,6 +13,7 @@ class Severity:
 @dataclass
 class BcSeverities:
     NONE = 'NONE'
+    INFO = 'INFO'
     LOW = 'LOW'
     MEDIUM = 'MEDIUM'
     HIGH = 'HIGH'
@@ -24,12 +25,13 @@ class BcSeverities:
 
 Severities = {
     BcSeverities.NONE: Severity(BcSeverities.NONE, 0),
-    BcSeverities.LOW: Severity(BcSeverities.LOW, 1),
-    BcSeverities.MEDIUM: Severity(BcSeverities.MEDIUM, 2),
-    BcSeverities.MODERATE: Severity(BcSeverities.MEDIUM, 2),
-    BcSeverities.HIGH: Severity(BcSeverities.HIGH, 3),
-    BcSeverities.IMPORTANT: Severity(BcSeverities.HIGH, 3),
-    BcSeverities.CRITICAL: Severity(BcSeverities.CRITICAL, 4),
+    BcSeverities.INFO: Severity(BcSeverities.INFO, 1),
+    BcSeverities.LOW: Severity(BcSeverities.LOW, 2),
+    BcSeverities.MEDIUM: Severity(BcSeverities.MEDIUM, 3),
+    BcSeverities.MODERATE: Severity(BcSeverities.MEDIUM, 4),
+    BcSeverities.HIGH: Severity(BcSeverities.HIGH, 5),
+    BcSeverities.IMPORTANT: Severity(BcSeverities.HIGH, 5),
+    BcSeverities.CRITICAL: Severity(BcSeverities.CRITICAL, 6),
     BcSeverities.OFF: Severity(BcSeverities.OFF, 999),
 }
 

--- a/checkov/common/bridgecrew/severities.py
+++ b/checkov/common/bridgecrew/severities.py
@@ -24,14 +24,14 @@ class BcSeverities:
 
 
 Severities = {
-    BcSeverities.NONE: Severity(BcSeverities.NONE, 0),
+    BcSeverities.NONE: Severity(BcSeverities.NONE, -999),
     BcSeverities.INFO: Severity(BcSeverities.INFO, 1),
     BcSeverities.LOW: Severity(BcSeverities.LOW, 2),
     BcSeverities.MEDIUM: Severity(BcSeverities.MEDIUM, 3),
-    BcSeverities.MODERATE: Severity(BcSeverities.MEDIUM, 4),
-    BcSeverities.HIGH: Severity(BcSeverities.HIGH, 5),
-    BcSeverities.IMPORTANT: Severity(BcSeverities.HIGH, 5),
-    BcSeverities.CRITICAL: Severity(BcSeverities.CRITICAL, 6),
+    BcSeverities.MODERATE: Severity(BcSeverities.MEDIUM, 3),
+    BcSeverities.HIGH: Severity(BcSeverities.HIGH, 4),
+    BcSeverities.IMPORTANT: Severity(BcSeverities.HIGH, 4),
+    BcSeverities.CRITICAL: Severity(BcSeverities.CRITICAL, 5),
     BcSeverities.OFF: Severity(BcSeverities.OFF, 999),
 }
 

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -106,7 +106,7 @@ class TestBCApiUrl(unittest.TestCase):
         check_no_desc_title = tf_registry.get_check_by_id('CKV_AWS_53')
 
         self.assertEqual(check_same_severity.name, 'Ensure IAM password policy requires at least one uppercase letter')
-        self.assertEqual(check_same_severity.severity, Severities[BcSeverities.MEDIUM])
+        self.assertEqual(check_same_severity.severity, Severities[BcSeverities.INFO])
         self.assertEqual(check_different_severity.severity, Severities[BcSeverities.CRITICAL])
         self.assertEqual(check_no_desc_title.severity, Severities[BcSeverities.MEDIUM])
 
@@ -124,7 +124,7 @@ class TestBCApiUrl(unittest.TestCase):
         self.assertEqual(check_same_severity.name, 'AWS IAM password policy does not have an uppercase character')
         self.assertEqual(check_different_severity.name, 'AWS IAM policy attached to users')
         self.assertEqual(check_no_desc_title.name, 'Ensure S3 bucket has block public ACLS enabled')
-        self.assertEqual(check_same_severity.severity, Severities[BcSeverities.MEDIUM])
+        self.assertEqual(check_same_severity.severity, Severities[BcSeverities.INFO])
         self.assertEqual(check_different_severity.severity, Severities[BcSeverities.HIGH])
         self.assertEqual(check_different_severity.severity, Severities[BcSeverities.HIGH])
 
@@ -165,8 +165,8 @@ def mock_customer_run_config():
                 "id": "BC_AWS_IAM_5",
                 "title": "Ensure IAM password policy requires at least one uppercase letter",
                 "guideline": "https://docs.bridgecrew.io/docs/iam_5",
-                "severity": "MEDIUM",
-                "pcSeverity": "MEDIUM",
+                "severity": "INFO",
+                "pcSeverity": "INFO",
                 "category": "IAM",
                 "checkovId": "CKV_AWS_15",
                 "constructiveTitle": "Ensure AWS IAM password policy has an uppercase character",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally we encourage adding a scope to the prefix, which indicates the targeted framework, otherwise 'general' will be assumed.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Adds a new severity level so that it is supported when we add it to the platform.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
