### PR TITLE
fix(github): bug fixes in CKV_GITHUB_6, CKV_GITHUB_7, CKV_GITHUB_9

### DIFF
--- a/checkov/github/checks/webhooks_https_orgs.py
+++ b/checkov/github/checks/webhooks_https_orgs.py
@@ -34,10 +34,8 @@ class WebhookHttpsOrg(BaseGithubCheck):
                     secret = item_config.get('secret', '')
                     if re.match("^http://", url) or insecure_ssl != '0' and secret != '********':  # nosec
                         return CheckResult.FAILED, item_config
-        if org_webhooks_schema.validate(conf):
             return CheckResult.PASSED, conf
-
-        return None
+        return CheckResult.UNKNOWN, conf
 
 
 check = WebhookHttpsOrg()

--- a/checkov/github/checks/webhooks_https_repos.py
+++ b/checkov/github/checks/webhooks_https_repos.py
@@ -33,9 +33,8 @@ class WebhookHttpsRepo(BaseGithubCheck):
                     insecure_ssl = item_config.get('insecure_ssl', '0')
                     if re.match("^http://", url) or insecure_ssl != '0':
                         return CheckResult.FAILED, item_config
-        if repository_webhooks_schema.validate(conf):
             return CheckResult.PASSED, conf
-        return None
+        return CheckResult.UNKNOWN, conf
 
 
 check = WebhookHttpsRepo()

--- a/checkov/github/dal.py
+++ b/checkov/github/dal.py
@@ -11,7 +11,7 @@ from checkov.github.schemas.org_security import schema as org_security_schema
 
 
 class Github(BaseVCSDAL):
-    github_conf_dir_path: str # noqa: CCE003  # a static attribute
+    github_conf_dir_path: str  # noqa: CCE003  # a static attribute
     github_conf_file_paths: dict[str, Path]  # noqa: CCE003  # a static attribute
 
     def __init__(self) -> None:

--- a/checkov/github/dal.py
+++ b/checkov/github/dal.py
@@ -82,10 +82,7 @@ class Github(BaseVCSDAL):
         return data
 
     def get_repository_collaborators(self) -> dict[str, Any] | None:
-        if self.org:
-            endpoint = "repos/{}/{}/collaborators".format(self.org, self.current_repository)
-        else:
-            endpoint = "repos/{}/{}/collaborators".format(self.repo_owner, self.current_repository)
+        endpoint = "repos/{}/{}/collaborators".format(self.repo_owner, self.current_repository)
         data = self._request(endpoint=endpoint, allowed_status_codes=[200])
         if not data:
             return None
@@ -97,10 +94,7 @@ class Github(BaseVCSDAL):
             BaseVCSDAL.persist(path=self.github_conf_file_paths["repository_collaborators"], conf=repository_collaborators)
 
     def get_repository_webhooks(self) -> dict[str, Any] | None:
-        if self.org:
-            endpoint = "repos/{}/{}/hooks".format(self.org, self.current_repository)
-        else:
-            endpoint = "repos/{}/{}/hooks".format(self.repo_owner, self.current_repository)
+        endpoint = "repos/{}/{}/hooks".format(self.repo_owner, self.current_repository)
         data = self._request(endpoint=endpoint, allowed_status_codes=[200])
         if not data:
             return None

--- a/checkov/github/dal.py
+++ b/checkov/github/dal.py
@@ -14,19 +14,19 @@ class Github(BaseVCSDAL):
     def __init__(self) -> None:
         super().__init__()
         self.github_conf_dir_path: str
-        self.github_conf_file_paths: dict
+        self.github_conf_file_paths: dict[str, Path]
 
     def setup_conf_dir(self) -> None:
         github_conf_dir_name = os.getenv('CKV_GITHUB_CONF_DIR_NAME', 'github_conf')
         self.github_conf_dir_path = os.path.join(os.getcwd(), github_conf_dir_name)
