### PR TITLE
fix(general): handle fixes for cloned OOTB policies

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
@@ -70,7 +70,7 @@ class FixesIntegration(BaseIntegrationFeature):
                 ckv_id = metadata_integration.get_ckv_id_from_bc_id(fix['policyId'])
                 if not ckv_id:
                     logging.debug(f"BC ID {fix['policyId']} has no checkov ID - might be a cloned policy")
-                    ckv_id = fix['policyId']
+                    ckv_id = fix.get('policyId', '')
 
                 failed_check = failed_check_by_check_resource.get((ckv_id, fix['resourceId']))  # type:ignore[arg-type]  # ckv_id is not None here
                 if not failed_check:

--- a/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
@@ -72,7 +72,7 @@ class FixesIntegration(BaseIntegrationFeature):
                     logging.debug(f"BC ID {fix['policyId']} has no checkov ID - might be a cloned policy")
                     ckv_id = fix['policyId']
 
-                failed_check = failed_check_by_check_resource.get((ckv_id, fix['resourceId']))
+                failed_check = failed_check_by_check_resource.get((ckv_id, fix['resourceId']))  # type:ignore[arg-type]  # ckv_id is not None here
                 if not failed_check:
                     logging.warning(f'Could not find the corresponding failed check for the fix for ID {ckv_id} and resource {fix["resourceId"]}')
                     continue

--- a/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
@@ -69,9 +69,13 @@ class FixesIntegration(BaseIntegrationFeature):
             for fix in all_fixes:
                 ckv_id = metadata_integration.get_ckv_id_from_bc_id(fix['policyId'])
                 if not ckv_id:
-                    logging.error(f"BC ID {fix['policyId']} has no checkov ID")
+                    logging.debug(f"BC ID {fix['policyId']} has no checkov ID - might be a cloned policy")
+                    ckv_id = fix['policyId']
+
+                failed_check = failed_check_by_check_resource.get((ckv_id, fix['resourceId']))
+                if not failed_check:
+                    logging.warning(f'Could not find the corresponding failed check for the fix for ID {ckv_id} and resource {fix["resourceId"]}')
                     continue
