### PR TITLE
fix(kubernetes): [CKV_K8S_68] Remove unnecessary condition check from ApiServerAnonymousAuth.py

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/ApiServerAnonymousAuth.py
+++ b/checkov/kubernetes/checks/resource/k8s/ApiServerAnonymousAuth.py
@@ -14,7 +14,7 @@ class ApiServerAnonymousAuth(BaseK8sContainerCheck):
         self.evaluated_container_keys = ["command"]
         if conf.get("command"):
             if "kube-apiserver" in conf["command"]:
-                if "--anonymous-auth=true" in conf["command"] or "--anonymous-auth=false" not in conf["command"]:
+                if "--anonymous-auth=false" not in conf["command"]:
                     return CheckResult.FAILED
 
         return CheckResult.PASSED


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

The earlier code was only checking if the `--anonymous-auth=true` is not needed.

### Fixes 
Optimised `CKV_K8S_68` to check only for `--anonymous-auth=false`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
