### PR TITLE
fix(general): use current branch name instead of master for the checkov-action 

### DIFF
--- a/github_action_resources/entrypoint.sh
+++ b/github_action_resources/entrypoint.sh
@@ -82,7 +82,7 @@ fi
 
 API_KEY=${API_KEY_VARIABLE}
 
-GIT_BRANCH=${GITHUB_HEAD_REF:=master}
+GIT_BRANCH=${GITHUB_HEAD_REF:="$GITHUB_REF_NAME"}
 export BC_FROM_BRANCH=${GIT_BRANCH}
 export BC_TO_BRANCH=${GITHUB_BASE_REF}
 export BC_PR_ID=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')

--- a/github_action_resources/entrypoint.sh
+++ b/github_action_resources/entrypoint.sh
@@ -83,6 +83,7 @@ fi
 API_KEY=${API_KEY_VARIABLE}
 
 GIT_BRANCH=${GITHUB_HEAD_REF:="$GITHUB_REF_NAME"}
+GIT_BRANCH=${GIT_BRANCH:=master}
 export BC_FROM_BRANCH=${GIT_BRANCH}
 export BC_TO_BRANCH=${GITHUB_BASE_REF}
 export BC_PR_ID=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Use `GITHUB_REF_NAME` instead of `master` when `GITHUB_HEAD_REF` is null. This is only relevant when the workflow is triggered by direct commits to the default branch or a manual trigger. 
Reference - https://docs.github.com/en/actions/learn-github-actions/environment-variables

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
