### PR TITLE
feat(sca): Add root path references to shorten file paths in Image Referencer results

### DIFF
--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -178,7 +178,8 @@ class ImageReferencerMixin:
                 file_path=dockerfile_path,
                 file_content=f'image: {image.name}',
                 docker_image_name=image.name,
-                related_resource_id=image.related_resource_id)
+                related_resource_id=image.related_resource_id,
+                root_folder=root_path)
             report.image_cached_results.append(image_scanning_report)
 
             result = cached_results.get("results", [{}])[0]

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -147,6 +147,9 @@ class Runner(PackageRunner):
             return report
         if files:
             self.pbar.initiate(len(files))
+            # 'root_folder' should contain the common prefix so the absolute full path can be shortened later
+            root_folder = os.path.split(os.path.commonprefix(files))[0]
+
             for file in files:
                 self.pbar.set_additional_data({'Current File Scanned': os.path.relpath(file, root_folder)})
                 self.iterate_image_files(file, report, runner_filter)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

2 small changes that turn absolute paths in the platform results to short paths, without the root folder of the scan

This is how the path looks like after the fix, when scanning a single file
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/63583491/193584577-eb06baaa-7b05-48df-89bd-e38cdee74d4e.png">


Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
