### PR TITLE
Add versioned kubernetes resources to terraform kubernetes checks (1/5)

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/AllowPrivilegeEscalation.py
+++ b/checkov/terraform/checks/resource/kubernetes/AllowPrivilegeEscalation.py
@@ -14,7 +14,7 @@ class AllowPrivilegeEscalation(BaseResourceCheck):
 
         name = "Containers should not run with allowPrivilegeEscalation"
         id = "CKV_K8S_20"
-        supported_resources = ['kubernetes_pod']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/AllowedCapabilities.py
+++ b/checkov/terraform/checks/resource/kubernetes/AllowedCapabilities.py
@@ -12,7 +12,7 @@ class AllowedCapabilities(BaseResourceCheck):
 
         id = "CKV_K8S_25"
 
-        supported_resources = ['kubernetes_pod']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/AllowedCapabilitiesSysAdmin.py
+++ b/checkov/terraform/checks/resource/kubernetes/AllowedCapabilitiesSysAdmin.py
@@ -10,7 +10,7 @@ class AllowedCapabilitiesSysAdmin(BaseResourceCheck):
         # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
         id = "CKV_K8S_39"
 
-        supported_resources = ['kubernetes_pod']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/CPULimits.py
+++ b/checkov/terraform/checks/resource/kubernetes/CPULimits.py
@@ -10,7 +10,7 @@ class CPULimits(BaseResourceCheck):
     def __init__(self) -> None:
         name = "CPU Limits should be set"
         id = "CKV_K8S_11"
