### PR TITLE
feat(terraform): add CKV_AWS_272 to validate Lambda function code-signing

### DIFF
--- a/checkov/terraform/checks/resource/aws/LambdaCodeSigningConfigured.py
+++ b/checkov/terraform/checks/resource/aws/LambdaCodeSigningConfigured.py
@@ -1,0 +1,21 @@
+from checkov.common.models.consts import ANY_VALUE
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class LambdaDLQConfigured(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
+        id = "CKV_AWS_116"
+        supported_resources = ['aws_lambda_function']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "dead_letter_config/[0]/target_arn"
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = LambdaDLQConfigured()

--- a/checkov/terraform/checks/resource/aws/LambdaCodeSigningConfigured.py
+++ b/checkov/terraform/checks/resource/aws/LambdaCodeSigningConfigured.py
@@ -5,7 +5,7 @@ from checkov.common.models.enums import CheckCategories
 
 class LambdaCodeSigningConfigured(BaseResourceValueCheck):
     def __init__(self):
-        name = "Ensure that AWS Lambda function is configured for a code-signing with signing profiles, which define the trusted publishers for this function"
+        name = "Ensure AWS Lambda function is configured to validate code-signing"
         id = "CKV_AWS_272"
         supported_resources = ['aws_lambda_function']
         categories = [CheckCategories.GENERAL_SECURITY]

--- a/checkov/terraform/checks/resource/aws/LambdaCodeSigningConfigured.py
+++ b/checkov/terraform/checks/resource/aws/LambdaCodeSigningConfigured.py
@@ -8,7 +8,7 @@ class LambdaCodeSigningConfigured(BaseResourceValueCheck):
         name = "Ensure AWS Lambda function is configured to validate code-signing"
         id = "CKV_AWS_272"
         supported_resources = ['aws_lambda_function']
-        categories = [CheckCategories.GENERAL_SECURITY]
+        categories = [CheckCategories.SUPPLY_CHAIN]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):

--- a/checkov/terraform/checks/resource/aws/LambdaCodeSigningConfigured.py
+++ b/checkov/terraform/checks/resource/aws/LambdaCodeSigningConfigured.py
@@ -3,19 +3,19 @@ from checkov.terraform.checks.resource.base_resource_value_check import BaseReso
 from checkov.common.models.enums import CheckCategories
 
 
-class LambdaDLQConfigured(BaseResourceValueCheck):
+class LambdaCodeSigningConfigured(BaseResourceValueCheck):
     def __init__(self):
-        name = "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-        id = "CKV_AWS_116"
+        name = "Ensure that AWS Lambda function is configured for a code-signing with signing profiles, which define the trusted publishers for this function"
+        id = "CKV_AWS_272"
         supported_resources = ['aws_lambda_function']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):
-        return "dead_letter_config/[0]/target_arn"
+        return "code_signing_config_arn"
 
     def get_expected_value(self):
         return ANY_VALUE
 
 
-check = LambdaDLQConfigured()
+check = LambdaCodeSigningConfigured()

--- a/tests/terraform/checks/resource/aws/example_LambdaCodeSigningConfigured/main.tf
+++ b/tests/terraform/checks/resource/aws/example_LambdaCodeSigningConfigured/main.tf
@@ -1,0 +1,16 @@
+# pass
+
+resource "aws_lambda_function" "pass" {
+  function_name = "test-env"
+  role          = ""
+  runtime       = "python3.8"
+  code_signing_config_arn = "123123123"
+}
+
+# fail
+
+resource "aws_lambda_function" "fail" {
+  function_name = "stest-env"
+  role          = ""
+  runtime       = "python3.8"
+}

--- a/tests/terraform/checks/resource/aws/test_LambdaCodeSigningConfigured.py
+++ b/tests/terraform/checks/resource/aws/test_LambdaCodeSigningConfigured.py
@@ -1,0 +1,38 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.aws.LambdaCodeSigningConfigured import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestLambdaCodeSigningConfigured(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+                        resource "aws_lambda_function" "fail" {
+                          function_name = "stest-env"
+                          role          = ""
+                          runtime       = "python3.8"
+                        }
+                        """)
+        resource_conf = hcl_res['resource'][0]['aws_lambda_function']['fail']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+                    resource "aws_lambda_function" "pass" {
+                      function_name = "test-env"
+                      role          = ""
+                      runtime       = "python3.8"
+                      code_signing_config_arn = "123123123"
+                    }
+                        """)
+        resource_conf = hcl_res['resource'][0]['aws_lambda_function']['pass']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Validate CKV_AWS_272 to check that lambda resource has code_signing_config_arn.
A code-signing configuration includes a set of signing profiles, which define the trusted publishers for this function.

### Fix
Optimised CKV_AWS_272 to check that lambda resource has code_signing_config_arn 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
