### PR TITLE
fix(argo): only scan Argo Workflows files

### DIFF
--- a/checkov/argo_workflows/runner.py
+++ b/checkov/argo_workflows/runner.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from checkov.common.checks.base_check_registry import BaseCheckRegistry
 
 API_VERSION_PATTERN = re.compile(r"^apiVersion:\s*argoproj.io/", re.MULTILINE)
+KIND_PATTERN = re.compile(r"^kind:\s*Workflow", re.MULTILINE)
 
 
 class Runner(YamlRunner, ImageReferencer):
@@ -44,9 +45,12 @@ class Runner(YamlRunner, ImageReferencer):
             return None
 
         content = Path(file_path).read_text()
-        match = re.search(API_VERSION_PATTERN, content)
-        if match:
-            return content
+        match_api = re.search(API_VERSION_PATTERN, content)
+        if match_api:
+            match_kind = re.search(KIND_PATTERN, content)
+            if match_kind:
+                # only scan Argo Workflows
+                return content
 
         return None
 

--- a/tests/argo_workflows/examples/argo_cd_application.yaml
+++ b/tests/argo_workflows/examples/argo_cd_application.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: guestbook
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+    targetRevision: HEAD
+    path: guestbook
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: guestbook

--- a/tests/argo_workflows/test_runner.py
+++ b/tests/argo_workflows/test_runner.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-from pytest_mock import MockerFixture
-
 from checkov.argo_workflows.runner import Runner
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.bridgecrew.severities import Severities, BcSeverities
@@ -66,6 +64,23 @@ def test_runner_failing_check():
     assert summary["failed"] == 1
     assert summary["skipped"] == 0
     assert summary["parsing_errors"] == 0
+
+
+def test_runner_ignore_argo_cd():
+    # given
+    test_file = EXAMPLES_DIR / "argo_cd_application.yaml"
+
+    # when
+    report = Runner().run(root_folder="", files=[str(test_file)], runner_filter=RunnerFilter())
+
+    # then
+    summary = report.get_summary()
+
+    assert summary["passed"] == 0
+    assert summary["failed"] == 0
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0
+    assert summary["resource_count"] == 0
 
 
 def test_get_image():


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- additionally checking for the `kind` being `Workflow` 

Fixes #3510 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
