### PR TITLE
fix(sca): do not skip the scan if BC_LIC is used with --check

### DIFF
--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -15,6 +15,7 @@ from checkov.common.bridgecrew.vulnerability_scanning.integrations.docker_image_
 from checkov.common.output.common import ImageDetails
 from checkov.common.output.report import Report, CheckType
 from checkov.common.runners.base_runner import strtobool
+from checkov.common.sca.commons import should_run_scan
 from checkov.common.sca.output import parse_vulns_to_records, get_license_statuses
 
 if TYPE_CHECKING:
@@ -124,7 +125,7 @@ class ImageReferencerMixin:
         from checkov.common.bridgecrew.platform_integration import bc_integration
 
         # skip complete run, if flag '--check' was used without a CVE check ID
-        if runner_filter.checks and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter.checks):
+        if not should_run_scan(runner_filter.checks):
             return None
 
         images = self.extract_images(graph_connector=graph_connector)

--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -124,7 +124,7 @@ class ImageReferencerMixin:
         from checkov.common.bridgecrew.platform_integration import bc_integration
 
         # skip complete run, if flag '--check' was used without a CVE check ID
-        if runner_filter.checks and all(not check.startswith("CKV_CVE") for check in runner_filter.checks):
+        if runner_filter.checks and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter.checks):
             return None
 
         images = self.extract_images(graph_connector=graph_connector)

--- a/checkov/common/sca/commons.py
+++ b/checkov/common/sca/commons.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+from typing import List, Optional
+
 from checkov.common.output.common import ImageDetails
 
 UNFIXABLE_VERSION = "N/A"
@@ -34,6 +37,6 @@ def normalize_twistcli_language(language: str) -> str:
     return TWISTCLI_TO_CHECKOV_LANG_NORMALIZATION.get(language, language)
 
 
-def should_run_scan(runner_filter_checks: list) -> bool:
-    return not(runner_filter_checks
+def should_run_scan(runner_filter_checks: Optional[List[str]]) -> bool:
+    return not (runner_filter_checks
                and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter_checks))

--- a/checkov/common/sca/commons.py
+++ b/checkov/common/sca/commons.py
@@ -38,5 +38,4 @@ def normalize_twistcli_language(language: str) -> str:
 
 
 def should_run_scan(runner_filter_checks: Optional[List[str]]) -> bool:
-    return not (runner_filter_checks
-               and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter_checks))
+    return not (runner_filter_checks and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter_checks))

--- a/checkov/common/sca/commons.py
+++ b/checkov/common/sca/commons.py
@@ -32,3 +32,8 @@ def normalize_twistcli_language(language: str) -> str:
     this function's goal is to normalize them
     """
     return TWISTCLI_TO_CHECKOV_LANG_NORMALIZATION.get(language, language)
+
+
+def should_run_scan(runner_filter_checks: list) -> bool:
+    return not(runner_filter_checks
+               and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter_checks))

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -20,6 +20,7 @@ from checkov.common.output.report import Report, merge_reports
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.output.common import ImageDetails
 from checkov.common.runners.base_runner import filter_ignored_paths, strtobool
+from checkov.common.sca.commons import should_run_scan
 from checkov.common.sca.output import parse_vulns_to_records, get_license_statuses
 from checkov.common.util.file_utils import compress_file_gzip_base64
 from checkov.common.util.dockerfile import is_docker_file
@@ -51,7 +52,7 @@ class Runner(PackageRunner):
         runner_filter = runner_filter or RunnerFilter()
 
         # skip complete run, if flag '--check' was used without a CVE check ID or the license policies
-        if runner_filter.checks and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter.checks):
+        if not should_run_scan(runner_filter.checks):
             return {}
 
         if not bc_integration.bc_api_key:
@@ -232,7 +233,7 @@ class Runner(PackageRunner):
         :return: vulnerability report
         """
         # skip complete run, if flag '--check' was used without a CVE check ID
