### PR TITLE
feat(general): add flag for summary position

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -178,7 +178,7 @@ class Report:
         created_baseline_path: str | None = None,
         baseline: Baseline | None = None,
         use_bc_ids: bool = False,
-        summary_position: bool = 'top'
+        summary_position: str = 'top'
     ) -> str:
         summary = self.get_summary()
         output_data = colored(f"{self.check_type} scan results:\n", "blue")

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -178,6 +178,7 @@ class Report:
         created_baseline_path: str | None = None,
         baseline: Baseline | None = None,
         use_bc_ids: bool = False,
+        summary_position_bottom: bool = False
     ) -> str:
         summary = self.get_summary()
         output_data = colored(f"{self.check_type} scan results:\n", "blue")
@@ -193,7 +194,8 @@ class Report:
                 message = f"\nFailed checks: {summary['failed']}, Skipped checks: {summary['skipped']}\n\n"
             else:
                 message = f"\nPassed checks: {summary['passed']}, Failed checks: {summary['failed']}, Skipped checks: {summary['skipped']}\n\n"
-        output_data += colored(message, "cyan")
+        if not summary_position_bottom:
+            output_data += colored(message, "cyan")
         # output for vulnerabilities is different
         if self.check_type in (CheckType.SCA_PACKAGE, CheckType.SCA_IMAGE):
             if self.failed_checks or self.skipped_checks:
@@ -222,6 +224,8 @@ class Report:
                 f"Baseline analysis report using {baseline.path} - only new failed checks with respect to the baseline are reported",
                 "blue",
             )
+        if summary_position_bottom:
+            output_data += colored(message, "cyan")
         return output_data
 
     @staticmethod

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -178,7 +178,7 @@ class Report:
         created_baseline_path: str | None = None,
         baseline: Baseline | None = None,
         use_bc_ids: bool = False,
-        summary_position_bottom: bool = False
+        summary_position: bool = 'top'
     ) -> str:
         summary = self.get_summary()
         output_data = colored(f"{self.check_type} scan results:\n", "blue")
@@ -194,7 +194,7 @@ class Report:
                 message = f"\nFailed checks: {summary['failed']}, Skipped checks: {summary['skipped']}\n\n"
             else:
                 message = f"\nPassed checks: {summary['passed']}, Failed checks: {summary['failed']}, Skipped checks: {summary['skipped']}\n\n"
-        if not summary_position_bottom:
+        if summary_position == 'top':
             output_data += colored(message, "cyan")
         # output for vulnerabilities is different
         if self.check_type in (CheckType.SCA_PACKAGE, CheckType.SCA_IMAGE):
@@ -224,7 +224,7 @@ class Report:
                 f"Baseline analysis report using {baseline.path} - only new failed checks with respect to the baseline are reported",
                 "blue",
             )
-        if summary_position_bottom:
+        if summary_position == 'bottom':
             output_data += colored(message, "cyan")
         return output_data
 

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -46,6 +46,7 @@ _BaseRunner = TypeVar("_BaseRunner", bound="BaseRunner[Any]")
 
 CHECK_BLOCK_TYPES = frozenset(["resource", "data", "provider", "module"])
 OUTPUT_CHOICES = ["cli", "cyclonedx", "json", "junitxml", "github_failed_only", "sarif", "csv"]
+SUMMARY_POSITIONS = frozenset(['top', 'bottom'])
 OUTPUT_DELIMITER = "\n--- OUTPUT DELIMITER ---\n"
 
 
@@ -249,7 +250,7 @@ class RunnerRegistry:
                     created_baseline_path=created_baseline_path,
                     baseline=baseline,
                     use_bc_ids=config.output_bc_ids,
-                    summary_position_bottom=config.summary_position_bottom
+                    summary_position=config.summary_position
                 )
             print(cli_output)
             # Remove colors from the cli output
@@ -270,7 +271,7 @@ class RunnerRegistry:
                     created_baseline_path=created_baseline_path,
                     baseline=baseline,
                     use_bc_ids=config.output_bc_ids,
