### PR TITLE
feat(terraform): add versioned kubernetes resources to terraform kubernetes checks (3/5)

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/ImageDigest.py
+++ b/checkov/terraform/checks/resource/kubernetes/ImageDigest.py
@@ -15,7 +15,7 @@ class ImageDigest(BaseResourceCheck):
          """
         name = "Image should use digest"
         id = "CKV_K8S_43"
-        supported_resources = ["kubernetes_pod"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/ImagePullPolicyAlways.py
+++ b/checkov/terraform/checks/resource/kubernetes/ImagePullPolicyAlways.py
@@ -14,7 +14,7 @@ class ImagePullPolicyAlways(BaseResourceCheck):
         """
         name = "Image Pull Policy should be Always"
         id = "CKV_K8S_15"
-        supported_resources = ["kubernetes_pod"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/ImageTagFixed.py
+++ b/checkov/terraform/checks/resource/kubernetes/ImageTagFixed.py
@@ -12,7 +12,7 @@ class ImageTagFixed(BaseResourceCheck):
          """
         name = "Image Tag should be fixed - not latest or blank"
         id = "CKV_K8S_14"
-        supported_resources = ["kubernetes_pod"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/LivenessProbe.py
+++ b/checkov/terraform/checks/resource/kubernetes/LivenessProbe.py
@@ -9,7 +9,7 @@ class LivenessProbe(BaseResourceValueCheck):
     def __init__(self):
         name = "Liveness Probe Should be Configured"
         id = "CKV_K8S_8"
-        supported_resources = ["kubernetes_pod"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
                          missing_block_result=CheckResult.FAILED)

--- a/checkov/terraform/checks/resource/kubernetes/MemoryLimits.py
+++ b/checkov/terraform/checks/resource/kubernetes/MemoryLimits.py
@@ -6,7 +6,7 @@ class MemoryLimits(BaseResourceCheck):
     def __init__(self):
         name = "Memory Limits should be set"
         id = "CKV_K8S_12"
-        supported_resources = ["kubernetes_pod"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/MemoryRequests.py
+++ b/checkov/terraform/checks/resource/kubernetes/MemoryRequests.py
@@ -6,7 +6,7 @@ class MemoryRequests(BaseResourceCheck):
     def __init__(self):
         name = "Memory requests should be set"
         id = "CKV_K8S_13"
-        supported_resources = ["kubernetes_pod"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/tests/terraform/checks/resource/kubernetes/example_ImageDigest/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ImageDigest/main.tf
@@ -92,6 +92,100 @@ resource "kubernetes_pod" "unknown" {
   }
 }
 
+#not set
+resource "kubernetes_pod_v1" "unknown" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+      {
+        image = "nginx"
+        name  = "example22"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ,
+      {
+        image = "nginx:1.7.9"
+        name  = "example22222"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 #not set modern
 resource "kubernetes_pod" "fail" {
   metadata {
@@ -183,8 +277,154 @@ resource "kubernetes_pod" "fail" {
   }
 }
 
+#not set modern
+resource "kubernetes_pod_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx"
+      name  = "example22"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
 #digest
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108"
+      name  = "example22"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+#digest
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_ImageDigest/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ImageDigest/main3.tf
@@ -18,3 +18,25 @@ resource "kubernetes_pod" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_pod_v1" "examplePod" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    automount_service_account_token = true
+    security_context{
+    }
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+  }
+}
+

--- a/tests/terraform/checks/resource/kubernetes/example_ImagePullPolicyAlways/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ImagePullPolicyAlways/main.tf
@@ -92,8 +92,160 @@ resource "kubernetes_pod" "unknown" {
   }
 }
 
+#not set
+resource "kubernetes_pod_v1" "unknown" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+      {
+        image = "nginx"
+        name  = "example22"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ,
+      {
+        image = "nginx:1.7.9"
+        name  = "example22222"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 #not set modern
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx"
+      name  = "example22"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+#not set modern
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -208,9 +360,123 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+#latest but specified wrong
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:latest"
+      image_pull_policy = "Never"
+      name  = "example22"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
 
 #latest so pass
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:latest"
+      name  = "example22"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+#latest so pass
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }
@@ -325,3 +591,61 @@ resource "kubernetes_pod" "pass2" {
   }
 }
 
+#happy path
+resource "kubernetes_pod_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      image_pull_policy = "Always"
+      name  = "example22"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_ImagePullPolicyAlways/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ImagePullPolicyAlways/main3.tf
@@ -18,3 +18,24 @@ resource "kubernetes_pod" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_pod_v1" "examplePod" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    automount_service_account_token = true
+    security_context{
+    }
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_ImageTagFixed/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ImageTagFixed/main.tf
@@ -92,8 +92,193 @@ resource "kubernetes_pod" "unknown" {
   }
 }
 
+#not set
+resource "kubernetes_pod_v1" "unknown" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+      {
+        image = "nginx"
+        name  = "example22"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ,
+      {
+        image = "nginx:1.7.9"
+        name  = "example22222"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 #not set modern
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx"
+      name  = "example22"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+#not set modern
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -273,8 +458,189 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+#latest
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:latest"
+      name  = "example22"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 #regular
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+#regular
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }
@@ -451,4 +817,89 @@ resource "kubernetes_pod" "pass2" {
   }
 }
 
+#digest
+resource "kubernetes_pod_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+  }
 
+  spec {
+    container {
+      image = "nginx@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108"
+      name  = "example22"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_LivenessProbe/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_LivenessProbe/main.tf
@@ -51,7 +51,99 @@ resource "kubernetes_pod" "pass" {
   }
 }
 
+resource "kubernetes_pod_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_LivenessProbe/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_LivenessProbe/main3.tf
@@ -18,3 +18,25 @@ resource "kubernetes_pod" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_pod_v1" "examplePod" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    automount_service_account_token = true
+    security_context{
+    }
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+  }
+}
+

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main.tf
@@ -5,6 +5,13 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -48,8 +55,98 @@ resource "kubernetes_pod" "fail3" {
   }
 }
 
+# fails no resource
+resource "kubernetes_pod_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 # fails no limits
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+# fails no limits
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -144,8 +241,106 @@ resource "kubernetes_pod" "fail4" {
   }
 }
 
+# fails no cpu limit
+resource "kubernetes_pod_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu= "500m"
+        }
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
 
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          memory= "1Gi"
+        }
+
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main2.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main2.tf
@@ -5,6 +5,13 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -48,8 +55,98 @@ resource "kubernetes_pod" "fail3" {
   }
 }
 
+# fails no resource
+resource "kubernetes_pod_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 # fails no limits
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+# fails no limits
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -142,8 +239,104 @@ resource "kubernetes_pod" "fail4" {
   }
 }
 
+# fails no cpu limit
+resource "kubernetes_pod_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        limits = "x"
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
 
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          memory= "1Gi"
+        }
+
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main3.tf
@@ -18,3 +18,24 @@ resource "kubernetes_pod" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_pod_v1" "examplePod" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    automount_service_account_token = true
+    security_context{
+    }
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main.tf
@@ -5,6 +5,13 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -48,8 +55,98 @@ resource "kubernetes_pod" "fail3" {
   }
 }
 
+# fails no resource
+resource "kubernetes_pod_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 # fails no requests
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+# fails no requests
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -144,8 +241,107 @@ resource "kubernetes_pod" "fail4" {
   }
 }
 
+# fails no memory requests
+resource "kubernetes_pod_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        requests = {
+          cpu = "500m"
+        }
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        requests = {
+          memory = "1Gi"
+        }
+
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main2.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main2.tf
@@ -5,6 +5,13 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -48,8 +55,98 @@ resource "kubernetes_pod" "fail3" {
   }
 }
 
+# fails no resource
+resource "kubernetes_pod_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 # fails no requests
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+# fails no requests
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -142,8 +239,104 @@ resource "kubernetes_pod" "fail4" {
   }
 }
 
+# fails no memory requests
+resource "kubernetes_pod_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        requests = "x"
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
 
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      resources {
+        requests = {
+          memory = "1Gi"
+        }
+
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main3.tf
@@ -18,3 +18,25 @@ resource "kubernetes_pod" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_pod_v1" "examplePod" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    automount_service_account_token = true
+    security_context{
+    }
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+  }
+}
+

--- a/tests/terraform/checks/resource/kubernetes/test_ImageDigest.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ImageDigest.py
@@ -19,17 +19,19 @@ class TestImageDigest(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
+            "kubernetes_pod_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 1 * 2)
+        self.assertEqual(summary["failed"], 1 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ImagePullPolicyAlways.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ImagePullPolicyAlways.py
@@ -20,18 +20,22 @@ class TestImagePullPolicyAlways(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod.pass2",
+            "kubernetes_pod_v1.pass",
+            "kubernetes_pod_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod.fail2",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ImageTagFixed.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ImageTagFixed.py
@@ -20,18 +20,22 @@ class TestImageTagFixed(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod.pass2",
+            "kubernetes_pod_v1.pass",
+            "kubernetes_pod_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod.fail2",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_LivenessProbe.py
+++ b/tests/terraform/checks/resource/kubernetes/test_LivenessProbe.py
@@ -19,17 +19,19 @@ class TestLivenessProbe(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
+            "kubernetes_pod_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 1 * 2)
+        self.assertEqual(summary["failed"], 1 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_MemoryLimits.py
+++ b/tests/terraform/checks/resource/kubernetes/test_MemoryLimits.py
@@ -19,6 +19,7 @@ class TestMemoryLimits(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
@@ -26,13 +27,17 @@ class TestMemoryLimits(unittest.TestCase):
             "kubernetes_pod.fail2",
             "kubernetes_pod.fail3",
             "kubernetes_pod.fail4",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
+            "kubernetes_pod_v1.fail3",
+            "kubernetes_pod_v1.fail4",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 8)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 8 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_MemoryRequests.py
+++ b/tests/terraform/checks/resource/kubernetes/test_MemoryRequests.py
@@ -19,6 +19,7 @@ class TestMemoryRequests(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
@@ -26,13 +27,17 @@ class TestMemoryRequests(unittest.TestCase):
             "kubernetes_pod.fail2",
             "kubernetes_pod.fail3",
             "kubernetes_pod.fail4",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
+            "kubernetes_pod_v1.fail3",
+            "kubernetes_pod_v1.fail4",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 8)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 8 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
This PR adds add the new resource names to the existing checks. PR 3 of 5.

Fixes #3650

## Edited policies
* CKV_K8S_43
  Add resource: kubernetes_pod_v1
* CKV_K8S_15
  Add resource: kubernetes_pod_v1
* CKV_K8S_14
  Add resource: kubernetes_pod_v1
* CKV_K8S_8
  Add resource: kubernetes_pod_v1
* CKV_K8S_12
  Add resource: kubernetes_pod_v1
* CKV_K8S_13
  Add resource: kubernetes_pod_v1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules