### PR TITLE
feat(terraform): add versioned kubernetes resources to terraform kubernetes checks (2/5)

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/DefaultNamespace.py
+++ b/checkov/terraform/checks/resource/kubernetes/DefaultNamespace.py
@@ -7,11 +7,19 @@ class DefaultNamespace(BaseResourceCheck):
         # CIS-1.5 5.7.4
         name = "The default namespace should not be used"
         id = "CKV_K8S_21"
-        supported_resources = ["kubernetes_pod", "kubernetes_deployment", "kubernetes_daemonset",
-                               "kubernetes_stateful_set", "kubernetes_replication_controller", "kubernetes_job",
-                               "kubernetes_cron_job", "kubernetes_service", "kubernetes_secret",
-                               "kubernetes_service_account", "kubernetes_role_binding", "kubernetes_config_map",
-                               "kubernetes_ingress"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1",
+                               "kubernetes_daemonset", "kubernetes_daemon_set_v1",
+                               "kubernetes_stateful_set", "kubernetes_stateful_set_v1",
+                               "kubernetes_replication_controller", "kubernetes_replication_controller_v1",
+                               "kubernetes_job", "kubernetes_job_v1",
+                               "kubernetes_cron_job", "kubernetes_cron_job_v1",
+                               "kubernetes_service", "kubernetes_service_v1",
+                               "kubernetes_secret", "kubernetes_secret_v1",
+                               "kubernetes_service_account", "kubernetes_service_account_v1",
+                               "kubernetes_role_binding", "kubernetes_role_binding_v1",
+                               "kubernetes_config_map", "kubernetes_config_map_v1",
+                               "kubernetes_ingress", "kubernetes_ingress_v1"]
 
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/checkov/terraform/checks/resource/kubernetes/DefaultServiceAccount.py
+++ b/checkov/terraform/checks/resource/kubernetes/DefaultServiceAccount.py
@@ -12,7 +12,7 @@ class DefaultServiceAccount(BaseResourceCheck):
         name = "Ensure that default service accounts are not actively used"
         # Check automountServiceAccountToken in default service account in runtime
         id = "CKV_K8S_41"
