### PR TITLE
feat(kustomize): stop kustomize run, if there is nothing to process

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -99,7 +99,6 @@ jobs:
       - name: Build & install checkov package
         run: |
           pipenv --python ${{ matrix.python }}
-          pipenv run pip install --upgrade pip
           pipenv run pip install pytest pytest-xdist
           pipenv run python setup.py sdist bdist_wheel
           bash -c 'pipenv run pip install dist/checkov-*.whl'

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -421,6 +421,10 @@ class Runner(BaseRunner):
         self, root_folder: str | None, files: list[str] | None, runner_filter: RunnerFilter
     ) -> None:
         kustomize_dirs = find_kustomize_directories(root_folder, files, runner_filter.excluded_paths)
+        if not kustomize_dirs:
+            # nothing to process
+            return
+
         for kustomize_dir in kustomize_dirs:
             self.kustomizeProcessedFolderAndMeta[kustomize_dir] = self._parseKustomization(kustomize_dir)
         self.target_folder_path = tempfile.mkdtemp()
@@ -474,6 +478,11 @@ class Runner(BaseRunner):
 
         self.run_kustomize_to_k8s(root_folder, files, runner_filter)
         report = Report(self.check_type)
+
+        if not self.kustomizeProcessedFolderAndMeta:
+            # nothing to process
+            return report
+
         target_dir = ""
         try:
             k8s_runner = K8sKustomizeRunner()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- if we can't find any `kustomize` related files, then we don't need to further do anything and can return the report early
- removed the pip upgrade, which causes errors in Windows builds

Fixes #3673

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
