### PR TITLE
chore(Dockerfile): simplify dependency to speed up the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,22 +8,21 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
             ca-certificates \
             git \
-            wget \
             curl \
             openssh-client \
     ; \
     \
-    wget -q -O get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3; \
+    curl -sSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3; \
     chmod 700 get_helm.sh; \
     VERIFY_CHECKSUM=true ./get_helm.sh; \
     rm ./get_helm.sh; \
     \
-    wget -q -O get_kustomize.sh https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh; \
+    curl -sSLo get_kustomize.sh https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh; \
     chmod 700 get_kustomize.sh; \
     ./get_kustomize.sh; mv /kustomize /usr/bin/kustomize; \
     rm ./get_kustomize.sh; \
     \
-    apt-get remove -y wget curl; \
+    apt-get remove -y curl; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.pyston
+++ b/Dockerfile.pyston
@@ -6,21 +6,20 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
             ca-certificates \
             git \
-            wget \
             curl \
     ; \
     \
-    wget -q -O get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3; \
+    curl -sSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3; \
     chmod 700 get_helm.sh; \
     VERIFY_CHECKSUM=true ./get_helm.sh; \
     rm ./get_helm.sh; \
     \
-    wget -q -O get_kustomize.sh https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh; \
+    curl -sSLo get_kustomize.sh https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh; \
     chmod 700 get_kustomize.sh; \
     ./get_kustomize.sh; mv /kustomize /usr/bin/kustomize; \
     rm ./get_kustomize.sh; \
     \
-    apt-get remove -y wget curl; \
+    apt-get remove -y curl; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description

There's no need to have `wget` and `curl` in the build process, especially they're both going to be removed at the end of the build, simplify the dependency in Dockerfile can speed up the Docker image build process, save some time and network bandwidth.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