-        supported_resources = ["kubernetes_service_account"]
+        supported_resources = ["kubernetes_service_account", "kubernetes_service_account_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/DefaultServiceAccountBinding.py
+++ b/checkov/terraform/checks/resource/kubernetes/DefaultServiceAccountBinding.py
@@ -8,7 +8,8 @@ class DefaultServiceAccountBinding(BaseResourceCheck):
         name = "Ensure that default service accounts are not actively used"
         # Check no role/clusterrole is bound to a default service account (to ensure not actively used)
         id = "CKV_K8S_42"
-        supported_resources = ["kubernetes_role_binding", "kubernetes_cluster_role_binding"]
+        supported_resources = ["kubernetes_role_binding", "kubernetes_role_binding_v1",
+                               "kubernetes_cluster_role_binding", "kubernetes_cluster_role_binding_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/DockerSocketVolume.py
+++ b/checkov/terraform/checks/resource/kubernetes/DockerSocketVolume.py
@@ -15,7 +15,9 @@ class DockerSocketVolume(BaseResourceCheck):
         # Location: *.spec.template.spec.volumes[].hostPath.path
         id = "CKV_K8S_27"
         name = "Do not expose the docker daemon socket to containers"
-        supported_resources = ("kubernetes_pod", "kubernetes_deployment", "kubernetes_daemonset")
+        supported_resources = ("kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1",
+                               "kubernetes_daemonset", "kubernetes_daemon_set_v1")
         categories = (CheckCategories.NETWORKING,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/DropCapabilities.py
+++ b/checkov/terraform/checks/resource/kubernetes/DropCapabilities.py
@@ -11,7 +11,7 @@ class DropCapabilities(BaseResourceCheck):
         name = "Minimize the admission of containers with the NET_RAW capability"
         id = "CKV_K8S_28"
 
-        supported_resources = ('kubernetes_pod',)
+        supported_resources = ('kubernetes_pod', 'kubernetes_pod_v1')
         categories = (CheckCategories.GENERAL_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/HostPort.py
+++ b/checkov/terraform/checks/resource/kubernetes/HostPort.py
@@ -16,7 +16,7 @@ class HostPort(BaseResourceCheck):
                """
         name = "Do not specify hostPort unless absolutely necessary"
         id = "CKV_K8S_26"
-        supported_resources = ["kubernetes_pod"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/tests/terraform/checks/resource/kubernetes/example_DefaultNamespace/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_DefaultNamespace/main.tf
@@ -48,8 +48,105 @@ resource "kubernetes_pod" "fail" {
   }
 }
 
+resource "kubernetes_pod_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+
+    container {
+      image             = "nginx"
+      image_pull_policy = "Never"
+      name              = "example"
+
+      security_context {
+        privileged = true
+        allow_privilege_escalation = true
+      }
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 #set default
 resource "kubernetes_pod" "fail2" {
+  metadata {
+    name = "terraform-example"
+    namespace = "default"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+
+    container {
+      image             = "nginx"
+      image_pull_policy = "Never"
+      name              = "example"
+
+      security_context {
+        privileged = true
+        allow_privilege_escalation = true
+      }
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "fail2" {
   metadata {
     name = "terraform-example"
     namespace = "default"
@@ -147,7 +244,116 @@ resource "kubernetes_pod" "pass" {
   }
 }
 
+resource "kubernetes_pod_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    namespace = "brian"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+
+    container {
+      image             = "nginx"
+      image_pull_policy = "Never"
+      name              = "example"
+
+      security_context {
+        privileged = true
+        allow_privilege_escalation = true
+      }
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "prometheus"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "prometheus"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "prometheus"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
   metadata {
     name = "terraform-example"
     labels = {
@@ -268,7 +474,128 @@ resource "kubernetes_deployment" "pass" {
   }
 }
 
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    namespace = "brian"
+    labels = {
+      k8s-app = "prometheus"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "prometheus"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "prometheus"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
 resource "kubernetes_daemonset" "pass" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "something"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_daemon_set_v1" "pass" {
   metadata {
     name      = "terraform-example"
     namespace = "something"
@@ -387,7 +714,250 @@ resource "kubernetes_daemonset" "fail" {
   }
 }
 
+resource "kubernetes_daemon_set_v1" "fail" {
+  metadata {
+    name      = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
+        }
+      }
+    }
+  }
+}
+
 resource "kubernetes_stateful_set" "fail" {
+  metadata {
+    annotations = {
+      SomeAnnotation = "foobar"
+    }
+
+    labels = {
+      k8s-app                           = "prometheus"
+      "kubernetes.io/cluster-service"   = "true"
+      "addonmanager.kubernetes.io/mode" = "Reconcile"
+      version                           = "v2.2.1"
+    }
+
+    name = "prometheus"
+  }
+
+  spec {
+    pod_management_policy  = "Parallel"
+    replicas               = 1
+    revision_history_limit = 5
+
+    selector {
+      match_labels = {
+        k8s-app = "prometheus"
+      }
+    }
+
+    service_name = "prometheus"
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "prometheus"
+        }
+
+        annotations = {}
+      }
+
+      spec {
+        service_account_name = "prometheus"
+
+        init_container {
+          name              = "init-chown-data"
+          image             = "busybox:latest"
+          image_pull_policy = "IfNotPresent"
+          command           = ["chown", "-R", "65534:65534", "/data"]
+
+          volume_mount {
+            name       = "prometheus-data"
+            mount_path = "/data"
+            sub_path   = ""
+          }
+        }
+
+        container {
+          name              = "prometheus-server-configmap-reload"
+          image             = "jimmidyson/configmap-reload:v0.1"
+          image_pull_policy = "IfNotPresent"
+
+          args = [
+            "--volume-dir=/etc/config",
+            "--webhook-url=http://localhost:9090/-/reload",
+          ]
+
+          volume_mount {
+            name       = "config-volume"
+            mount_path = "/etc/config"
+            read_only  = true
+          }
+
+          resources {
+            limits = {
+              cpu    = "10m"
+              memory = "10Mi"
+            }
+
+            requests = {
+              cpu    = "10m"
+              memory = "10Mi"
+            }
+          }
+        }
+
+        container {
+          name              = "prometheus-server"
+          image             = "prom/prometheus:v2.2.1"
+          image_pull_policy = "IfNotPresent"
+
+          args = [
+            "--config.file=/etc/config/prometheus.yml",
+            "--storage.tsdb.path=/data",
+            "--web.console.libraries=/etc/prometheus/console_libraries",
+            "--web.console.templates=/etc/prometheus/consoles",
+            "--web.enable-lifecycle",
+          ]
+
+          port {
+            container_port = 9090
+          }
+
+          resources {
+            limits = {
+              cpu    = "200m"
+              memory = "1000Mi"
+            }
+
+            requests = {
+              cpu    = "200m"
+              memory = "1000Mi"
+            }
+          }
+
+          volume_mount {
+            name       = "config-volume"
+            mount_path = "/etc/config"
+          }
+
+          volume_mount {
+            name       = "prometheus-data"
+            mount_path = "/data"
+            sub_path   = ""
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/-/ready"
+              port = 9090
+            }
+
+            initial_delay_seconds = 30
+            timeout_seconds       = 30
+          }
+
+          liveness_probe {
+            http_get {
+              path   = "/-/healthy"
+              port   = 9090
+              scheme = "HTTPS"
+            }
+
+            initial_delay_seconds = 30
+            timeout_seconds       = 30
+          }
+        }
+
+        termination_grace_period_seconds = 300
+
+        volume {
+          name = "config-volume"
+
+          config_map {
+            name = "prometheus-config"
+          }
+        }
+      }
+    }
+
+    update_strategy {
+      type = "RollingUpdate"
+
+      rolling_update {
+        partition = 1
+      }
+    }
+
+    volume_claim_template {
+      metadata {
+        name = "prometheus-data"
+      }
+
+      spec {
+        access_modes       = ["ReadWriteOnce"]
+        storage_class_name = "standard"
+
+        resources {
+          requests = {
+            storage = "16Gi"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_stateful_set_v1" "fail" {
   metadata {
     annotations = {
       SomeAnnotation = "foobar"
@@ -756,7 +1326,250 @@ resource "kubernetes_stateful_set" "pass" {
   }
 }
 
+resource "kubernetes_stateful_set_v1" "pass" {
+  metadata {
+    namespace = "brian"
+    annotations = {
+      SomeAnnotation = "foobar"
+    }
+
+    labels = {
+      k8s-app                           = "prometheus"
+      "kubernetes.io/cluster-service"   = "true"
+      "addonmanager.kubernetes.io/mode" = "Reconcile"
+      version                           = "v2.2.1"
+    }
+
+    name = "prometheus"
+  }
+
+  spec {
+    pod_management_policy  = "Parallel"
+    replicas               = 1
+    revision_history_limit = 5
+
+    selector {
+      match_labels = {
+        k8s-app = "prometheus"
+      }
+    }
+
+    service_name = "prometheus"
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "prometheus"
+        }
+
+        annotations = {}
+      }
+
+      spec {
+        service_account_name = "prometheus"
+
+        init_container {
+          name              = "init-chown-data"
+          image             = "busybox:latest"
+          image_pull_policy = "IfNotPresent"
+          command           = ["chown", "-R", "65534:65534", "/data"]
+
+          volume_mount {
+            name       = "prometheus-data"
+            mount_path = "/data"
+            sub_path   = ""
+          }
+        }
+
+        container {
+          name              = "prometheus-server-configmap-reload"
+          image             = "jimmidyson/configmap-reload:v0.1"
+          image_pull_policy = "IfNotPresent"
+
+          args = [
+            "--volume-dir=/etc/config",
+            "--webhook-url=http://localhost:9090/-/reload",
+          ]
+
+          volume_mount {
+            name       = "config-volume"
+            mount_path = "/etc/config"
+            read_only  = true
+          }
+
+          resources {
+            limits = {
+              cpu    = "10m"
+              memory = "10Mi"
+            }
+
+            requests = {
+              cpu    = "10m"
+              memory = "10Mi"
+            }
+          }
+        }
+
+        container {
+          name              = "prometheus-server"
+          image             = "prom/prometheus:v2.2.1"
+          image_pull_policy = "IfNotPresent"
+
+          args = [
+            "--config.file=/etc/config/prometheus.yml",
+            "--storage.tsdb.path=/data",
+            "--web.console.libraries=/etc/prometheus/console_libraries",
+            "--web.console.templates=/etc/prometheus/consoles",
+            "--web.enable-lifecycle",
+          ]
+
+          port {
+            container_port = 9090
+          }
+
+          resources {
+            limits = {
+              cpu    = "200m"
+              memory = "1000Mi"
+            }
+
+            requests = {
+              cpu    = "200m"
+              memory = "1000Mi"
+            }
+          }
+
+          volume_mount {
+            name       = "config-volume"
+            mount_path = "/etc/config"
+          }
+
+          volume_mount {
+            name       = "prometheus-data"
+            mount_path = "/data"
+            sub_path   = ""
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/-/ready"
+              port = 9090
+            }
+
+            initial_delay_seconds = 30
+            timeout_seconds       = 30
+          }
+
+          liveness_probe {
+            http_get {
+              path   = "/-/healthy"
+              port   = 9090
+              scheme = "HTTPS"
+            }
+
+            initial_delay_seconds = 30
+            timeout_seconds       = 30
+          }
+        }
+
+        termination_grace_period_seconds = 300
+
+        volume {
+          name = "config-volume"
+
+          config_map {
+            name = "prometheus-config"
+          }
+        }
+      }
+    }
+
+    update_strategy {
+      type = "RollingUpdate"
+
+      rolling_update {
+        partition = 1
+      }
+    }
+
+    volume_claim_template {
+      metadata {
+        name = "prometheus-data"
+      }
+
+      spec {
+        access_modes       = ["ReadWriteOnce"]
+        storage_class_name = "standard"
+
+        resources {
+          requests = {
+            storage = "16Gi"
+          }
+        }
+      }
+    }
+  }
+}
+
 resource "kubernetes_replication_controller" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    selector = {
+      test = "MyExampleApp"
+    }
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+        annotations = {
+          "key1" = "value1"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 8080
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_replication_controller_v1" "fail" {
   metadata {
     name = "terraform-example"
     labels = {
@@ -873,7 +1686,87 @@ resource "kubernetes_replication_controller" "pass" {
   }
 }
 
+resource "kubernetes_replication_controller_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+    namespace = "brian"
+  }
+
+  spec {
+    selector = {
+      test = "MyExampleApp"
+    }
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+        annotations = {
+          "key1" = "value1"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 8080
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 resource "kubernetes_job" "fail" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    template {
+      metadata {}
+      spec {
+        container {
+          name    = "pi"
+          image   = "perl"
+          command = ["perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        }
+        restart_policy = "Never"
+      }
+    }
+    backoff_limit = 4
+  }
+  wait_for_completion = false
+}
+
+resource "kubernetes_job_v1" "fail" {
   metadata {
     name = "demo"
   }
@@ -916,7 +1809,59 @@ resource "kubernetes_job" "pass" {
   wait_for_completion = false
 }
 
+resource "kubernetes_job_v1" "pass" {
+  metadata {
+    name = "demo"
+    namespace = "brian"
+  }
+  spec {
+    template {
+      metadata {}
+      spec {
+        container {
+          name    = "pi"
+          image   = "perl"
+          command = ["perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        }
+        restart_policy = "Never"
+      }
+    }
+    backoff_limit = 4
+  }
+  wait_for_completion = false
+}
+
 resource "kubernetes_cron_job" "fail" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_cron_job_v1" "fail" {
   metadata {
     name = "demo"
   }
@@ -977,7 +1922,77 @@ resource "kubernetes_cron_job" "pass" {
   }
 }
 
+resource "kubernetes_cron_job_v1" "pass" {
+  metadata {
+    name = "demo"
+    namespace = "brian"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 resource "kubernetes_ingress" "fail" {
+  metadata {
+    name = "example-ingress"
+  }
+
+  spec {
+    backend {
+      service_name = "MyApp1"
+      service_port = 8080
+    }
+
+    rule {
+      http {
+        path {
+          backend {
+            service_name = "MyApp1"
+            service_port = 8080
+          }
+
+          path = "/app1/*"
+        }
+
+        path {
+          backend {
+            service_name = "MyApp2"
+            service_port = 8080
+          }
+
+          path = "/app2/*"
+        }
+      }
+    }
+
+    tls {
+      secret_name = "tls-secret"
+    }
+  }
+}
+
+resource "kubernetes_ingress_v1" "fail" {
   metadata {
     name = "example-ingress"
   }
@@ -1056,7 +2071,63 @@ resource "kubernetes_ingress" "pass" {
   }
 }
 
+resource "kubernetes_ingress_v1" "pass" {
+  metadata {
+    name = "example-ingress"
+    namespace = "brian"
+  }
+
+  spec {
+    backend {
+      service_name = "MyApp1"
+      service_port = 8080
+    }
+
+    rule {
+      http {
+        path {
+          backend {
+            service_name = "MyApp1"
+            service_port = 8080
+          }
+
+          path = "/app1/*"
+        }
+
+        path {
+          backend {
+            service_name = "MyApp2"
+            service_port = 8080
+          }
+
+          path = "/app2/*"
+        }
+      }
+    }
+
+    tls {
+      secret_name = "tls-secret"
+    }
+  }
+}
+
 resource "kubernetes_config_map" "fail" {
+  metadata {
+    name = "my-config"
+  }
+
+  data = {
+    api_host             = "myhost:443"
+    db_host              = "dbhost:5432"
+    "my_config_file.yml" = "${file("${path.module}/my_config_file.yml")}"
+  }
+
+  binary_data = {
+    "my_payload.bin" = "${filebase64("${path.module}/my_payload.bin")}"
+  }
+}
+
+resource "kubernetes_config_map_v1" "fail" {
   metadata {
     name = "my-config"
   }
@@ -1089,7 +2160,51 @@ resource "kubernetes_config_map" "pass" {
   }
 }
 
+resource "kubernetes_config_map_v1" "pass" {
+  metadata {
+    namespace = "brian"
+    name = "my-config"
+  }
+
+  data = {
+    api_host             = "myhost:443"
+    db_host              = "dbhost:5432"
+    "my_config_file.yml" = "${file("${path.module}/my_config_file.yml")}"
+  }
+
+  binary_data = {
+    "my_payload.bin" = "${filebase64("${path.module}/my_payload.bin")}"
+  }
+}
+
 resource "kubernetes_role_binding" "fail" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "admin"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = "kube-system"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
+resource "kubernetes_role_binding_v1" "fail" {
   metadata {
     name      = "terraform-example"
     namespace = "default"
@@ -1143,12 +2258,48 @@ resource "kubernetes_role_binding" "pass" {
   }
 }
 
+resource "kubernetes_role_binding_v1" "pass" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "brian"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "admin"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = "kube-system"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
 resource "kubernetes_service_account" "fail" {
   metadata {
     name = "terraform-example"
   }
   secret {
     name = "${kubernetes_secret.example.metadata.0.name}"
+  }
+}
+
+resource "kubernetes_service_account_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+  secret {
+    name = "${kubernetes_secret_v1.example.metadata.0.name}"
   }
 }
 
@@ -1159,6 +2310,16 @@ resource "kubernetes_service_account" "pass" {
   }
   secret {
     name = "${kubernetes_secret.example.metadata.0.name}"
+  }
+}
+
+resource "kubernetes_service_account_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    namespace="brian"
+  }
+  secret {
+    name = "${kubernetes_secret_v1.example.metadata.0.name}"
   }
 }
 
@@ -1175,7 +2336,34 @@ resource "kubernetes_secret" "fail" {
   type = "kubernetes.io/basic-auth"
 }
 
+resource "kubernetes_secret_v1" "fail" {
+  metadata {
+    name = "basic-auth"
+  }
+
+  data = {
+    username = "admin"
+    password = "P4ssw0rd"
+  }
+
+  type = "kubernetes.io/basic-auth"
+}
+
 resource "kubernetes_secret" "pass" {
+  metadata {
+    name = "basic-auth"
+    namespace = "brian"
+  }
+
+  data = {
+    username = "admin"
+    password = "P4ssw0rd"
+  }
+
+  type = "kubernetes.io/basic-auth"
+}
+
+resource "kubernetes_secret_v1" "pass" {
   metadata {
     name = "basic-auth"
     namespace = "brian"
@@ -1207,6 +2395,24 @@ resource "kubernetes_service" "fail" {
   }
 }
 
+resource "kubernetes_service_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    selector = {
+      app = kubernetes_pod_v1.example.metadata.0.labels.app
+    }
+    session_affinity = "ClientIP"
+    port {
+      port        = 8080
+      target_port = 80
+    }
+
+    type = "LoadBalancer"
+  }
+}
+
 resource "kubernetes_service" "pass" {
   metadata {
     name = "terraform-example"
@@ -1215,6 +2421,25 @@ resource "kubernetes_service" "pass" {
   spec {
     selector = {
       app = kubernetes_pod.example.metadata.0.labels.app
+    }
+    session_affinity = "ClientIP"
+    port {
+      port        = 8080
+      target_port = 80
+    }
+
+    type = "LoadBalancer"
+  }
+}
+
+resource "kubernetes_service_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    namespace = "brian"
+  }
+  spec {
+    selector = {
+      app = kubernetes_pod_v1.example.metadata.0.labels.app
     }
     session_affinity = "ClientIP"
     port {

--- a/tests/terraform/checks/resource/kubernetes/example_DefaultServiceAccount/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_DefaultServiceAccount/main.tf
@@ -4,7 +4,20 @@ resource "kubernetes_service_account" "fail" {
   }
 }
 
+resource "kubernetes_service_account_v1" "fail" {
+  metadata {
+    name = "default"
+  }
+}
+
 resource "kubernetes_service_account" "fail2" {
+  metadata {
+    name = "default"
+  }
+  automount_service_account_token=true
+}
+
+resource "kubernetes_service_account_v1" "fail2" {
   metadata {
     name = "default"
   }
@@ -18,7 +31,21 @@ resource "kubernetes_service_account" "pass" {
   automount_service_account_token=false
 }
 
+resource "kubernetes_service_account_v1" "pass" {
+  metadata {
+    name = "default"
+  }
+  automount_service_account_token=false
+}
+
+
 resource "kubernetes_service_account" "pass2" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
+resource "kubernetes_service_account_v1" "pass2" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_DefaultServiceAccountBinding/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_DefaultServiceAccountBinding/main.tf
@@ -25,7 +25,56 @@ resource "kubernetes_role_binding" "fail" {
   }
 }
 
+resource "kubernetes_role_binding_v1" "fail" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "admin"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = "kube-system"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
 resource "kubernetes_role_binding" "pass" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "admin"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
+resource "kubernetes_role_binding_v1" "pass" {
   metadata {
     name      = "terraform-example"
     namespace = "default"
@@ -73,7 +122,54 @@ resource "kubernetes_cluster_role_binding" "fail" {
   }
 }
 
+resource "kubernetes_cluster_role_binding_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = "kube-system"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
 resource "kubernetes_cluster_role_binding" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
+resource "kubernetes_cluster_role_binding_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_DockerSocketVolume/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_DockerSocketVolume/main.tf
@@ -68,7 +68,137 @@ resource "kubernetes_pod" "fail" {
 }
 
 
+resource "kubernetes_pod_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+
+    volume {
+      host_path {
+        path = "/var/run/docker.sock"
+        type = "Directory"
+      }
+    }
+
+    volume {
+      host_path {
+        path = "/var/run/docker.sock"
+        type = "Directory"
+      }
+    }
+
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+
+    volume {
+      host_path {
+        path = "/var/log"
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }
@@ -195,7 +325,139 @@ resource "kubernetes_deployment" "pass" {
   }
 }
 
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "prometheus"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "prometheus"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "prometheus"
+        }
+      }
+
+      spec {
+
+        volume {
+          host_path {
+            path = "/var/log"
+          }
+        }
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
 resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "prometheus"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "prometheus"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "prometheus"
+        }
+      }
+
+      spec {
+        volume {
+          host_path {
+            path = "/var/run/docker.sock"
+            type = "Directory"
+          }
+        }
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
   metadata {
     name = "terraform-example"
     labels = {
@@ -329,7 +591,142 @@ resource "kubernetes_daemonset" "fail" {
   }
 }
 
+resource "kubernetes_daemon_set_v1" "fail" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "something"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+
+        volume {
+          host_path {
+            path = "/var/run/docker.sock"
+            type = "Directory"
+          }
+        }
+
+        container {
+          image = "nginx:1.21.6"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
+        }
+      }
+    }
+  }
+}
+
 resource "kubernetes_daemonset" "pass" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "something"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+        volume {
+          host_path {
+            path = "/var/log"
+            type = "Directory"
+          }
+        }
+
+        container {
+          image = "nginx:1.21.6"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_daemon_set_v1" "pass" {
   metadata {
     name      = "terraform-example"
     namespace = "something"

--- a/tests/terraform/checks/resource/kubernetes/example_DropCapabilities/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_DropCapabilities/main.tf
@@ -5,8 +5,75 @@ resource "kubernetes_pod" "fail" {
   }
 }
 
+# fails no spec
+resource "kubernetes_pod_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
 #no capabilities
 resource "kubernetes_pod" "fail4" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      security_context {
+
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+#no capabilities
+resource "kubernetes_pod_v1" "fail4" {
   metadata {
     name = "terraform-example"
   }
@@ -120,8 +187,159 @@ resource "kubernetes_pod" "fail5" {
   }
 }
 
+#no context
+resource "kubernetes_pod_v1" "fail5" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 #doesnt drop any or net_raw
 resource "kubernetes_pod" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      security_context {
+        capabilities {
+          add = ["NET_BIND_SERVICE"]
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+    container {
+      image = "nginx:1.7.9"
+      name  = "example2"
+
+      security_context {
+        capabilities {
+          drop = ["ALL"]
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+#doesnt drop any or net_raw
+resource "kubernetes_pod_v1" "fail2" {
   metadata {
     name = "terraform-example"
   }
@@ -278,7 +496,165 @@ resource "kubernetes_pod" "fail3" {
 }
 
 
+#wrong drop
+resource "kubernetes_pod_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      security_context {
+        capabilities {
+          drop = ["NET_BIND_SERVICE"]
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      security_context {
+        capabilities {
+          drop = ["NET_BIND_SERVICE", "ALL"]
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+    container {
+      image = "nginx:1.7.9"
+      name  = "example2"
+
+      security_context {
+        capabilities {
+          drop = ["ALL"]
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_HostPort/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_HostPort/main.tf
@@ -5,6 +5,13 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail" {
   metadata {
@@ -49,7 +56,101 @@ resource "kubernetes_pod" "fail" {
   }
 }
 
+# fails no resource
+resource "kubernetes_pod_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+        host_port = 8080
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu = "500m"
+        }
+
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_HostPort/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_HostPort/main3.tf
@@ -18,3 +18,24 @@ resource "kubernetes_pod" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_pod_v1" "examplePod" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    automount_service_account_token = true
+    security_context{
+    }
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/test_DefaultNamespace.py
+++ b/tests/terraform/checks/resource/kubernetes/test_DefaultNamespace.py
@@ -31,6 +31,19 @@ class TestDefaultNamespace(unittest.TestCase):
             "kubernetes_role_binding.pass",
             "kubernetes_config_map.pass",
             "kubernetes_ingress.pass",
+            "kubernetes_pod_v1.pass",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_daemon_set_v1.pass",
+            "kubernetes_stateful_set_v1.pass",
+            "kubernetes_replication_controller_v1.pass",
+            "kubernetes_job_v1.pass",
+            "kubernetes_cron_job_v1.pass",
+            "kubernetes_service_v1.pass",
+            "kubernetes_secret_v1.pass",
+            "kubernetes_service_account_v1.pass",
+            "kubernetes_role_binding_v1.pass",
+            "kubernetes_config_map_v1.pass",
+            "kubernetes_ingress_v1.pass",
         }
 
         failing_resources = {
@@ -47,14 +60,28 @@ class TestDefaultNamespace(unittest.TestCase):
             "kubernetes_service_account.fail",
             "kubernetes_role_binding.fail",
             "kubernetes_config_map.fail",
-            "kubernetes_ingress.fail"
+            "kubernetes_ingress.fail",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_daemon_set_v1.fail",
+            "kubernetes_stateful_set_v1.fail",
+            "kubernetes_replication_controller_v1.fail",
+            "kubernetes_job_v1.fail",
+            "kubernetes_cron_job_v1.fail",
+            "kubernetes_service_v1.fail",
+            "kubernetes_secret_v1.fail",
+            "kubernetes_service_account_v1.fail",
+            "kubernetes_role_binding_v1.fail",
+            "kubernetes_config_map_v1.fail",
+            "kubernetes_ingress_v1.fail"
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 13)
-        self.assertEqual(summary["failed"], 14)
+        self.assertEqual(summary["passed"], 13 * 2)
+        self.assertEqual(summary["failed"], 14 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_DefaultServiceAccount.py
+++ b/tests/terraform/checks/resource/kubernetes/test_DefaultServiceAccount.py
@@ -20,18 +20,22 @@ class TestDefaultServiceAccount(unittest.TestCase):
         passing_resources = {
             "kubernetes_service_account.pass",
             "kubernetes_service_account.pass2",
+            "kubernetes_service_account_v1.pass",
+            "kubernetes_service_account_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_service_account.fail",
             "kubernetes_service_account.fail2",
+            "kubernetes_service_account_v1.fail",
+            "kubernetes_service_account_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_DefaultServiceAccountBinding.py
+++ b/tests/terraform/checks/resource/kubernetes/test_DefaultServiceAccountBinding.py
@@ -20,18 +20,22 @@ class TestDefaultServiceAccountBinding(unittest.TestCase):
         passing_resources = {
             "kubernetes_cluster_role_binding.pass",
             "kubernetes_role_binding.pass",
+            "kubernetes_cluster_role_binding_v1.pass",
+            "kubernetes_role_binding_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_cluster_role_binding.fail",
             "kubernetes_role_binding.fail",
+            "kubernetes_cluster_role_binding_v1.fail",
+            "kubernetes_role_binding_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_DockerSocketVolume.py
+++ b/tests/terraform/checks/resource/kubernetes/test_DockerSocketVolume.py
@@ -21,19 +21,25 @@ class TestDockerSocketVolume(unittest.TestCase):
             "kubernetes_pod.pass",
             "kubernetes_deployment.pass",
             "kubernetes_daemonset.pass",
+            "kubernetes_pod_v1.pass",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_daemon_set_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_deployment.fail",
             "kubernetes_daemonset.fail",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_daemon_set_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 3)
-        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["passed"], 3 * 2)
+        self.assertEqual(summary["failed"], 3 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_DropCapabilities.py
+++ b/tests/terraform/checks/resource/kubernetes/test_DropCapabilities.py
@@ -19,6 +19,7 @@ class TestDropCapabilities(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
@@ -27,13 +28,18 @@ class TestDropCapabilities(unittest.TestCase):
             "kubernetes_pod.fail3",
             "kubernetes_pod.fail4",
             "kubernetes_pod.fail5",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
+            "kubernetes_pod_v1.fail3",
+            "kubernetes_pod_v1.fail4",
+            "kubernetes_pod_v1.fail5",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 5)
+        self.assertEqual(summary["passed"], 1 * 2)
+        self.assertEqual(summary["failed"], 5 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_HostPort.py
+++ b/tests/terraform/checks/resource/kubernetes/test_HostPort.py
@@ -19,18 +19,21 @@ class TestHostPort(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod.fail2",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], 1 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
This PR adds add the new resource names to the existing checks. PR 2 of 5.

Fixes #3650

## Edited policies
* CKV_K8S_21 
 Add resources: kubernetes_pod_v1, kubernetes_deployment_v1, kubernetes_daemon_set_v1, kubernetes_stateful_set_v1, kubernetes_replication_controller_v1, kubernetes_job_v1, kubernetes_cron_job_v1, kubernetes_api_service_v1, kubernetes_secret_v1, kubernetes_service_account_v1, kubernetes_role_binding_v1, kubernetes_config_map_v1, kubernetes_ingress_v1
* CKV_K8S_41
  Add resources: kubernetes_service_account_v1
* CKV_K8S_42
  Add resources: kubernetes_role_binding_v1, kubernetes_cluster_role_binding_v1
* CKV_K8S_27
  Add resources: kubernetes_pod_v1, kubernetes_deployment_v1, kubernetes_daemon_set_v1
* CKV_K8S_28
  Add resource: kubernetes_pod_v1
* CKV_K8S_26
  Add resource: kubernetes_pod_v1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules