### PR TITLE
fix(terraform): gcp postgresql default values

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogCheckpoints.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogCheckpoints.py
@@ -34,13 +34,13 @@ class GoogleCloudPostgreSqlLogCheckpoints(BaseResourceCheck):
                     else:  # treating use cases of the following database_flags parsing (list of dictionaries with arrays): 'database_flags': [{'name': ['<key>'], 'value': ['<value>']},{'name': ['<key>'], 'value': ['<value>']}]
                         flags = [{key: flag[key][0] for key in flag} for flag in flags]
                     for flag in flags:
-                        if (flag['name'] == 'log_checkpoints') and (flag['value'] == 'off'):
+                        if (flag['name'] == 'log_checkpoints') and (flag['value'] == 'on'): # Must be explicitly set for check to pass
                             self.evaluated_keys = ['database_version/[0]/POSTGRES',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/name',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/value']
-                            return CheckResult.FAILED
+                            return CheckResult.PASSED
                     self.evaluated_keys = ['database_version/[0]/POSTGRES', 'settings/[0]/database_flags']
-            return CheckResult.PASSED
+            return CheckResult.FAILED
         return CheckResult.UNKNOWN
 
 

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogCheckpoints.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogCheckpoints.py
@@ -34,7 +34,7 @@ class GoogleCloudPostgreSqlLogCheckpoints(BaseResourceCheck):
                     else:  # treating use cases of the following database_flags parsing (list of dictionaries with arrays): 'database_flags': [{'name': ['<key>'], 'value': ['<value>']},{'name': ['<key>'], 'value': ['<value>']}]
                         flags = [{key: flag[key][0] for key in flag} for flag in flags]
                     for flag in flags:
-                        if (flag['name'] == 'log_checkpoints') and (flag['value'] == 'on'): # Must be explicitly set for check to pass
+                        if (flag['name'] == 'log_checkpoints') and (flag['value'] == 'on'):  # Must be explicitly set for check to pass
                             self.evaluated_keys = ['database_version/[0]/POSTGRES',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/name',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/value']

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogConnection.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogConnection.py
@@ -30,7 +30,7 @@ class GoogleCloudPostgreSqlLogConnection(BaseResourceCheck):
                     else:  # treating use cases of the following database_flags parsing (list of dictionaries with arrays): 'database_flags': [{'name': ['<key>'], 'value': ['<value>']},{'name': ['<key>'], 'value': ['<value>']}]
                         flags = [{key: flag[key][0] for key in flag} for flag in flags]
                     for flag in flags:
-                        if (flag['name'] == 'log_connections') and (flag['value'] == 'on'): # Must be explicitly set for check to pass
+                        if (flag['name'] == 'log_connections') and (flag['value'] == 'on'):  # Must be explicitly set for check to pass
                             self.evaluated_keys = ['database_version/[0]/POSTGRES',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/name',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/value']

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogConnection.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogConnection.py
@@ -30,14 +30,14 @@ class GoogleCloudPostgreSqlLogConnection(BaseResourceCheck):
                     else:  # treating use cases of the following database_flags parsing (list of dictionaries with arrays): 'database_flags': [{'name': ['<key>'], 'value': ['<value>']},{'name': ['<key>'], 'value': ['<value>']}]
                         flags = [{key: flag[key][0] for key in flag} for flag in flags]
                     for flag in flags:
-                        if (flag['name'] == 'log_connections') and (flag['value'] == 'off'):
+                        if (flag['name'] == 'log_connections') and (flag['value'] == 'on'): # Must be explicitly set for check to pass
                             self.evaluated_keys = ['database_version/[0]/POSTGRES',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/name',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/value']
-                            return CheckResult.FAILED
+                            return CheckResult.PASSED
                     self.evaluated_keys = ['database_version/[0]/POSTGRES', 'settings/[0]/database_flags']
 
-            return CheckResult.PASSED
+            return CheckResult.FAILED
         return CheckResult.UNKNOWN
 
 

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogDisconnection.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogDisconnection.py
@@ -36,14 +36,14 @@ class GoogleCloudPostgreSqlLogDisconnection(BaseResourceCheck):
                         # [{'name': ['<key>'], 'value': ['<value>']},{'name': ['<key>'], 'value': ['<value>']}]
                         flags = [{key: flag[key][0] for key in flag} for flag in flags]
                     for flag in flags:
-                        if (flag['name'] == 'log_disconnections') and (flag['value'] == 'off'):
+                        if (flag['name'] == 'log_disconnections') and (flag['value'] == 'on'): # Must be explicitly set for check to pass
                             self.evaluated_keys = ['database_version/[0]/POSTGRES',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/name',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/value']
-                            return CheckResult.FAILED
+                            return CheckResult.PASSED
                     self.evaluated_keys = ['database_version/[0]/POSTGRES', 'settings/[0]/database_flags']
 
-            return CheckResult.PASSED
+            return CheckResult.FAILED
         return CheckResult.UNKNOWN
 
 

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogDisconnection.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogDisconnection.py
@@ -36,7 +36,7 @@ class GoogleCloudPostgreSqlLogDisconnection(BaseResourceCheck):
                         # [{'name': ['<key>'], 'value': ['<value>']},{'name': ['<key>'], 'value': ['<value>']}]
                         flags = [{key: flag[key][0] for key in flag} for flag in flags]
                     for flag in flags:
-                        if (flag['name'] == 'log_disconnections') and (flag['value'] == 'on'): # Must be explicitly set for check to pass
+                        if (flag['name'] == 'log_disconnections') and (flag['value'] == 'on'):  # Must be explicitly set for check to pass
                             self.evaluated_keys = ['database_version/[0]/POSTGRES',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/name',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/value']

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogLockWaits.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogLockWaits.py
@@ -36,14 +36,14 @@ class GoogleCloudPostgreSqlLogLockWaits(BaseResourceCheck):
                         # [{'name': ['<key>'], 'value': ['<value>']},{'name': ['<key>'], 'value': ['<value>']}]
                         flags = [{key: flag[key][0] for key in flag} for flag in flags]
                     for flag in flags:
-                        if (flag['name'] == 'log_lock_waits') and (flag['value'] == 'off'):
+                        if (flag['name'] == 'log_lock_waits') and (flag['value'] == 'on'): # Must be explicitly set for check to pass
                             self.evaluated_keys = ['database_version/[0]/POSTGRES',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/name',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/value']
-                            return CheckResult.FAILED
+                            return CheckResult.PASSED
                     self.evaluated_keys = ['database_version/[0]/POSTGRES', 'settings/[0]/database_flags']
 
-            return CheckResult.PASSED
+            return CheckResult.FAILED
         return CheckResult.UNKNOWN
 
 

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogLockWaits.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogLockWaits.py
@@ -36,7 +36,7 @@ class GoogleCloudPostgreSqlLogLockWaits(BaseResourceCheck):
                         # [{'name': ['<key>'], 'value': ['<value>']},{'name': ['<key>'], 'value': ['<value>']}]
                         flags = [{key: flag[key][0] for key in flag} for flag in flags]
                     for flag in flags:
-                        if (flag['name'] == 'log_lock_waits') and (flag['value'] == 'on'): # Must be explicitly set for check to pass
+                        if (flag['name'] == 'log_lock_waits') and (flag['value'] == 'on'):  # Must be explicitly set for check to pass
                             self.evaluated_keys = ['database_version/[0]/POSTGRES',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/name',
                                                    f'{evaluated_keys_prefix}/[{flags.index(flag)}]/value']

--- a/tests/terraform/checks/resource/gcp/example_CloudPostgreSQLLogDisconnection/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_CloudPostgreSQLLogDisconnection/main.tf
@@ -41,49 +41,7 @@ resource "google_sql_database_instance" "fail" {
   }
 }
 
