### PR TITLE
fix(kubernetes): handled missing field secretKeyRef in template

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/Secrets.py
+++ b/checkov/kubernetes/checks/resource/k8s/Secrets.py
@@ -16,10 +16,10 @@ class Secrets(BaseK8sContainerCheck):
         self.evaluated_container_keys = ["env", "envFrom"]
         if conf.get("env"):
             for idx, e in enumerate(conf["env"]):
-                if "valueFrom" in e and e["valueFrom"] is not None:
-                    if "secretKeyRef" in e["valueFrom"]:
-                        self.evaluated_container_keys = [f"env/[{idx}]/valueFrom/secretKeyRef"]
-                        return CheckResult.FAILED
+                value_from = e.get("valueFrom")
+                if value_from and "secretKeyRef" in value_from:
+                    self.evaluated_container_keys = [f"env/[{idx}]/valueFrom/secretKeyRef"]
+                    return CheckResult.FAILED
         if conf.get("envFrom"):
             for idx, ef in enumerate(conf["envFrom"]):
                 if "secretRef" in ef:

--- a/checkov/kubernetes/checks/resource/k8s/Secrets.py
+++ b/checkov/kubernetes/checks/resource/k8s/Secrets.py
@@ -16,7 +16,7 @@ class Secrets(BaseK8sContainerCheck):
         self.evaluated_container_keys = ["env", "envFrom"]
         if conf.get("env"):
             for idx, e in enumerate(conf["env"]):
-                if "valueFrom" in e:
+                if "valueFrom" in e and e["valueFrom"] is not None:
                     if "secretKeyRef" in e["valueFrom"]:
                         self.evaluated_container_keys = [f"env/[{idx}]/valueFrom/secretKeyRef"]
                         return CheckResult.FAILED


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

handled missing field "secretKeyRef" in k8s secrets template.
No UT for this specific case wasn't added since a YAML with null value is not parsed in checkov (considered as a parsing error)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
