### PR TITLE
fix(secrets): change entropy limit in Combinator plugin

### DIFF
--- a/checkov/secrets/plugins/entropy_keyword_combinator.py
+++ b/checkov/secrets/plugins/entropy_keyword_combinator.py
@@ -13,12 +13,13 @@ if TYPE_CHECKING:
 
 MAX_LINE_LENGTH = 10000
 ENTROPY_KEYWORD_COMBINATOR_LIMIT = 3
+ENTROPY_KEYWORD_LIMIT = 4.5
 
 
 class EntropyKeywordCombinator(BasePlugin):
     secret_type = ""  # nosec  # noqa: CCE003  # a static attribute
 
-    def __init__(self, limit: float) -> None:
+    def __init__(self, limit: float = ENTROPY_KEYWORD_LIMIT) -> None:
         iac_limit = ENTROPY_KEYWORD_COMBINATOR_LIMIT
         self.high_entropy_scanners_iac = (Base64HighEntropyString(limit=iac_limit), HexHighEntropyString(limit=iac_limit))
         self.high_entropy_scanners = (Base64HighEntropyString(limit=limit), HexHighEntropyString(limit=limit))

--- a/checkov/secrets/plugins/entropy_keyword_combinator.py
+++ b/checkov/secrets/plugins/entropy_keyword_combinator.py
@@ -12,12 +12,13 @@ if TYPE_CHECKING:
     from detect_secrets.util.code_snippet import CodeSnippet
 
 MAX_LINE_LENGTH = 10000
+ENTROPY_KEYWORD_COMBINATOR_LIMIT = 4.5
 
 
 class EntropyKeywordCombinator(BasePlugin):
     secret_type = ""  # nosec  # noqa: CCE003  # a static attribute
 
-    def __init__(self, limit: float) -> None:
+    def __init__(self, limit: float = ENTROPY_KEYWORD_COMBINATOR_LIMIT) -> None:
         self.high_entropy_scanners = (Base64HighEntropyString(limit=limit), HexHighEntropyString(limit=limit))
         self.keyword_scanner = KeywordDetector()
 

--- a/checkov/secrets/plugins/entropy_keyword_combinator.py
+++ b/checkov/secrets/plugins/entropy_keyword_combinator.py
@@ -38,7 +38,7 @@ class EntropyKeywordCombinator(BasePlugin):
         one of the entropy scanners find a match (on a line which was already matched by keyword plugin) - it is returned.
         for source code files run and merge the two plugins.
         """
-        is_iac = True if f".{filename.split('.')[-1]}" not in SOURCE_CODE_EXTENSION else False
+        is_iac = f".{filename.split('.')[-1]}" not in SOURCE_CODE_EXTENSION
         if len(line) <= MAX_LINE_LENGTH:
             if is_iac:
                 keyword_matches = self.keyword_scanner.analyze_line(filename, line, line_number, **kwargs)

--- a/checkov/secrets/plugins/entropy_keyword_combinator.py
+++ b/checkov/secrets/plugins/entropy_keyword_combinator.py
@@ -12,13 +12,15 @@ if TYPE_CHECKING:
     from detect_secrets.util.code_snippet import CodeSnippet
 
 MAX_LINE_LENGTH = 10000
-ENTROPY_KEYWORD_COMBINATOR_LIMIT = 4.5
+ENTROPY_KEYWORD_COMBINATOR_LIMIT = 3
 
 
 class EntropyKeywordCombinator(BasePlugin):
     secret_type = ""  # nosec  # noqa: CCE003  # a static attribute
 
-    def __init__(self, limit: float = ENTROPY_KEYWORD_COMBINATOR_LIMIT) -> None:
+    def __init__(self, limit: float) -> None:
+        iac_limit = ENTROPY_KEYWORD_COMBINATOR_LIMIT
+        self.high_entropy_scanners_iac = (Base64HighEntropyString(limit=iac_limit), HexHighEntropyString(limit=iac_limit))
         self.high_entropy_scanners = (Base64HighEntropyString(limit=limit), HexHighEntropyString(limit=limit))
         self.keyword_scanner = KeywordDetector()
 
@@ -47,7 +49,7 @@ class EntropyKeywordCombinator(BasePlugin):
                 keyword_entropy = keyword_matches.union(entropy_matches)
                 return keyword_entropy
             if keyword_matches:
-                for entropy_scanner in self.high_entropy_scanners:
+                for entropy_scanner in self.high_entropy_scanners_iac:
                     matches = entropy_scanner.analyze_line(filename, line, line_number, **kwargs)
                     if matches:
                         return matches

--- a/checkov/secrets/plugins/entropy_keyword_combinator.py
+++ b/checkov/secrets/plugins/entropy_keyword_combinator.py
@@ -52,21 +52,6 @@ class EntropyKeywordCombinator(BasePlugin):
                     matches = entropy_scanner.analyze_line(filename, line, line_number, **kwargs)
                     if matches:
                         return matches
-
-            # keyword_matches = self.keyword_scanner.analyze_line(filename, line, line_number, **kwargs)
-            # if f".{filename.split('.')[-1]}" in SOURCE_CODE_EXTENSION:
-            #     for entropy_scanner in self.high_entropy_scanners:
-            #         matches = entropy_scanner.analyze_line(filename, line, line_number, **kwargs)
-            #         if matches:
-            #             entropy_matches = matches
-            #             break
-            #     keyword_entropy = keyword_matches.union(entropy_matches)
-            #     return keyword_entropy
-            # if keyword_matches:
-            #     for entropy_scanner in self.high_entropy_scanners_iac:
-            #         matches = entropy_scanner.analyze_line(filename, line, line_number, **kwargs)
-            #         if matches:
-            #             return matches
         return set()
 
     def analyze_string(self, string: str) -> Generator[str, None, None]:

--- a/checkov/secrets/plugins/entropy_keyword_combinator.py
+++ b/checkov/secrets/plugins/entropy_keyword_combinator.py
@@ -13,12 +13,15 @@ if TYPE_CHECKING:
 
 MAX_LINE_LENGTH = 10000
 ENTROPY_KEYWORD_COMBINATOR_LIMIT = 3
+ENTROPY_KEYWORD_LIMIT = 4.5
 
 
 class EntropyKeywordCombinator(BasePlugin):
     secret_type = ""  # nosec  # noqa: CCE003  # a static attribute
 
-    def __init__(self, limit: float = ENTROPY_KEYWORD_COMBINATOR_LIMIT) -> None:
+    def __init__(self, limit: float = ENTROPY_KEYWORD_LIMIT) -> None:
+        iac_limit = ENTROPY_KEYWORD_COMBINATOR_LIMIT
+        self.high_entropy_scanners_iac = (Base64HighEntropyString(limit=iac_limit), HexHighEntropyString(limit=iac_limit))
         self.high_entropy_scanners = (Base64HighEntropyString(limit=limit), HexHighEntropyString(limit=limit))
         self.keyword_scanner = KeywordDetector()
 
@@ -35,14 +38,22 @@ class EntropyKeywordCombinator(BasePlugin):
         one of the entropy scanners find a match (on a line which was already matched by keyword plugin) - it is returned.
         for source code files run and merge the two plugins.
         """
+        entropy_matches = set()
         if len(line) <= MAX_LINE_LENGTH:
-            if f".{filename.split('.')[-1]}" not in SOURCE_CODE_EXTENSION:
-                keyword_matches = self.keyword_scanner.analyze_line(filename, line, line_number, **kwargs)
-                if keyword_matches:
-                    for entropy_scanner in self.high_entropy_scanners:
-                        matches = entropy_scanner.analyze_line(filename, line, line_number, **kwargs)
-                        if matches:
-                            return matches
+            keyword_matches = self.keyword_scanner.analyze_line(filename, line, line_number, **kwargs)
+            if f".{filename.split('.')[-1]}" in SOURCE_CODE_EXTENSION:
+                for entropy_scanner in self.high_entropy_scanners:
+                    matches = entropy_scanner.analyze_line(filename, line, line_number, **kwargs)
+                    if matches:
+                        entropy_matches = matches
+                        break
+                keyword_entropy = keyword_matches.union(entropy_matches)
+                return keyword_entropy
+            if keyword_matches:
+                for entropy_scanner in self.high_entropy_scanners_iac:
+                    matches = entropy_scanner.analyze_line(filename, line, line_number, **kwargs)
+                    if matches:
+                        return matches
         return set()
 
     def analyze_string(self, string: str) -> Generator[str, None, None]:

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -69,62 +69,37 @@ MAX_FILE_SIZE = int(os.getenv('CHECKOV_MAX_FILE_SIZE', '5000000'))  # 5 MB is de
 class Runner(BaseRunner[None]):
     check_type = CheckType.SECRETS  # noqa: CCE003  # a static attribute
 
-    def run(
-            self,
+    def run(self,
             root_folder: str | None,
             external_checks_dir: list[str] | None = None,
             files: list[str] | None = None,
             runner_filter: RunnerFilter | None = None,
             collect_skip_comments: bool = True
-    ) -> Report:
+            ) -> Report:
         runner_filter = runner_filter or RunnerFilter()
         current_dir = Path(__file__).parent
         secrets = SecretsCollection()
         plugins_used = \
             [
-                {
-                    'name': 'AWSKeyDetector'
-                },
-                {
-                    'name': 'ArtifactoryDetector'
-                },
-                {
-                    'name': 'AzureStorageKeyDetector'
-                },
-                {
-                    'name': 'BasicAuthDetector'
-                },
-                {
-                    'name': 'CloudantDetector'
-                },
-                {
-                    'name': 'IbmCloudIamDetector'
-                },
-                {
-                    'name': 'MailchimpDetector'
-                },
-                {
-                    'name': 'PrivateKeyDetector'
-                },
-                {
-                    'name': 'SlackDetector'
-                },
-                {
-                    'name': 'SoftlayerDetector'
-                },
-                {
-                    'name': 'SquareOAuthDetector'
-                },
-                {
-                    'name': 'StripeDetector'
-                },
-                {
-                    'name': 'TwilioKeyDetector'
-                },
+                {'name': 'AWSKeyDetector'},
+                {'name': 'ArtifactoryDetector'},
+                {'name': 'AzureStorageKeyDetector'},
+                {'name': 'BasicAuthDetector'},
+                {'name': 'CloudantDetector'},
+                {'name': 'IbmCloudIamDetector'},
+                {'name': 'MailchimpDetector'},
+                {'name': 'PrivateKeyDetector'},
+                {'name': 'SlackDetector'},
+                {'name': 'SoftlayerDetector'},
+                {'name': 'SquareOAuthDetector'},
+                {'name': 'StripeDetector'},
+                {'name': 'TwilioKeyDetector'},
+                {'name': 'HexHighEntropyString'},
+                {'name': 'Base64HighEntropyString'},
+                {'name': 'TwilioKeyDetector'},
                 {
                     'name': 'EntropyKeywordCombinator',
-                    'path': f'file://{current_dir}/plugins/entropy_keyword_combinator.py',
-                    'limit': ENTROPY_KEYWORD_LIMIT
+                    'path': f'file://{current_dir}/plugins/entropy_keyword_combinator.py'
                 }
             ]
         custom_plugins = os.getenv("CHECKOV_CUSTOM_DETECTOR_PLUGINS_PATH")

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -94,9 +94,6 @@ class Runner(BaseRunner[None]):
                 {'name': 'SquareOAuthDetector'},
                 {'name': 'StripeDetector'},
                 {'name': 'TwilioKeyDetector'},