-        self.github_conf_file_paths: dict[str, Path] = {
+        self.github_conf_file_paths = {
             "org_security": Path(self.github_conf_dir_path) / "org_security.json",
             "branch_protection_rules": Path(self.github_conf_dir_path) / "branch_protection_rules.json",
             "org_webhooks": Path(self.github_conf_dir_path) / "org_webhooks.json",
             "repository_webhooks": Path(self.github_conf_dir_path) / "repository_webhooks.json",
             "repository_collaborators": Path(self.github_conf_dir_path) / "repository_collaborators.json"
         }
-        for github_conf_type, file_path in self.github_conf_file_paths.items():
+        for _github_conf_type, file_path in self.github_conf_file_paths.items():
             if os.path.isfile(file_path):
                 os.remove(file_path)
 

--- a/checkov/github/schemas/org_webhooks.py
+++ b/checkov/github/schemas/org_webhooks.py
@@ -103,7 +103,8 @@ class OrgWebhooksSchema(VCSSchema):
                         ]
                     },
                     "type": {
-                        "type": "string"
+                        "type": "string",
+                        "const": "Organization"
                     }
                 },
                 "required": [

--- a/checkov/github/schemas/repository_webhooks.py
+++ b/checkov/github/schemas/repository_webhooks.py
@@ -11,7 +11,8 @@ class RepositoryWebhookSchema(VCSSchema):
                 "type": "object",
                 "properties": {
                     "type": {
-                        "type": "string"
+                        "type": "string",
+                        "const": "Repository"
                     },
                     "id": {
                         "description": "Unique identifier of the webhook.",

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -281,7 +281,8 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
     url = None
     created_baseline_path = None
 
-    git_configuration_folders = [os.getcwd() + '/' + os.getenv('CKV_GITHUB_CONF_DIR_NAME', 'github_conf'),
+    default_github_dir_path = os.getcwd() + '/' + os.getenv('CKV_GITLAB_CONF_DIR_NAME', 'github_conf')
+    git_configuration_folders = [os.getenv("CKV_GITHUB_CONF_DIR_PATH", default_github_dir_path),
                                  os.getcwd() + '/' + os.getenv('CKV_GITLAB_CONF_DIR_NAME', 'gitlab_conf')]
 
     if config.directory:

--- a/docs/6.Contribution/Contribute New GitHub Policies.md
+++ b/docs/6.Contribution/Contribute New GitHub Policies.md
@@ -20,7 +20,7 @@ If not it can be added to that file like the following example:
 
 ```python
 
-class GitHub(BaseVCSDAL)
+class GitHub(BaseVCSDAL):
     ...
     ...
     def get_branch_protection_rules(self):
@@ -33,7 +33,7 @@ class GitHub(BaseVCSDAL)
     def persist_branch_protection_rules(self):
         data = self.get_branch_protection_rules()
         if data:
-            BaseVCSDAL.persist(path=self.github_branch_protection_rules_file_path, conf=data)        
+            BaseVCSDAL.persist(path=self.github_conf_file_paths["branch_protection_rules"], conf=data)        
     
     def persist_all_confs(self):
         if strtobool(os.getenv("CKV_GITHUB_CONFIG_FETCH_DATA", "True")):

--- a/docs/7.Scan Examples/Github.md
+++ b/docs/7.Scan Examples/Github.md
@@ -12,16 +12,16 @@ Full list of github organization and repository settings related checks can be f
 
 ## GitHub scanning configuration
 
-| Environment Variable          | Default value             | Description                                                                                          |
-|-------------|---------------------------|------------------------------------------------------------------------------------------------------|
-| CKV_GITHUB_CONFIG_FETCH_DATA| "True"                    | checkov will try to fetch GitHub configuration from API by default (unless no access token provided) |
-| CKV_GITHUB_CONF_DIR_NAME   | "github_conf"             | checkov will create a new directory named "github_conf" under current working directory              |
-| GITHUB_API_URL   | "https://api.github.com/" |                                                                                                      |
-| GITHUB_TOKEN   |                           | GitHub personal access token to be used to fetch GitHub configuration                                |
-| GITHUB_REF | refs/heads/master                    | Github branch for which to fetch branch protection rules configuration                               |
- | GITHUB_ORG   |                           | Github organization                                                                                  |
- | GITHUB_REPOSITORY |                      | Github repositry for which to fetch repository configuration info                                    |
- | GITHUB_REPO_OWNER |                           | Github repository owner user name                                                                    |
+| Environment Variable          | Default value             | Description                                                                                                                                   |
+|-------------|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| CKV_GITHUB_CONFIG_FETCH_DATA| "True"                    | checkov will try to fetch GitHub configuration from API by default (unless no access token provided)                                          |
+| CKV_GITHUB_CONF_DIR_NAME   | "github_conf"             | checkov will create a new directory named "github_conf" under current working directory                                                       |
+| GITHUB_API_URL   | "https://api.github.com/" |                                                                                                                                               |
+| GITHUB_TOKEN   |                           | GitHub personal access token to be used to fetch GitHub configuration                                                                         |
+| GITHUB_REF | refs/heads/master                    | Github branch for which to fetch branch protection rules configuration                                                                        |
+ | GITHUB_ORG   |                           | Github organization                                                                                                                           |
+ | GITHUB_REPOSITORY |                      | Github repositry for which to fetch repository configuration info                                                                             |
+ | GITHUB_REPO_OWNER |                           | The owner of the repository. This could be either Github repository owner user name or the organization name, in which the user is the owner. |
 
 ### Example organization security configuration
 

--- a/tests/github/test_dal.py
+++ b/tests/github/test_dal.py
@@ -48,8 +48,7 @@ def test_org_security_str_description(mocker: MockerFixture):
     assert result
 
 
-@mock.patch.dict(os.environ, {"GITHUB_ORG": "simpleOrg", "GITHUB_REPO_OWNER": "bridgecrew",
-                              "GITHUB_REPOSITORY": "main"}, clear=True)
+@mock.patch.dict(os.environ, {"GITHUB_REPO_OWNER": "bridgecrew", "GITHUB_REPOSITORY": "main"}, clear=True)
 def test_org_webhooks(mocker: MockerFixture):
     dal = Github()
     mock_data = [
@@ -79,8 +78,7 @@ def test_org_webhooks(mocker: MockerFixture):
     assert result
 
 
-@mock.patch.dict(os.environ, {"GITHUB_ORG": "simpleOrg", "GITHUB_REPO_OWNER": "bridgecrew",
-                              "GITHUB_REPOSITORY": "main"}, clear=True)
+@mock.patch.dict(os.environ, {"GITHUB_REPO_OWNER": "bridgecrew", "GITHUB_REPOSITORY": "main"}, clear=True)
 def test_repository_webhooks(mocker: MockerFixture):
     dal = Github()
     mock_data = [

--- a/tests/github/test_dal.py
+++ b/tests/github/test_dal.py
@@ -59,6 +59,6 @@ def test_validate_github_conf_paths():
 
     all_files_are_empty = True
     for github_conf_type, file_path in dal.github_conf_file_paths.items():
-        all_files_are_empty = not os.path.isfile(file_path) or os.path.getsize(file_path) == 0
+        all_files_are_empty &= not os.path.isfile(file_path) or os.path.getsize(file_path) == 0
 
     assert all_files_are_empty

--- a/tests/github/test_dal.py
+++ b/tests/github/test_dal.py
@@ -26,10 +26,11 @@ def test_org_security_null_description(mocker: MockerFixture):
     result = dal.get_organization_security()
     assert result
 
+
 @mock.patch.dict(os.environ, {"GITHUB_ORG": "simpleOrg"}, clear=True)
 def test_org_security_str_description(mocker: MockerFixture):
     dal = Github()
-    mock_data2 = {
+    mock_data = {
         "data": {
             "organization": {
                 "name": "Bridgecrew",
@@ -42,8 +43,70 @@ def test_org_security_str_description(mocker: MockerFixture):
             }
         }
     }
-    mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request_graphql", return_value=mock_data2)
+    mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request_graphql", return_value=mock_data)
     result = dal.get_organization_security()
+    assert result
+
+
+@mock.patch.dict(os.environ, {"GITHUB_ORG": "simpleOrg", "GITHUB_REPO_OWNER": "bridgecrew",
+                              "GITHUB_REPOSITORY": "main"}, clear=True)
+def test_org_webhooks(mocker: MockerFixture):
+    dal = Github()
+    mock_data = [
+        {
+            "type": "Organization",
+            "id": 0,
+            "name": "web",
+            "active": True,
+            "events": [
+                "*"
+            ],
+            "config": {
+                "content_type": "form",
+                "insecure_ssl": "0",
+                "url": "http://test-repo-webhook.com"
+            },
+            "updated_at": "2022-10-02T12:39:12Z",
+            "created_at": "2022-09-29T09:01:36Z",
+            "url": "",
+            "test_url": "",
+            "ping_url": "",
+            "deliveries_url": ""
+        }
+    ]
+    mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request", return_value=mock_data)
+    result = dal.get_repository_webhooks()
+    assert result
+
+
+@mock.patch.dict(os.environ, {"GITHUB_ORG": "simpleOrg", "GITHUB_REPO_OWNER": "bridgecrew",
+                              "GITHUB_REPOSITORY": "main"}, clear=True)
+def test_repository_webhooks(mocker: MockerFixture):
+    dal = Github()
+    mock_data = [
+        {
+            "type": "Repository",
+            "id": 0,
+            "name": "web",
+            "active": True,
+            "events": [
+                "*"
+            ],
+            "config": {
+                "content_type": "form",
+                "insecure_ssl": "0",
+                "url": "http://test-repo-webhook.com"
+            },
+            "updated_at": "2022-10-02T12:39:12Z",
+            "created_at": "2022-09-29T09:01:36Z",
+            "url": "",
+            "test_url": "",
+            "ping_url": "",
+            "deliveries_url": ""
+        }
+    ]
+    mocker.patch("checkov.common.vcs.base_vcs_dal.BaseVCSDAL._request", return_value=mock_data)
+    result = dal.get_repository_webhooks()
     assert result
 
 

--- a/tests/github/test_dal.py
+++ b/tests/github/test_dal.py
@@ -48,9 +48,17 @@ def test_org_security_str_description(mocker: MockerFixture):
 
 
 def test_validate_github_conf_paths():
+    # check that all the files in github_conf folder that should be updated with new data from GitHub api reply,
+    # are empty.In case of no reply-no old data should be left causing confusion with new retrieved data.
     dal = Github()
-    all_github_conf_files_conf_declared = dal.github_conf_dir_path \
-        and dal.github_org_security_file_path and dal.github_branch_protection_rules_file_path \
-        and dal.github_org_webhooks_file_path and dal.github_repository_webhooks_file_path \
-        and dal.github_repository_collaborators_file_path
-    assert all_github_conf_files_conf_declared
+    all_github_conf_files_conf_declared = \
+        {"org_security", "branch_protection_rules", "org_webhooks", "repository_webhooks", "repository_collaborators"} \
+        - dal.github_conf_file_paths.keys()
+
+    assert all_github_conf_files_conf_declared == set()
+
+    all_files_are_empty = True
+    for github_conf_type, file_path in dal.github_conf_file_paths.items():
+        all_files_are_empty = not os.path.isfile(file_path) or os.path.getsize(file_path) == 0
+
+    assert all_files_are_empty

--- a/tests/github/test_runner.py
+++ b/tests/github/test_runner.py
@@ -22,14 +22,14 @@ class TestRunnerValid(unittest.TestCase):
         runner = Runner()
         runner.github.github_conf_dir_path = valid_dir_path
 
-        checks = ["CKV_GITHUB_6","CKV_GITHUB_7"]
+        checks = ["CKV_GITHUB_6", "CKV_GITHUB_7"]
         report = runner.run(
             root_folder=valid_dir_path,
             runner_filter=RunnerFilter(checks=checks)
         )
         self.assertEqual(len(report.failed_checks), 1)
         self.assertEqual(report.parsing_errors, [])
-        self.assertEqual(len(report.passed_checks), 3)
+        self.assertEqual(len(report.passed_checks), 2)
         self.assertEqual(report.skipped_checks, [])
 
     @mock.patch.dict(os.environ, {"CKV_GITHUB_CONFIG_FETCH_DATA": "False", "PYCHARM_HOSTED": "1",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**


## Description

Fix of couple bugs in GitHub checks

### Description
The bugs:
1. The route for repo under org should be different from that with no org, that is repo under a repo owner.
2. The reply for repo webhooks can be parsed also as an org webhook reply, causing the same webhook to appear under org webhook and repo webhook, which is double in 2 different checks.
3. The github_conf files are created on demand, hence causing leftovers from the previous runs - and mixing check results between different runs.

The fix:
1. Use the `GITHUB_REPO_OWNER` to access webhooks/collaborators for a repo, instead of `GITHUB_ORG`
2. change JSON schema to parse repo webhook reply as only repo webhook reply and same for org webhook reply. (added 2 tests)
3. remove all existing non-empty files that can be used in this run under the dir that is declared in CKV_GITHUB_CONF_DIR_NAME. (test changed to check that the files are actually empty in the initialization of the class)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
