### PR TITLE
fix(terraform): local_authentication_disabled - cosmodb check to look at SQL Api only CKV_AZURE_140

### DIFF
--- a/checkov/terraform/checks/resource/azure/CosmosDBLocalAuthDisabled.py
+++ b/checkov/terraform/checks/resource/azure/CosmosDBLocalAuthDisabled.py
@@ -1,10 +1,8 @@
-from typing import Any
-
-from checkov.common.models.enums import CheckCategories
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
 
 
-class CosmosDBLocalAuthDisabled(BaseResourceValueCheck):
+class CosmosDBLocalAuthDisabled(BaseResourceCheck):
     def __init__(self) -> None:
         # This is the full description of your check
         description = "Ensure that Local Authentication is disabled on CosmosDB"
@@ -19,11 +17,14 @@ class CosmosDBLocalAuthDisabled(BaseResourceValueCheck):
         categories = (CheckCategories.IAM,)
         super().__init__(name=description, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self) -> str:
-        return "local_authentication_disabled"
-        
-    def get_expected_value(self) -> Any:
-        return True
+    def scan_resource_conf(self, conf):
+        if isinstance(conf['kind'], list) and conf['kind'] == ["GlobalDocumentDB"]:
+            if 'local_authentication_disabled' in conf:
+                if isinstance(conf['local_authentication_disabled'], list) and conf['local_authentication_disabled'] == [True]:
+                    return CheckResult.PASSED
+            self.evaluated_keys = ['local_authentication_disabled']
+            return CheckResult.FAILED
+        return CheckResult.UNKNOWN
 
 
 check = CosmosDBLocalAuthDisabled()

--- a/checkov/terraform/checks/resource/azure/CosmosDBLocalAuthDisabled.py
+++ b/checkov/terraform/checks/resource/azure/CosmosDBLocalAuthDisabled.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class CosmosDBLocalAuthDisabled(BaseResourceCheck):
+class CosmosDBLocalAuthDisabled(BaseResourceValueCheck):
     def __init__(self) -> None:
         # This is the full description of your check
         description = "Ensure that Local Authentication is disabled on CosmosDB"
@@ -17,14 +21,16 @@ class CosmosDBLocalAuthDisabled(BaseResourceCheck):
         categories = (CheckCategories.IAM,)
         super().__init__(name=description, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        if isinstance(conf['kind'], list) and conf['kind'] == ["GlobalDocumentDB"]:
-            if 'local_authentication_disabled' in conf:
-                if isinstance(conf['local_authentication_disabled'], list) and conf['local_authentication_disabled'] == [True]:
-                    return CheckResult.PASSED
-            self.evaluated_keys = ['local_authentication_disabled']
-            return CheckResult.FAILED
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        if conf.get("kind") == ["GlobalDocumentDB"]:
+            return super().scan_resource_conf(conf)
         return CheckResult.UNKNOWN
+
+    def get_inspected_key(self) -> str:
+        return "local_authentication_disabled"
+
+    def get_expected_value(self) -> Any:
+        return True
 
 
 check = CosmosDBLocalAuthDisabled()

--- a/tests/terraform/checks/resource/azure/example_CosmosDBLocalAuthDisabled/CosmosDBLocalAuthDisabled.tf
+++ b/tests/terraform/checks/resource/azure/example_CosmosDBLocalAuthDisabled/CosmosDBLocalAuthDisabled.tf
@@ -1,5 +1,80 @@
-## SHOULD PASS: Explicitly setting local_authentication_disabled to true
-resource "azurerm_cosmosdb_account" "ckv_unittest_pass" {
+resource "azurerm_cosmosdb_account" "pass" {
+  name                          = "pike-sql"
+  location                      = "uksouth"
+  resource_group_name           = "pike"
+  offer_type                    = "Standard"
+  kind                          = "GlobalDocumentDB"
+  local_authentication_disabled = true
+  enable_free_tier              = true
+
+  consistency_policy {
+    consistency_level       = "Session"
+    max_interval_in_seconds = 5
+    max_staleness_prefix    = 100
+  }
+
+  geo_location {
+    location          = "uksouth"
+    failover_priority = 0
+  }
+  tags = {
+    "defaultExperience"       = "Core (SQL)"
+    "hidden-cosmos-mmspecial" = ""
+  }
+}
+
+resource "azurerm_cosmosdb_account" "fail" {
+  name                          = "pike-sql"
+  location                      = "uksouth"
+  resource_group_name           = "pike"
+  offer_type                    = "Standard"
+  kind                          = "GlobalDocumentDB"
+  local_authentication_disabled = false
+  enable_free_tier              = true
+
+  consistency_policy {
+    consistency_level       = "Session"
+    max_interval_in_seconds = 5
+    max_staleness_prefix    = 100
+  }
+
+  geo_location {
+    location          = "uksouth"
+    failover_priority = 0
+  }
+  tags = {
+    "defaultExperience"       = "Core (SQL)"
+    "hidden-cosmos-mmspecial" = ""
+  }
+}
+
+resource "azurerm_cosmosdb_account" "fail2" {
+  name                          = "pike-sql"
+  location                      = "uksouth"
+  resource_group_name           = "pike"
+  offer_type                    = "Standard"
+  kind                          = "GlobalDocumentDB"
+  //local_authentication_disabled = false
+  enable_free_tier              = true
+
+  consistency_policy {
+    consistency_level       = "Session"
+    max_interval_in_seconds = 5
+    max_staleness_prefix    = 100
+  }
+
+  geo_location {
+    location          = "uksouth"
+    failover_priority = 0
+  }
+  tags = {
+    "defaultExperience"       = "Core (SQL)"
+    "hidden-cosmos-mmspecial" = ""
+  }
+}
+
+## SHOULD ignore: local_authentication_disabled can only be set on SQL api - kind = "GlobalDocumentDB"
+resource "azurerm_cosmosdb_account" "ignore" {
   name                          = "cosmos-db"
   location                      = azurerm_resource_group.rg.location
   resource_group_name           = azurerm_resource_group.rg.name
@@ -19,8 +94,8 @@ resource "azurerm_cosmosdb_account" "ckv_unittest_pass" {
   }
 }
 
-## SHOULD FAIL: Explicitly setting local_authentication_disabled to false
-resource "azurerm_cosmosdb_account" "ckv_unittest_fail" {
+
+resource "azurerm_cosmosdb_account" "ignore2" {
   name                          = "cosmos-db"
   location                      = azurerm_resource_group.rg.location
   resource_group_name           = azurerm_resource_group.rg.name
@@ -40,8 +115,8 @@ resource "azurerm_cosmosdb_account" "ckv_unittest_fail" {
   }
 }
 
-## SHOULD FAIL: Default value of local_authentication_disabled is false
-resource "azurerm_cosmosdb_account" "ckv_unittest_fail_2" {
+
+resource "azurerm_cosmosdb_account" "ignore3" {
   name                = "cosmos-db"
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name

--- a/tests/terraform/checks/resource/azure/test_CosmosDBLocalAuthDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_CosmosDBLocalAuthDisabled.py
@@ -18,11 +18,11 @@ class TestCosmosDBLocalAuthDisabled(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            'azurerm_cosmosdb_account.ckv_unittest_pass'
+            'azurerm_cosmosdb_account.pass'
         }
         failing_resources = {
-            'azurerm_cosmosdb_account.ckv_unittest_fail',
-            'azurerm_cosmosdb_account.ckv_unittest_fail_2'
+            'azurerm_cosmosdb_account.fail',
+            'azurerm_cosmosdb_account.fail2'
         }
         skipped_resources = {}
 


### PR DESCRIPTION
The current check is invalid, only the SQL api of cosmosdb can have this property set, if you try the results on any other type:

`Error: creating Database Account: (Name "pike-cosmos-db" / Resource Group "pike"): creating/updating CosmosDB Account "pike-cosmos-db" (Resource Group "pike"): documentdb.DatabaseAccountsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="BadRequest" Message="DisableLocalAuth is only allowed to be configured for SQL API account.\r\nActivityId: 18c78879-d6e5-465f-90b0-756d721115fa, Microsoft.Azure.Documents.Common/2.14.0"`

Now we check the kind of the db and ignore if not **GlobalDocumentDB**