### PR TITLE
fix(terraform): fix external modules ids in graph report

### DIFF
--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -216,12 +216,13 @@ class Runner(ImageReferencerMixin, BaseRunner):
                     if platform.system() == "Windows":
                         root_folder = os.path.split(full_file_path)[0]
                     resource_id = ".".join(entity_context['definition_path'])
+                    resource = resource_id
                     module_dependency = entity.get("module_dependency_")
                     module_dependency_num = entity.get("module_dependency_num_")
                     if module_dependency and module_dependency_num:
                         referrer_id = self._find_id_for_referrer(f'{full_file_path}[{module_dependency}#{module_dependency_num}]')
                         if referrer_id:
-                            resource_id = f'{referrer_id}.{resource_id}'
+                            resource = f'{referrer_id}.{resource_id}'
                     record = Record(
                         check_id=check.id,
                         bc_check_id=check.bc_id,
@@ -231,7 +232,7 @@ class Runner(ImageReferencerMixin, BaseRunner):
                         file_path=f"/{os.path.relpath(full_file_path, root_folder)}",
                         file_line_range=[entity_context.get('start_line'),
                                          entity_context.get('end_line')],
-                        resource=resource_id,
+                        resource=resource,
                         entity_tags=entity.get('tags', {}),
                         evaluations=entity_evaluations,
                         check_class=check.__class__.__module__,
@@ -243,7 +244,7 @@ class Runner(ImageReferencerMixin, BaseRunner):
                         connected_node=connected_node_data
                     )
                     if self.breadcrumbs:
-                        breadcrumb = self.breadcrumbs.get(record.file_path, {}).get(record.resource)
+                        breadcrumb = self.breadcrumbs.get(record.file_path, {}).get(resource_id)
                         if breadcrumb:
                             record = GraphRecord(record, breadcrumb)
                     record.set_guideline(check.guideline)

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -215,6 +215,13 @@ class Runner(ImageReferencerMixin, BaseRunner):
                     connected_node_data = self.get_connected_node(entity, root_folder)
                     if platform.system() == "Windows":
                         root_folder = os.path.split(full_file_path)[0]
+                    resource_id = ".".join(entity_context['definition_path'])
+                    module_dependency = entity.get("module_dependency_")
+                    module_dependency_num = entity.get("module_dependency_num_")
+                    if module_dependency and module_dependency_num:
+                        referrer_id = self._find_id_for_referrer(f'{full_file_path}[{module_dependency}#{module_dependency_num}]')
+                        if referrer_id:
+                            resource_id = f'{referrer_id}.{resource_id}'
                     record = Record(
                         check_id=check.id,
                         bc_check_id=check.bc_id,
@@ -224,7 +231,7 @@ class Runner(ImageReferencerMixin, BaseRunner):
                         file_path=f"/{os.path.relpath(full_file_path, root_folder)}",
                         file_line_range=[entity_context.get('start_line'),
                                          entity_context.get('end_line')],
-                        resource=".".join(entity_context['definition_path']),
+                        resource=resource_id,
                         entity_tags=entity.get('tags', {}),
                         evaluations=entity_evaluations,
                         check_class=check.__class__.__module__,

--- a/tests/terraform/graph/runner/test_graph_builder.py
+++ b/tests/terraform/graph/runner/test_graph_builder.py
@@ -67,5 +67,6 @@ class TestGraphBuilder(TestCase):
                 bc = bc[0]
                 self.assertEqual(bc.get('type'), 'module')
                 self.assertEqual(os.path.relpath(bc.get('path'), resources_path), 'examples/complete/main.tf')
+                self.assertEqual(record.resource, 'module.s3_bucket.aws_s3_bucket.default')
 
         self.assertTrue(found_versioning_failure)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

fix external module resources ids in the graph report to contain the referrer id (module.[module_name]) as a prefix.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
