### PR TITLE
platform(general): revert dropping checks metadata for empty reports

### DIFF
--- a/checkov/common/bridgecrew/wrapper.py
+++ b/checkov/common/bridgecrew/wrapper.py
@@ -89,10 +89,6 @@ def enrich_and_persist_checks_metadata(
     """
     checks_metadata_paths: dict[str, dict[str, str]] = {}
     for scan_report in scan_reports:
-        if scan_report.is_empty():
-            # only save checks metadata for reports with check results
-            continue
-
         check_type = scan_report.check_type
         checks_metadata_object = _extract_checks_metadata(scan_report, full_repo_object_key)
         checks_metadata_object_path = f'{full_repo_object_key}/{checkov_results_prefix}/{check_type}/checks_metadata.json'


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

revert dropping metadata field for empty reports since it's causing issues in platform

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