-resource "google_sql_database_instance" "pass3" {
-  database_version = "POSTGRES_12"
-  name             = "general-pos121"
-  project          = "gcp-bridgecrew-deployment"
-  region           = "us-central1"
-  settings {
-    activation_policy = "ALWAYS"
-    availability_type = "ZONAL"
-    database_flags {
-      name  = "log_checkpoints"
-      value = "off"
-    }
-    database_flags {
-      name  = "log_connections"
-      value = "on"
-    }
-    database_flags {
-      name  = "log_disconnections"
-      value = "on"
-    }
-    database_flags {
-      name  = "log_min_messages"
-      value = "debug6"
-    }
-    database_flags {
-      name  = "log_lock_waits"
-      value = "on"
-    }
-    database_flags {
-      name  = "log_temp_files"
-      value = "10"
-    }
-    database_flags {
-      name  = "log_min_duration_statement"
-      value = "1"
-    }
-    pricing_plan = "PER_USE"
-
-    tier = "db-custom-1-3840"
-  }
-}
-
-resource "google_sql_database_instance" "pass2" {
+resource "google_sql_database_instance" "fail2" {
   database_version = "POSTGRES_14"
   name             = "general-pos121"
   project          = "gcp-bridgecrew-deployment"
@@ -98,10 +56,6 @@ resource "google_sql_database_instance" "pass2" {
     database_flags {
       name  = "log_connections"
       value = "off"
-    }
-    database_flags {
-      name  = "log_disconnections"
-      value = "on"
     }
     database_flags {
       name  = "log_min_messages"
@@ -134,6 +88,10 @@ resource "google_sql_database_instance" "pass" {
   settings {
     activation_policy = "ALWAYS"
     availability_type = "ZONAL"
+    database_flags {
+      name  = "log_disconnections"
+      value = "on"
+    }
     database_flags {
       name  = "log_min_messages"
       value = "debug6"

--- a/tests/terraform/checks/resource/gcp/example_CloudPostgreSqlLogLockWaits/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_CloudPostgreSqlLogLockWaits/main.tf
@@ -41,7 +41,7 @@ resource "google_sql_database_instance" "fail" {
   }
 }
 
-resource "google_sql_database_instance" "pass2" {
+resource "google_sql_database_instance" "fail2" {
   database_version = "POSTGRES_12"
   name             = "general-pos121"
   project          = "gcp-bridgecrew-deployment"
@@ -66,10 +66,6 @@ resource "google_sql_database_instance" "pass2" {
       value = "debug6"
     }
     database_flags {
-      name  = "log_lock_waits"
-      value = "on"
-    }
-    database_flags {
       name  = "log_temp_files"
       value = "10"
     }
@@ -91,6 +87,10 @@ resource "google_sql_database_instance" "pass" {
   settings {
     activation_policy = "ALWAYS"
     availability_type = "ZONAL"
+    database_flags {
+      name  = "log_lock_waits"
+      value = "on"
+    }
     database_flags {
       name  = "log_min_messages"
       value = "debug6"

--- a/tests/terraform/checks/resource/gcp/example_GoogleCloudPostgreSqlLogCheckpoints/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleCloudPostgreSqlLogCheckpoints/main.tf
@@ -43,7 +43,7 @@ resource "google_sql_database_instance" "fail" {
 }
 
 
-resource "google_sql_database_instance" "pass2" {
+resource "google_sql_database_instance" "fail2" {
   database_version = "POSTGRES_12"
   name             = "general-pos121"
   project          = "gcp-bridgecrew-deployment"
@@ -51,10 +51,6 @@ resource "google_sql_database_instance" "pass2" {
   settings {
     activation_policy = "ALWAYS"
     availability_type = "ZONAL"
-    database_flags {
-      name  = "log_checkpoints"
-      value = "on"
-    }
     database_flags {
       name  = "log_connections"
       value = "on"
@@ -92,6 +88,10 @@ resource "google_sql_database_instance" "pass" {
   settings {
     activation_policy = "ALWAYS"
     availability_type = "ZONAL"
+    database_flags {
+      name  = "log_checkpoints"
+      value = "on"
+    }
     database_flags {
       name  = "log_disconnections"
       value = "on"

--- a/tests/terraform/checks/resource/gcp/example_GoogleCloudPostgreSqlLogConnection/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleCloudPostgreSqlLogConnection/main.tf
@@ -43,7 +43,7 @@ resource "google_sql_database_instance" "fail" {
 }
 
 
-resource "google_sql_database_instance" "pass2" {
+resource "google_sql_database_instance" "fail2" {
   database_version = "POSTGRES_12"
   name             = "general-pos121"
   project          = "gcp-bridgecrew-deployment"
@@ -54,10 +54,6 @@ resource "google_sql_database_instance" "pass2" {
     database_flags {
       name  = "log_checkpoints"
       value = "off"
-    }
-    database_flags {
-      name  = "log_connections"
-      value = "on"
     }
     database_flags {
       name  = "log_disconnections"
@@ -92,6 +88,10 @@ resource "google_sql_database_instance" "pass" {
   settings {
     activation_policy = "ALWAYS"
     availability_type = "ZONAL"
+    database_flags {
+      name  = "log_connections"
+      value = "on"
+    }
     database_flags {
       name  = "log_disconnections"
       value = "on"

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogCheckpoints.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogCheckpoints.py
@@ -19,11 +19,11 @@ class TestGoogleCloudPostgreSqlLogCheckpoints(unittest.TestCase):
 
         passing_resources = {
             "google_sql_database_instance.pass",
-            "google_sql_database_instance.pass2",
         }
 
         failing_resources = {
             "google_sql_database_instance.fail",
+            "google_sql_database_instance.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogCheckpoints.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogCheckpoints.py
@@ -29,8 +29,8 @@ class TestGoogleCloudPostgreSqlLogCheckpoints(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogConnection.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogConnection.py
@@ -29,8 +29,8 @@ class TestGoogleCloudPostgreSqlLogConnection(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogConnection.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogConnection.py
@@ -19,11 +19,11 @@ class TestGoogleCloudPostgreSqlLogConnection(unittest.TestCase):
 
         passing_resources = {
             "google_sql_database_instance.pass",
-            "google_sql_database_instance.pass2",
         }
 
         failing_resources = {
             "google_sql_database_instance.fail",
+            "google_sql_database_instance.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogDisconnection.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogDisconnection.py
@@ -30,8 +30,8 @@ class TestGoogleCloudPostgreSqlLogDisconnection(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 3)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogDisconnection.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogDisconnection.py
@@ -20,12 +20,11 @@ class TestGoogleCloudPostgreSqlLogDisconnection(unittest.TestCase):
 
         passing_resources = {
             "google_sql_database_instance.pass",
-            "google_sql_database_instance.pass2",
-            "google_sql_database_instance.pass3",
         }
 
         failing_resources = {
             "google_sql_database_instance.fail",
+            "google_sql_database_instance.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogLockWaits.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogLockWaits.py
@@ -20,11 +20,11 @@ class TestGoogleCloudPostgreSqlLogLockWaits(unittest.TestCase):
 
         passing_resources = {
             "google_sql_database_instance.pass",
-            "google_sql_database_instance.pass2",
         }
 
         failing_resources = {
             "google_sql_database_instance.fail",
+            "google_sql_database_instance.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogLockWaits.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudPostgreSqlLogLockWaits.py
@@ -30,8 +30,8 @@ class TestGoogleCloudPostgreSqlLogLockWaits(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fix checks when using default (undeclared) settings from GCP.

Fixes #3323 

## Edited policies

`CKV_GCP_51`, `CKV_GCP_52`, `CKV_GCP_53` and `CKV_GCP_54`.

### Description

When scanning terraform plan with checkov and running infrastructure with something like steampipe, result should match. Here is a list of all available PostgreSQL database flags with their respective default values: https://cloud.google.com/sql/docs/postgres/flags#list-flags-postgres

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
