### PR TITLE
chore: enable flake8 for kustomize and add missing type hints

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,7 @@ max-line-length = 120
 # E203,E501 don't work with black together
 ignore = E203,E302,E305,E501,E731,W292,W293,W503,W504,DUO107,DUO104,DUO130,DUO109,DUO116,B950,TC001,TC003,TC006
 select = C,E,F,W,B,B9,A,TC
-extend-exclude = .github, .pytest_cache, docs/*, venv/*, tests/*, flake8_plugins/*, checkov/example_runner/*, checkov/kustomize/*
+extend-exclude = .github, .pytest_cache, docs/*, venv/*, tests/*, flake8_plugins/*
 
 [flake8:local-plugins]
 extension =

--- a/checkov/arm/parser/cfn_yaml.py
+++ b/checkov/arm/parser/cfn_yaml.py
@@ -116,8 +116,8 @@ NodeConstructor.add_constructor(
 
 class Representer(Representer):
     def represent_none(self, data):
-        return self.represent_scalar(u'tag:yaml.org,2002:null',
-                                     u'')
+        return self.represent_scalar(u'tag:yaml.org,2002:null', u'')
+
 
 class MarkedLoader(Reader, Scanner, Parser, Composer, NodeConstructor, Representer, Resolver):
     """

--- a/checkov/bitbucket/runner.py
+++ b/checkov/bitbucket/runner.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from checkov.common.checks.base_check_registry import BaseCheckRegistry
     from checkov.common.output.report import Report
 
+
 class Runner(JsonRunner):
     check_type = CheckType.BITBUCKET_CONFIGURATION  # noqa: CCE003  # a static attribute
 

--- a/checkov/circleci_pipelines/checks/SuspectCurlInScript.py
+++ b/checkov/circleci_pipelines/checks/SuspectCurlInScript.py
@@ -5,6 +5,7 @@ from checkov.circleci_pipelines.base_circleci_pipelines_check import BaseCircleC
 from checkov.common.models.enums import CheckResult
 from checkov.yaml_doc.enums import BlockType
 
+
 class SuspectCurlInScript(BaseCircleCIPipelinesCheck):
     def __init__(self) -> None:
         name = "Suspicious use of curl in run task"
@@ -13,7 +14,7 @@ class SuspectCurlInScript(BaseCircleCIPipelinesCheck):
             name=name,
             id=id,
             block_type=BlockType.ARRAY,
-            supported_entities=['jobs.*.steps[]']
+            supported_entities=('jobs.*.steps[]',)
         )
 
     def scan_conf(self, conf: dict[str, Any]) -> tuple[CheckResult, dict[str, Any]]:

--- a/checkov/circleci_pipelines/checks/latest_image.py
+++ b/checkov/circleci_pipelines/checks/latest_image.py
@@ -5,6 +5,7 @@ from checkov.circleci_pipelines.base_circleci_pipelines_check import BaseCircleC
 from checkov.common.models.enums import CheckResult
 from checkov.yaml_doc.enums import BlockType
 
+
 class ImageReferenceLatestTag(BaseCircleCIPipelinesCheck):
     def __init__(self) -> None:
         name = "Ensure the pipeline image uses a non latest version tag"
@@ -13,7 +14,7 @@ class ImageReferenceLatestTag(BaseCircleCIPipelinesCheck):
             name=name,
             id=id,
             block_type=BlockType.ARRAY,
-            supported_entities=['jobs.*.docker[].{image: image, __startline__: __startline__, __endline__:__endline__}']
+            supported_entities=('jobs.*.docker[].{image: image, __startline__: __startline__, __endline__:__endline__}',)
         )
 
     def scan_conf(self, conf: dict[str, Any]) -> tuple[CheckResult, dict[str, Any]]:

--- a/checkov/circleci_pipelines/checks/prevent_development_orbs.py
+++ b/checkov/circleci_pipelines/checks/prevent_development_orbs.py
@@ -5,6 +5,7 @@ from checkov.circleci_pipelines.base_circleci_pipelines_check import BaseCircleC
 from checkov.common.models.enums import CheckResult
 from checkov.yaml_doc.enums import BlockType
 
+
 class PreventDevelopmentOrbs(BaseCircleCIPipelinesCheck):
     def __init__(self) -> None:
         name = "Ensure mutable development orbs are not used."
@@ -13,7 +14,7 @@ class PreventDevelopmentOrbs(BaseCircleCIPipelinesCheck):
             name=name,
             id=id,
             block_type=BlockType.ARRAY,
-            supported_entities=["orbs.{orbs: @}"]
+            supported_entities=("orbs.{orbs: @}",)
         )
 
     def scan_conf(self, conf: dict[str, Any]) -> tuple[CheckResult, dict[str, Any]]:
@@ -26,5 +27,6 @@ class PreventDevelopmentOrbs(BaseCircleCIPipelinesCheck):
                     return CheckResult.FAILED, conf
         
         return CheckResult.PASSED, conf
+
 
 check = PreventDevelopmentOrbs()

--- a/checkov/circleci_pipelines/checks/prevent_volatile_orbs.py
+++ b/checkov/circleci_pipelines/checks/prevent_volatile_orbs.py
@@ -5,6 +5,7 @@ from checkov.circleci_pipelines.base_circleci_pipelines_check import BaseCircleC
 from checkov.common.models.enums import CheckResult
 from checkov.yaml_doc.enums import BlockType
 
+
 class PreventVolatileOrbs(BaseCircleCIPipelinesCheck):
     def __init__(self) -> None:
         name = "Ensure unversioned volatile orbs are not used."
@@ -13,7 +14,7 @@ class PreventVolatileOrbs(BaseCircleCIPipelinesCheck):
             name=name,
             id=id,
             block_type=BlockType.ARRAY,
-            supported_entities=["orbs.{orbs: @}"]
+            supported_entities=("orbs.{orbs: @}",)
         )
 
     def scan_conf(self, conf: dict[str, Any]) -> tuple[CheckResult, dict[str, Any]]:
@@ -26,5 +27,6 @@ class PreventVolatileOrbs(BaseCircleCIPipelinesCheck):
                     return CheckResult.FAILED, conf
         
         return CheckResult.PASSED, conf
+
 
 check = PreventVolatileOrbs()

--- a/checkov/circleci_pipelines/runner.py
+++ b/checkov/circleci_pipelines/runner.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 WORKFLOW_DIRECTORY = "circleci"
 
+
 class Runner(YamlRunner, ImageReferencer):
     check_type = CheckType.CIRCLECI_PIPELINES  # noqa: CCE003  # a static attribute
 

--- a/checkov/cloudformation/checks/resource/aws/ALBListenerTLS12.py
+++ b/checkov/cloudformation/checks/resource/aws/ALBListenerTLS12.py
@@ -14,6 +14,7 @@ supported_policy_prefixes = {
     'TLS': ("ELBSecurityPolicy-TLS13-1-3-2021-06", "ELBSecurityPolicy-TLS13-1-2", "ELBSecurityPolicy-FS-1-2", "ELBSecurityPolicy-TLS-1-2")
 }
 
+
 class ALBListenerTLS12(BaseResourceCheck):
     def __init__(self) -> None:
         name = "Ensure that Load Balancer Listener is using at least TLS v1.2"

--- a/checkov/cloudformation/checks/resource/aws/APIGatewayAuthorization.py
+++ b/checkov/cloudformation/checks/resource/aws/APIGatewayAuthorization.py
@@ -1,21 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
 
-class APIGatewayAuthorization(BaseResourceCheck):
 
-    def __init__(self):
+class APIGatewayAuthorization(BaseResourceCheck):
+    def __init__(self) -> None:
         name = "Ensure there is no open access to back-end resources through API"
         id = "CKV_AWS_59"
-        supported_resources = ['AWS::ApiGateway::Method']
-        categories = [CheckCategories.GENERAL_SECURITY]
+        supported_resources = ('AWS::ApiGateway::Method',)
+        categories = (CheckCategories.GENERAL_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:
         if 'Properties' in conf.keys():
             if 'HttpMethod' in conf['Properties'].keys() and 'AuthorizationType' in conf['Properties'].keys():
                 if conf['Properties']['HttpMethod'] != "OPTIONS" and conf['Properties']['AuthorizationType'] == "NONE":
                     if 'ApiKeyRequired' not in conf['Properties'].keys() or conf['Properties']['ApiKeyRequired'] is False:
                         return CheckResult.FAILED
         return CheckResult.PASSED
+
 
 check = APIGatewayAuthorization()

--- a/checkov/cloudformation/checks/resource/aws/AmazonMQBrokerPublicAccess.py
+++ b/checkov/cloudformation/checks/resource/aws/AmazonMQBrokerPublicAccess.py
@@ -1,19 +1,27 @@
+from typing import Any
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
-class AmazonMQBrokerPublicAccess(BaseResourceValueCheck):
 
-    def __init__(self):
+class AmazonMQBrokerPublicAccess(BaseResourceValueCheck):
+    def __init__(self) -> None:
         name = "Ensure Amazon MQ Broker should not have public access"
         id = "CKV_AWS_69"
-        supported_resources = ['AWS::AmazonMQ::Broker']
-        categories = [CheckCategories.GENERAL_SECURITY]
-        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources, missing_block_result=CheckResult.FAILED)
+        supported_resources = ('AWS::AmazonMQ::Broker',)
+        categories = (CheckCategories.GENERAL_SECURITY,)
+        super().__init__(
+            name=name,
+            id=id,
+            categories=categories,
+            supported_resources=supported_resources,
+            missing_block_result=CheckResult.FAILED,
+        )
 
-    def get_expected_value(self):
+    def get_expected_value(self) -> Any:
         return False
 
-    def get_inspected_key(self):
+    def get_inspected_key(self) -> str:
         """
             validates Amazon MQ Broker should not have public access
             https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html

--- a/checkov/cloudformation/checks/resource/aws/EC2PublicIP.py
+++ b/checkov/cloudformation/checks/resource/aws/EC2PublicIP.py
@@ -5,6 +5,7 @@ from typing import Any
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
 
+
 class EC2PublicIP(BaseResourceCheck):
     def __init__(self) -> None:
         name = "EC2 instance should not have public IP."

--- a/checkov/cloudformation/checks/resource/aws/EKSNodeGroupRemoteAccess.py
+++ b/checkov/cloudformation/checks/resource/aws/EKSNodeGroupRemoteAccess.py
@@ -1,17 +1,20 @@
-from typing import List
+from __future__ import annotations
+
+from typing import Any
 
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
 
+
 class EKSNodeGroupRemoteAccess(BaseResourceCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure AWS EKS node group does not have implicit SSH access from 0.0.0.0/0"
         id = "CKV_AWS_100"
-        supported_resources = ['AWS::EKS::Nodegroup']
-        categories = [CheckCategories.KUBERNETES]
+        supported_resources = ('AWS::EKS::Nodegroup',)
+        categories = (CheckCategories.KUBERNETES,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:
         if 'Properties' in conf.keys():
             if 'RemoteAccess' in conf['Properties'].keys():
                 if 'Ec2SshKey' in conf['Properties']['RemoteAccess'].keys():
@@ -21,7 +24,7 @@ class EKSNodeGroupRemoteAccess(BaseResourceCheck):
                         return CheckResult.FAILED
         return CheckResult.PASSED
 
-    def get_evaluated_keys(self) -> List[str]:
+    def get_evaluated_keys(self) -> list[str]:
         return ["Properties/RemoteAccess/Ec2SshKey", "Properties/RemoteAccess/SourceSecurityGroups"]
 
 

--- a/checkov/cloudformation/checks/resource/aws/SecurityGroupRuleDescription.py
+++ b/checkov/cloudformation/checks/resource/aws/SecurityGroupRuleDescription.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
 
+
 class SecurityGroupRuleDescription(BaseResourceCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure every security groups rule has a description"
         id = "CKV_AWS_23"
-        supported_resource = ['AWS::EC2::SecurityGroup', 'AWS::EC2::SecurityGroupIngress', 'AWS::EC2::SecurityGroupEgress']
-        categories = [CheckCategories.NETWORKING]
+        supported_resource = ('AWS::EC2::SecurityGroup', 'AWS::EC2::SecurityGroupIngress', 'AWS::EC2::SecurityGroupEgress')
+        categories = (CheckCategories.NETWORKING,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resource)
 
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:
         """
             Looks for description in security group rules :
             https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html

--- a/checkov/example_runner/checks/base_example_runner_check.py
+++ b/checkov/example_runner/checks/base_example_runner_check.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 from checkov.common.checks.base_check import BaseCheck
 from checkov.common.models.enums import CheckCategories
 
+
 # Change the class name to your runner
 # Eg. BaseXXXXXXXXXXXXXCheck
 class BaseExampleRunnerCheck(BaseCheck):

--- a/checkov/example_runner/checks/job/ExampleCheckTrueFalse.py
+++ b/checkov/example_runner/checks/job/ExampleCheckTrueFalse.py
@@ -22,7 +22,7 @@
 #       ACTIONS_ALLOW_UNSECURE_COMMANDS: false
 #     run: |
 #       echo "ok"
-# 
+#
 from __future__ import annotations
 
 from typing import Any
@@ -38,7 +38,7 @@ class ExampleCheckTrueFalse(BaseExampleRunnerJobCheck):
     def __init__(self) -> None:
         # Describe the check for the user
         name = "Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn't true on environment variables on a job"
-        # Give the check a unique id eg. CKV_TLA_24 where 
+        # Give the check a unique id eg. CKV_TLA_24 where
         #  CKV is standard for python checks
         #  TLA = Three letter acronym for your runner check type: GHA is GitHub Actions
         #  24 is the number in sequence of checks.  Must be unique!
@@ -52,9 +52,9 @@ class ExampleCheckTrueFalse(BaseExampleRunnerJobCheck):
         )
 
     def scan_entity_conf(self, conf: dict[str, Any], entity_type: str) -> tuple[CheckResult, dict[str, Any]]:  # type:ignore[override]  # return type is different than the base class
-        # The block type is passed as a data structure.  
+        # The block type is passed as a data structure.
         # Add logic to parse the structure for the misconfig
-        # Remember to always return a PASSED or FAILED. 
+        # Remember to always return a PASSED or FAILED.
         # It is easy to miss a result in complex logic
         if "env" not in conf:
             return CheckResult.PASSED, conf

--- a/checkov/example_runner/runner.py
+++ b/checkov/example_runner/runner.py
@@ -14,6 +14,7 @@ from checkov.yaml_doc.runner import Runner as YamlRunner
 if TYPE_CHECKING:
     from checkov.common.checks.base_check_registry import BaseCheckRegistry
 
+
 # Inherit either that YamlRunner or the JSONRunner or ObjectRunner
 # depending on IaC type or for the latter if a totally new IaC type
 class Runner(YamlRunner):
@@ -23,10 +24,10 @@ class Runner(YamlRunner):
     # ...
     #   MY_TYPE = "my_type"
     #
-    check_type = CheckType.MY_TYPE  # type:ignore[attr-defined]  # just used as an example
+    check_type = CheckType.MY_TYPE  # type:ignore[attr-defined]  # noqa: CCE003  # a static attribute
 
     # Define your block type
-    block_type_registries = {
+    block_type_registries = {  # noqa: CCE003  # a static attribute
         "jobs": job_registry,
     }
 

--- a/checkov/kubernetes/checks/resource/k8s/AllowPrivilegeEscalationPSP.py
+++ b/checkov/kubernetes/checks/resource/k8s/AllowPrivilegeEscalationPSP.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.kubernetes.checks.resource.base_spec_check import BaseK8Check
 
-class AllowPrivilegeEscalationPSP(BaseK8Check):
 
-    def __init__(self):
+class AllowPrivilegeEscalationPSP(BaseK8Check):
+    def __init__(self) -> None:
         # CIS-1.3 1.7.5
         # CIS-1.5 5.2.5
         # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -15,11 +19,11 @@ class AllowPrivilegeEscalationPSP(BaseK8Check):
         # Location: PodSecurityPolicy.spec.allowPrivilegeEscalation
         name = "Containers should not run with allowPrivilegeEscalation"
         id = "CKV_K8S_5"
-        supported_kind = ['PodSecurityPolicy']
-        categories = [CheckCategories.KUBERNETES]
+        supported_kind = ('PodSecurityPolicy',)
+        categories = (CheckCategories.KUBERNETES,)
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
-    def scan_spec_conf(self, conf):
+    def scan_spec_conf(self, conf: dict[str, Any]) -> CheckResult:
         if "spec" in conf:
             if "allowPrivilegeEscalation" in conf["spec"]:
                 if conf["spec"]["allowPrivilegeEscalation"]:
@@ -28,5 +32,6 @@ class AllowPrivilegeEscalationPSP(BaseK8Check):
                     return CheckResult.PASSED
             else:
                 return CheckResult.FAILED
+
 
 check = AllowPrivilegeEscalationPSP()

--- a/checkov/kubernetes/checks/resource/k8s/ApiServerAdmissionControlEventRateLimit.py
+++ b/checkov/kubernetes/checks/resource/k8s/ApiServerAdmissionControlEventRateLimit.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.kubernetes.checks.resource.base_spec_check import BaseK8Check
 
+
 class ApiServerAdmissionControlEventRateLimit(BaseK8Check):
-    def __init__(self):
+    def __init__(self) -> None:
         id = "CKV_K8S_78"
         name = "Ensure that the admission control plugin EventRateLimit is set"
-        categories = [CheckCategories.KUBERNETES]
-        supported_kind = ['AdmissionConfiguration']
+        categories = (CheckCategories.KUBERNETES,)
+        supported_kind = ('AdmissionConfiguration',)
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
-    def scan_spec_conf(self, conf):
+    def scan_spec_conf(self, conf: dict[str, Any]) -> CheckResult:
         if "plugins" not in conf:
             return CheckResult.FAILED
         plugins = conf["plugins"]
@@ -18,5 +23,6 @@ class ApiServerAdmissionControlEventRateLimit(BaseK8Check):
                 return CheckResult.PASSED
 
         return CheckResult.FAILED
+
 
 check = ApiServerAdmissionControlEventRateLimit()

--- a/checkov/kubernetes/checks/resource/k8s/ApiServerAuthorizationModeNotAlwaysAllow.py
+++ b/checkov/kubernetes/checks/resource/k8s/ApiServerAuthorizationModeNotAlwaysAllow.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 from checkov.common.models.enums import CheckResult
 from checkov.kubernetes.checks.resource.base_container_check import BaseK8sContainerCheck
 
+
 class ApiServerAuthorizationModeNotAlwaysAllow(BaseK8sContainerCheck):
     def __init__(self) -> None:
         id = "CKV_K8S_74"
@@ -21,5 +22,6 @@ class ApiServerAuthorizationModeNotAlwaysAllow(BaseK8sContainerCheck):
                         break
            
         return CheckResult.PASSED
+
 
 check = ApiServerAuthorizationModeNotAlwaysAllow()

--- a/checkov/kubernetes/checks/resource/k8s/ApiServerAuthorizationModeRBAC.py
+++ b/checkov/kubernetes/checks/resource/k8s/ApiServerAuthorizationModeRBAC.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 from checkov.common.models.enums import CheckResult
 from checkov.kubernetes.checks.resource.base_container_check import BaseK8sContainerCheck
 
+
 class ApiServerAuthorizationModeRBAC(BaseK8sContainerCheck):
     def __init__(self) -> None:
         id = "CKV_K8S_77"
@@ -22,5 +23,6 @@ class ApiServerAuthorizationModeRBAC(BaseK8sContainerCheck):
                 return CheckResult.PASSED if hasRBACAuthorizationMode else CheckResult.FAILED
            
         return CheckResult.PASSED
+
 
 check = ApiServerAuthorizationModeRBAC()

--- a/checkov/kubernetes/checks/resource/k8s/WildcardRoles.py
+++ b/checkov/kubernetes/checks/resource/k8s/WildcardRoles.py
@@ -1,16 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.kubernetes.checks.resource.base_spec_check import BaseK8Check
 
+
 class WildcardRoles(BaseK8Check):
     # CIS-1.6 5.1.3
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Minimize wildcard use in Roles and ClusterRoles"
         id = "CKV_K8S_49"
-        categories = [CheckCategories.KUBERNETES]
-        supported_kind = ['Role', 'ClusterRole']
+        categories = (CheckCategories.KUBERNETES,)
+        supported_kind = ('Role', 'ClusterRole',)
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
-    def scan_spec_conf(self, conf):
+    def scan_spec_conf(self, conf: dict[str, Any]) -> CheckResult:
         if isinstance(conf.get("rules"), list) and len(conf.get("rules")) > 0:
             if "apiGroups" in conf["rules"][0]:
                 if any("*" in s for s in conf["rules"][0]["apiGroups"]):
@@ -23,5 +28,6 @@ class WildcardRoles(BaseK8Check):
                     return CheckResult.FAILED
 
         return CheckResult.PASSED
+
 
 check = WildcardRoles()

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -211,6 +211,7 @@ class Runner(BaseRunner):
 def get_relative_file_path(file_abs_path: str, root_folder: str) -> str:
     return f"/{os.path.relpath(file_abs_path, root_folder)}"
 
+
 def _get_entity_abs_path(root_folder: str | None, entity_file_path: str) -> str:
     if entity_file_path[0] == '/' and (root_folder and not entity_file_path.startswith(root_folder)):
         path_to_convert = (root_folder + entity_file_path) if root_folder else entity_file_path

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -37,22 +37,22 @@ class K8sKustomizeRunner(K8sRunner):
         graph_manager: GraphManager | None = None,
         external_registries: list[BaseRegistry] | None = None
     ) -> None:
-        db_connector = db_connector or NetworkxConnector()
 
         super().__init__(graph_class, db_connector, source, graph_manager, external_registries, CheckType.KUSTOMIZE)
         self.check_type = CheckType.KUSTOMIZE
         self.report_mutator_data = {}
         self.pbar.turn_off_progress_bar()
 
-    def set_external_data(self,
-                          definitions: Optional[Dict[str, Dict[str, Any]]],
-                          context: Optional[Dict[str, Dict[str, Any]]],
-                          breadcrumbs: Optional[Dict[str, Dict[str, Any]]],
-                          report_mutator_data: Optional[Dict[str, Dict[str, Any]]]
-                          ):
+    def set_external_data(
+        self,
+        definitions: Optional[Dict[str, Dict[str, Any]]],
+        context: Optional[Dict[str, Dict[str, Any]]],
+        breadcrumbs: Optional[Dict[str, Dict[str, Any]]],
+        report_mutator_data: Optional[Dict[str, Dict[str, Any]]]
+    ) -> None:
         super().set_external_data(definitions, context, breadcrumbs)
         self.report_mutator_data = report_mutator_data
-        
+
     def set_report_mutator_data(self, report_mutator_data: Optional[Dict[str, Dict[str, Any]]]) -> None:
         self.report_mutator_data = report_mutator_data
 
@@ -86,7 +86,7 @@ class K8sKustomizeRunner(K8sRunner):
                 check_class=check.__class__.__module__, file_abs_path=realKustomizeEnvMetadata['filePath'], severity=check.severity)
             record.set_guideline(check.guideline)
             report.add_record(record=record)
-        
+
         return report
 
     def line_range(self, code_lines):
@@ -190,7 +190,7 @@ class Runner(BaseRunner):
                 fileContent = yaml.safe_load(kustomizationFile)
             except yaml.YAMLError:
                 logging.info(f"Failed to load Kustomize metadata from {kustomization_path}.", exc_info=True)
-    
+
             if 'resources' in fileContent:
                 logging.debug(f"Kustomization contains resources: section. Likley a base. {kustomization_path}")
                 metadata['type'] = "base"
@@ -213,7 +213,7 @@ class Runner(BaseRunner):
 
             if metadata.get('type') == "overlay":
                 self.potentialOverlays.append(metadata['filePath'])
-               
+
         return metadata
 
     def check_system_deps(self):
@@ -235,13 +235,13 @@ class Runner(BaseRunner):
                         logging.info(f"Found working version of {self.check_type} dependancy {self.kubectl_command}: {kubectlVersion}")
                         self.templateRendererCommand = self.kubectl_command
                         return None
-            
+
             except Exception:
                 logging.debug(f"An error occured testing the {self.kubectl_command} command: {e}")
                 pass
 
         elif shutil.which(self.kustomize_command) is not None:
-    
+
             try:
                 proc = subprocess.Popen([self.kustomize_command, 'version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # nosec
                 o, e = proc.communicate()
@@ -258,7 +258,7 @@ class Runner(BaseRunner):
             except Exception:
                 logging.debug(f"An error occured testing the {self.kustomize_command} command: {e}")
                 pass
-        
+
         else:
             logging.info(f"Could not find usable tools locally to process {self.check_type} checks. Framework will be disabled for this run.")
             return self.check_type
@@ -315,8 +315,7 @@ class Runner(BaseRunner):
                     if cur_writer:
                         # Here we are about to close a "complete" file. The function will validate it looks like a K8S manifest before continuing.
                         Runner._curWriterValidateStoreMapAndClose(cur_writer, file_path, shared_kustomize_file_mappings)
-                    file_path = os.path.join(extract_dir, str(source))
-                    parent = os.path.dirname(file_path)
+                    parent = os.path.dirname(os.path.join(extract_dir, str(source)))
                     os.makedirs(parent, exist_ok=True)
                     cur_source_file = source
                     cur_writer = open(os.path.join(extract_dir, str(source)), 'a')
@@ -402,7 +401,7 @@ class Runner(BaseRunner):
         cur_writer = Runner._get_parsed_output(file_path, extract_dir, output_str, shared_kustomize_file_mappings)
         if cur_writer:
             Runner._curWriterValidateStoreMapAndClose(cur_writer, file_path, shared_kustomize_file_mappings)
-        
+
     @staticmethod
     def _run_kustomize_parser(
         filePath: str,
@@ -426,7 +425,7 @@ class Runner(BaseRunner):
         for filePath in self.kustomizeProcessedFolderAndMeta:
             if self.kustomizeProcessedFolderAndMeta[filePath].get('type') == 'overlay':
                 self._handle_overlay_case(filePath)
-        
+
         if platform.system() == 'Windows':
             sharedKustomizeFileMappings: dict[str, str] = {}
             for filePath in self.kustomizeProcessedFolderAndMeta:
@@ -434,7 +433,7 @@ class Runner(BaseRunner):
                                              self.templateRendererCommand, self.target_folder_path)
             self.kustomizeFileMappings = sharedKustomizeFileMappings
             return
-        
+
         manager = multiprocessing.Manager()
         # make sure we have new dict
         sharedKustomizeFileMappings = copy.copy(manager.dict())

--- a/checkov/serverless/checks/function/aws/AdminPolicyDocument.py
+++ b/checkov/serverless/checks/function/aws/AdminPolicyDocument.py
@@ -2,12 +2,13 @@ from checkov.serverless.checks.function.base_function_check import BaseFunctionC
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.serverless.parsers.parser import IAM_ROLE_STATEMENTS_TOKEN
 
+
 class AdminPolicyDocument(BaseFunctionCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure IAM policies that allow full \"*-*\" administrative privileges are not created"
         id = "CKV_AWS_1"
-        supported_entities = ['serverless_aws']
-        categories = [CheckCategories.IAM]
+        supported_entities = ('serverless_aws',)
+        categories = (CheckCategories.IAM,)
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities)
 
     def scan_function_conf(self, conf):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally we encourage adding a scope to the prefix, which indicates the targeted framework, otherwise 'general' will be assumed.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- the last folder to enable `flake8` for 🚀 
- also added missing type hints for `kustomize` and adjusted the naming to be Python styled, there is still work left, but at some point I had to stop 😄 
- already started to fix an other flake8 issue, but there more files to be adjusted, will be finished in an other PR

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
