### PR TITLE
fix(kubernetes): [CKV_K8S_90] Remove unnecessary condition check from ApiServerProfiling.py

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/ApiServerProfiling.py
+++ b/checkov/kubernetes/checks/resource/k8s/ApiServerProfiling.py
@@ -14,7 +14,7 @@ class ApiServerProfiling(BaseK8sContainerCheck):
         self.evaluated_container_keys = ["command"]
         if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
-                if "--profiling=true" in conf["command"] or "--profiling=false" not in conf["command"]:
+                if "--profiling=false" not in conf["command"]:
                     return CheckResult.FAILED
 
         return CheckResult.PASSED


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

The earlier code was only checking if the `--profiling=true` is not needed.

### Fixes 
Optimised `CKV_K8S_90` to check only for `--profiling=false`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
