### PR TITLE
feat(terraform): GCP Cloud functions should define access

### DIFF
--- a/checkov/terraform/checks/graph_checks/gcp/CloudFunctionsDefineAccess.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/CloudFunctionsDefineAccess.yaml
@@ -1,0 +1,19 @@
+metadata:
+  id: "CKV2_GCP_10"
+  name: "Ensure Cloud functions have access defined"
+  category: "Security"
+definition:
+  and:
+    - cond_type: filter
+      attribute: resource_type
+      value:
+        - google_cloudfunctions_function
+      operator: within
+    - resource_types:
+        - google_cloudfunctions_function
+      connected_resource_types:
+        - google_cloudfunctions_function_iam_policy
+        - google_cloudfunctions_function_iam_binding
+        - google_cloudfunctions_function_iam_member
+      operator:  exists
+      cond_type: connection

--- a/tests/terraform/graph/checks/resources/CloudFunctionsDefineAccess/expected.yaml
+++ b/tests/terraform/graph/checks/resources/CloudFunctionsDefineAccess/expected.yaml
@@ -1,0 +1,4 @@
+fail:
+  - "google_cloudfunctions_function.fail"
+pass:
+  - "google_cloudfunctions_function.pass"

--- a/tests/terraform/graph/checks/resources/CloudFunctionsDefineAccess/main.tf
+++ b/tests/terraform/graph/checks/resources/CloudFunctionsDefineAccess/main.tf
@@ -1,0 +1,31 @@
+resource "google_cloudfunctions_function_iam_member" "member" {
+  project = google_cloudfunctions_function.pass.project
+  region = google_cloudfunctions_function.pass.region
+  cloud_function = google_cloudfunctions_function.pass.name
+  role = "roles/viewer"
+  member = "user:jane@example.com"
+}
+
+resource "google_cloudfunctions_function" "pass" {
+  name        = "function-test"
+  description = "My function"
+  runtime     = "nodejs16"
+
+  available_memory_mb   = 128
+  source_archive_bucket = google_storage_bucket.bucket.name
+  source_archive_object = google_storage_bucket_object.archive.name
+  trigger_http          = true
+  entry_point           = "helloGET"
+}
+
+resource "google_cloudfunctions_function" "fail" {
+  name        = "function-test"
+  description = "My function"
+  runtime     = "nodejs16"
+
+  available_memory_mb   = 128
+  source_archive_bucket = google_storage_bucket.bucket.name
+  source_archive_object = google_storage_bucket_object.archive.name
+  trigger_http          = true
+  entry_point           = "helloGET"
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -23,6 +23,9 @@ class TestYamlPolicies(unittest.TestCase):
         warnings.filterwarnings("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 
+    def test_CloudFunctionsDefineAccess(self):
+        self.go("CloudFunctionsDefineAccess")
+
     def test_ADORepositoryHasMinTwoReviewers(self):
         self.go("ADORepositoryHasMinTwoReviewers")
 


### PR DESCRIPTION
"As of November 1, 2019, newly created Functions are private-by-default and will require appropriate IAM permissions to be invoked."

cloudfunctions need to be accompanied by a permission resource

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally we encourage adding a scope to the prefix, which indicates the targeted framework, otherwise 'general' will be assumed.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
