### PR TITLE
feat(imageReferencer): Split `PRESENT_CACHED_RESULTS` env var to 2 feature flag like vars

### DIFF
--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -174,11 +174,12 @@ class Runner(PackageRunner):
             if image_referencer.is_workflow_file(abs_fname):
                 images = image_referencer.get_images(file_path=abs_fname)
                 for image in images:
-                    if not strtobool(os.getenv('CHECKOV_PRESENT_CACHED_RESULTS', "False")):
+                    if strtobool(os.getenv('CKV_CREATE_SCA_IMAGE_REPORTS_FOR_IR', "True")):
                         image_report = self.get_image_report(dockerfile_path=abs_fname, image=image,
                                                              runner_filter=runner_filter)
                         merge_reports(report, image_report)
-                    else:
+                    if strtobool(os.getenv('CKV_CREATE_IMAGE_CACHED_REPORTS_FOR_IR', "False")) or strtobool(os.getenv('CHECKOV_PRESENT_CACHED_RESULTS', "False")):
+                        # TODO: delete the old env var option (CHECKOV_PRESENT_CACHED_RESULTS) after full migration
                         image_cached_report: dict[str, Any] = self.get_image_cached_results(dockerfile_path=abs_fname, image=image)
                         if image_cached_report:
                             report.image_cached_results.append(image_cached_report)

--- a/tests/sca_image/test_runner.py
+++ b/tests/sca_image/test_runner.py
@@ -289,11 +289,19 @@ def test_run_with_empty_scan_result(mock_bc_integration):
     assert len(report.parsing_errors) == 0
 
 
-@mock.patch.dict(os.environ, {"CHECKOV_PRESENT_CACHED_RESULTS": "True"})
+@mock.patch.dict(os.environ, {"CKV_CREATE_IMAGE_CACHED_REPORTS_FOR_IR": "True"})
 @mock.patch.dict(os.environ, {"CKV_IGNORE_HIDDEN_DIRECTORIES": "false"})
 @mock.patch('checkov.sca_image.runner.Runner.get_image_cached_results', mock_scan_image)
 @responses.activate
-def test_run_with_present_cached_results_env():
+def test_run_with_image_cached_reports_env(mock_bc_integration, image_name2, cached_scan_result2):
+    image_id_encoded = quote_plus(f"image:{image_name2}")
+
+    responses.add(
+        method=responses.GET,
+        url=mock_bc_integration.bc_api_url + f"/api/v1/vulnerabilities/scan-results/{image_id_encoded}",
+        json=cached_scan_result2,
+        status=200,
+    )
 
     image_runner = Runner()
     runner_filter = RunnerFilter(framework=['sca_image'])
@@ -301,7 +309,7 @@ def test_run_with_present_cached_results_env():
     report = image_runner.run(root_folder=WORKFLOW_IMAGE_EXAMPLES_DIR, runner_filter=runner_filter)
 
     assert len(report.passed_checks) == 0
-    assert len(report.failed_checks) == 0
+    assert len(report.failed_checks) == 1
     assert len(report.skipped_checks) == 0
     assert len(report.parsing_errors) == 0
     assert len(report.image_cached_results) == 1
@@ -309,7 +317,7 @@ def test_run_with_present_cached_results_env():
 
 @mock.patch.dict(os.environ, {"CKV_IGNORE_HIDDEN_DIRECTORIES": "false"})
 @responses.activate
-def test_run_without_present_cached_results_env(mock_bc_integration, image_name2, cached_scan_result2):
+def test_run_without_image_cached_reports_env(mock_bc_integration, image_name2, cached_scan_result2):
     # given
     image_id_encoded = quote_plus(f"image:{image_name2}")
 
@@ -331,10 +339,36 @@ def test_run_without_present_cached_results_env(mock_bc_integration, image_name2
     assert len(report.parsing_errors) == 0
     assert len(report.image_cached_results) == 0
 
+@mock.patch.dict(os.environ, {"CKV_CREATE_IMAGE_CACHED_REPORTS_FOR_IR": "True"})
+@mock.patch.dict(os.environ, {"CKV_CREATE_SCA_IMAGE_REPORTS_FOR_IR": "False"})
+@mock.patch.dict(os.environ, {"CKV_IGNORE_HIDDEN_DIRECTORIES": "false"})
+@mock.patch('checkov.sca_image.runner.Runner.get_image_cached_results', mock_scan_image)
+@responses.activate
+def test_run_with_image_cached_reports_and_without_sca_reports_env(mock_bc_integration, image_name2, cached_scan_result2):
+    image_id_encoded = quote_plus(f"image:{image_name2}")
+
+    responses.add(
+        method=responses.GET,
+        url=mock_bc_integration.bc_api_url + f"/api/v1/vulnerabilities/scan-results/{image_id_encoded}",
+        json=cached_scan_result2,
+        status=200,
+    )
+
+    image_runner = Runner()
+    runner_filter = RunnerFilter(framework=['sca_image'])
+    image_runner.image_referencers = [GHA_Runner()]
+    report = image_runner.run(root_folder=WORKFLOW_IMAGE_EXAMPLES_DIR, runner_filter=runner_filter)
+
+    assert len(report.passed_checks) == 0
+    assert len(report.failed_checks) == 0
+    assert len(report.skipped_checks) == 0
+    assert len(report.parsing_errors) == 0
+    assert len(report.image_cached_results) == 1
+
 
 @responses.activate
 @mock.patch('checkov.github_actions.runner.Runner.get_images', mock_get_images)
-@mock.patch.dict(os.environ, {"CHECKOV_PRESENT_CACHED_RESULTS": "True"})
+@mock.patch.dict(os.environ, {"CKV_CREATE_IMAGE_CACHED_REPORTS_FOR_IR": "True"})
 def test_run_with_error_from_scan_results(mock_bc_integration, image_name2, cached_scan_result3):
     image_id_encoded = quote_plus(f"image:{image_name2}")
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