-                {'name': 'HexHighEntropyString'},
-                {'name': 'Base64HighEntropyString'},
-                {'name': 'TwilioKeyDetector'},
                 {
                     'name': 'EntropyKeywordCombinator',
                     'path': f'file://{current_dir}/plugins/entropy_keyword_combinator.py',

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -93,8 +93,6 @@ class Runner(BaseRunner[None]):
                 {'name': 'SquareOAuthDetector'},
                 {'name': 'StripeDetector'},
                 {'name': 'TwilioKeyDetector'},
-                {'name': 'Base64HighEntropyString'},  # default limit from secrets lib is 4.5
-                {'name': 'HexHighEntropyString'},  # default limit from secrets lib is 4.5
                 {
                     'name': 'EntropyKeywordCombinator',
                     'path': f'file://{current_dir}/plugins/entropy_keyword_combinator.py'

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -60,7 +60,6 @@ SECRET_TYPE_TO_ID = {
 }
 CHECK_ID_TO_SECRET_TYPE = {v: k for k, v in SECRET_TYPE_TO_ID.items()}
 
-ENTROPY_KEYWORD_LIMIT = 4.5
 PROHIBITED_FILES = ['Pipfile.lock', 'yarn.lock', 'package-lock.json', 'requirements.txt']
 
 MAX_FILE_SIZE = int(os.getenv('CHECKOV_MAX_FILE_SIZE', '5000000'))  # 5 MB is default limit
@@ -96,8 +95,7 @@ class Runner(BaseRunner[None]):
                 {'name': 'TwilioKeyDetector'},
                 {
                     'name': 'EntropyKeywordCombinator',
-                    'path': f'file://{current_dir}/plugins/entropy_keyword_combinator.py',
-                    'limit': ENTROPY_KEYWORD_LIMIT
+                    'path': f'file://{current_dir}/plugins/entropy_keyword_combinator.py'
                 }
             ]
         custom_plugins = os.getenv("CHECKOV_CUSTOM_DETECTOR_PLUGINS_PATH")

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -60,7 +60,7 @@ SECRET_TYPE_TO_ID = {
 }
 CHECK_ID_TO_SECRET_TYPE = {v: k for k, v in SECRET_TYPE_TO_ID.items()}
 
-ENTROPY_KEYWORD_LIMIT = 3
+ENTROPY_KEYWORD_LIMIT = 4.5
 PROHIBITED_FILES = ['Pipfile.lock', 'yarn.lock', 'package-lock.json', 'requirements.txt']
 
 MAX_FILE_SIZE = int(os.getenv('CHECKOV_MAX_FILE_SIZE', '5000000'))  # 5 MB is default limit
@@ -99,7 +99,8 @@ class Runner(BaseRunner[None]):
                 {'name': 'TwilioKeyDetector'},
                 {
                     'name': 'EntropyKeywordCombinator',
-                    'path': f'file://{current_dir}/plugins/entropy_keyword_combinator.py'
+                    'path': f'file://{current_dir}/plugins/entropy_keyword_combinator.py',
+                    'limit': ENTROPY_KEYWORD_LIMIT
                 }
             ]
         custom_plugins = os.getenv("CHECKOV_CUSTOM_DETECTOR_PLUGINS_PATH")

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -93,6 +93,8 @@ class Runner(BaseRunner[None]):
                 {'name': 'SquareOAuthDetector'},
                 {'name': 'StripeDetector'},
                 {'name': 'TwilioKeyDetector'},
+                {'name': 'Base64HighEntropyString'},  # default limit from secrets lib is 4.5
+                {'name': 'HexHighEntropyString'},  # default limit from secrets lib is 4.5
                 {
                     'name': 'EntropyKeywordCombinator',
                     'path': f'file://{current_dir}/plugins/entropy_keyword_combinator.py'

--- a/tests/secrets/resources/cfn/secret-no-false-positive.yml
+++ b/tests/secrets/resources/cfn/secret-no-false-positive.yml
@@ -1,0 +1,29 @@
+"""
+
+no False Positive - where it's not an actual secret
+check_metadata_values = ('bafadssda$#%2', 'bdfsver#$@%')
+CHECKOV_METADATA_RESULT = 'checkov_results5243gvr'
+check1 = {'blabla': 'blabla1'}
+check2 = {'blabla': 'blabla2'}
+check1['some_key_1235#$@'] = check2.get('some_value_1235')
+
+
+"""
+
+  CleanBucketFunction:
+    Type: "AWS::Lambda::Function"
+    DependsOn: CleanupRole
+    Properties:
+      Handler: index.clearS3Bucket
+      Role:
+        Fn::GetAtt: CleanupRole.Arn
+      Runtime: nodejs12.x
+      Timeout: 25
+      Code:
+        ZipFile: |
+          no False Positive - where it's not an actual secret
+          check_metadata_values = ('bafadssda$#%2', 'bdfsver#$@%')
+          CHECKOV_METADATA_RESULT = 'checkov_results5243gvr'
+          check1 = {'blabla': 'blabla1'}
+          check2 = {'blabla': 'blabla2'}
+          check1['some_key_1235#$@'] = check2.get('some_value_1235')

--- a/tests/secrets/resources/cfn/secret-no-false-positive.yml
+++ b/tests/secrets/resources/cfn/secret-no-false-positive.yml
@@ -1,13 +1,5 @@
 """
-
 no False Positive - where it's not an actual secret
-check_metadata_values = ('bafadssda$#%2', 'bdfsver#$@%')
-CHECKOV_METADATA_RESULT = 'checkov_results5243gvr'
-check1 = {'blabla': 'blabla1'}
-check2 = {'blabla': 'blabla2'}
-check1['some_key_1235#$@'] = check2.get('some_value_1235')
-
-
 """
 
   CleanBucketFunction:
@@ -27,3 +19,4 @@ check1['some_key_1235#$@'] = check2.get('some_value_1235')
           check1 = {'blabla': 'blabla1'}
           check2 = {'blabla': 'blabla2'}
           check1['some_key_1235#$@'] = check2.get('some_value_1235')
+          not_a_secr_k = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"

--- a/tests/secrets/resources/file_type/test.py
+++ b/tests/secrets/resources/file_type/test.py
@@ -1,3 +1,11 @@
+# no False Positive - where it's not an actual secret
+check_metadata_values = ('bafadssda$#%2', 'bdfsver#$@%')
+CHECKOV_METADATA_RESULT = 'checkov_results5243gvr'
+check1 = {'blabla': 'blabla1'}
+check2 = {'blabla': 'blabla2'}
+check1['some_key_1235#$@'] = check2.get('some_value_1235')
+
+
 access_key = "AKIAIOSFODNN7EXAMPLE"
 secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 if __name__ == '__main__':

--- a/tests/secrets/test_plugin.py
+++ b/tests/secrets/test_plugin.py
@@ -23,7 +23,7 @@ class TestCombinatorPlugin(unittest.TestCase):
         self.assertEqual(0, len(result))
 
     def test_popular_kubernetes_manifest_password(self):
-        result = self.plugin.analyze_line("mock.yaml", 'pwd: "correcthorsebatterystaple"', 5)
+        result = self.plugin.analyze_line("mock.yaml", 'pwd: "correcthorsebatterystaple"', 5)  # fails now
         self.assertEqual(1, len(result))
         secret = result.pop()
         self.assertEqual("Base64 High Entropy String", secret.type)

--- a/tests/secrets/test_plugin.py
+++ b/tests/secrets/test_plugin.py
@@ -30,12 +30,6 @@ class TestCombinatorPlugin(unittest.TestCase):
         self.assertEqual("bfd3617727eab0e800e62a776c76381defbc4145", secret.secret_hash)
 
     def test_source_code_file_value(self):
+        # combinator plugin should ignore source code files
         result = self.plugin.analyze_line("main.py", 'api_key = "7T)G#dl5}c=T>kf$G3Bon^!R?kzF00"', 1)
-        self.assertEqual(1, len(result))
-        secret = result.pop()
-        self.assertEqual("Secret Keyword", secret.type)
-        self.assertEqual("93beaa774e56483f19e4fe916ce87e62d4b3ea85", secret.secret_hash)
-
-    def test_source_code_no_false_positive(self):
-        result = self.plugin.analyze_line("main.py", "check1['some_key_1235#$@'] = check2.get('some_value_1235')", 1)
         self.assertEqual(0, len(result))

--- a/tests/secrets/test_plugin.py
+++ b/tests/secrets/test_plugin.py
@@ -1,12 +1,11 @@
 import unittest
 
 from checkov.secrets.plugins.entropy_keyword_combinator import EntropyKeywordCombinator
-from checkov.secrets.runner import ENTROPY_KEYWORD_LIMIT
 
 
 class TestCombinatorPlugin(unittest.TestCase):
     def setUp(self) -> None:
-        self.plugin = EntropyKeywordCombinator(ENTROPY_KEYWORD_LIMIT)
+        self.plugin = EntropyKeywordCombinator()
 
     def test_positive_value(self):
         result = self.plugin.analyze_line("mock.tf", 'api_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMAAAKEY"', 5)
@@ -36,3 +35,7 @@ class TestCombinatorPlugin(unittest.TestCase):
         secret = result.pop()
         self.assertEqual("Secret Keyword", secret.type)
         self.assertEqual("93beaa774e56483f19e4fe916ce87e62d4b3ea85", secret.secret_hash)
+
+    def test_source_code_no_false_positive(self):
+        result = self.plugin.analyze_line("main.py", "check_metadata_values = ('bafadssda$#%2', 'bdfsver#$@%')", 1)
+        self.assertEqual(0, len(result))

--- a/tests/secrets/test_plugin.py
+++ b/tests/secrets/test_plugin.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 from checkov.secrets.plugins.entropy_keyword_combinator import EntropyKeywordCombinator
@@ -29,13 +30,18 @@ class TestCombinatorPlugin(unittest.TestCase):
         self.assertEqual("Base64 High Entropy String", secret.type)
         self.assertEqual("bfd3617727eab0e800e62a776c76381defbc4145", secret.secret_hash)
 
-    def test_source_code_file_value(self):
+    def test_no_false_positive_py(self):
+        # combinator plugin should ignore source code files
         result = self.plugin.analyze_line("main.py", 'api_key = "7T)G#dl5}c=T>kf$G3Bon^!R?kzF00"', 1)
-        self.assertEqual(1, len(result))
-        secret = result.pop()
-        self.assertEqual("Secret Keyword", secret.type)
-        self.assertEqual("93beaa774e56483f19e4fe916ce87e62d4b3ea85", secret.secret_hash)
-
-    def test_source_code_no_false_positive(self):
-        result = self.plugin.analyze_line("main.py", "check1['some_key_1235#$@'] = check2.get('some_value_1235')", 1)
         self.assertEqual(0, len(result))
+
+    def test_no_false_positive_yml_1(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        file_name = "secret-no-false-positive.yml"
+        valid_file_path = current_dir + f"/resources/cfn/{file_name}"
+        with open(file=valid_file_path) as f:
+            for i, line in enumerate(f.readlines()):
+                result = self.plugin.analyze_line(file_name, line, i)
+                self.assertEqual(0, len(result))
+
+

--- a/tests/secrets/test_plugin.py
+++ b/tests/secrets/test_plugin.py
@@ -1,12 +1,11 @@
 import unittest
 
 from checkov.secrets.plugins.entropy_keyword_combinator import EntropyKeywordCombinator
-from checkov.secrets.runner import ENTROPY_KEYWORD_LIMIT
 
 
 class TestCombinatorPlugin(unittest.TestCase):
     def setUp(self) -> None:
-        self.plugin = EntropyKeywordCombinator(ENTROPY_KEYWORD_LIMIT)
+        self.plugin = EntropyKeywordCombinator()
 
     def test_positive_value(self):
         result = self.plugin.analyze_line("mock.tf", 'api_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMAAAKEY"', 5)

--- a/tests/secrets/test_plugin.py
+++ b/tests/secrets/test_plugin.py
@@ -23,7 +23,7 @@ class TestCombinatorPlugin(unittest.TestCase):
         self.assertEqual(0, len(result))
 
     def test_popular_kubernetes_manifest_password(self):
-        result = self.plugin.analyze_line("mock.yaml", 'pwd: "correcthorsebatterystaple"', 5)  # fails now
+        result = self.plugin.analyze_line("mock.yaml", 'pwd: "correcthorsebatterystaple"', 5)
         self.assertEqual(1, len(result))
         secret = result.pop()
         self.assertEqual("Base64 High Entropy String", secret.type)

--- a/tests/secrets/test_plugin.py
+++ b/tests/secrets/test_plugin.py
@@ -30,6 +30,12 @@ class TestCombinatorPlugin(unittest.TestCase):
         self.assertEqual("bfd3617727eab0e800e62a776c76381defbc4145", secret.secret_hash)
 
     def test_source_code_file_value(self):
-        # combinator plugin should ignore source code files
         result = self.plugin.analyze_line("main.py", 'api_key = "7T)G#dl5}c=T>kf$G3Bon^!R?kzF00"', 1)
+        self.assertEqual(1, len(result))
+        secret = result.pop()
+        self.assertEqual("Secret Keyword", secret.type)
+        self.assertEqual("93beaa774e56483f19e4fe916ce87e62d4b3ea85", secret.secret_hash)
+
+    def test_source_code_no_false_positive(self):
+        result = self.plugin.analyze_line("main.py", "check1['some_key_1235#$@'] = check2.get('some_value_1235')", 1)
         self.assertEqual(0, len(result))

--- a/tests/secrets/test_plugin.py
+++ b/tests/secrets/test_plugin.py
@@ -1,11 +1,12 @@
 import unittest
 
 from checkov.secrets.plugins.entropy_keyword_combinator import EntropyKeywordCombinator
+from checkov.secrets.runner import ENTROPY_KEYWORD_LIMIT
 
 
 class TestCombinatorPlugin(unittest.TestCase):
     def setUp(self) -> None:
-        self.plugin = EntropyKeywordCombinator()
+        self.plugin = EntropyKeywordCombinator(ENTROPY_KEYWORD_LIMIT)
 
     def test_positive_value(self):
         result = self.plugin.analyze_line("mock.tf", 'api_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMAAAKEY"', 5)

--- a/tests/secrets/test_plugin.py
+++ b/tests/secrets/test_plugin.py
@@ -37,5 +37,5 @@ class TestCombinatorPlugin(unittest.TestCase):
         self.assertEqual("93beaa774e56483f19e4fe916ce87e62d4b3ea85", secret.secret_hash)
 
     def test_source_code_no_false_positive(self):
-        result = self.plugin.analyze_line("main.py", "check_metadata_values = ('bafadssda$#%2', 'bdfsver#$@%')", 1)
+        result = self.plugin.analyze_line("main.py", "check1['some_key_1235#$@'] = check2.get('some_value_1235')", 1)
         self.assertEqual(0, len(result))

--- a/tests/secrets/test_runner.py
+++ b/tests/secrets/test_runner.py
@@ -1,7 +1,6 @@
 import unittest
 
 import os
-from pathlib import Path
 
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as metadata_integration
@@ -48,7 +47,7 @@ class TestRunnerValid(unittest.TestCase):
         valid_dir_path = current_dir + "/resources/terraform"
         runner = Runner()
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='secrets'))
+                            runner_filter=RunnerFilter(framework=['secrets']))
         self.assertEqual(len(report.passed_checks), 0)
         self.assertEqual(report.parsing_errors, [])
         self.assertEqual(report.failed_checks, [])
@@ -60,7 +59,7 @@ class TestRunnerValid(unittest.TestCase):
         valid_dir_path = current_dir + "/resources/terraform_failed"
         runner = Runner()
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='secrets'))
+                            runner_filter=RunnerFilter(framework=['secrets']))
         self.assertEqual(2, len(report.failed_checks))
         self.assertEqual(report.parsing_errors, [])
         self.assertEqual(report.passed_checks, [])
@@ -68,12 +67,13 @@ class TestRunnerValid(unittest.TestCase):
         report.print_console()
 
     def test_runner_tf_skip_check(self):
-        valid_dir_path = Path(__file__).parent / "resources/terraform_skip"
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/resources/terraform_skip"
 
         report = Runner().run(
             root_folder=valid_dir_path,
             external_checks_dir=None,
-            runner_filter=RunnerFilter(framework='secrets')
+            runner_filter=RunnerFilter(framework=['secrets'])
         )
 
         self.assertEqual(len(report.skipped_checks), 1)
@@ -88,7 +88,7 @@ class TestRunnerValid(unittest.TestCase):
         valid_dir_path = current_dir + "/resources/cfn"
         runner = Runner()
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='secrets', checks=['CKV_SECRET_2']))
+                            runner_filter=RunnerFilter(framework=['secrets'], checks=['CKV_SECRET_2']))
         self.assertEqual(len(report.skipped_checks), 0)
         self.assertEqual(len(report.failed_checks), 1)
         self.assertEqual(report.parsing_errors, [])
@@ -99,7 +99,7 @@ class TestRunnerValid(unittest.TestCase):
         valid_dir_path = current_dir + "/resources/cfn"
         runner = Runner()
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='secrets', checks=['CKV_SECRET*']))
+                            runner_filter=RunnerFilter(framework=['secrets'], checks=['CKV_SECRET*']))
         self.assertEqual(len(report.skipped_checks), 0)
         self.assertEqual(len(report.failed_checks), 2)
         self.assertEqual(report.parsing_errors, [])
@@ -110,7 +110,7 @@ class TestRunnerValid(unittest.TestCase):
         valid_dir_path = current_dir + "/resources/cfn"
         runner = Runner()
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='secrets', skip_checks=['CKV_SECRET_2']))
+                            runner_filter=RunnerFilter(framework=['secrets'], skip_checks=['CKV_SECRET_2']))
         self.assertEqual(len(report.skipped_checks), 0)
         self.assertEqual(len(report.failed_checks), 1)
         self.assertEqual(report.failed_checks[0].check_id, 'CKV_SECRET_6')
@@ -129,7 +129,7 @@ class TestRunnerValid(unittest.TestCase):
 
         runner = Runner()
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='secrets', checks=['CKV_SECRET_2']))
+                            runner_filter=RunnerFilter(framework=['secrets'], checks=['CKV_SECRET_2']))
         self.assertEqual(report.failed_checks[0].severity, Severities[BcSeverities.LOW])
 
     def test_runner_check_severity(self):
@@ -147,7 +147,7 @@ class TestRunnerValid(unittest.TestCase):
 
         runner = Runner()
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='secrets', checks=['MEDIUM']))
+                            runner_filter=RunnerFilter(framework=['secrets'], checks=['MEDIUM']))
         self.assertEqual(len(report.skipped_checks), 0)
         self.assertEqual(len(report.failed_checks), 1)
         self.assertEqual(report.failed_checks[0].check_id, 'CKV_SECRET_6')
@@ -169,7 +169,7 @@ class TestRunnerValid(unittest.TestCase):
 
         runner = Runner()
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='secrets', skip_checks=['MEDIUM']))
+                            runner_filter=RunnerFilter(framework=['secrets'], skip_checks=['MEDIUM']))
         self.assertEqual(len(report.skipped_checks), 0)
         self.assertEqual(len(report.failed_checks), 1)
         self.assertEqual(report.failed_checks[0].check_id, 'CKV_SECRET_6')
@@ -181,7 +181,7 @@ class TestRunnerValid(unittest.TestCase):
         valid_dir_path = current_dir + "/resources/cfn"
         runner = Runner()
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='secrets', skip_checks=['CKV_SECRET*']))
+                            runner_filter=RunnerFilter(framework=['secrets'], skip_checks=['CKV_SECRET*']))
         self.assertEqual(len(report.skipped_checks), 0)
         self.assertEqual(len(report.failed_checks), 0)
         self.assertEqual(report.parsing_errors, [])
@@ -211,7 +211,7 @@ class TestRunnerValid(unittest.TestCase):
         }
 
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='secrets'))
+                            runner_filter=RunnerFilter(framework=['secrets']))
         for fc in report.failed_checks:
             if fc.check_id == 'CKV_SECRET_2':
                 self.assertEqual(fc.bc_check_id, 'BC_GIT_2')
@@ -286,6 +286,7 @@ class TestRunnerValid(unittest.TestCase):
                                                        enable_secret_scan_all_files=True))
         self.assertEqual(len(report.failed_checks), 4)
 
+
     def test_runner_no_requested_file(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         valid_dir_path = current_dir + "/resources"
@@ -294,6 +295,23 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework=['secrets']))
         self.assertEqual(len(report.failed_checks), 9)
 
+    def test_true_positive_py(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_file_path = current_dir + "/resources/file_type/test.py"
+        runner = Runner()
+        report = runner.run(root_folder=None, files=[valid_file_path], external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework=['secrets'], enable_secret_scan_all_files=True))
+        self.assertEqual(len(report.failed_checks), 2)
+
+    def test_no_false_positive_yml_2(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/resources/cfn"
+        valid_file_path = valid_dir_path + "/secret-no-false-positive.yml"
+        runner = Runner()
+        report = runner.run(root_folder=None, files=[valid_file_path], external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework=['secrets'],
+                                                       enable_secret_scan_all_files=True))
+        self.assertEqual(len(report.failed_checks), 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Sets a different limit for entropy for the standalone plugin vs. the combinator plugin.

The change would cause finding fewer false positive secrets in source code, but leaves the Iac findings as it.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
