### PR TITLE
fix(cloudformation): Fixed unexpected null properties for LaunchConfigurationEBSEncryption

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/LaunchConfigurationEBSEncryption.py
+++ b/checkov/cloudformation/checks/resource/aws/LaunchConfigurationEBSEncryption.py
@@ -17,7 +17,10 @@ class LaunchConfigurationEBSEncryption(BaseResourceCheck):
         :param conf: aws_launch_configuration configuration
         :return: <CheckResult>
         """
-        block_device_mappings = conf.get('Properties', {}).get('BlockDeviceMappings')
+        properties = conf.get('Properties', {})
+        if properties is None:
+            return CheckResult.UNKNOWN
+        block_device_mappings = properties.get('BlockDeviceMappings')
         if block_device_mappings is None:
             return CheckResult.UNKNOWN
         if not isinstance(block_device_mappings, list):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Null properties causes the above check to fail because of an unexpected null value for a property, the PR validates the object is not null before parsing it.
No UT for this specific case wasn't added since a CFN YAML with null value is not parsed in checkov (considered as a parsing error)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
