### PR TITLE
feat(terraform): add versioned kubernetes resources to terraform kubernetes checks (4/5)

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/MinimiseCapabilities.py
+++ b/checkov/terraform/checks/resource/kubernetes/MinimiseCapabilities.py
@@ -9,7 +9,7 @@ class MinimiseCapabilities(BaseResourceCheck):
         name = "Minimise the admission of containers with capabilities assigned"
         id = "CKV_K8S_37"
 
-        supported_resources = ['kubernetes_pod']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/PodSecurityContext.py
+++ b/checkov/terraform/checks/resource/kubernetes/PodSecurityContext.py
@@ -10,7 +10,9 @@ class PodSecurityContext(BaseResourceCheck):
         # Security context can be set at pod or container level.
         id = "CKV_K8S_29"
 
-        supported_resources = ('kubernetes_pod', 'kubernetes_deployment', 'kubernetes_daemonset')
+        supported_resources = ('kubernetes_pod', 'kubernetes_pod_v1',
+                               'kubernetes_deployment', 'kubernetes_deployment_v1',
+                               'kubernetes_daemonset', 'kubernetes_daemon_set_v1')
         categories = (CheckCategories.GENERAL_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/PrivilegedContainer.py
+++ b/checkov/terraform/checks/resource/kubernetes/PrivilegedContainer.py
@@ -10,7 +10,7 @@ class PrivilegedContainers(BaseResourceCheck):
         name = "Do not admit privileged containers"
         id = "CKV_K8S_16"
 
-        supported_resources = ['kubernetes_pod']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/ReadinessProbe.py
+++ b/checkov/terraform/checks/resource/kubernetes/ReadinessProbe.py
@@ -9,7 +9,7 @@ class ReadinessProbe(BaseResourceValueCheck):
     def __init__(self):
         name = "Readiness Probe Should be Configured"
         id = "CKV_K8S_9"
-        supported_resources = ["kubernetes_pod"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
                          missing_block_result=CheckResult.FAILED)

--- a/checkov/terraform/checks/resource/kubernetes/ReadonlyRootFilesystem.py
+++ b/checkov/terraform/checks/resource/kubernetes/ReadonlyRootFilesystem.py
@@ -8,7 +8,7 @@ class ReadonlyRootFilesystem(BaseResourceCheck):
         name = "Use read-only filesystem for containers where possible"
         id = "CKV_K8S_22"
 
-        supported_resources = ['kubernetes_pod']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/terraform/checks/resource/kubernetes/Secrets.py
+++ b/checkov/terraform/checks/resource/kubernetes/Secrets.py
@@ -9,7 +9,7 @@ class Secrets(BaseResourceCheck):
         name = "Prefer using secrets as files over secrets as environment variables"
         id = "CKV_K8S_35"
 
-        supported_resources = ['kubernetes_pod']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/tests/terraform/checks/resource/kubernetes/example_MinimiseCapabilities/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MinimiseCapabilities/main.tf
@@ -85,6 +85,92 @@ resource "kubernetes_pod" "fail" {
   }
 }
 
+resource "kubernetes_pod_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+
+    container {
+      image             = "nginx"
+      image_pull_policy = "Never"
+      name              = "example"
+
+      security_context {
+        privileged                 = true
+        allow_privilege_escalation = true
+        capabilities {
+          add  = ["NET_RAW"]
+          drop = ["NET_BIND_SERVICE"]
+        }
+      }
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+        host_port      = 8080
+      }
+
+      # resources = {
+      #   requests = {
+      #     memory = "50Mi"
+      #   }
+      #   limits ={
+      #     memory = "50Mi"
+      #   }
+      # }
+      # liveness_probe {
+      #   http_get {
+      #     path = "/nginx_status"
+      #     port = 80
+
+      #     http_header {
+      #       name  = "X-Custom-Header"
+      #       value = "Awesome"
+      #     }
+      #   }
+
+      #   initial_delay_seconds = 3
+      #   period_seconds        = 3
+      # }
+    }
+    # readiness_probe {
+    #     failure_threshold = 3
+    #     http_get {
+    #       path = "/health"
+    #       port = "10254"
+    #       scheme = "http"
+    #     }
+    #     period_seconds = 10
+    #     success_threshold = 1
+    #     timeout_seconds = 10
+    #   }
+    # }
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "fail2" {
   metadata {
     name = "terraform-example"
@@ -170,7 +256,178 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+
+    container {
+      image             = "nginx"
+      image_pull_policy = "Never"
+      name              = "example"
+
+      security_context {
+        privileged                 = true
+        allow_privilege_escalation = true
+        capabilities {
+          add  = ["NET_RAW"]
+        }
+      }
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+        host_port      = 8080
+      }
+
+      # resources = {
+      #   requests = {
+      #     memory = "50Mi"
+      #   }
+      #   limits ={
+      #     memory = "50Mi"
+      #   }
+      # }
+      # liveness_probe {
+      #   http_get {
+      #     path = "/nginx_status"
+      #     port = 80
+
+      #     http_header {
+      #       name  = "X-Custom-Header"
+      #       value = "Awesome"
+      #     }
+      #   }
+
+      #   initial_delay_seconds = 3
+      #   period_seconds        = 3
+      # }
+    }
+    # readiness_probe {
+    #     failure_threshold = 3
+    #     http_get {
+    #       path = "/health"
+    #       port = "10254"
+    #       scheme = "http"
+    #     }
+    #     period_seconds = 10
+    #     success_threshold = 1
+    #     timeout_seconds = 10
+    #   }
+    # }
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    host_ipc = true
+    host_pid = true
+
+
+    container {
+      image             = "nginx"
+      image_pull_policy = "Never"
+      name              = "example"
+
+      security_context {
+        privileged                 = true
+        allow_privilege_escalation = true
+        capabilities {
+          add  = ["NET_RAW"]
+          drop = ["ALL"]
+        }
+      }
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+        host_port      = 8080
+      }
+
+      # resources = {
+      #   requests = {
+      #     memory = "50Mi"
+      #   }
+      #   limits ={
+      #     memory = "50Mi"
+      #   }
+      # }
+      # liveness_probe {
+      #   http_get {
+      #     path = "/nginx_status"
+      #     port = 80
+
+      #     http_header {
+      #       name  = "X-Custom-Header"
+      #       value = "Awesome"
+      #     }
+      #   }
+
+      #   initial_delay_seconds = 3
+      #   period_seconds        = 3
+      # }
+    }
+    # readiness_probe {
+    #     failure_threshold = 3
+    #     http_get {
+    #       path = "/health"
+    #       port = "10254"
+    #       scheme = "http"
+    #     }
+    #     period_seconds = 10
+    #     success_threshold = 1
+    #     timeout_seconds = 10
+    #   }
+    # }
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_PodSecurityContext/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_PodSecurityContext/main.tf
@@ -5,6 +5,13 @@ resource "kubernetes_pod" "fail" {
   }
 }
 