-        supported_resources = ["kubernetes_pod"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/CPURequests.py
+++ b/checkov/terraform/checks/resource/kubernetes/CPURequests.py
@@ -6,7 +6,7 @@ class CPURequests(BaseResourceCheck):
     def __init__(self):
         name = "CPU requests should be set"
         id = "CKV_K8S_10"
-        supported_resources = ["kubernetes_pod"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/ContainerSecurityContext.py
+++ b/checkov/terraform/checks/resource/kubernetes/ContainerSecurityContext.py
@@ -11,7 +11,7 @@ class ContainerSecurityContext(BaseResourceCheck):
         # Location: container .securityContext
         id = "CKV_K8S_30"
 
-        supported_resources = ['kubernetes_pod']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/tests/terraform/checks/resource/kubernetes/example_AllowPrivilegeEscalation/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_AllowPrivilegeEscalation/main.tf
@@ -93,6 +93,101 @@ resource "kubernetes_pod" "unknown" {
 }
 
 
+#ignore as old tf
+resource "kubernetes_pod_v1" "unknown" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+      {
+        image = "nginx:1.7.9"
+        name  = "example22"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ,
+      {
+        image = "nginx:1.7.9"
+        name  = "example22222"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
 resource "kubernetes_pod" "fail" {
   metadata {
     name = "terraform-example"
@@ -184,8 +279,192 @@ resource "kubernetes_pod" "fail" {
   }
 }
 
+
+resource "kubernetes_pod_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        privileged = true
+        allow_privilege_escalation = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
 #not set
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+#not set
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }
@@ -336,8 +615,76 @@ resource "kubernetes_pod" "pass2" {
   }
 }
 
+#set to false
+resource "kubernetes_pod_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        privileged = false
+        allow_privilege_escalation = false
+      }
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 
 resource "kubernetes_pod" "unknown_2" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
+
+resource "kubernetes_pod_v1" "unknown_2" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_AllowedCapabilities/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_AllowedCapabilities/main.tf
@@ -91,7 +91,196 @@ resource "kubernetes_pod" "ignore" {
   }
 }
 
+resource "kubernetes_pod_v1" "ignore" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+      {
+        image = "nginx:1.7.9"
+        name  = "example22"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ,
+      {
+        image = "nginx:1.7.9"
+        name  = "example22222"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        capabilities {
+          add = ["NET_BIND_SERVICE"]
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        capabilities {
+          add = ["NET_BIND_SERVICE"]
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -247,7 +436,124 @@ resource "kubernetes_pod" "pass2" {
   }
 }
 
+resource "kubernetes_pod_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        capabilities {
+          add = []
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get  {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        capabilities {
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_AllowedCapabilitiesSysAdmin/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_AllowedCapabilitiesSysAdmin/main.tf
@@ -91,7 +91,199 @@ resource "kubernetes_pod" "ignore" {
   }
 }
 
+
+resource "kubernetes_pod_v1" "ignore" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+      {
+        image = "nginx:1.7.9"
+        name  = "example22"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ,
+      {
+        image = "nginx:1.7.9"
+        name  = "example22222"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        capabilities {
+          add = ["SYS_ADMIN"]
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        capabilities {
+          add = ["NET_BIND_SERVICE"]
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -247,7 +439,184 @@ resource "kubernetes_pod" "pass2" {
   }
 }
 
+
+resource "kubernetes_pod" "pass2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        capabilities {
+          add = []
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get  {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        capabilities {
+          add = []
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get  {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        capabilities {
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_CPULimits/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_CPULimits/main.tf
@@ -5,6 +5,14 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+
+# fails no spec
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -48,8 +56,98 @@ resource "kubernetes_pod" "fail3" {
   }
 }
 
+# fails no resource
+resource "kubernetes_pod_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 # fails no limits
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+# fails no limits
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -145,6 +243,55 @@ resource "kubernetes_pod" "fail4" {
 }
 
 
+# fails no cpu limit
+resource "kubernetes_pod_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          memory = "1Gi"
+        }
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "pass" {
   metadata {
     name = "terraform-example"
@@ -195,7 +342,84 @@ resource "kubernetes_pod" "pass" {
   }
 }
 
+resource "kubernetes_pod_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu = "500m"
+        }
+
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "unknown" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "unknown" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_CPURequests/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_CPURequests/main.tf
@@ -5,6 +5,13 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -48,8 +55,99 @@ resource "kubernetes_pod" "fail3" {
   }
 }
 
+# fails no resource
+resource "kubernetes_pod_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
 # fails no requests
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+# fails no requests
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -144,8 +242,106 @@ resource "kubernetes_pod" "fail4" {
   }
 }
 
+# fails no cpu limit
+resource "kubernetes_pod_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        requests = {
+          memory = "1Gi"
+        }
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
 
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        requests = {
+          cpu = "500m"
+        }
+
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_CPURequests/main2.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_CPURequests/main2.tf
@@ -5,8 +5,58 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+# fails no resource
+resource "kubernetes_pod_v1" "fail3" {
   metadata {
     name = "terraform-example"
   }
@@ -95,6 +145,54 @@ resource "kubernetes_pod" "fail" {
   }
 }
 
+# fails no requests
+resource "kubernetes_pod_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
 # fails no cpu limit
 resource "kubernetes_pod" "fail4" {
   metadata {
@@ -144,8 +242,105 @@ resource "kubernetes_pod" "fail4" {
   }
 }
 
+# fails no cpu limit
+resource "kubernetes_pod_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        requests = {
+          memory = "1Gi"
+        }
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 
 resource "kubernetes_pod" "fail5" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        requests = "x"
+
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "fail5" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_CPURequests/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_CPURequests/main3.tf
@@ -18,3 +18,24 @@ resource "kubernetes_pod" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_pod_v1" "examplePod" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    automount_service_account_token = true
+    security_context{
+    }
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_ContainerSecurityContext/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ContainerSecurityContext/main.tf
@@ -82,7 +82,145 @@ resource "kubernetes_pod" "fail" {
   }
 }
 
+
+resource "kubernetes_pod_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+
+    container {
+      image             = "nginx"
+      image_pull_policy = "Never"
+      name              = "example"
+
+      security_context {
+        privileged                 = true
+        allow_privilege_escalation = true
+        capabilities {
+          add  = ["NET_RAW"]
+          drop = ["NET_BIND_SERVICE"]
+        }
+      }
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+        host_port      = 8080
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/test_AllowPrivilegeEscalation.py
+++ b/tests/terraform/checks/resource/kubernetes/test_AllowPrivilegeEscalation.py
@@ -20,17 +20,20 @@ class TestAllowPrivilegeEscalation(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod.pass2",
+            "kubernetes_pod_v1.pass",
+            "kubernetes_pod_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
+            "kubernetes_pod_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 1 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_AllowedCapabilities.py
+++ b/tests/terraform/checks/resource/kubernetes/test_AllowedCapabilities.py
@@ -20,17 +20,20 @@ class TestAllowedCapabilities(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod.pass2",
+            "kubernetes_pod_v1.pass",
+            "kubernetes_pod_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
+            "kubernetes_pod_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 1 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_AllowedCapabilitiesSysAdmin.py
+++ b/tests/terraform/checks/resource/kubernetes/test_AllowedCapabilitiesSysAdmin.py
@@ -20,17 +20,20 @@ class TestAllowedCapabilitiesSysAdmin(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod.pass2",
+            "kubernetes_pod_v1.pass",
+            "kubernetes_pod_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
+            "kubernetes_pod_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 1 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_CPULimits.py
+++ b/tests/terraform/checks/resource/kubernetes/test_CPULimits.py
@@ -19,6 +19,7 @@ class TestCPULimits(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
@@ -26,13 +27,17 @@ class TestCPULimits(unittest.TestCase):
             "kubernetes_pod.fail2",
             "kubernetes_pod.fail3",
             "kubernetes_pod.fail4",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
+            "kubernetes_pod_v1.fail3",
+            "kubernetes_pod_v1.fail4",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["passed"], 1 * 2)
+        self.assertEqual(summary["failed"], 4 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_CPURequests.py
+++ b/tests/terraform/checks/resource/kubernetes/test_CPURequests.py
@@ -19,6 +19,7 @@ class TestCPURequests(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
@@ -27,13 +28,18 @@ class TestCPURequests(unittest.TestCase):
             "kubernetes_pod.fail3",
             "kubernetes_pod.fail4",
             "kubernetes_pod.fail5",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
+            "kubernetes_pod_v1.fail3",
+            "kubernetes_pod_v1.fail4",
+            "kubernetes_pod_v1.fail5",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 9)
+        self.assertEqual(summary["passed"], 1 * 2)
+        self.assertEqual(summary["failed"], 9 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ContainerSecurityContext.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ContainerSecurityContext.py
@@ -19,17 +19,19 @@ class TestContainerSecurityContext(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
+            "kubernetes_pod_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 1 * 2)
+        self.assertEqual(summary["failed"], 1 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
This PR adds add the new resource names to the existing checks. PR 1 of 5.

Fixes #3650

## Edited policies
* CKV_K8S_20
  Add resource: kubernetes_pod_v1
* CKV_K8S_25
  Add resource: kubernetes_pod_v1
* CKV_K8S_39
  Add resource: kubernetes_pod_v1
* CKV_K8S_11
  Add resource: kubernetes_pod_v1
* CKV_K8S_10
  Add resource: kubernetes_pod_v1
* CKV_K8S_30
  Add resource: kubernetes_pod_v1


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules