### PR TITLE
break(terraform): return UNKNOWN for unrendered values in graph checks

### DIFF
--- a/checkov/common/checks_infra/solvers/attribute_solvers/any_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/any_attribute_solver.py
@@ -6,6 +6,7 @@ from checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver
 
 class AnyResourceSolver(BaseAttributeSolver):
     operator = Operators.ANY  # noqa: CCE003  # a static attribute
+    is_value_attribute_check = False  # noqa: CCE003  # a static attribute
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         return vertex is not None

--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -30,6 +30,7 @@ OPERATION_TO_FUNC = {
 
 class BaseAttributeSolver(BaseSolver):
     operator = ""  # noqa: CCE003  # a static attribute
+    is_value_attribute_check = True    # noqa: CCE003  # a static attribute
 
     def __init__(self, resource_types: List[str], attribute: Optional[str], value: Any, is_jsonpath_check: bool = False
                  ) -> None:
@@ -55,9 +56,10 @@ class BaseAttributeSolver(BaseSolver):
 
     def get_operation(self, vertex: Dict[str, Any]) -> Optional[bool]:
         attr_val = vertex.get(self.attribute)   # type:ignore[arg-type]  # due to attribute can be None
-        # if this value contains an underendered variable, then we cannot evaluate the check,
+        # if this value contains an underendered variable, then we cannot evaluate value checks,
         # and will return None (for UNKNOWN)
-        if self._is_variable_dependant(attr_val, vertex['source_']):
+        if self.is_value_attribute_check and self._is_variable_dependant(attr_val, vertex['source_']) \
+                and self.value != '':
             return None
 
         if self.attribute and (self.is_jsonpath_check or re.match(WILDCARD_PATTERN, self.attribute)):

--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -62,9 +62,12 @@ class BaseAttributeSolver(BaseSolver):
 
         if self.attribute and (self.is_jsonpath_check or re.match(WILDCARD_PATTERN, self.attribute)):
             attribute_matches = self.get_attribute_matches(vertex)
-            filtered_attribute_matches = [a for a in attribute_matches if
-                                          not self._is_variable_dependant(vertex.get(a), vertex['source_'])] \
-                if self.is_value_attribute_check and self.value != '' else attribute_matches
+            filtered_attribute_matches = attribute_matches
+            if self.is_value_attribute_check and self.value != '':
+                filtered_attribute_matches = [
+                    a for a in attribute_matches
+                    if not self._is_variable_dependant(vertex.get(a), vertex['source_'])
+                ]
 
             if attribute_matches:
                 if self.is_jsonpath_check:

--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 import re
-from typing import List, Tuple, Dict, Any, Optional, Pattern, TYPE_CHECKING
+from typing import List, Tuple, Dict, Any, Optional, Pattern
 
 from jsonpath_ng.ext import parse
 
@@ -14,8 +14,7 @@ from checkov.common.graph.graph_builder.graph_components.block_types import Bloc
 from checkov.common.util.var_utils import is_terraform_variable_dependent
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType as TerraformBlockType
 
-if TYPE_CHECKING:
-    from networkx import DiGraph
+from networkx import DiGraph
 
 SUPPORTED_BLOCK_TYPES = {BlockType.RESOURCE, TerraformBlockType.DATA}
 WILDCARD_PATTERN = re.compile(r"(\S+[.][*][.]*)+")

--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import concurrent.futures
 import re
 from typing import List, Tuple, Dict, Any, Optional, Pattern, TYPE_CHECKING

--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -54,11 +54,11 @@ class BaseAttributeSolver(BaseSolver):
         return passed_vertices, failed_vertices
 
     def get_operation(self, vertex: Dict[str, Any]) -> Optional[bool]:
-        attr_val = vertex.get(self.attribute)
+        attr_val = vertex.get(self.attribute)   # type:ignore[arg-type]  # due to attribute can be None
         # if this value contains an underendered variable, then we cannot evaluate the check,
         # and will return None (for UNKNOWN)
         if self._is_variable_dependant(attr_val, vertex['source_']):
-            return
+            return None
 
         if self.attribute and (self.is_jsonpath_check or re.match(WILDCARD_PATTERN, self.attribute)):
             attribute_matches = self.get_attribute_matches(vertex)

--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 import re
-from typing import List, Tuple, Dict, Any, Optional, Pattern
+from typing import List, Tuple, Dict, Any, Optional, Pattern, TYPE_CHECKING
 
 from jsonpath_ng.ext import parse
 
@@ -14,7 +14,8 @@ from checkov.common.graph.graph_builder.graph_components.block_types import Bloc
 from checkov.common.util.var_utils import is_terraform_variable_dependent
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType as TerraformBlockType
 
-from networkx import DiGraph
+if TYPE_CHECKING:
+    from networkx import DiGraph
 
 SUPPORTED_BLOCK_TYPES = {BlockType.RESOURCE, TerraformBlockType.DATA}
 WILDCARD_PATTERN = re.compile(r"(\S+[.][*][.]*)+")

--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -58,6 +58,7 @@ class BaseAttributeSolver(BaseSolver):
         attr_val = vertex.get(self.attribute)   # type:ignore[arg-type]  # due to attribute can be None
         # if this value contains an underendered variable, then we cannot evaluate value checks,
         # and will return None (for UNKNOWN)
+        # handle edge cases in some policies that explicitly look for blank values
         if self.is_value_attribute_check and self._is_variable_dependant(attr_val, vertex['source_']) \
                 and self.value != '':
             return None

--- a/checkov/common/checks_infra/solvers/attribute_solvers/ending_with_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/ending_with_attribute_solver.py
@@ -9,10 +9,4 @@ class EndingWithAttributeSolver(BaseAttributeSolver):
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         attr = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
-
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr, vertex["source_"]):
-            return True
-
         return isinstance(attr, str) and attr.endswith(self.value)

--- a/checkov/common/checks_infra/solvers/attribute_solvers/equals_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/equals_attribute_solver.py
@@ -9,11 +9,6 @@ class EqualsAttributeSolver(BaseAttributeSolver):
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         attr_val = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        # handle edge cases in some policies that explicitly look for blank values
-        if self.value != '' and self._is_variable_dependant(attr_val, vertex['source_']):
-            return True
         if type(attr_val) == bool or type(self.value) == bool:
             # handle cases like str(False) == "false"
             # generally self.value will be a string, but could be a bool if the policy was created straight from json

--- a/checkov/common/checks_infra/solvers/attribute_solvers/exists_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/exists_attribute_solver.py
@@ -6,6 +6,7 @@ from checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver
 
 class ExistsAttributeSolver(BaseAttributeSolver):
     operator = Operators.EXISTS  # noqa: CCE003  # a static attribute
+    is_value_attribute_check = False  # noqa: CCE003  # a static attribute
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         return vertex.get(attribute) is not None  # type:ignore[arg-type]  # due to attribute can be None

--- a/checkov/common/checks_infra/solvers/attribute_solvers/greater_than_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/greater_than_attribute_solver.py
@@ -10,10 +10,6 @@ class GreaterThanAttributeSolver(BaseAttributeSolver):
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         vertex_attr = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(vertex_attr, vertex['source_']):
-            return True
         attr_float = force_float(vertex_attr)
         value_float = force_float(self.value)
 

--- a/checkov/common/checks_infra/solvers/attribute_solvers/greater_than_or_equal_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/greater_than_or_equal_attribute_solver.py
@@ -11,10 +11,6 @@ class GreaterThanOrEqualAttributeSolver(BaseAttributeSolver):
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
 
         vertex_attr = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(vertex_attr, vertex['source_']):
-            return True
         attr_float = force_float(vertex_attr)
         value_float = force_float(self.value)
 

--- a/checkov/common/checks_infra/solvers/attribute_solvers/intersects_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/intersects_attribute_solver.py
@@ -10,11 +10,6 @@ class IntersectsAttributeSolver(BaseAttributeSolver):
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         attr = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
 
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr, vertex['source_']):
-            return True
-
         if isinstance(self.value, str) and isinstance(attr, Iterable):
             return self.value in attr
 

--- a/checkov/common/checks_infra/solvers/attribute_solvers/is_empty_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/is_empty_attribute_solver.py
@@ -10,11 +10,6 @@ class IsEmptyAttributeSolver(BaseAttributeSolver):
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         attr = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
 
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr, vertex["source_"]):
-            return True
-
         if isinstance(attr, (list, Sized)):
             return len(attr) == 0
 

--- a/checkov/common/checks_infra/solvers/attribute_solvers/is_true_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/is_true_attribute_solver.py
@@ -12,9 +12,4 @@ class IsTrueAttributeSolver(BaseAttributeSolver):
         if attr is None:
             return False
 
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr, vertex['source_']):
-            return True
-
         return attr is True

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_equals_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_equals_attribute_solver.py
@@ -13,11 +13,6 @@ class LengthEqualsAttributeSolver(BaseAttributeSolver):
             return False
 
         attr = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr, vertex['source_']):
-            return True
-
         if isinstance(attr, Sized):
             return len(attr) == force_int(self.value)
 

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_greater_than_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_greater_than_attribute_solver.py
@@ -13,11 +13,6 @@ class LengthGreaterThanAttributeSolver(BaseAttributeSolver):
         if attr is None:
             return False
         
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr, vertex['source_']):
-            return True
-
         value_int = force_int(self.value)
 
         if value_int is None:

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_greater_than_or_equal_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_greater_than_or_equal_attribute_solver.py
@@ -13,11 +13,6 @@ class LengthGreaterThanOrEqualAttributeSolver(LengthLessThanAttributeSolver):
         if attr is None:
             return False
 
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr, vertex['source_']):
-            return True
-
         value_int = force_int(self.value)
 
         if value_int is None:

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_less_than_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_less_than_attribute_solver.py
@@ -13,11 +13,6 @@ class LengthLessThanAttributeSolver(BaseAttributeSolver):
         if attr is None:
             return False
 
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr, vertex['source_']):
-            return True
-
         value_int = force_int(self.value)
 
         if value_int is None:

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_less_than_or_equal_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_less_than_or_equal_attribute_solver.py
@@ -13,11 +13,6 @@ class LengthLessThanOrEqualAttributeSolver(LengthGreaterThanAttributeSolver):
         if attr is None:
             return False
 
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr, vertex['source_']):
-            return True
-
         value_int = force_int(self.value)
 
         if value_int is None:

--- a/checkov/common/checks_infra/solvers/attribute_solvers/less_than_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/less_than_attribute_solver.py
@@ -11,10 +11,4 @@ class LessThanAttributeSolver(GreaterThanOrEqualAttributeSolver):
         if vertex.get(attribute) is None:  # type:ignore[arg-type]  # due to attribute can be None
             return False
 
-        attr_val = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr_val, vertex['source_']):
-            return True
-
         return not super()._get_operation(vertex, attribute)

--- a/checkov/common/checks_infra/solvers/attribute_solvers/less_than_or_equal_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/less_than_or_equal_attribute_solver.py
@@ -11,10 +11,4 @@ class LessThanOrEqualAttributeSolver(GreaterThanAttributeSolver):
         if vertex.get(attribute) is None:  # type:ignore[arg-type]  # due to attribute can be None
             return False
 
-        attr_val = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr_val, vertex['source_']):
-            return True
-
         return not super()._get_operation(vertex, attribute)

--- a/checkov/common/checks_infra/solvers/attribute_solvers/not_equals_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/not_equals_attribute_solver.py
@@ -8,9 +8,4 @@ class NotEqualsAttributeSolver(EqualsAttributeSolver):
     operator = Operators.NOT_EQUALS  # noqa: CCE003  # a static attribute
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
-        attr_val = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr_val, vertex['source_']):
-            return True
         return not super()._get_operation(vertex, attribute)

--- a/checkov/common/checks_infra/solvers/attribute_solvers/not_exists_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/not_exists_attribute_solver.py
@@ -6,6 +6,7 @@ from .exists_attribute_solver import ExistsAttributeSolver
 
 class NotExistsAttributeSolver(ExistsAttributeSolver):
     operator = Operators.NOT_EXISTS  # noqa: CCE003  # a static attribute
+    is_value_attribute_check = False  # noqa: CCE003  # a static attribute
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         return not super()._get_operation(vertex, attribute)

--- a/checkov/common/checks_infra/solvers/attribute_solvers/not_exists_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/not_exists_attribute_solver.py
@@ -6,7 +6,6 @@ from .exists_attribute_solver import ExistsAttributeSolver
 
 class NotExistsAttributeSolver(ExistsAttributeSolver):
     operator = Operators.NOT_EXISTS  # noqa: CCE003  # a static attribute
-    is_value_attribute_check = False  # noqa: CCE003  # a static attribute
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         return not super()._get_operation(vertex, attribute)

--- a/checkov/common/checks_infra/solvers/attribute_solvers/starting_with_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/starting_with_attribute_solver.py
@@ -9,10 +9,4 @@ class StartingWithAttributeSolver(BaseAttributeSolver):
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         attr = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
-
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr, vertex["source_"]):
-            return True
-
         return isinstance(attr, str) and attr.startswith(self.value)

--- a/checkov/common/checks_infra/solvers/attribute_solvers/within_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/within_attribute_solver.py
@@ -9,8 +9,4 @@ class WithinAttributeSolver(BaseAttributeSolver):
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         attr = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
-        # if this value contains an underendered variable, then we cannot evaluate the check,
-        # so return True (since we cannot return UNKNOWN)
-        if self._is_variable_dependant(attr, vertex['source_']):
-            return True
         return attr in self.value

--- a/checkov/common/checks_infra/solvers/complex_solvers/and_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/and_solver.py
@@ -19,9 +19,9 @@ class AndSolver(BaseComplexSolver):
     def get_operation(self, vertex: Dict[str, Any]) -> Optional[bool]:
         has_unrendered_attribute = False
         for solver in self.solvers:
-            result = solver.get_operation(vertex)
-            if result is None:
+            operation = solver.get_operation(vertex)
+            if operation is None:
                 has_unrendered_attribute = True
-            elif not result:
+            elif not operation:
                 return False
         return None if has_unrendered_attribute else True

--- a/checkov/common/checks_infra/solvers/complex_solvers/and_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/and_solver.py
@@ -1,4 +1,4 @@
-from typing import List, Any, Dict
+from typing import List, Any, Dict, Optional
 
 from checkov.common.graph.checks_infra.enums import Operators
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
@@ -16,8 +16,12 @@ class AndSolver(BaseComplexSolver):
     def _get_operation(self, *args: Any, **kwargs: Any) -> Any:
         return reduce(and_, args)
 
-    def get_operation(self, vertex: Dict[str, Any]) -> bool:
+    def get_operation(self, vertex: Dict[str, Any]) -> Optional[bool]:
+        has_unrendered_attribute = False
         for solver in self.solvers:
-            if not solver.get_operation(vertex):
+            result = solver.get_operation(vertex)
+            if result is None:
+                has_unrendered_attribute = True
+            elif not result:
                 return False
-        return True
+        return None if has_unrendered_attribute else True

--- a/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
@@ -25,6 +25,7 @@ class BaseComplexSolver(BaseSolver):
     def _get_negative_op(self, *args: Any) -> Any:
         return not self._get_operation(args)
 
+    @abstractmethod
     def get_operation(self, vertex: Dict[str, Any]) -> Optional[bool]:
         raise NotImplementedError()
 

--- a/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import List, Any, Tuple, Dict, TYPE_CHECKING
+from typing import List, Any, Tuple, Dict, TYPE_CHECKING, Optional
 
 from checkov.common.graph.checks_infra.enums import SolverType
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
@@ -25,16 +23,20 @@ class BaseComplexSolver(BaseSolver):
     def _get_negative_op(self, *args: Any) -> Any:
         return not self._get_operation(args)
 
-    def run(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    def get_operation(self, vertex: Dict[str, Any]) -> Optional[bool]:
+        raise NotImplementedError()
+
+    def run(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         passed_vertices = []
         failed_vertices = []
+        unknown_vertices = []
         for _, data in graph_connector.nodes(data=True):
             if self.resource_type_pred(data, self.resource_types):
                 result = self.get_operation(data)
                 if result is None:
-                    continue
-                if result:
+                    unknown_vertices.append(data)
+                elif result:
                     passed_vertices.append(data)
                 else:
                     failed_vertices.append(data)
-        return passed_vertices, failed_vertices
+        return passed_vertices, failed_vertices, unknown_vertices

--- a/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Any, Tuple, Dict, TYPE_CHECKING, Optional
 
 from checkov.common.graph.checks_infra.enums import SolverType

--- a/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import List, Any, Tuple, Dict, TYPE_CHECKING, Optional
 
 from checkov.common.graph.checks_infra.enums import SolverType

--- a/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
@@ -33,7 +33,7 @@ class BaseComplexSolver(BaseSolver):
                 result = self.get_operation(data)
                 if result is None:
                     continue
-                if self.get_operation(data):
+                if result:
                     passed_vertices.append(data)
                 else:
                     failed_vertices.append(data)

--- a/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
@@ -30,6 +30,9 @@ class BaseComplexSolver(BaseSolver):
         failed_vertices = []
         for _, data in graph_connector.nodes(data=True):
             if self.resource_type_pred(data, self.resource_types):
+                result = self.get_operation(data)
+                if result is None:
+                    continue
                 if self.get_operation(data):
                     passed_vertices.append(data)
                 else:

--- a/checkov/common/checks_infra/solvers/complex_solvers/not_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/not_solver.py
@@ -1,4 +1,4 @@
-from typing import List, Any, Dict
+from typing import List, Any, Dict, Optional
 
 from checkov.common.graph.checks_infra.enums import Operators
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
@@ -18,5 +18,6 @@ class NotSolver(BaseComplexSolver):
             raise Exception('The "not" operator must have exactly one child')
         return not args[0]
 
-    def get_operation(self, vertex: Dict[str, Any]) -> bool:
-        return not self.solvers[0].get_operation(vertex)
+    def get_operation(self, vertex: Dict[str, Any]) -> Optional[bool]:
+        result = self.solvers[0].get_operation(vertex)
+        return None if result is None else not result

--- a/checkov/common/checks_infra/solvers/complex_solvers/or_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/or_solver.py
@@ -19,9 +19,9 @@ class OrSolver(BaseComplexSolver):
     def get_operation(self, vertex: Dict[str, Any]) -> Optional[bool]:
         has_unrendered_attribute = False
         for solver in self.solvers:
-            result = solver.get_operation(vertex)
-            if result:
+            operation = solver.get_operation(vertex)
+            if operation:
                 return True
-            if result is None:
+            if operation is None:
                 has_unrendered_attribute = True
         return None if has_unrendered_attribute else False

--- a/checkov/common/checks_infra/solvers/complex_solvers/or_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/or_solver.py
@@ -1,4 +1,4 @@
-from typing import List, Any, Dict
+from typing import List, Any, Dict, Optional
 
 from checkov.common.graph.checks_infra.enums import Operators
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
@@ -16,8 +16,12 @@ class OrSolver(BaseComplexSolver):
     def _get_operation(self, *args: Any, **kwargs: Any) -> Any:
         return reduce(or_, args)
 
-    def get_operation(self, vertex: Dict[str, Any]) -> bool:
+    def get_operation(self, vertex: Dict[str, Any]) -> Optional[bool]:
+        has_unrendered_attribute = False
         for solver in self.solvers:
-            if solver.get_operation(vertex):
+            result = solver.get_operation(vertex)
+            if result:
                 return True
-        return False
+            if result is None:
+                has_unrendered_attribute = True
+        return None if has_unrendered_attribute else False

--- a/checkov/common/checks_infra/solvers/connections_solvers/and_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/and_connection_solver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from typing import Optional, List, Tuple, Dict, Any, TYPE_CHECKING
 

--- a/checkov/common/checks_infra/solvers/connections_solvers/and_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/and_connection_solver.py
@@ -33,7 +33,7 @@ class AndConnectionSolver(ComplexConnectionSolver):
             passed.extend(passed_solver)
             failed.extend(failed_solver)
             unknown.extend(unknown_solver)
-            failed_or_unknown_ids.extend([f[CustomAttributes.ID] for f in itertools.chain(failed_solver, unknown_solver)])
+            failed_or_unknown_ids.extend(f[CustomAttributes.ID] for f in itertools.chain(failed_solver, unknown_solver))
 
         failed_ids = [f[CustomAttributes.ID] for f in failed]
         unknown_ids = [u[CustomAttributes.ID] for u in unknown]

--- a/checkov/common/checks_infra/solvers/connections_solvers/and_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/and_connection_solver.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import itertools
 from typing import Optional, List, Tuple, Dict, Any, TYPE_CHECKING
 
 from checkov.common.graph.checks_infra.enums import Operators
@@ -17,24 +16,22 @@ class AndConnectionSolver(ComplexConnectionSolver):
     def __init__(self, solvers: Optional[List[BaseSolver]], operator: str) -> None:
         super().__init__(solvers, operator)
 
-    def get_operation(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    def get_operation(self, graph_connector: DiGraph) -> \
+            Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         if not self.vertices_under_resource_types:
-            return [], []
+            return [], [], []
         subgraph = graph_connector.subgraph(graph_connector)
-        passed, failed = self.run_attribute_solvers(subgraph)
+        passed, failed, unknown = self.run_attribute_solvers(subgraph)
+        passed_connections, failed_connections, unknown_connections = self.run_connection_solvers(subgraph)
+        passed.extend(passed_connections)
+        failed.extend(failed_connections)
+        unknown.extend(unknown_connections)
+
         failed_ids = [f[CustomAttributes.ID] for f in failed]
-        passed = [p for p in passed if p[CustomAttributes.ID] not in failed_ids]
-
-        for connection_solver in self.get_sorted_connection_solvers():
-            connection_solver.set_vertices(subgraph, failed)
-            passed_solver, failed_solver = connection_solver.get_operation(subgraph)
-            passed.extend(passed_solver)
-            failed.extend(failed_solver)
-            failed_ids.extend([f[CustomAttributes.ID] for f in failed_solver])
-
-        passed = [p for p in passed if p[CustomAttributes.ID] not in failed_ids]
-
-        return self.filter_results(passed, failed)
+        unknown_ids = [u[CustomAttributes.ID] for u in unknown]
+        passed = [p for p in passed if p[CustomAttributes.ID] not in itertools.chain(failed_ids, unknown_ids)]
+        unknown = [u for u in unknown if u[CustomAttributes.ID] not in failed_ids]
+        return self.filter_results(passed, failed, unknown)
 
     def _get_operation(self, *args: Any, **kwargs: Any) -> None:
         pass

--- a/checkov/common/checks_infra/solvers/connections_solvers/base_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/base_connection_solver.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import itertools
 from typing import Any, List, Dict, Optional, Tuple, TYPE_CHECKING
 
@@ -31,7 +29,7 @@ class BaseConnectionSolver(BaseSolver):
         self.vertices_under_connected_resources_types = vertices_under_connected_resources_types or []
         self.excluded_vertices: List[Dict[str, Any]] = []
 
-    def run(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    def run(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         self.set_vertices(graph_connector, [])
 
         subgraph = self.reduce_graph_by_target_types(graph_connector)
@@ -80,7 +78,8 @@ class BaseConnectionSolver(BaseSolver):
 
         return graph_connector.subgraph(resource_nodes)
 
-    def get_operation(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    def get_operation(self, graph_connector: DiGraph) -> \
+            Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         raise NotImplementedError
 
     def _get_operation(self, *args: Any, **kwargs: Any) -> Any:

--- a/checkov/common/checks_infra/solvers/connections_solvers/base_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/base_connection_solver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from typing import Any, List, Dict, Optional, Tuple, TYPE_CHECKING
 

--- a/checkov/common/checks_infra/solvers/connections_solvers/base_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/base_connection_solver.py
@@ -30,9 +30,10 @@ class BaseConnectionSolver(BaseSolver):
         self.vertices_under_resource_types = vertices_under_resource_types or []
         self.vertices_under_connected_resources_types = vertices_under_connected_resources_types or []
         self.excluded_vertices: List[Dict[str, Any]] = []
+        self.unknown_vertices: List[Dict[str, Any]] = []
 
     def run(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
-        self.set_vertices(graph_connector, [])
+        self.set_vertices(graph_connector, [], [])
 
         subgraph = self.reduce_graph_by_target_types(graph_connector)
 
@@ -46,7 +47,7 @@ class BaseConnectionSolver(BaseSolver):
     def is_associated_vertex(self, vertex_type: str) -> bool:
         return vertex_type in itertools.chain(self.resource_types, self.connected_resources_types)
 
-    def set_vertices(self, graph_connector: DiGraph, exclude_vertices: List[Dict[str, Any]]) -> None:
+    def set_vertices(self, graph_connector: DiGraph, exclude_vertices: List[Dict[str, Any]], unknown_vertices: List[Dict[str, Any]]) -> None:
         self.vertices_under_resource_types = [
             v for _, v in graph_connector.nodes(data=True) if self.resource_type_pred(v, self.resource_types)
         ]
@@ -57,6 +58,11 @@ class BaseConnectionSolver(BaseSolver):
             v
             for v in itertools.chain(self.vertices_under_resource_types, self.vertices_under_connected_resources_types)
             if v in exclude_vertices
+        ]
+        self.unknown_vertices = [
+            v
+            for v in itertools.chain(self.vertices_under_resource_types, self.vertices_under_connected_resources_types)
+            if v in unknown_vertices
         ]
 
     def reduce_graph_by_target_types(self, graph_connector: DiGraph) -> DiGraph:

--- a/checkov/common/checks_infra/solvers/connections_solvers/complex_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/complex_connection_solver.py
@@ -91,7 +91,9 @@ class ComplexConnectionSolver(BaseConnectionSolver):
 
     def run_connection_solvers(self, graph_connector: DiGraph) -> \
             Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
-        passed, failed, unknown = [], [], []
+        passed: List[Dict[str, Any]] = []
+        failed: List[Dict[str, Any]] = []
+        unknown: List[Dict[str, Any]] = []
         for connection_solver in self.get_sorted_connection_solvers():
             connection_solver.set_vertices(graph_connector, failed)
             passed_solver, failed_solver, unknown_solver = connection_solver.get_operation(graph_connector)

--- a/checkov/common/checks_infra/solvers/connections_solvers/complex_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/complex_connection_solver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from typing import List, Optional, Dict, Any, Tuple, TYPE_CHECKING
 

--- a/checkov/common/checks_infra/solvers/connections_solvers/complex_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/complex_connection_solver.py
@@ -88,17 +88,3 @@ class ComplexConnectionSolver(BaseConnectionSolver):
             unknown_attributes.extend(unknown_solver)
 
         return passed_attributes, failed_attributes, unknown_attributes
-
-    def run_connection_solvers(self, graph_connector: DiGraph) -> \
-            Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
-        passed: List[Dict[str, Any]] = []
-        failed: List[Dict[str, Any]] = []
-        unknown: List[Dict[str, Any]] = []
-        for connection_solver in self.get_sorted_connection_solvers():
-            connection_solver.set_vertices(graph_connector, failed)
-            passed_solver, failed_solver, unknown_solver = connection_solver.get_operation(graph_connector)
-            passed.extend(passed_solver)
-            failed.extend(failed_solver)
-            unknown.extend(unknown_solver)
-
-        return passed, failed, unknown

--- a/checkov/common/checks_infra/solvers/connections_solvers/complex_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/complex_connection_solver.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import itertools
 from typing import List, Optional, Dict, Any, Tuple, TYPE_CHECKING
 
@@ -37,16 +35,18 @@ class ComplexConnectionSolver(BaseConnectionSolver):
         return list({(check[CustomAttributes.ID], check[CustomAttributes.FILE_PATH]): check for check in checks}.values())
 
     def filter_results(
-        self, passed: List[Dict[str, Any]], failed: List[Dict[str, Any]]
-    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        self, passed: List[Dict[str, Any]], failed: List[Dict[str, Any]], unknown: List[Dict[str, Any]]
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         filter_solvers = [sub_solver for sub_solver in self.solvers if isinstance(sub_solver, BaseFilterSolver)]
         for sub_solver in filter_solvers:
             filter_pred = sub_solver._get_operation()
             passed = list(filter(filter_pred, passed))
             failed = list(filter(filter_pred, failed))
+            unknown = list(filter(filter_pred, unknown))
         passed = self.filter_duplicates(passed)
         failed = self.filter_duplicates(failed)
-        return passed, failed
+        unknown = self.filter_duplicates(unknown)
+        return passed, failed, unknown
 
     def get_sorted_connection_solvers(self) -> List[BaseConnectionSolver]:
         connection_solvers = [sub_solver for sub_solver in self.solvers if isinstance(sub_solver, BaseConnectionSolver)]
@@ -71,15 +71,30 @@ class ComplexConnectionSolver(BaseConnectionSolver):
         sorted_connection_solvers.extend(connection_solvers_with_filtered_resource_types)
         return sorted_connection_solvers
 
-    def run_attribute_solvers(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    def run_attribute_solvers(self, graph_connector: DiGraph) -> \
+            Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         attribute_solvers = [
             sub_solver
             for sub_solver in self.solvers
             if isinstance(sub_solver, (BaseAttributeSolver, BaseComplexSolver))
         ]
-        passed_attributes, failed_attributes = [], []
+        passed_attributes, failed_attributes, unknown_attributes = [], [], []
         for attribute_solver in attribute_solvers:
-            passed_solver, failed_solver = attribute_solver.run(graph_connector)
+            passed_solver, failed_solver, unknown_solver = attribute_solver.run(graph_connector)
             passed_attributes.extend(passed_solver)
             failed_attributes.extend(failed_solver)
-        return passed_attributes, failed_attributes
+            unknown_attributes.extend(unknown_solver)
+
+        return passed_attributes, failed_attributes, unknown_attributes
+
+    def run_connection_solvers(self, graph_connector: DiGraph) -> \
+            Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+        passed, failed, unknown = [], [], []
+        for connection_solver in self.get_sorted_connection_solvers():
+            connection_solver.set_vertices(graph_connector, failed)
+            passed_solver, failed_solver, unknown_solver = connection_solver.get_operation(graph_connector)
+            passed.extend(passed_solver)
+            failed.extend(failed_solver)
+            unknown.extend(unknown_solver)
+
+        return passed, failed, unknown

--- a/checkov/common/checks_infra/solvers/connections_solvers/connection_exists_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/connection_exists_solver.py
@@ -29,6 +29,7 @@ class ConnectionExistsSolver(BaseConnectionSolver):
             Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         passed = []
         failed = []
+        unknown = []
         for u, v in edge_dfs(graph_connector):
             origin_attributes = graph_connector.nodes(data=True)[u]
             opposite_vertices = None
@@ -43,6 +44,8 @@ class ConnectionExistsSolver(BaseConnectionSolver):
             if destination_attributes in opposite_vertices:
                 if origin_attributes in self.excluded_vertices or destination_attributes in self.excluded_vertices:
                     failed.extend([origin_attributes, destination_attributes])
+                elif origin_attributes in self.unknown_vertices or destination_attributes in self.unknown_vertices:
+                    unknown.extend([origin_attributes, destination_attributes])
                 else:
                     passed.extend([origin_attributes, destination_attributes])
                 destination_attributes['connected_node'] = origin_attributes
@@ -67,7 +70,7 @@ class ConnectionExistsSolver(BaseConnectionSolver):
                 for v in itertools.chain(
                     self.vertices_under_resource_types, self.vertices_under_connected_resources_types
                 )
-                if v not in passed
+                if v not in itertools.chain(passed, unknown)
             ]
         )
-        return passed, failed, []
+        return passed, failed, unknown

--- a/checkov/common/checks_infra/solvers/connections_solvers/connection_exists_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/connection_exists_solver.py
@@ -25,7 +25,8 @@ class ConnectionExistsSolver(BaseConnectionSolver):
             vertices_under_connected_resources_types,
         )
 
-    def get_operation(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    def get_operation(self, graph_connector: DiGraph) -> \
+            Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         passed = []
         failed = []
         for u, v in edge_dfs(graph_connector):
@@ -69,4 +70,4 @@ class ConnectionExistsSolver(BaseConnectionSolver):
                 if v not in passed
             ]
         )
-        return passed, failed
+        return passed, failed, []

--- a/checkov/common/checks_infra/solvers/connections_solvers/connection_not_exists_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/connection_not_exists_solver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Dict, Any, Tuple, TYPE_CHECKING
 
 from checkov.common.graph.checks_infra.enums import Operators

--- a/checkov/common/checks_infra/solvers/connections_solvers/connection_not_exists_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/connection_not_exists_solver.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List, Optional, Dict, Any, Tuple, TYPE_CHECKING
 
 from checkov.common.graph.checks_infra.enums import Operators
@@ -26,6 +24,7 @@ class ConnectionNotExistsSolver(ConnectionExistsSolver):
             vertices_under_connected_resources_types,
         )
 
-    def get_operation(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        passed, failed = super().get_operation(graph_connector)
-        return failed, passed
+    def get_operation(self, graph_connector: DiGraph) -> \
+            Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+        passed, failed, unknown = super().get_operation(graph_connector)
+        return failed, passed, unknown

--- a/checkov/common/checks_infra/solvers/connections_solvers/connection_one_exists_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/connection_one_exists_solver.py
@@ -29,4 +29,5 @@ class ConnectionOneExistsSolver(ConnectionExistsSolver):
             Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         passed, failed, unknown = super().get_operation(graph_connector)
         failed = [f for f in failed if f not in passed]
+        unknown = [u for u in unknown if u not in passed]
         return passed, failed, unknown

--- a/checkov/common/checks_infra/solvers/connections_solvers/connection_one_exists_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/connection_one_exists_solver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Dict, Any, Tuple, TYPE_CHECKING
 from checkov.common.checks_infra.solvers import ConnectionExistsSolver
 from checkov.common.graph.checks_infra.enums import Operators

--- a/checkov/common/checks_infra/solvers/connections_solvers/connection_one_exists_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/connection_one_exists_solver.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List, Optional, Dict, Any, Tuple, TYPE_CHECKING
 from checkov.common.checks_infra.solvers import ConnectionExistsSolver
 from checkov.common.graph.checks_infra.enums import Operators
@@ -25,7 +23,8 @@ class ConnectionOneExistsSolver(ConnectionExistsSolver):
             vertices_under_connected_resources_types,
         )
 
-    def get_operation(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        passed, failed = super().get_operation(graph_connector)
+    def get_operation(self, graph_connector: DiGraph) -> \
+            Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+        passed, failed, unknown = super().get_operation(graph_connector)
         failed = [f for f in failed if f not in passed]
-        return passed, failed
+        return passed, failed, unknown

--- a/checkov/common/checks_infra/solvers/connections_solvers/or_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/or_connection_solver.py
@@ -45,9 +45,11 @@ class OrConnectionSolver(ComplexConnectionSolver):
     @staticmethod
     def _filter_failed(failed: List[Dict[str, Any]], passed: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         filterd_failed = []
+        passed_ids = [p[CustomAttributes.ID] for p in passed]
+        passed_paths = [p[CustomAttributes.FILE_PATH] for p in passed]
         for fail in failed:
-            if fail[CustomAttributes.ID] not in [p[CustomAttributes.ID] for p in passed]:
+            if fail[CustomAttributes.ID] not in passed_ids:
                 filterd_failed.append(fail)
-            elif fail[CustomAttributes.FILE_PATH] not in [p[CustomAttributes.FILE_PATH] for p in passed]:
+            elif fail[CustomAttributes.FILE_PATH] not in passed_paths:
                 filterd_failed.append(fail)
         return filterd_failed

--- a/checkov/common/checks_infra/solvers/connections_solvers/or_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/or_connection_solver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from typing import Optional, List, Tuple, Dict, Any, TYPE_CHECKING
 

--- a/checkov/common/checks_infra/solvers/connections_solvers/or_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/or_connection_solver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 from typing import Optional, List, Tuple, Dict, Any, TYPE_CHECKING
 
+from checkov.common.checks_infra.solvers.connections_solvers.base_connection_solver import BaseConnectionSolver
 from checkov.common.graph.checks_infra.enums import Operators
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
 from checkov.common.checks_infra.solvers.connections_solvers.complex_connection_solver import ComplexConnectionSolver
@@ -21,14 +22,18 @@ class OrConnectionSolver(ComplexConnectionSolver):
     def get_operation(self, graph_connector: DiGraph) -> \
             Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         passed, failed, unknown = self.run_attribute_solvers(graph_connector)
-        passed_connections, failed_connections, unknown_connections = self.run_connection_solvers(graph_connector)
-        passed.extend(passed_connections)
-        failed.extend(failed_connections)
-        unknown.extend(unknown_connections)
+        connection_solvers = [sub_solver for sub_solver in self.solvers if isinstance(sub_solver, BaseConnectionSolver)]
+        for connection_solver in connection_solvers:
+            connection_solver.set_vertices(graph_connector, [], [])
+            passed_solver, failed_solver, unknown_solver = connection_solver.get_operation(graph_connector)
+            passed.extend(passed_solver)
+            failed.extend(failed_solver)
+            unknown.extend(unknown_solver)
 
         passed_path_and_ids = [(p[CustomAttributes.ID], p[CustomAttributes.FILE_PATH]) for p in passed]
         unknown_path_and_ids = [(u[CustomAttributes.ID], u[CustomAttributes.FILE_PATH]) for u in unknown]
-        unknown = [u for u in unknown if u[CustomAttributes.ID] not in passed_path_and_ids]
+        unknown = [u for u in unknown if (u[CustomAttributes.ID], u[CustomAttributes.FILE_PATH]) not in
+                   passed_path_and_ids]
         failed = [f for f in failed if (f[CustomAttributes.ID], f[CustomAttributes.FILE_PATH]) not in
                   itertools.chain(passed_path_and_ids, unknown_path_and_ids)]
         return self.filter_results(passed, failed, unknown)

--- a/checkov/common/checks_infra/solvers/connections_solvers/or_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/or_connection_solver.py
@@ -1,10 +1,8 @@
-from __future__ import annotations
-
+import itertools
 from typing import Optional, List, Tuple, Dict, Any, TYPE_CHECKING
 
 from checkov.common.graph.checks_infra.enums import Operators
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
-from checkov.common.checks_infra.solvers.connections_solvers.base_connection_solver import BaseConnectionSolver
 from checkov.common.checks_infra.solvers.connections_solvers.complex_connection_solver import ComplexConnectionSolver
 from checkov.common.graph.graph_builder.graph_components.attribute_names import CustomAttributes
 
@@ -18,38 +16,17 @@ class OrConnectionSolver(ComplexConnectionSolver):
     def __init__(self, solvers: Optional[List[BaseSolver]], operator: str) -> None:
         super().__init__(solvers, operator)
 
-    def get_operation(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        passed, failed = self.run_attribute_solvers(graph_connector)
-        failed = OrConnectionSolver._filter_failed(failed, passed)
-        connection_solvers = [sub_solver for sub_solver in self.solvers if isinstance(sub_solver, BaseConnectionSolver)]
-        passed_connections = []
-        failed_by_hash: Dict[str, Dict[str, Any]] = {}
-        for connection_solver in connection_solvers:
-            connection_solver.set_vertices(graph_connector, [])
-            passed_solver, failed_solvers = connection_solver.get_operation(graph_connector)
-            passed_connections.extend(passed_solver)
-            for f in failed_solvers:
-                if f[CustomAttributes.ID] not in [p[CustomAttributes.ID] for p in passed_connections]:
-                    failed_by_hash.setdefault(f[CustomAttributes.HASH], {"v": f, "count": 0})
-                    failed_by_hash[f[CustomAttributes.HASH]]["count"] += 1
-
-        for data in failed_by_hash.values():
-            if data["count"] == len(connection_solvers) or data["v"] not in passed_connections:
-                failed.append(data["v"])
-
+    def get_operation(self, graph_connector: DiGraph) -> \
+            Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+        passed, failed, unknown = self.run_attribute_solvers(graph_connector)
+        passed_connections, failed_connections, unknown_connections = self.run_connection_solvers(graph_connector)
         passed.extend(passed_connections)
-        failed = OrConnectionSolver._filter_failed(failed, passed)
+        failed.extend(failed_connections)
+        unknown.extend(unknown_connections)
 
-        return self.filter_results(passed, failed)
-
-    @staticmethod
-    def _filter_failed(failed: List[Dict[str, Any]], passed: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        filterd_failed = []
-        passed_ids = [p[CustomAttributes.ID] for p in passed]
-        passed_paths = [p[CustomAttributes.FILE_PATH] for p in passed]
-        for fail in failed:
-            if fail[CustomAttributes.ID] not in passed_ids:
-                filterd_failed.append(fail)
-            elif fail[CustomAttributes.FILE_PATH] not in passed_paths:
-                filterd_failed.append(fail)
-        return filterd_failed
+        passed_path_and_ids = [(p[CustomAttributes.ID], p[CustomAttributes.FILE_PATH]) for p in passed]
+        unknown_path_and_ids = [(u[CustomAttributes.ID], u[CustomAttributes.FILE_PATH]) for u in unknown]
+        unknown = [u for u in unknown if u[CustomAttributes.ID] not in passed_path_and_ids]
+        failed = [f for f in failed if (f[CustomAttributes.ID], f[CustomAttributes.FILE_PATH]) not in
+                  itertools.chain(passed_path_and_ids, unknown_path_and_ids)]
+        return self.filter_results(passed, failed, unknown)

--- a/checkov/common/checks_infra/solvers/filter_solvers/base_filter_solver.py
+++ b/checkov/common/checks_infra/solvers/filter_solvers/base_filter_solver.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING, Tuple, List, Dict, Optional
 
 from checkov.common.graph.checks_infra.enums import SolverType
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
@@ -10,12 +8,12 @@ if TYPE_CHECKING:
 
 
 class BaseFilterSolver(BaseSolver):
-    def __init__(self, resource_types: list[str], attribute: str | None, value: Any) -> None:
+    def __init__(self, resource_types: List[str], attribute: Optional[str], value: Any) -> None:
         super().__init__(SolverType.FILTER)
         self.resource_types = resource_types
         self.attribute = attribute
         self.value = value
-        self.vertices: list[dict[str, Any]] = []
+        self.vertices: List[Dict[str, Any]] = []
 
     def get_operation(self, *args: Any, **kwargs: Any) -> bool:
         raise NotImplementedError()
@@ -23,5 +21,5 @@ class BaseFilterSolver(BaseSolver):
     def _get_operation(self, *args: Any, **kwargs: Any) -> Callable[..., bool]:
         raise NotImplementedError()
 
-    def run(self, graph_connector: DiGraph) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    def run(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         raise NotImplementedError()

--- a/checkov/common/checks_infra/solvers/filter_solvers/base_filter_solver.py
+++ b/checkov/common/checks_infra/solvers/filter_solvers/base_filter_solver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Callable, TYPE_CHECKING, Tuple, List, Dict, Optional
 
 from checkov.common.graph.checks_infra.enums import SolverType

--- a/checkov/common/checks_infra/solvers/filter_solvers/within_filter_solver.py
+++ b/checkov/common/checks_infra/solvers/filter_solvers/within_filter_solver.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any, Callable
+from typing import Any, Callable, List
 
 from checkov.common.graph.checks_infra.enums import Operators
 from checkov.common.checks_infra.solvers.filter_solvers.base_filter_solver import BaseFilterSolver
@@ -9,7 +7,7 @@ from checkov.common.checks_infra.solvers.filter_solvers.base_filter_solver impor
 class WithinFilterSolver(BaseFilterSolver):
     operator = Operators.WITHIN  # noqa: CCE003  # a static attribute
 
-    def __init__(self, resource_types: list[str], attribute: str, value: Any) -> None:
+    def __init__(self, resource_types: List[str], attribute: str, value: Any) -> None:
         super().__init__(resource_types=resource_types, attribute=attribute, value=value)
 
     def get_operation(self, *args: Any, **kwargs: Any) -> bool:

--- a/checkov/common/checks_infra/solvers/filter_solvers/within_filter_solver.py
+++ b/checkov/common/checks_infra/solvers/filter_solvers/within_filter_solver.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Dict
 
 from checkov.common.graph.checks_infra.enums import Operators
 from checkov.common.checks_infra.solvers.filter_solvers.base_filter_solver import BaseFilterSolver
@@ -14,7 +14,7 @@ class WithinFilterSolver(BaseFilterSolver):
         return self._get_operation()(*args)
 
     def _get_operation(self, *args: Any, **kwargs: Any) -> Callable[..., bool]:
-        def op(check: dict[str, Any]) -> bool:
+        def op(check: Dict[str, Any]) -> bool:
             if not self.attribute:
                 return False
 

--- a/checkov/common/graph/checks_infra/base_check.py
+++ b/checkov/common/graph/checks_infra/base_check.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import itertools
 from typing import Optional, Tuple, List, Dict, Any, TYPE_CHECKING
 
@@ -30,13 +28,13 @@ class BaseGraphCheck:
         self.benchmarks: Dict[str, List[str]] = {}
         self.severity: Optional[Severity] = None
         self.bc_category: Optional[str] = None
-        self.frameworks: list[str] = []
+        self.frameworks: List[str] = []
         self.is_jsonpath_check: bool = False
 
     def set_solver(self, solver: BaseSolver) -> None:
         self.solver = solver
 
-    def run(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    def run(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         if not self.solver:
             raise AttributeError("solver attribute was not set")
 

--- a/checkov/common/graph/checks_infra/base_check.py
+++ b/checkov/common/graph/checks_infra/base_check.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import itertools
-from typing import Optional, Tuple, List, Dict, Any, TYPE_CHECKING
+from typing import Optional, Tuple, List, Dict, Any
 
 
 from checkov.common.graph.checks_infra.enums import SolverType
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
 
-if TYPE_CHECKING:
-    from checkov.common.bridgecrew.severities import Severity
-    from networkx import DiGraph
+from checkov.common.bridgecrew.severities import Severity
+from networkx import DiGraph
 
 
 class BaseGraphCheck:

--- a/checkov/common/graph/checks_infra/base_check.py
+++ b/checkov/common/graph/checks_infra/base_check.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import itertools
-from typing import Optional, Tuple, List, Dict, Any
+from typing import Optional, Tuple, List, Dict, Any, TYPE_CHECKING
 
 
 from checkov.common.graph.checks_infra.enums import SolverType
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
 
-from checkov.common.bridgecrew.severities import Severity
-from networkx import DiGraph
+if TYPE_CHECKING:
+    from checkov.common.bridgecrew.severities import Severity
+    from networkx import DiGraph
 
 
 class BaseGraphCheck:

--- a/checkov/common/graph/checks_infra/base_check.py
+++ b/checkov/common/graph/checks_infra/base_check.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from typing import Optional, Tuple, List, Dict, Any, TYPE_CHECKING
 

--- a/checkov/common/graph/checks_infra/registry.py
+++ b/checkov/common/graph/checks_infra/registry.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import concurrent.futures
 import logging
 
@@ -37,21 +35,22 @@ class BaseRegistry:
         return check_results
 
     def run_check_parallel(
-        self, check: BaseGraphCheck, check_results: dict[BaseGraphCheck, list[dict[str, Any]]], graph_connector: DiGraph
+        self, check: BaseGraphCheck, check_results: Dict[BaseGraphCheck, List[Dict[str, Any]]], graph_connector: DiGraph
     ) -> None:
         logging.debug(f'Running graph check: {check.id}')
-        passed, failed = check.run(graph_connector)
+        passed, failed, unknown = check.run(graph_connector)
         evaluated_keys = check.get_evaluated_keys()
         check_result = self._process_check_result(passed, [], CheckResult.PASSED, evaluated_keys)
         check_result = self._process_check_result(failed, check_result, CheckResult.FAILED, evaluated_keys)
+        check_result = self._process_check_result(unknown, check_result, CheckResult.UNKNOWN, evaluated_keys)
         check_results[check] = check_result
 
     @staticmethod
     def _process_check_result(
-        results: list[dict[str, Any]],
-        processed_results: list[dict[str, Any]],
-        result: CheckResult, evaluated_keys: list[str],
-    ) -> list[dict[str, Any]]:
+        results: List[Dict[str, Any]],
+        processed_results: List[Dict[str, Any]],
+        result: CheckResult, evaluated_keys: List[str],
+    ) -> List[Dict[str, Any]]:
         for vertex in results:
             processed_results.append({"result": result, "entity": vertex, "evaluated_keys": evaluated_keys})
         return processed_results

--- a/checkov/common/graph/checks_infra/registry.py
+++ b/checkov/common/graph/checks_infra/registry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import concurrent.futures
 import logging
 

--- a/checkov/common/graph/checks_infra/solvers/base_solver.py
+++ b/checkov/common/graph/checks_infra/solvers/base_solver.py
@@ -24,7 +24,7 @@ class BaseSolver:
         raise NotImplementedError()
 
     @abstractmethod
-    def run(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    def run(self, graph_connector: DiGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         raise NotImplementedError()
 
     @staticmethod

--- a/tests/common/output/test_junit_report.py
+++ b/tests/common/output/test_junit_report.py
@@ -73,13 +73,12 @@ class TestJunitReport(unittest.TestCase):
                 "".join(
                     [
                         '<?xml version="1.0" ?>\n',
-                        '<testsuites disabled="0" errors="0" failures="1" tests="3" time="0.0">\n',
-                        '\t<testsuite disabled="0" errors="0" failures="1" name="terraform scan" skipped="1" tests="3" time="0">\n',
+                        '<testsuites disabled="0" errors="0" failures="1" tests="2" time="0.0">\n',
+                        '\t<testsuite disabled="0" errors="0" failures="1" name="terraform scan" skipped="1" tests="2" time="0">\n',
                         "\t\t<properties>\n",
                         '\t\t\t<property name="file" value="fixtures/main.tf"/>\n',
                         '\t\t\t<property name="framework" value="[\'terraform\']"/>\n',
                         "\t\t</properties>\n",
-                        '\t\t<testcase name="[NONE][CKV_AWS_21] Ensure all data stored in the S3 bucket have versioning enabled" classname="/main.tf.aws_s3_bucket.destination" file="/main.tf"/>\n',
                         '\t\t<testcase name="[NONE][CKV_AWS_18] Ensure the S3 bucket has access logging enabled" classname="/main.tf.aws_s3_bucket.destination" file="/main.tf">\n',
                         '\t\t\t<failure type="failure" message="Ensure the S3 bucket has access logging enabled">\n',
                         "Resource: aws_s3_bucket.destination\n",

--- a/tests/terraform/graph/checks/resources/EIPAllocatedToVPCAttachedEC2/expected.yaml
+++ b/tests/terraform/graph/checks/resources/EIPAllocatedToVPCAttachedEC2/expected.yaml
@@ -2,8 +2,6 @@ pass:
   - "aws_eip.ok_eip"
   - "aws_eip.ok_eip_assoc"
   - "aws_eip.ok_eip_nat"
-  - "aws_eip.ok_eip_module"
-  - "aws_eip.ok_eip_data"
   - "aws_eip.eip_ok_transer_server"
 fail:
   - "aws_eip.not_ok_eip"

--- a/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/expected.yaml
+++ b/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/expected.yaml
@@ -1,14 +1,11 @@
 pass:
   - "aws_route53_record.pass"
   - "aws_route53_record.pass2"
-  - "aws_route53_record.pass3"
-  - "aws_route53_record.pass4"
   - "aws_route53_record.pass5"
   - "aws_route53_record.legacy-tf"
   - "aws_route53_record.pass_eb"
   - "aws_route53_record.pass_apiv2"
   - "aws_route53_record.pass_alb"
-  - "aws_route53_record.pass_var"
   - "aws_route53_record.pass_lightsail"
 fail:
   - "aws_route53_record.fail"

--- a/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
+++ b/tests/terraform/graph/checks/resources/Route53ARecordAttachedResource/main.tf
@@ -74,7 +74,7 @@ resource "aws_route53_record" "ignore2" {
   records = ["1.1.1.1"]
 }
 
-resource "aws_route53_record" "pass3" {
+resource "aws_route53_record" "unknown" {
   zone_id = var.zone_id
   name = "test.example.com"
   type = "A"
@@ -85,7 +85,7 @@ resource "aws_route53_record" "pass3" {
   }
 }
 
-resource "aws_route53_record" "pass4" {
+resource "aws_route53_record" "unknown2" {
   zone_id = data.aws_route53_zone.example.zone_id
   name    = "example"
   type    = "A"
@@ -131,7 +131,7 @@ resource "aws_route53_record" "pass5" {
 variable "aws_alb_dns_name" {}
 variable "aws_alb_zone_id" {}
 
-resource "aws_route53_record" "pass_var" {
+resource "aws_route53_record" "unknown3" {
   zone_id = data.aws_route53_zone.example.zone_id
   name    = "example"
   type    = "A"

--- a/tests/terraform/graph/checks/resources/S3BucketEncryption/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3BucketEncryption/expected.yaml
@@ -2,11 +2,8 @@ pass:
   - "aws_s3_bucket.bucket_good_1"
   - "aws_s3_bucket.bucket_good_2"
   - "aws_s3_bucket.bucket_good_3"
-  - "aws_s3_bucket.bucket_good_4"
   - "aws_s3_bucket.bucket_good_5"
   - "aws_s3_bucket.bucket_good_6"
-  - "aws_s3_bucket.bucket_good_7"
-  - "aws_s3_bucket.bucket_good_8"
 fail:
   - "aws_s3_bucket.bucket_bad_1"
   - "aws_s3_bucket.bucket_bad_2"

--- a/tests/terraform/graph/checks/resources/S3BucketEncryption/main.tf
+++ b/tests/terraform/graph/checks/resources/S3BucketEncryption/main.tf
@@ -19,8 +19,8 @@ resource "aws_s3_bucket" "bucket_good_3" {
   }
 }
 
-resource "aws_s3_bucket" "bucket_good_4" {
-  bucket = "bucket_good"
+resource "aws_s3_bucket" "bucket_unknown" {
+  bucket = "bucket_unknown"
 
   server_side_encryption_configuration {
     rule {
@@ -52,8 +52,8 @@ resource "aws_s3_bucket" "bucket_good_6" {
   bucket = "bucket_good"
 }
 
-resource "aws_s3_bucket" "bucket_good_7" {
-  bucket = "bucket_good"
+resource "aws_s3_bucket" "bucket_unknown2" {
+  bucket = "bucket_unknown"
 
   server_side_encryption_configuration {
     rule {
@@ -65,7 +65,7 @@ resource "aws_s3_bucket" "bucket_good_7" {
   }
 }
 
-resource "aws_s3_bucket" "bucket_good_8" {
+resource "aws_s3_bucket" "bucket_unknown3" {
   bucket = "bucket_good"
 }
 
@@ -149,8 +149,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "good_sse_3" {
   }
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "good_sse_4" {
-  bucket = aws_s3_bucket.bucket_good_8.bucket
+resource "aws_s3_bucket_server_side_encryption_configuration" "unknown_sse_4" {
+  bucket = aws_s3_bucket.bucket_unknown3.bucket
 
   rule {
     apply_server_side_encryption_by_default {

--- a/tests/terraform/graph/checks/resources/S3BucketReplicationConfiguration/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3BucketReplicationConfiguration/expected.yaml
@@ -2,9 +2,6 @@ pass:
   - "aws_s3_bucket.enabled"
   - "aws_s3_bucket.enabled_v4"
   - "aws_s3_bucket.enabled_var"
-  - "aws_s3_bucket.unknown_var"
-  - "aws_s3_bucket.legacy_syntax"
-  - "aws_s3_bucket.legacy_syntax_v4"
 fail:
   - "aws_s3_bucket.default"
   - "aws_s3_bucket.disabled"

--- a/tests/terraform/graph/checks/resources/S3BucketVersioning/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3BucketVersioning/expected.yaml
@@ -2,9 +2,6 @@ pass:
   - "aws_s3_bucket.enabled"
   - "aws_s3_bucket.enabled_v4"
   - "aws_s3_bucket.enabled_var"
-  - "aws_s3_bucket.unknown_var"
-  - "aws_s3_bucket.legacy_syntax"
-  - "aws_s3_bucket.legacy_syntax_v4"
 fail:
   - "aws_s3_bucket.default"
   - "aws_s3_bucket.disabled"

--- a/tests/terraform/graph/checks/resources/S3KMSEncryptedByDefault/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3KMSEncryptedByDefault/expected.yaml
@@ -1,10 +1,7 @@
 pass:
   - "aws_s3_bucket.bucket_good_1"
   - "aws_s3_bucket.bucket_good_3"
-  - "aws_s3_bucket.bucket_good_4"
   - "aws_s3_bucket.bucket_good_6"
-  - "aws_s3_bucket.bucket_good_7"
-  - "aws_s3_bucket.bucket_good_8"
 fail:
   - "aws_s3_bucket.bucket_bad_1"
   - "aws_s3_bucket.bucket_bad_2"

--- a/tests/terraform/graph/checks/resources/S3KMSEncryptedByDefault/main.tf
+++ b/tests/terraform/graph/checks/resources/S3KMSEncryptedByDefault/main.tf
@@ -15,8 +15,8 @@ resource "aws_s3_bucket" "bucket_good_3" {
   }
 }
 
-resource "aws_s3_bucket" "bucket_good_4" {
-  bucket = "bucket_good"
+resource "aws_s3_bucket" "bucket_unknown" {
+  bucket = "bucket_unknown"
 
   server_side_encryption_configuration {
     rule {
@@ -32,8 +32,8 @@ resource "aws_s3_bucket" "bucket_good_6" {
   bucket = "bucket_good"
 }
 
-resource "aws_s3_bucket" "bucket_good_7" {
-  bucket = "bucket_good"
+resource "aws_s3_bucket" "bucket_unknown2" {
+  bucket = "bucket_unknown"
 
   server_side_encryption_configuration {
     rule {
@@ -45,7 +45,7 @@ resource "aws_s3_bucket" "bucket_good_7" {
   }
 }
 
-resource "aws_s3_bucket" "bucket_good_8" {
+resource "aws_s3_bucket" "bucket_unknown3" {
   bucket = "bucket_good"
 }
 
@@ -120,7 +120,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "good_sse_3" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "good_sse_4" {
-  bucket = aws_s3_bucket.bucket_good_8.bucket
+  bucket = aws_s3_bucket.bucket_unknown3.bucket
 
   rule {
     apply_server_side_encryption_by_default {

--- a/tests/terraform/graph/checks/resources/S3PublicACLRead/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3PublicACLRead/expected.yaml
@@ -1,10 +1,7 @@
 pass:
   - "aws_s3_bucket.private_acl"
-  - "aws_s3_bucket.unknown_var"
   - "aws_s3_bucket.private_acl_v4"
   - "aws_s3_bucket.no_acl"
-  - "aws_s3_bucket.unknown_var_legacy"
-  - "aws_s3_bucket.unknown_var_v4_legacy"
   - "aws_s3_bucket.no_grant"
   - "aws_s3_bucket.grant_onwer"
 fail:

--- a/tests/terraform/graph/checks/resources/S3PublicACLWrite/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3PublicACLWrite/expected.yaml
@@ -1,10 +1,7 @@
 pass:
   - "aws_s3_bucket.private_acl"
-  - "aws_s3_bucket.unknown_var"
   - "aws_s3_bucket.private_acl_v4"
   - "aws_s3_bucket.no_acl"
-  - "aws_s3_bucket.unknown_var_legacy"
-  - "aws_s3_bucket.unknown_var_v4_legacy"
   - "aws_s3_bucket.no_grant"
   - "aws_s3_bucket.grant_onwer"
 fail:

--- a/tests/terraform/graph/checks/test_yaml_connected_nodes.py
+++ b/tests/terraform/graph/checks/test_yaml_connected_nodes.py
@@ -28,21 +28,15 @@ class TestYamlConnectedNodes(unittest.TestCase):
 
         assert report.passed_checks[0].connected_node is None
         assert report.passed_checks[1].connected_node is None
-        assert report.passed_checks[2].connected_node is None
-        assert report.passed_checks[3].connected_node is None
+        assert report.passed_checks[2].connected_node['file_path'] == '/main.tf'
+        assert report.passed_checks[2].connected_node['resource'] == 'aws_s3_bucket_server_side_encryption_configuration.good_sse_1'
+        assert report.passed_checks[2].connected_node['file_line_range'] == [117, 126]
+        assert report.passed_checks[3].connected_node['file_path'] == '/main.tf'
+        assert report.passed_checks[3].connected_node['resource'] == 'aws_s3_bucket_server_side_encryption_configuration.good_sse_2'
+        assert report.passed_checks[3].connected_node['file_line_range'] == [128, 137]
         assert report.passed_checks[4].connected_node['file_path'] == '/main.tf'
-        assert report.passed_checks[4].connected_node['resource'] == 'aws_s3_bucket_server_side_encryption_configuration.good_sse_1'
-        assert report.passed_checks[4].connected_node['file_line_range'] == [117, 126]
-        assert report.passed_checks[5].connected_node['file_path'] == '/main.tf'
-        assert report.passed_checks[5].connected_node['resource'] == 'aws_s3_bucket_server_side_encryption_configuration.good_sse_2'
-        assert report.passed_checks[5].connected_node['file_line_range'] == [128, 137]
-        assert report.passed_checks[6].connected_node['file_path'] == '/main.tf'
-        assert report.passed_checks[6].connected_node['resource'] == 'aws_s3_bucket_server_side_encryption_configuration.good_sse_3'
-        assert report.passed_checks[6].connected_node['file_line_range'] == [139, 150]
-        assert report.passed_checks[7].connected_node['file_path'] == '/main.tf'
-        assert report.passed_checks[7].connected_node['resource'] == 'aws_s3_bucket_server_side_encryption_configuration.good_sse_4'
-        assert report.passed_checks[7].connected_node['file_line_range'] == [152, 161]
-
+        assert report.passed_checks[4].connected_node['resource'] == 'aws_s3_bucket_server_side_encryption_configuration.good_sse_3'
+        assert report.passed_checks[4].connected_node['file_line_range'] == [139, 150]
 
     def test_S3BucketLogging_connected_node(self):
         report = self.get_report("S3BucketLogging")

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -263,16 +263,16 @@ class TestYamlPolicies(unittest.TestCase):
         registry.load_checks()
         self.assertGreater(len(registry.checks), 0)
 
-    def go(self, dir_name: str , check_name: str | None = None) -> None:
+    def go(self, dir_name: str, check_name: str | None = None) -> None:
         dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                 f"resources/{dir_name}")
+        check_name = dir_name if check_name is None else check_name
         assert os.path.exists(dir_path)
         policy_dir_path = os.path.dirname(checks.__file__)
         assert os.path.exists(policy_dir_path)
         found = False
         for root, d_names, f_names in os.walk(policy_dir_path):
             for f_name in f_names:
-                check_name = dir_name if check_name is None else check_name
                 if f_name == f"{check_name}.yaml":
                     found = True
                     policy = load_yaml_data(f_name, root)

--- a/tests/terraform/graph/checks_infra/attribute_solvers/ending_with_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/ending_with_solver/test_solver.py
@@ -31,7 +31,7 @@ class TestEndingWithSolver(TestBaseSolver):
     def test_unrendered(self):
         root_folder = '../../../resources/variable_rendering/unrendered'
         check_id = "UnrenderedVar"
-        should_pass = ['aws_s3_bucket.pass1', 'aws_s3_bucket.pass2', 'aws_s3_bucket.pass3']
+        should_pass = []
         should_fail = []
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/test_solver.py
@@ -42,7 +42,7 @@ class TestEqualsSolver(TestBaseSolver):
     def test_equals_solver_unrendered(self):
         root_folder = '../../../resources/variable_rendering/unrendered'
         check_id = "UnrenderedVar"
-        should_pass = ['aws_s3_bucket.pass1', 'aws_s3_bucket.pass2', 'aws_s3_bucket.pass3']
+        should_pass = []
         should_fail = []
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 

--- a/tests/terraform/graph/checks_infra/attribute_solvers/greater_than_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/greater_than_solver/test_solver.py
@@ -60,7 +60,7 @@ class TestGreaterThanLessThanSolvers(TestBaseSolver):
     def test_greater_than_solver_unrendered(self):
         root_folder = '../../../resources/variable_rendering/unrendered'
         check_id = "GT"
-        should_pass = ['aws_s3_bucket.pass1', 'aws_s3_bucket.pass2', 'aws_s3_bucket.pass3']
+        should_pass = []
         should_fail = []
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
@@ -69,7 +69,7 @@ class TestGreaterThanLessThanSolvers(TestBaseSolver):
     def test_less_than_solver_unrendered(self):
         root_folder = '../../../resources/variable_rendering/unrendered'
         check_id = "LT"
-        should_pass = ['aws_s3_bucket.pass1', 'aws_s3_bucket.pass2', 'aws_s3_bucket.pass3']
+        should_pass = []
         should_fail = []
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
@@ -78,7 +78,7 @@ class TestGreaterThanLessThanSolvers(TestBaseSolver):
     def test_greater_than_or_equal_solver_unrendered(self):
         root_folder = '../../../resources/variable_rendering/unrendered'
         check_id = "GTE"
-        should_pass = ['aws_s3_bucket.pass1', 'aws_s3_bucket.pass2', 'aws_s3_bucket.pass3']
+        should_pass = []
         should_fail = []
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
@@ -87,7 +87,7 @@ class TestGreaterThanLessThanSolvers(TestBaseSolver):
     def test_less_than_or_equal_solver_unrendered(self):
         root_folder = '../../../resources/variable_rendering/unrendered'
         check_id = "LTE"
-        should_pass = ['aws_s3_bucket.pass1', 'aws_s3_bucket.pass2', 'aws_s3_bucket.pass3']
+        should_pass = []
         should_fail = []
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
@@ -203,7 +203,7 @@ class TestGreaterThanLessThanSolvers(TestBaseSolver):
         self.assertFalse(cls([], None, 2)._get_operation({'a': 1, 'source_': 'Terraform'}, 'b'))
 
         # unrendered variable
-        self.assertTrue(cls([], None, '1')._get_operation({'a': 'var.x', 'source_': 'Terraform'}, 'a'))
+        self.assertIsNone(cls([], 'a', '1').get_operation({'a': 'var.x', 'source_': 'Terraform'}))
 
     def test_lte_combinations(self):
         cls = LessThanOrEqualAttributeSolver
@@ -239,4 +239,4 @@ class TestGreaterThanLessThanSolvers(TestBaseSolver):
         self.assertFalse(cls([], None, 2)._get_operation({'a': 1, 'source_': 'Terraform'}, 'b'))
 
         # unrendered variable
-        self.assertTrue(cls([], None, '1')._get_operation({'a': 'var.x', 'source_': 'Terraform'}, 'a'))
+        self.assertIsNone(cls([], 'a', '1').get_operation({'a': 'var.x', 'source_': 'Terraform'}))

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_solver/test_solver.py
@@ -31,7 +31,7 @@ class TestNotEqualsSolver(TestBaseSolver):
     def test_not_equals_solver_unrendered(self):
         root_folder = '../../../resources/variable_rendering/unrendered'
         check_id = "UnrenderedVar"
-        should_pass = ['aws_s3_bucket.pass1', 'aws_s3_bucket.pass2', 'aws_s3_bucket.pass3']
+        should_pass = []
         should_fail = []
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 

--- a/tests/terraform/graph/checks_infra/attribute_solvers/starting_with_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/starting_with_solver/test_solver.py
@@ -22,7 +22,7 @@ class TestStartingWithSolver(TestBaseSolver):
     def test_unrendered(self):
         root_folder = '../../../resources/variable_rendering/unrendered'
         check_id = "UnrenderedVar"
-        should_pass = ['aws_s3_bucket.pass1', 'aws_s3_bucket.pass2', 'aws_s3_bucket.pass3']
+        should_pass = []
         should_fail = []
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 

--- a/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/test_solver.py
@@ -31,7 +31,7 @@ class TestWithinSolver(TestBaseSolver):
     def test_within_unrendered(self):
         root_folder = '../../../resources/variable_rendering/unrendered'
         check_id = "UnrenderedVar"
-        should_pass = ['aws_s3_bucket.pass1', 'aws_s3_bucket.pass2', 'aws_s3_bucket.pass3']
+        should_pass = []
         should_fail = []
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -1191,7 +1191,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework=["terraform"],
                                                        checks=checks_allow_list, skip_checks=skip_checks))
 
-        self.assertEqual(len(report.passed_checks), 7)
+        self.assertEqual(len(report.passed_checks), 1)
         self.assertEqual(len(report.failed_checks), 1)
 
     def test_resource_values_do_exist(self):
@@ -1207,7 +1207,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework=["terraform"],
                                                        checks=checks_allow_list, skip_checks=skip_checks))
 
-        self.assertEqual(len(report.passed_checks), 5)
+        self.assertEqual(len(report.passed_checks), 3)
         self.assertEqual(len(report.failed_checks), 3)
 
     def test_resource_negative_values_dont_exist(self):
@@ -1223,7 +1223,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework='terraform',
                                                        checks=checks_allow_list, skip_checks=skip_checks))
 
-        self.assertEqual(len(report.passed_checks), 7)
+        self.assertEqual(len(report.passed_checks), 1)
         self.assertEqual(len(report.failed_checks), 1)
 
     def test_resource_negative_values_do_exist(self):
@@ -1239,7 +1239,7 @@ class TestRunnerValid(unittest.TestCase):
                             runner_filter=RunnerFilter(framework=["terraform"],
                                                        checks=checks_allow_list, skip_checks=skip_checks))
 
-        self.assertEqual(len(report.passed_checks), 5)
+        self.assertEqual(len(report.passed_checks), 3)
         self.assertEqual(len(report.failed_checks), 3)
 
     def test_no_duplicate_results(self):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Added `UNKNOWN` graph check result for unrendered attributes.

Added a new list of unknown results to the return value of the solvers' `run` function.
Changed the return value of `get_operation` function in attribute and complex solvers to Optional[bool], None value will indicate `UNKNOWN` check result.
Added a new list of unknown results to the return value of the connections solvers' `get_operation` function.

Removed the handling of this use case in specific solvers.
Adjusted the solvers' tests to expect `UNKNOWN` results for those use cases.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