+# fails no spec
+resource "kubernetes_pod_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
 #no context
 resource "kubernetes_pod" "fail2" {
   metadata {
@@ -60,7 +67,157 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+#no context
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      security_context {
+        capabilities {
+          drop = ["NET_BIND_SERVICE", "ALL"]
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+    container {
+      image = "nginx:1.7.9"
+      name  = "example2"
+
+      security_context {
+        capabilities {
+          drop = ["ALL"]
+        }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }
@@ -215,7 +372,131 @@ resource "kubernetes_deployment" "fail" {
   }
 }
 
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.21.6"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
 resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          security_context {
+            capabilities {
+              drop = ["NET_BIND_SERVICE", "ALL"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
   metadata {
     name = "terraform-example"
     labels = {
@@ -339,7 +620,130 @@ resource "kubernetes_daemonset" "fail" {
   }
 }
 
+resource "kubernetes_daemon_set_v1" "fail" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "something"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.21.6"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
+        }
+      }
+    }
+  }
+}
+
 resource "kubernetes_daemonset" "pass" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "something"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          security_context {
+            capabilities {
+              drop = ["NET_BIND_SERVICE", "ALL"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_daemon_set_v1" "pass" {
   metadata {
     name      = "terraform-example"
     namespace = "something"

--- a/tests/terraform/checks/resource/kubernetes/example_PrivilegedContainers/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_PrivilegedContainers/main.tf
@@ -93,7 +93,190 @@ resource "kubernetes_pod" "fail_container" {
 }
 
 
+resource "kubernetes_pod_v1" "fail_container" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+      {
+        image = "nginx:1.7.9"
+        name  = "example22"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ,
+      {
+        image = "nginx:1.7.9"
+        name  = "example22222"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -272,7 +455,186 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }
@@ -448,4 +810,89 @@ resource "kubernetes_pod" "pass2" {
   }
 }
 
+resource "kubernetes_pod_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
 

--- a/tests/terraform/checks/resource/kubernetes/example_ReadinessProbe/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ReadinessProbe/main.tf
@@ -64,9 +64,125 @@ resource "kubernetes_pod" "pass" {
   }
 }
 
+resource "kubernetes_pod_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
 
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+
+      readiness_probe {
+        failure_threshold = 3
+        http_get {
+          path = "/health"
+          port = "10254"
+          scheme = "http"
+        }
+        period_seconds = 10
+        success_threshold = 1
+        timeout_seconds = 10
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
 
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/example_ReadinessProbe/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ReadinessProbe/main3.tf
@@ -18,3 +18,24 @@ resource "kubernetes_pod" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_pod_v1" "examplePod" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    automount_service_account_token = true
+    security_context{
+    }
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_ReadonlyRootFilesystem/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ReadonlyRootFilesystem/main.tf
@@ -92,8 +92,191 @@ resource "kubernetes_pod" "fail_container" {
   }
 }
 
+resource "kubernetes_pod_v1" "fail_container" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+      {
+        image = "nginx:1.7.9"
+        name  = "example22"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ,
+      {
+        image = "nginx:1.7.9"
+        name  = "example22222"
+
+        security_context = {
+          privileged = true
+        }
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port = {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 #missing
 resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "fail" {
   metadata {
     name = "terraform-example"
   }
@@ -274,6 +457,97 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
+#false
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        privileged = false
+        read_only_root_filesystem = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "pass" {
   metadata {
     name = "terraform-example"
@@ -332,4 +606,60 @@ resource "kubernetes_pod" "pass" {
   }
 }
 
+resource "kubernetes_pod_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
 
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context {
+        privileged = false
+        read_only_root_filesystem = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_Secrets/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_Secrets/main.tf
@@ -64,6 +64,71 @@ resource "kubernetes_pod" "fail" {
   }
 }
 
+resource "kubernetes_pod_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+
+        value_from {
+
+          secret_key_ref {
+            key = "hjjhjh"
+          }
+        }
+      }
+
+      env_from {
+        secret_ref {
+          name = "wwww"
+        }
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
 
  resource "kubernetes_pod" "fail2" {
   metadata {
@@ -119,8 +184,109 @@ resource "kubernetes_pod" "fail" {
   }
 }
 
+resource "kubernetes_pod_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env_from {
+        secret_ref {
+          name = "wwww"
+        }
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
 
  resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
   }
@@ -224,7 +390,114 @@ resource "kubernetes_pod" "pass2" {
   }
 }
 
+resource "kubernetes_pod_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+
+        value_from {
+        }
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
 resource "kubernetes_pod" "pass3" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env_from {
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod_v1" "pass3" {
   metadata {
     name = "terraform-example"
   }

--- a/tests/terraform/checks/resource/kubernetes/test_MinimiseCapabilities.py
+++ b/tests/terraform/checks/resource/kubernetes/test_MinimiseCapabilities.py
@@ -19,18 +19,21 @@ class TestMinimiseCapabilities(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod.fail2",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], 1 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_PodSecurityContext.py
+++ b/tests/terraform/checks/resource/kubernetes/test_PodSecurityContext.py
@@ -21,6 +21,9 @@ class TestPodSecurityContext(unittest.TestCase):
             "kubernetes_pod.pass",
             "kubernetes_deployment.pass",
             "kubernetes_daemonset.pass",
+            "kubernetes_pod_v1.pass",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_daemon_set_v1.pass",
         }
 
         failing_resources = {
@@ -28,13 +31,17 @@ class TestPodSecurityContext(unittest.TestCase):
             "kubernetes_pod.fail2",
             "kubernetes_deployment.fail",
             "kubernetes_daemonset.fail",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_daemon_set_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 3)
-        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["passed"], 3 * 2)
+        self.assertEqual(summary["failed"], 4 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_PrivilegedContainers.py
+++ b/tests/terraform/checks/resource/kubernetes/test_PrivilegedContainers.py
@@ -20,18 +20,22 @@ class TestPrivilegedContainer(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod.pass2",
+            "kubernetes_pod_v1.pass",
+            "kubernetes_pod_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod.fail2",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ReadinessProbe.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ReadinessProbe.py
@@ -19,17 +19,19 @@ class TestReadinessProbe(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
+            "kubernetes_pod_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 1 * 2)
+        self.assertEqual(summary["failed"], 1 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ReadonlyRootFilesystem.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ReadonlyRootFilesystem.py
@@ -19,18 +19,21 @@ class TestReadonlyRootFilesystem(unittest.TestCase):
 
         passing_resources = {
             "kubernetes_pod.pass",
+            "kubernetes_pod_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod.fail2",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], 1 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_Secrets.py
+++ b/tests/terraform/checks/resource/kubernetes/test_Secrets.py
@@ -21,18 +21,23 @@ class TestSecrets(unittest.TestCase):
             "kubernetes_pod.pass",
             "kubernetes_pod.pass2",
             "kubernetes_pod.pass3",
+            "kubernetes_pod_v1.pass",
+            "kubernetes_pod_v1.pass2",
+            "kubernetes_pod_v1.pass3",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod.fail2",
+            "kubernetes_pod_v1.fail",
+            "kubernetes_pod_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 3)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], 3 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
This PR adds add the new resource names to the existing checks. PR 4 of 5.

Fixes #3650

## Edited policies
* CKV_K8S_37
  Add resource: kubernetes_pod_v1
* CKV_K8S_29
  Add resources: kubernetes_pod_v1, kubernetes_deployment_v1, kubernetes_daemon_set_v1
* CKV_K8S_16
  Add resource: kubernetes_pod_v1
* CKV_K8S_9
  Add resource: kubernetes_pod_v1
* CKV_K8S_22
  Add resource: kubernetes_pod_v1
* CKV_K8S_35
  Add resource: kubernetes_pod_v1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules