### PR TITLE
fix: Add .hcl and .bicep files to the supported file extensions

### DIFF
--- a/checkov/common/models/consts.py
+++ b/checkov/common/models/consts.py
@@ -1,9 +1,7 @@
 import re
 
-from checkov.common.util.config_utils import should_scan_hcl_files
-
 SCAN_HCL_FLAG = "CKV_SCAN_HCL"
-SUPPORTED_FILE_EXTENSIONS = [".tf", ".yml", ".yaml", ".json", ".template"]
+SUPPORTED_FILE_EXTENSIONS = [".tf", ".yml", ".yaml", ".json", ".template", ".bicep", ".hcl"]
 SUPPORTED_PACKAGE_FILES = {
     "bower.json",
     "build.gradle",
@@ -19,8 +17,6 @@ SUPPORTED_PACKAGE_FILES = {
 }
 SUPPORTED_FILES = SUPPORTED_PACKAGE_FILES.union({"Dockerfile"})
 
-if should_scan_hcl_files():
-    SUPPORTED_FILE_EXTENSIONS.append(".hcl")
 ANY_VALUE = "CKV_ANY"
 DOCKER_IMAGE_REGEX = re.compile(r'(?:[^\s\/]+\/)?([^\s:]+):?([^\s]*)')
 access_key_pattern = re.compile("(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])")  # nosec

--- a/checkov/common/models/consts.py
+++ b/checkov/common/models/consts.py
@@ -1,6 +1,5 @@
 import re
 
-SCAN_HCL_FLAG = "CKV_SCAN_HCL"
 SUPPORTED_FILE_EXTENSIONS = [".tf", ".yml", ".yaml", ".json", ".template", ".bicep", ".hcl"]
 SUPPORTED_PACKAGE_FILES = {
     "bower.json",

--- a/checkov/common/util/config_utils.py
+++ b/checkov/common/util/config_utils.py
@@ -24,8 +24,3 @@ def get_default_config_paths(argv: list[str]) -> list[str]:
         if v in ('-d', '--directory'):
             dir_paths += config_file_paths(argv[i + 1])
     return dir_paths + cwd_path + home_paths
-
-
-def should_scan_hcl_files() -> bool:
-    from checkov.common.models.consts import SCAN_HCL_FLAG  # prevent circular import
-    return os.getenv(SCAN_HCL_FLAG, default="false").lower() == "true"

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -563,10 +563,11 @@ def add_parser_args(parser: ArgumentParser) -> None:
                env_var='CKV_SECRETS_SCAN_FILE_TYPE',
                action='append',
                help='add scan secret for requested files. You can specify this argument multiple times to add '
-                    'multiple file types. To scan all types (".tf", ".yml", ".yaml", ".json", '
-                    '".template", ".py", ".js", ".properties", ".pem", ".php", ".xml", ".ts", ".env", "Dockerfile", '
+                    'multiple file types. To scan all types (".tf", ".hcl", ".yml", ".yaml", ".json", ".template", '
+                    '".bicep", ".py", ".js", ".properties", ".pem", ".php", ".xml", ".ts", ".env", "Dockerfile", '
                     '".java", ".rb", ".go", ".cs", ".txt") specify the argument with `--secrets-scan-file-type all`. '
-                    'default scan will be for ".tf", ".yml", ".yaml", ".json", ".template" and exclude "Pipfile.lock", "yarn.lock", "package-lock.json", "requirements.txt"')
+                    'default scan will be for ".tf", ".hcl", ".yml", ".yaml", ".json", ".template", ".bicep" and '
+                    'exclude "Pipfile.lock", "yarn.lock", "package-lock.json", "requirements.txt"')
 
 
 def get_external_checks_dir(config: Any) -> Any:

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -15,7 +15,6 @@ import hcl2
 from lark import Tree
 
 from checkov.common.runners.base_runner import filter_ignored_paths, IGNORE_HIDDEN_DIRECTORY_ENV
-from checkov.common.util.config_utils import should_scan_hcl_files
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR, RESOLVED_MODULE_ENTRY_NAME
 from checkov.common.util.json_utils import CustomJSONEncoder
 from checkov.common.variables.context import EvaluationContext
@@ -78,7 +77,6 @@ class Parser:
         self.external_modules_source_map = {}
         self.module_address_map = {}
         self.tf_var_files = tf_var_files
-        self.scan_hcl = should_scan_hcl_files()
         self.dirname_cache = {}
 
         if self.out_evaluations_context is None:
@@ -115,10 +113,8 @@ class Parser:
         load_tf_modules(directory)
         self._parse_directory(dir_filter=lambda d: self._check_process_dir(d), vars_files=vars_files)
 
