### PR TITLE
fix(github): fix variables initialization

### DIFF
--- a/checkov/github/dal.py
+++ b/checkov/github/dal.py
@@ -9,13 +9,15 @@ from checkov.github.schemas.org_security import schema as org_security_schema
 
 
 class Github(BaseVCSDAL):
+    github_conf_dir_path: str
+    github_org_security_file_path: str
+    github_branch_protection_rules_file_path: str
+    github_org_webhooks_file_path: str
+    github_repository_webhooks_file_path: str
+    github_repository_collaborators_file_path: str
+    org: str
+
     def __init__(self) -> None:
-        self.github_conf_dir_path = ""
-        self.github_org_security_file_path = ""
-        self.github_branch_protection_rules_file_path = ""
-        self.github_org_webhooks_file_path = ""
-        self.github_repository_webhooks_file_path = ""
-        self.github_repository_collaborators_file_path = ""
         super().__init__()
 
     def setup_conf_dir(self) -> None:

--- a/checkov/github/dal.py
+++ b/checkov/github/dal.py
@@ -9,16 +9,15 @@ from checkov.github.schemas.org_security import schema as org_security_schema
 
 
 class Github(BaseVCSDAL):
-    github_conf_dir_path: str
-    github_org_security_file_path: str
-    github_branch_protection_rules_file_path: str
-    github_org_webhooks_file_path: str
-    github_repository_webhooks_file_path: str
-    github_repository_collaborators_file_path: str
-    org: str
 
     def __init__(self) -> None:
         super().__init__()
+        self.github_conf_dir_path: str
+        self.github_org_security_file_path: str
+        self.github_branch_protection_rules_file_path: str
+        self.github_org_webhooks_file_path: str
+        self.github_repository_webhooks_file_path: str
+        self.github_repository_collaborators_file_path: str
 
     def setup_conf_dir(self) -> None:
         # files downloaded from github will be persistent in this directory

--- a/checkov/github/dal.py
+++ b/checkov/github/dal.py
@@ -10,13 +10,13 @@ from checkov.github.schemas.org_security import schema as org_security_schema
 
 class Github(BaseVCSDAL):
     def __init__(self) -> None:
-        super().__init__()
         self.github_conf_dir_path = ""
         self.github_org_security_file_path = ""
         self.github_branch_protection_rules_file_path = ""
         self.github_org_webhooks_file_path = ""
         self.github_repository_webhooks_file_path = ""
         self.github_repository_collaborators_file_path = ""
+        super().__init__()
 
     def setup_conf_dir(self) -> None:
         # files downloaded from github will be persistent in this directory

--- a/checkov/github/dal.py
+++ b/checkov/github/dal.py
@@ -11,7 +11,6 @@ from checkov.github.schemas.org_security import schema as org_security_schema
 class Github(BaseVCSDAL):
     def __init__(self) -> None:
         super().__init__()
-
         self.github_conf_dir_path = ""
         self.github_org_security_file_path = ""
         self.github_branch_protection_rules_file_path = ""

--- a/tests/github/test_dal.py
+++ b/tests/github/test_dal.py
@@ -25,3 +25,12 @@ def test_org_security(mocker: MockerFixture):
     mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request_graphql", return_value=mock_data)
     result = dal.get_organization_security()
     assert result
+
+
+def test_validate_github_conf_paths():
+    dal = Github()
+    all_github_conf_files_conf_declared = dal.github_conf_dir_path \
+        and dal.github_org_security_file_path and dal.github_branch_protection_rules_file_path \
+        and dal.github_org_webhooks_file_path and dal.github_repository_webhooks_file_path \
+        and dal.github_repository_collaborators_file_path
+    assert all_github_conf_files_conf_declared


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

The initialization of the variables in the init of GitHub class is done before the type is set to string (by assigning the "" string). This caused to no checks at all from the GitHub framework (as no repo/account/rtc. are set in the first place)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
