### PR TITLE
fix(terraform): handle unexpected value for enabled_cloudwatch_logs_exports

### DIFF
--- a/checkov/terraform/checks/resource/aws/DBInstanceLogging.py
+++ b/checkov/terraform/checks/resource/aws/DBInstanceLogging.py
@@ -17,8 +17,10 @@ class DBInstanceLogging(BaseResourceValueCheck):
         return "enabled_cloudwatch_logs_exports/[0]"
 
     def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
-        logs_exports = conf.get('enabled_cloudwatch_logs_exports', [[]])[0]
-        return CheckResult.PASSED if logs_exports else CheckResult.FAILED
+        logs_exports = conf.get('enabled_cloudwatch_logs_exports', [[]])
+        if len(logs_exports) == 0:
+            return CheckResult.FAILED
+        return CheckResult.PASSED if logs_exports[0] else CheckResult.FAILED
 
     def get_expected_value(self) -> Any:
         return ANY_VALUE

--- a/checkov/terraform/checks/resource/aws/DBInstanceLogging.py
+++ b/checkov/terraform/checks/resource/aws/DBInstanceLogging.py
@@ -18,7 +18,7 @@ class DBInstanceLogging(BaseResourceValueCheck):
 
     def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
         logs_exports = conf.get('enabled_cloudwatch_logs_exports', [[]])
-        if len(logs_exports) == 0:
+        if not logs_exports:
             return CheckResult.FAILED
         return CheckResult.PASSED if logs_exports[0] else CheckResult.FAILED
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Handled an unexpected value in DBInstanceLogging check for enabled_cloudwatch_logs_exports.
No UT added for this specific case since I could not reproduce the template that caused this value (empty list).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
