### PR TITLE
feat(graph): add support for guideline field to custom graph checks

### DIFF
--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -134,6 +134,7 @@ class NXGraphCheckParser(BaseGraphCheckParser):
         check.name = raw_check.get("metadata", {}).get("name", "")
         check.category = raw_check.get("metadata", {}).get("category", "")
         check.frameworks = raw_check.get("metadata", {}).get("frameworks", [])
+        check.guideline = raw_check.get("metadata", {}).get("guideline")
         solver = self.get_check_solver(check)
         check.set_solver(solver)
 

--- a/docs/3.Custom Policies/YAML Custom Policies.md
+++ b/docs/3.Custom Policies/YAML Custom Policies.md
@@ -20,6 +20,7 @@ The Metadata includes:
 * Policy Name
 * ID - `CKV2_<provider>_<number>`
 * Category
+* Guideline (optional)
 
 The possible values for category are:
 
@@ -32,6 +33,17 @@ The possible values for category are:
 * CONVENTION
 * SECRETS
 * KUBERNETES
+* APPLICATION_SECURITY
+* SUPPLY_CHAIN
+* API_SECURITY
+
+```yaml
+metadata:
+  id: "CKV2_CUSTOM_1"
+  name: "Ensure bucket has versioning and owner tag"
+  category: "BACKUP_AND_RECOVERY"
+  guideline: "https://docs.bridgecrew.io/docs/ckv2_custom_1"
+```
 
 ## Policy Definition
 
@@ -39,7 +51,7 @@ The policy definition consists of:
 
 * **Definition Block(s)** - either *Attribute Block(s)* or *Connection State Block(s)* or both
 * **Logical Operator(s)** (optional)
-* **Filter**(optional)
+* **Filter** (optional)
 
 The top level object under `definition` must be a single object (not a list). It can be an attribute block, a connection block, or a logical operator (`and`, `or`, `not`).
 

--- a/tests/terraform/runner/extra_yaml_checks/bucket_versioned_owned.yaml
+++ b/tests/terraform/runner/extra_yaml_checks/bucket_versioned_owned.yaml
@@ -2,6 +2,7 @@ metadata:
   id: "CKV2_CUSTOM_1"
   name: "Ensure bucket has versioning and owner tag"
   category: "BACKUP_AND_RECOVERY"
+  guideline: "https://docs.bridgecrew.io/docs/ckv2_custom_1"
 definition:
   and:
     - cond_type: "attribute"

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -182,6 +182,10 @@ class TestRunnerValid(unittest.TestCase):
 
         self.assertEqual(passing_custom, 0)
         self.assertEqual(failed_custom, 3)
+
+        graph_record = next(record for record in report.failed_checks if record.check_id == "CKV2_CUSTOM_1")
+        self.assertEqual(graph_record.guideline, "https://docs.bridgecrew.io/docs/ckv2_custom_1")
+
         # Remove external checks from registry.
         runner.graph_registry.checks[:] = [check for check in runner.graph_registry.checks if "CUSTOM" not in check.id]
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- add guideline field support to custom graph checks

Fixes #3594
Fixes #2826

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
