### PR TITLE
fix(github): changed the schema to accept no description for org

### DIFF
--- a/checkov/github/schemas/org_security.py
+++ b/checkov/github/schemas/org_security.py
@@ -19,7 +19,10 @@ class OrgSecuritySchema(VCSSchema):
                                     "type": "string"
                                 },
                                 "description": {
-                                    "type": "string"
+                                    "oneOf": [
+                                        {"type": "string"},
+                                        {"type": "null"}
+                                    ]
                                 },
                                 "ipAllowListEnabledSetting": {
                                     "type": "string"

--- a/tests/github/test_dal.py
+++ b/tests/github/test_dal.py
@@ -7,7 +7,7 @@ from checkov.github.dal import Github
 
 
 @mock.patch.dict(os.environ, {"GITHUB_ORG": "simpleOrg"}, clear=True)
-def test_org_security(mocker: MockerFixture):
+def test_org_security_null_description(mocker: MockerFixture):
     dal = Github()
     mock_data = {
         "data": {
@@ -23,8 +23,12 @@ def test_org_security(mocker: MockerFixture):
         }
     }
     mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request_graphql", return_value=mock_data)
-    result1 = dal.get_organization_security()
+    result = dal.get_organization_security()
+    assert result
 
+@mock.patch.dict(os.environ, {"GITHUB_ORG": "simpleOrg"}, clear=True)
+def test_org_security_str_description(mocker: MockerFixture):
+    dal = Github()
     mock_data2 = {
         "data": {
             "organization": {
@@ -39,8 +43,8 @@ def test_org_security(mocker: MockerFixture):
         }
     }
     mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request_graphql", return_value=mock_data2)
-    result2 = dal.get_organization_security()
-    assert result1 and result2
+    result = dal.get_organization_security()
+    assert result
 
 
 def test_validate_github_conf_paths():

--- a/tests/github/test_dal.py
+++ b/tests/github/test_dal.py
@@ -14,7 +14,7 @@ def test_org_security(mocker: MockerFixture):
             "organization": {
                 "name": "Bridgecrew",
                 "login": "Bridgecrew-dev",
-                "description": "",
+                "description": None,
                 "ipAllowListEnabledSetting": "DISABLED",
                 "ipAllowListForInstalledAppsEnabledSetting": "DISABLED",
                 "requiresTwoFactorAuthentication": False,
@@ -23,8 +23,24 @@ def test_org_security(mocker: MockerFixture):
         }
     }
     mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request_graphql", return_value=mock_data)
-    result = dal.get_organization_security()
-    assert result
+    result1 = dal.get_organization_security()
+
+    mock_data2 = {
+        "data": {
+            "organization": {
+                "name": "Bridgecrew",
+                "login": "Bridgecrew-dev",
+                "description": "",
+                "ipAllowListEnabledSetting": "DISABLED",
+                "ipAllowListForInstalledAppsEnabledSetting": "DISABLED",
+                "requiresTwoFactorAuthentication": False,
+                "samlIdentityProvider": None
+            }
+        }
+    }
+    mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request_graphql", return_value=mock_data2)
+    result2 = dal.get_organization_security()
+    assert result1 and result2
 
 
 def test_validate_github_conf_paths():


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Update of organization schema for GitHub.

### Description
In GitHub, the organization security schema had a description field set to match a string although None is a legal value too. 
This caused the data returned from the GitHub API to mismatch the schema in this case, and hence no github_conf file for org security was created. In this case checks CKV_GITHUB_1-3 were skipped.

### Fix
Change the schema to match both.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
