### PR TITLE
chore: filtering the checkov's version when testing cyclonedx-bom-report

### DIFF
--- a/tests/sca_image/test_output_reports.py
+++ b/tests/sca_image/test_output_reports.py
@@ -1,6 +1,7 @@
 import os.path
 from pathlib import Path
 import xml.dom.minidom
+from typing import List
 
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.output.csv import CSVSBOM
@@ -8,6 +9,19 @@ from checkov.common.output.cyclonedx import CycloneDX
 
 EXAMPLES_DIR = Path(__file__).parent / "examples"
 OUTPUTS_DIR = Path(__file__).parent / "outputs"
+
+
+def _get_deterministic_items_in_cyclonedx(pretty_xml_as_list: List[str]) -> List[str]:
+    # the lines with the fields "serialNumber", "bom-ref" and "timestamp" contain some not-deterministic data (uuids,
+    # timestamp). so we skip these lines by the first 'if when checking whether we get the expected results
+    # in addition also the line that display the checkov version may be changeable, so we skip it as well
+    # (in the second 'if')
+    filtered_list = []
+    for i, line in enumerate(pretty_xml_as_list):
+        if "bom-ref" not in line and "serialNumber" not in line and "timestamp" not in line:
+            if i == 0 or "<name>checkov</name>" not in pretty_xml_as_list[i-1]:
+                filtered_list.append(line)
+    return filtered_list
 
 
 def test_console_output(sca_image_report):
@@ -40,21 +54,19 @@ def test_console_output(sca_image_report):
     )
 
 
-# def test_get_cyclonedx_report(sca_image_report, tmp_path: Path):
-#     cyclonedx_reports = [sca_image_report]
-#     cyclonedx = CycloneDX(repo_id="bridgecrewio/example", reports=cyclonedx_reports)
-#     cyclonedx_output = cyclonedx.get_xml_output()
-#     dom = xml.dom.minidom.parseString(cyclonedx_output)
-#     pretty_xml_as_string = str(dom.toprettyxml())
-#     with open(os.path.join(OUTPUTS_DIR, "results_cyclonedx.xml")) as f_xml:
-#         expected_pretty_xml = f_xml.read()
-#
-#     # the lines with the fields "serialNumber", "bom-ref" and "timestamp" contain some not-deterministic data (uuids,
-#     # timestamp). so we skip these lines when checking whether we get the expected results
-#     actual_pretty_xml_as_list = [line for line in pretty_xml_as_string.split("\n") if "bom-ref" not in line and "serialNumber" not in line and "timestamp" not in line]
-#     expected_pretty_xml_as_list = [line for line in expected_pretty_xml.split("\n") if "bom-ref" not in line and "serialNumber" not in line and "timestamp" not in line]
-#
-#     assert actual_pretty_xml_as_list == expected_pretty_xml_as_list
+def test_get_cyclonedx_report(sca_image_report, tmp_path: Path):
+    cyclonedx_reports = [sca_image_report]
+    cyclonedx = CycloneDX(repo_id="bridgecrewio/example", reports=cyclonedx_reports)
+    cyclonedx_output = cyclonedx.get_xml_output()
+    dom = xml.dom.minidom.parseString(cyclonedx_output)
+    pretty_xml_as_string = str(dom.toprettyxml())
+    with open(os.path.join(OUTPUTS_DIR, "results_cyclonedx.xml")) as f_xml:
+        expected_pretty_xml = f_xml.read()
+
+    actual_pretty_xml_as_list = _get_deterministic_items_in_cyclonedx(pretty_xml_as_string.split("\n"))
+    expected_pretty_xml_as_list = _get_deterministic_items_in_cyclonedx(expected_pretty_xml.split("\n"))
+
+    assert actual_pretty_xml_as_list == expected_pretty_xml_as_list
 
 
 def test_get_csv_report(sca_image_report, tmp_path: Path):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
filtering the checkov's version when testing cyclonedx-bom-report - it should be done as it broke the UTs in the "build" action (as checkov's version change each time) and we don't really need to care about the version when testing the entire report

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