-                failed_check = failed_check_by_check_resource[(ckv_id, fix['resourceId'])]
                 failed_check.fixed_definition = fix['fixedDefinition']
 
     def _get_fixes_for_file(

--- a/tests/common/integration_features/resources/main.tf
+++ b/tests/common/integration_features/resources/main.tf
@@ -1,0 +1,3 @@
+resource "aws_subnet" "s" {
+  map_public_ip_on_launch = true
+}

--- a/tests/common/integration_features/test_fixes_integration.py
+++ b/tests/common/integration_features/test_fixes_integration.py
@@ -105,11 +105,10 @@ class TestFixesIntegration(unittest.TestCase):
         self.assertTrue(all(r.fixed_definition is not None for r in report.failed_checks))
 
     def setUp(self) -> None:
-        global _old_check_metadata
-        _old_check_metadata = metadata_integration.check_metadata
+        self._old_check_metadata = metadata_integration.check_metadata
 
     def tearDown(self) -> None:
-        metadata_integration.check_metadata = _old_check_metadata
+        metadata_integration.check_metadata = self._old_check_metadata
 
 
 def mock_fixes_response(check_type: str, filename: str, file_contents: str, failed_checks: Iterable[Record]

--- a/tests/common/integration_features/test_fixes_integration.py
+++ b/tests/common/integration_features/test_fixes_integration.py
@@ -1,7 +1,19 @@
-import unittest
+from __future__ import annotations
 
+import os
+import unittest
+from typing import Any, Iterable
+
+from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.bridgecrew.integration_features.features.fixes_integration import FixesIntegration
+from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as metadata_integration
 from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
+from checkov.common.models.enums import CheckResult
+from checkov.common.output.record import Record
+from checkov.common.output.report import Report
+
+
+_old_check_metadata = None
 
 
 class TestFixesIntegration(unittest.TestCase):
@@ -25,6 +37,102 @@ class TestFixesIntegration(unittest.TestCase):
 
         fixes_integration.integration_feature_failures = True
         self.assertFalse(fixes_integration.is_valid())
+
+    def test_apply_fixes_to_report(self):
+        instance = BcPlatformIntegration()
+        instance.skip_fixes = False
+        instance.platform_integration_configured = True
+
+        fixes_integration = FixesIntegration(instance)
+        fixes_integration._get_fixes_for_file = mock_fixes_response
+
+        metadata_integration.check_metadata = {
+            'custom_aws_12345': {'guideline': 'https://docs.bridgecrew.io/docs/ensure-vpc-subnets-do-not-assign-public-ip-by-default'},
+            'CKV_AWS_130': {
+                'id': 'BC_AWS_NETWORKING_53',
+                'title': 'Ensure VPC subnets do not assign public IP by default',
+                'guideline': 'https://docs.bridgecrew.io/docs/ensure-vpc-subnets-do-not-assign-public-ip-by-default',
+                'severity': 'MEDIUM',
+                'pcSeverity': 'MEDIUM',
+                'category': 'Networking',
+                'checkovId': 'CKV_AWS_130',
+                'constructiveTitle': 'Ensure VPC subnets do not assign public IP by default',
+                'descriptiveTitle': 'AWS VPC subnets should not allow automatic public IP assignment',
+                'pcPolicyId': '11743cd3-35e4-4639-91e1-bc87b52d4cf5',
+                'additionalPcPolicyIds': ['11743cd3-35e4-4639-91e1-bc87b52d4cf5'],
+                'benchmarks': {}
+            }
+        }
+
+        metadata_integration.bc_to_ckv_id_mapping = {
+            'BC_AWS_NETWORKING_53': 'CKV_AWS_130'
+        }
+
+        report = Report(CheckType.TERRAFORM)
+
+        file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources', 'main.tf')
+
+        report.add_record(Record(
+            check_id='CKV_AWS_130',
+            bc_check_id='BC_AWS_NETWORKING_53',
+            check_result={'result': CheckResult.FAILED, 'evaluated_keys': ['map_public_ip_on_launch']},
+            check_name='Ensure VPC subnets do not assign public IP by default',
+            check_class='checkov.terraform.checks.resource.aws.SubnetPublicIP',
+            code_block=[(1, 'resource "aws_subnet" "s" {\n'), (2, '  map_public_ip_on_launch = true\n'), (3, '}\n')],
+            evaluations=None,
+            file_abs_path=file,
+            file_line_range=[2, 3],
+            file_path='/main.tf',
+            resource='aws_subnet.s'
+        ))
+
+        report.add_record(Record(
+            check_id='custom_aws_12345',
+            bc_check_id='custom_aws_12345',
+            check_result={'result': CheckResult.FAILED, 'evaluated_keys': ['map_public_ip_on_launch']},
+            check_name='Cloned-Ensure VPC subnets do not assign public IP by default',
+            check_class='checkov.terraform.checks.resource.aws.SubnetPublicIP',
+            code_block=[(1, 'resource "aws_subnet" "s" {\n'), (2, '  map_public_ip_on_launch = true\n'), (3, '}\n')],
+            evaluations=None,
+            file_abs_path=file,
+            file_line_range=[2, 3],
+            file_path='/main.tf',
+            resource='aws_subnet.s'
+        ))
+
+        fixes_integration.post_runner(report)
+
+        self.assertTrue(all(r.fixed_definition is not None for r in report.failed_checks))
+
+    def setUp(self) -> None:
+        global _old_check_metadata
+        _old_check_metadata = metadata_integration.check_metadata
+
+    def tearDown(self) -> None:
+        metadata_integration.check_metadata = _old_check_metadata
+
+
+def mock_fixes_response(check_type: str, filename: str, file_contents: str, failed_checks: Iterable[Record]
+    ) -> dict[str, Any] | None:
+    return {
+        'filePath': '/private/tmp/custom/main.tf',
+        'fixes': [
+            {
+                'resourceId': 'aws_subnet.s',
+                'policyId': 'BC_AWS_NETWORKING_53',
+                'originalStartLine': 1,
+                'originalEndLine': 3,
+                'fixedDefinition': 'resource "aws_subnet" "s" {\n}\n'
+            },
+            {
+                'resourceId': 'aws_subnet.s',
+                'policyId': 'custom_aws_12345',
+                'originalStartLine': 1,
+                'originalEndLine': 3,
+                'fixedDefinition': 'resource "aws_subnet" "s" {\n}\n'
+            }
+        ]
+    }
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Handles a case where fixes get returned with a custom policy ID, when an OOTB fixable policy is cloned. Checkov would fail to map them to the correct record, and logged an error message. This also resulted in the IDE extensions thinking the scan failed.

This fixes the core issue and also logs the actual error, if it occurs, at a lower level, because it does not break the overall scan.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
