### PR TITLE
fix(general): only add `helpUri` to SARIF if it is non-empty

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -263,9 +263,11 @@ class Report:
                 "help": {
                     "text": f'"{record.check_name}\nResource: {record.resource}"',
                 },
-                "helpUri": help_uri,
                 "defaultConfiguration": {"level": "error"},
             }
+            if help_uri is not None and len(help_uri) > 0:
+                rule["helpUri"] = help_uri
+
             if record.check_id not in ruleset:
                 ruleset.add(record.check_id)
                 rules.append(rule)

--- a/tests/sca_image/test_output_reports.py
+++ b/tests/sca_image/test_output_reports.py
@@ -134,7 +134,6 @@ def test_get_sarif_json(sca_image_report_scope_function):
                                        "help": {
                                            "text": "\"SCA license\nResource: path/to/Dockerfile (sha256:123456).perl\""
                                        },
-                                       "helpUri": None,
                                        "defaultConfiguration": {
                                            "level": "error"
                                        }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Only add the `helpUri` to the SARIF rules when there is one.

Fixes #3540

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