-        if runner_filter.checks and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter.checks):
+        if not should_run_scan(runner_filter.checks):
             return Report(self.check_type)
 
         cached_results: Dict[str, Any] = image_scanner.get_scan_results_from_cache(f"image:{image.name}")

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -50,8 +50,8 @@ class Runner(PackageRunner):
     ) -> Dict[str, Any]:
         runner_filter = runner_filter or RunnerFilter()
 
-        # skip complete run, if flag '--check' was used without a CVE check ID
-        if runner_filter.checks and all(not check.startswith("CKV_CVE") for check in runner_filter.checks):
+        # skip complete run, if flag '--check' was used without a CVE check ID or the license policies
+        if runner_filter.checks and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter.checks):
             return {}
 
         if not bc_integration.bc_api_key:
@@ -232,7 +232,7 @@ class Runner(PackageRunner):
         :return: vulnerability report
         """
         # skip complete run, if flag '--check' was used without a CVE check ID
-        if runner_filter.checks and all(not check.startswith("CKV_CVE") for check in runner_filter.checks):
+        if runner_filter.checks and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter.checks):
             return Report(self.check_type)
 
         cached_results: Dict[str, Any] = image_scanner.get_scan_results_from_cache(f"image:{image.name}")

--- a/checkov/sca_package/runner.py
+++ b/checkov/sca_package/runner.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 from typing import Sequence, Any
 
+from checkov.common.sca.commons import should_run_scan
 from checkov.common.sca.output import parse_vulns_to_records
 from checkov.common.typing import _LicenseStatus
 from checkov.common.bridgecrew.platform_integration import bc_integration
@@ -36,7 +37,7 @@ class Runner(BaseRunner):
         excluded_file_names = excluded_file_names or set()
 
         # skip complete run, if flag '--check' was used without a CVE check ID or the license policies
-        if runner_filter.checks and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter.checks):
+        if not should_run_scan(runner_filter.checks):
             return None
 
         if not bc_integration.bc_api_key:

--- a/checkov/sca_package/runner.py
+++ b/checkov/sca_package/runner.py
@@ -35,8 +35,8 @@ class Runner(BaseRunner):
         runner_filter = runner_filter or RunnerFilter()
         excluded_file_names = excluded_file_names or set()
 
-        # skip complete run, if flag '--check' was used without a CVE check ID
-        if runner_filter.checks and all(not check.startswith("CKV_CVE") for check in runner_filter.checks):
+        # skip complete run, if flag '--check' was used without a CVE check ID or the license policies
+        if runner_filter.checks and all(not (check.startswith("CKV_CVE") or check.startswith("BC_CVE") or check.startswith("BC_LIC")) for check in runner_filter.checks):
             return None
 
         if not bc_integration.bc_api_key:

--- a/tests/sca_image/test_runner.py
+++ b/tests/sca_image/test_runner.py
@@ -113,19 +113,12 @@ def test_runner_honors_enforcement_rules(mock_bc_integration, image_name, cached
 
     # when
     image_runner = Runner()
-    filter = RunnerFilter(framework=['sca_image'], use_enforcement_rules=True)
-    # this is not quite a true test, because the checks don't have severities. However, this shows that the check registry
-    # passes the report type properly to RunnerFilter.should_run_check, and we have tests for that method
-    filter.enforcement_rule_configs = {CheckType.SCA_IMAGE: Severities[BcSeverities.OFF]}
+    filter = RunnerFilter(framework=['sca_image'], checks=['BC_LIC_1'])
     image_runner.image_referencers = [GHA_Runner()]
     report = image_runner.run(root_folder=WORKFLOW_EXAMPLES_DIR, runner_filter=filter)
 
-    summary = report.get_summary()
     # then
-    assert summary["passed"] == 0
-    assert summary["failed"] == 0
-    assert summary["skipped"] == 5
-    assert summary["parsing_errors"] == 0
+    assert not [c for c in report.passed_checks + report.failed_checks if c.check_id.startswith('CKV_CVE')]
 
 
 def test_run(sca_image_report):

--- a/tests/sca_image/test_runner.py
+++ b/tests/sca_image/test_runner.py
@@ -113,13 +113,66 @@ def test_runner_honors_enforcement_rules(mock_bc_integration, image_name, cached
 
     # when
     image_runner = Runner()
+    filter = RunnerFilter(framework=['sca_image'], use_enforcement_rules=True)
+    # this is not quite a true test, because the checks don't have severities. However, this shows that the check registry
+    # passes the report type properly to RunnerFilter.should_run_check, and we have tests for that method
+    filter.enforcement_rule_configs = {CheckType.SCA_IMAGE: Severities[BcSeverities.OFF]}
+    image_runner.image_referencers = [GHA_Runner()]
+    report = image_runner.run(root_folder=WORKFLOW_EXAMPLES_DIR, runner_filter=filter)
+
+    summary = report.get_summary()
+    # then
+    assert summary["passed"] == 0
+    assert summary["failed"] == 0
+    assert summary["skipped"] == 5
+    assert summary["parsing_errors"] == 0
+
+
+def test_run_license_policy(mock_bc_integration, image_name, cached_scan_result):
+    # given
+    image_id_encoded = quote_plus(f"image:{image_name}")
+
+    response_json = {
+        "violations": [
+            {
+                "name": "readline",
+                "version": "8.1.2-r0",
+                "license": "Apache-2.0",
+                "policy": "BC_LIC_1",
+                "status": "OPEN"
+            },
+            {
+                "name": "libnsl",
+                "version": "2.0.0-r0",
+                "license": "Apache-2.0",
+                "policy": "BC_LIC_1",
+                "status": "COMPLIANT"
+            },
+        ]
+    }
+
+    responses.add(
+        method=responses.POST,
+        url=mock_bc_integration.bc_api_url + "/api/v1/vulnerabilities/packages/get-licenses-violations",
+        json=response_json,
+        status=200
+    )
+    responses.add(
+        method=responses.GET,
+        url=mock_bc_integration.bc_api_url + f"/api/v1/vulnerabilities/scan-results/{image_id_encoded}",
+        json=cached_scan_result,
+        status=200,
+    )
+
+    # when
+    image_runner = Runner()
     filter = RunnerFilter(framework=['sca_image'], checks=['BC_LIC_1'])
     image_runner.image_referencers = [GHA_Runner()]
     report = image_runner.run(root_folder=WORKFLOW_EXAMPLES_DIR, runner_filter=filter)
 
     # then
     assert not [c for c in report.passed_checks + report.failed_checks if c.check_id.startswith('CKV_CVE')]
-
+    
 
 def test_run(sca_image_report):
     # given

--- a/tests/sca_package/test_runner.py
+++ b/tests/sca_package/test_runner.py
@@ -126,7 +126,7 @@ def test_run_license_policy(mocker: MockerFixture, scan_result):
 
     # when
     runner = Runner()
-    filter = RunnerFilter(framework=['sca_package'])
+    filter = RunnerFilter(framework=['sca_package'], checks=['BC_LIC_1'])
     report = runner.run(root_folder=EXAMPLES_DIR, runner_filter=filter)
 
     # then

--- a/tests/sca_package/test_runner.py
+++ b/tests/sca_package/test_runner.py
@@ -117,6 +117,22 @@ def test_runner_honors_enforcement_rules(mocker: MockerFixture, scan_result):
     assert summary["parsing_errors"] == 0
 
 
+def test_run_license_policy(mocker: MockerFixture, scan_result):
+    # given
+    bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
+    scanner_mock = MagicMock()
+    scanner_mock.return_value.scan.return_value = scan_result
+    mocker.patch("checkov.sca_package.runner.Scanner", side_effect=scanner_mock)
+
+    # when
+    runner = Runner()
+    filter = RunnerFilter(framework=['sca_package'])
+    report = runner.run(root_folder=EXAMPLES_DIR, runner_filter=filter)
+
+    # then
+    assert not [c for c in report.passed_checks + report.failed_checks if c.check_id.startswith('CKV_CVE')]
+
+
 def test_run_with_empty_scan_result(mocker: MockerFixture):
     # given
     bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixes an issue where running with `-c BC_LIC_1` caused the SCA scans to get skipped entirely, returning no results.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
