### PR TITLE
chore: change changelog creation to leverage GH releases

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -5,18 +5,13 @@
   },
   "CHECKS": {
     "prefixes": [
-      "fix: ",
-      "feat: ",
-      "break: ",
-      "docs: ",
-      "chore: ",
-      "platform: "
+      "chore: "
     ],
-    "regexp": "(fix|feat|break|docs|chore|platform)\\((arm|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph)\\): "
+    "regexp": "(fix|feat|break|docs|chore|platform)\\((argo|arm|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph)\\): "
   },
   "MESSAGES": {
     "success": "PR title is valid",
     "failure": "PR title is invalid",
-    "notice": "Valid prefixes are: fix, feat, break, docs, chore, platform."
+    "notice": "Title needs to pass regex '(fix|feat|break|docs|chore|platform)\\((argo|arm|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph)\\): '"
   }
 }

--- a/.github/release-changelog-config.json
+++ b/.github/release-changelog-config.json
@@ -1,0 +1,46 @@
+{
+    "categories": [
+        {
+            "title": "## Breaking Change",
+            "labels": ["break"]
+        },
+        {
+            "title": "## Feature",
+            "labels": ["feat"]
+        },
+        {
+            "title": "## Bug Fix",
+            "labels": ["fix"]
+        },
+        {
+            "title": "## Platform",
+            "labels": ["platform"]
+        },
+        {
+            "title": "## Documentation",
+            "labels": ["docs"]
+        }
+    ],
+    "sort": {
+        "order": "ASC",
+        "on_property": "title"
+    },
+    "template": "${{CHANGELOG}}",
+    "pr_template": "- ${{TITLE}} - #${{NUMBER}}",
+    "empty_template": "- no noteworthy changes",
+    "label_extractor": [
+        {
+            "pattern": "([^\\(]+)\\(.+\\): .+",
+            "on_property": "title",
+            "target": "$1"
+        }
+    ],
+    "transformers": [
+        {
+            "pattern": "([^\\(]+)\\(?([^\\)]+)?\\)?: (.+)",
+            "target": "- **$2:** $3"
+        }
+    ],
+    "max_pull_requests": 100,
+    "max_back_track_time_days": 7
+}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,41 +13,53 @@ jobs:
     runs-on: [self-hosted, public, linux, x64]
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT_SECRET }}
       - name: Prepare Release
         id: prepare_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # grab latest release and tag to compare and decide to create a new one
           create_release=true
-          release_notes="minor improvements and fixes"
-          latest_gh_release=$(curl -s https://api.github.com/repos/bridgecrewio/checkov/releases/latest  | grep -Po '"tag_name": "\K.*?(?=")')
+          latest_gh_release=$(curl -s "https://api.github.com/repos/${{ github.repository }}/releases/latest"  | grep -Po '"tag_name": "\K.*?(?=")')
           latest_tag=$(git describe --abbrev=0 --tags)
-          
+
           if [ "$latest_gh_release" = "$latest_tag" ]
           then
             create_release=false
           fi
-          
+
           echo "::set-output name=create_release::$create_release"
+          echo "::set-output name=latest_release_version::$latest_gh_release"
           echo "::set-output name=version::$latest_tag"
-          echo "::set-output name=notes::$release_notes"
+      - name: Build GitHub Release changelog
+        if: steps.prepare_release.outputs.create_release == 'true'
+        id: build_github_release
+        uses: mikepenz/release-changelog-builder-action@000e44613cdb6c340ac98cb1582f99e8d3230058  # v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_SECRET }}
+        with:
+          configuration: ".github/release-changelog-config.json"
+          fromTag: ${{ steps.prepare_release.outputs.latest_release_version }}
+          toTag: ${{ steps.prepare_release.outputs.version }}
       - name: Create GitHub Release
         if: steps.prepare_release.outputs.create_release == 'true'
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5  # v1
         with:
           tag_name: ${{ steps.prepare_release.outputs.version }}
           name: ${{ steps.prepare_release.outputs.version }}
-          body: ${{ steps.prepare_release.outputs.notes }}
+          body: ${{ steps.build_github_release.outputs.changelog }}
       - name: Update CHANGELOG.md
         if: steps.prepare_release.outputs.create_release == 'true'
-        uses: BobAnkh/auto-generate-changelog@4a2eb69805db4af39f374dc95eb502669fb4af95  # v1
+        uses: stefanzweifel/changelog-updater-action@d03272ada6fcd985ecd5cedbf984f472081b7b92  # v1
         with:
-          ACCESS_TOKEN: ${{ secrets.GH_PAT_SECRET }}
-          PATH: "CHANGELOG.md"
-          TYPE: "feat:Feature,fix:Bug Fix,break:Breaking Change,platform:Platform,docs:Documentation"
+          latest-version: ${{ steps.prepare_release.outputs.version }}
+          release-notes: ${{ steps.build_github_release.outputs.changelog }}
+      - name: Commit updated CHANGELOG.md
+        if: steps.prepare_release.outputs.create_release == 'true'
+        uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80  # v4
+        with:
+          commit_message: "chore: update release notes"
+          file_pattern: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# CHANGELOG
+
+## [Unreleased](https://github.com/bridgecrewio/checkov/compare/2.1.188...HEAD)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally we encourage adding a scope to the prefix, which indicates the targeted framework, otherwise 'general' will be assumed.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- changed the way on how the changelog is created, additionallythe GH release will now also get the release notes for noteworthy changes
- I hope I chose the right token 🤞  

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