-    def parse_file(
-        self, file: str, parsing_errors: Optional[Dict[str, Exception]] = None, scan_hcl: bool = False
-    ) -> Optional[Dict[str, Any]]:
-        if file.endswith(".tf") or file.endswith(".tf.json") or (scan_hcl and file.endswith(".hcl")):
+    def parse_file(self, file: str, parsing_errors: Optional[Dict[str, Exception]] = None) -> Optional[Dict[str, Any]]:
+        if file.endswith(".tf") or file.endswith(".tf.json") or file.endswith(".hcl"):
             parse_result = _load_or_die_quietly(file, parsing_errors)
             if parse_result:
                 parse_result = self._serialize_definitions(parse_result)

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -227,7 +227,7 @@ class Parser:
                 explicit_var_files.append(file)
 
             # Resource files
-            elif file.name.endswith(".tf") or (self.scan_hcl and file.name.endswith('.hcl')):  # TODO: add support for .tf.json
+            elif file.name.endswith(".tf") or file.name.endswith('.hcl'):  # TODO: add support for .tf.json
                 tf_files_to_load.append(file)
 
         files_to_data = self._load_files(tf_files_to_load)

--- a/tests/common/utils/test_utils.py
+++ b/tests/common/utils/test_utils.py
@@ -3,8 +3,6 @@ import re
 import unittest
 
 from checkov.common.comment.enum import COMMENT_REGEX
-from checkov.common.models.consts import SCAN_HCL_FLAG
-from checkov.common.util.config_utils import should_scan_hcl_files
 from checkov.common.util.data_structures_utils import merge_dicts
 from checkov.common.util.http_utils import normalize_prisma_url, normalize_bc_url
 
@@ -39,21 +37,6 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(len(res), 2)
         self.assertEqual(res['a'], '1')
         self.assertEqual(res['b'], '2')
-
-    def test_should_scan_hcl_env_var(self):
-        orig_value = os.getenv(SCAN_HCL_FLAG)
-
-        os.unsetenv(SCAN_HCL_FLAG)
-        self.assertFalse(should_scan_hcl_files())
-
-        os.environ[SCAN_HCL_FLAG] = 'FALSE'
-        self.assertFalse(should_scan_hcl_files())
-
-        os.environ[SCAN_HCL_FLAG] = 'TrUe'
-        self.assertTrue(should_scan_hcl_files())
-
-        if orig_value:
-            os.environ[SCAN_HCL_FLAG] = orig_value
 
     def test_normalize_prisma_url(self):
         self.assertEqual('https://api0.prismacloud.io', normalize_prisma_url('https://api0.prismacloud.io'))

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -14,7 +14,6 @@ from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.bridgecrew.severities import Severities, BcSeverities
 
 from checkov.common.checks_infra.registry import get_graph_checks_registry
-from checkov.common.models.consts import SCAN_HCL_FLAG
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.common.output.report import Report
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
@@ -1252,39 +1251,18 @@ class TestRunnerValid(unittest.TestCase):
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
         dir_to_scan = os.path.join(current_dir, 'resources', 'tf_with_hcl_files')
-        orig_value = os.getenv(SCAN_HCL_FLAG)
-
-        os.environ[SCAN_HCL_FLAG] = 'false'
-        runner = Runner()
-        report = runner.run(root_folder=dir_to_scan, external_checks_dir=None, files=None)
-        self.assertEqual(len(report.resources), 1)
-
-        os.environ[SCAN_HCL_FLAG] = 'true'
         runner = Runner()
         report = runner.run(root_folder=dir_to_scan, external_checks_dir=None, files=None)
         self.assertEqual(len(report.resources), 2)
-
-        if orig_value:
-            os.environ[SCAN_HCL_FLAG] = orig_value
 
     def test_runner_scan_hcl_file(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
         file_to_scan = os.path.join(current_dir, 'resources', 'tf_with_hcl_files', 'example_acl_fail.hcl')
-        orig_value = os.getenv(SCAN_HCL_FLAG)
 
-        os.environ[SCAN_HCL_FLAG] = 'false'
-        runner = Runner()
-        report = runner.run(root_folder=None, external_checks_dir=None, files=[file_to_scan])
-        self.assertEqual(len(report.resources), 0)
-
-        os.environ[SCAN_HCL_FLAG] = 'true'
         runner = Runner()
         report = runner.run(root_folder=None, external_checks_dir=None, files=[file_to_scan])
         self.assertEqual(len(report.resources), 1)
-
-        if orig_value:
-            os.environ[SCAN_HCL_FLAG] = orig_value
 
     def test_runner_exclude_file(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

We have been scanning .hcl and .bicep files, but they weren't listed as supported files and .hcl specifically was not scanned.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
