### PR TITLE
fix(kubernetes): handled missing key in k8s templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,5 @@ repos:
         language_version: python3.9
         entry: pipenv-setup check
         args: []
+        additional_dependencies:
+          - vistir<0.7.0  # can be removed, when v4.0.0 of pipenv-setup comes out

--- a/checkov/kubernetes/checks/resource/base_root_container_check.py
+++ b/checkov/kubernetes/checks/resource/base_root_container_check.py
@@ -35,7 +35,7 @@ class BaseK8sRootContainerCheck(BaseK8Check):
             if "spec" in conf:
                 spec = conf["spec"]
         elif conf['kind'] == 'CronJob':
-            if "spec" in conf and "jobTemplate" in conf["spec"] and "spec" in conf["spec"]["jobTemplate"] and "template" in conf["spec"]["jobTemplate"]["spec"] and "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
+            if "spec" in conf and "jobTemplate" in conf["spec"] and "spec" in conf["spec"]["jobTemplate"] and conf["spec"]["jobTemplate"]["spec"] and "template" in conf["spec"]["jobTemplate"]["spec"] and "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
             inner_spec = self.get_inner_entry(conf, "spec")

--- a/checkov/kubernetes/checks/resource/k8s/Seccomp.py
+++ b/checkov/kubernetes/checks/resource/k8s/Seccomp.py
@@ -39,7 +39,7 @@ class Seccomp(BaseK8Check):
             if "spec" in conf:
                 if "jobTemplate" in conf["spec"]:
                     if "spec" in conf["spec"]["jobTemplate"]:
-                        if "template" in conf["spec"]["jobTemplate"]["spec"]:
+                        if conf["spec"]["jobTemplate"]["spec"] and "template" in conf["spec"]["jobTemplate"]["spec"]:
                             if "metadata" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                                 metadata = conf["spec"]["jobTemplate"]["spec"]["template"]["metadata"]
                             elif "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

handled empty field "spec" in k8s templates.
No UT for this specific case wasn't added since a YAML with null value is not parsed in checkov (considered as a parsing error)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