-                    summary_position_bottom=config.summary_position_bottom
+                    summary_position=config.summary_position
                 ))
                 master_report.failed_checks += report.failed_checks
                 master_report.skipped_checks += report.skipped_checks

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -249,6 +249,7 @@ class RunnerRegistry:
                     created_baseline_path=created_baseline_path,
                     baseline=baseline,
                     use_bc_ids=config.output_bc_ids,
+                    summary_position_bottom=config.summary_position_bottom
                 )
             print(cli_output)
             # Remove colors from the cli output
@@ -269,6 +270,7 @@ class RunnerRegistry:
                     created_baseline_path=created_baseline_path,
                     baseline=baseline,
                     use_bc_ids=config.output_bc_ids,
+                    summary_position_bottom=config.summary_position_bottom
                 ))
                 master_report.failed_checks += report.failed_checks
                 master_report.skipped_checks += report.skipped_checks

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -575,7 +575,7 @@ def add_parser_args(parser: ArgumentParser) -> None:
                action='append',
                help='black file list to filter out from the secret scanner')
     parser.add('--summary-position-bottom', action='store_true',
-               help='change the summary to be appended in the bottom after the policy violations')
+               help='Change the summary to be appended in the bottom after the policy violations')
 
 
 def get_external_checks_dir(config: Any) -> Any:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -574,6 +574,8 @@ def add_parser_args(parser: ArgumentParser) -> None:
                env_var='CKV_SECRETS_SCAN_BLACK_LIST',
                action='append',
                help='black file list to filter out from the secret scanner')
+    parser.add('--summary-position-bottom', action='store_true',
+               help='change the summary to be appended in the bottom after the policy violations')
 
 
 def get_external_checks_dir(config: Any) -> Any:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -33,7 +33,7 @@ from checkov.common.goget.github.get_git import GitGetter
 from checkov.common.images.image_referencer import enable_image_referencer
 from checkov.common.output.baseline import Baseline
 from checkov.common.bridgecrew.check_type import CheckType
-from checkov.common.runners.runner_registry import RunnerRegistry, OUTPUT_CHOICES
+from checkov.common.runners.runner_registry import RunnerRegistry, OUTPUT_CHOICES, SUMMARY_POSITIONS
 from checkov.common.util import prompt
 from checkov.common.util.banner import banner as checkov_banner
 from checkov.common.util.config_utils import get_default_config_paths
@@ -574,8 +574,9 @@ def add_parser_args(parser: ArgumentParser) -> None:
                env_var='CKV_SECRETS_SCAN_BLACK_LIST',
                action='append',
                help='black file list to filter out from the secret scanner')
-    parser.add('--summary-position-bottom', action='store_true',
-               help='Change the summary to be appended in the bottom after the policy violations')
+    parser.add('--summary-position', default='top', choices=SUMMARY_POSITIONS,
+               help='Chose whether the summary will be appended on top (before the checks results) or on bottom '
+                    '(after check results), default is on top.')
 
 
 def get_external_checks_dir(config: Any) -> Any:

--- a/docs/2.Basics/CLI Command Reference.md
+++ b/docs/2.Basics/CLI Command Reference.md
@@ -57,3 +57,4 @@ nav_order: 2
 | `--output-baseline-as-skipped` | Output checks that are skipped due to baseline file presence |
 | `--skip-cve-package SKIP_CVE_PACKAGE` | Filter scan to run on all packages but a specific package identifier (deny list), You can specify this argument multiple times to skip multiple packages |
 | `--policy-metadata-filter POLICY_METADATA_FILTER` | Comma separated key:value string to filter policies based on Prisma Cloud policy metadata. See https://prisma.pan.dev/api/cloud/cspm/policy#operation/get-policy-filters-and-options for information on allowed filters. Format: policy.label=test,cloud.type=aws |
+| `--summary-position` | Chose whether the summary will be appended on top (before the checks results) or on bottom (after check results), default is on top. |


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixes https://github.com/bridgecrewio/checkov/issues/3222

### Description
Added a flag to enable changing the summary position within the report. Default behavior didn't change - summary at the top. adding the flag --summary-position-bottom will move it to the bottom.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
