### PR TITLE
fix(terraform): extend CKV2_AWS_15 to support aws_lb_target_group

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/AutoScallingEnabledELB.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/AutoScallingEnabledELB.yaml
@@ -4,6 +4,11 @@ metadata:
   category: "NETWORKING"
 definition:
   and:
+    - cond_type: filter
+      attribute: resource_type
+      value:
+        - aws_autoscaling_attachment
+      operator: within
     - cond_type: attribute
       resource_types:
           - aws_autoscaling_group
@@ -16,19 +21,28 @@ definition:
         - aws_autoscaling_attachment
       operator:  exists
       cond_type: connection
-    - resource_types:
-        - aws_elb
-      connected_resource_types:
-        - aws_autoscaling_attachment
-      operator:  exists
-      cond_type: connection
-    - cond_type: attribute
-      resource_types:
-          - aws_elb
-      attribute: health_check
-      operator: exists
-    - cond_type: filter
-      attribute: resource_type
-      value:
-        - aws_autoscaling_attachment
-      operator: within
+    - or:
+        - and:
+            - resource_types:
+                - aws_elb
+              connected_resource_types:
+                - aws_autoscaling_attachment
+              operator:  exists
+              cond_type: connection
+            - cond_type: attribute
+              resource_types:
+                  - aws_elb
+              attribute: health_check
+              operator: exists
+        - and:
+            - resource_types:
+                - aws_lb_target_group
+              connected_resource_types:
+                - aws_autoscaling_attachment
+              operator:  exists
+              cond_type: connection
+            - cond_type: attribute
+              resource_types:
+                  - aws_lb_target_group
+              attribute: health_check
+              operator: exists

--- a/tests/terraform/graph/checks/resources/AutoScallingEnabledELB/expected.yaml
+++ b/tests/terraform/graph/checks/resources/AutoScallingEnabledELB/expected.yaml
@@ -1,4 +1,6 @@
 pass:
   - "aws_autoscaling_attachment.test_ok_attachment"
+  - "aws_autoscaling_attachment.alb_pass"
 fail:
   - "aws_autoscaling_attachment.test_bad_attachment"
+  - "aws_autoscaling_attachment.alb_fail"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- extended the check to also accept `aws_lb_target_group` as attachment

Fixes #3592 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
