### PR TITLE
fix(kubernetes): minor fix for getting entity type from template

### DIFF
--- a/checkov/kubernetes/checks/resource/base_registry.py
+++ b/checkov/kubernetes/checks/resource/base_registry.py
@@ -6,7 +6,7 @@ class Registry(BaseCheckRegistry):
         super().__init__(report_type)
 
     def extract_entity_details(self, entity):
-        kind = entity["kind"]
+        kind = entity.get("kind")
         conf = entity
         return kind, conf
 

--- a/checkov/kubernetes/checks/resource/base_registry.py
+++ b/checkov/kubernetes/checks/resource/base_registry.py
@@ -6,7 +6,7 @@ class Registry(BaseCheckRegistry):
         super().__init__(report_type)
 
     def extract_entity_details(self, entity):
-        kind = entity.get("kind")
+        kind = entity.get("kind") or ""
         conf = entity
         return kind, conf
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

avoid exception when extracting entity type from a k8s template

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
