### PR TITLE
fix(kubernetes): Handle templates without name for PeerClientCertAuthTrue check

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/PeerClientCertAuthTrue.py
+++ b/checkov/kubernetes/checks/resource/k8s/PeerClientCertAuthTrue.py
@@ -12,7 +12,7 @@ class PeerClientCertAuthTrue(BaseK8Check):
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_kind)
 
     def scan_spec_conf(self, conf, entity_type=None):
-        if conf.get("metadata")['name'] == 'etcd':
+        if conf.get("metadata", {}).get('name') == 'etcd':
             containers = conf.get('spec')['containers']
             for container in containers:
                 if container.get("args") is not None:

--- a/tests/kubernetes/checks/example_PeerClientCertAuthTrue/PeerClientCertAuthTrue-UNKNOWN.yaml
+++ b/tests/kubernetes/checks/example_PeerClientCertAuthTrue/PeerClientCertAuthTrue-UNKNOWN.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: should-fail
+spec:
+  hostNetwork: true
+  containers:
+    - name: "kuku1"
+      image: "b.gcr.io/kuar/etcd:2.2.0"
+      args:
+        - "--name=etcd0"
+        - "--advertise-client-urls=http://10.0.0.1:2379"
+        - "--listen-client-urls=http://0.0.0.0:2379"
+        - "--listen-peer-urls=http://0.0.0.0:2380"
+        - "--data-dir=/var/lib/etcd/data"
+        - "--wal-dir=/var/lib/etcd/wal"
+        - "--election-timeout=1000"
+        - "--heartbeat-interval=100"
+        - "--snapshot-count=10000"
+        - "--max-snapshots=5"
+        - "--max-wals=5"
+        - "--initial-advertise-peer-urls=http://10.0.0.1:2380"
+        - "--initial-cluster=etcd0=http://10.0.0.1:2380,etcd1=http://10.0.0.2:2380,etcd2=http://10.0.0.2:2380"
+        - "--initial-cluster-state=new"
+        - "--initial-cluster-token=cluster0"
+        - "--peer-client-cert-auth=false"
+      ports:
+        - name: client
+          containerPort: 2379
+          protocol: "TCP"
+        - name: peer
+          containerPort: 2380
+          protocol: "TCP"
+      resources:
+        limits:
+          cpu: "1000m"
+          memory: "256Mi"
+      volumeMounts:
+        - name: "etcd-data"
+          mountPath: /var/lib/etcd/data
+        - name: "etcd-wal"
+          mountPath: /var/lib/etcd/wal
+  volumes:
+    - name: "etcd-wal"
+      awsElasticBlockStore:
+        volumeID: vol-1234wal0
+        fsType: ext4
+    - name: "etcd-data"
+      awsElasticBlockStore:
+        volumeID: vol-1234data0
+      fsType: ext4


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Setting to unknown templates with no `name` in their `metadata` for PeerClientCertAuthTrue check.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
