### PR TITLE
fix(terraform): APIGatewayAuthorization check missing authorization

### DIFF
--- a/checkov/terraform/checks/resource/aws/APIGatewayAuthorization.py
+++ b/checkov/terraform/checks/resource/aws/APIGatewayAuthorization.py
@@ -13,7 +13,7 @@ class APIGatewayAuthorization(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if 'http_method' in conf and conf['http_method'][0] != "OPTIONS" and conf['authorization'][0] == "NONE" \
+        if 'http_method' in conf and conf['http_method'][0] != "OPTIONS" and ('authorization' not in conf or conf['authorization'][0] == "NONE") \
                 and ('api_key_required' not in conf or conf['api_key_required'][0] is False):
             return CheckResult.FAILED
         return CheckResult.PASSED

--- a/tests/terraform/checks/resource/aws/test_APIGatewayAuthorization.py
+++ b/tests/terraform/checks/resource/aws/test_APIGatewayAuthorization.py
@@ -14,7 +14,6 @@ class TestAPIGatewayAuthorization(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-
     def test_success(self):
         resource_conf = {"rest_api_id": ["${var.rest_api_id}"],
                          "resource_id": ["${var.resource_id}"],
@@ -31,6 +30,13 @@ class TestAPIGatewayAuthorization(unittest.TestCase):
                          "api_key_required": [True]}
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_authorization_missing(self):
+        resource_conf = {"rest_api_id": ["${var.rest_api_id}"],
+                         "resource_id": ["${var.resource_id}"],
+                         "http_method": ["${var.method}"]}
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
handle a case where the authorization field is missing in APIGatewayAuthorization check

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
