### PR TITLE
feat(terraform): include pods of kubernetes_deployment in kubernetes_pod checks (1/4)

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/AllowPrivilegeEscalation.py
+++ b/checkov/terraform/checks/resource/kubernetes/AllowPrivilegeEscalation.py
@@ -14,7 +14,8 @@ class AllowPrivilegeEscalation(BaseResourceCheck):
 
         name = "Containers should not run with allowPrivilegeEscalation"
         id = "CKV_K8S_20"
-        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1',
+                               'kubernetes_deployment', 'kubernetes_deployment_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
@@ -24,6 +25,16 @@ class AllowPrivilegeEscalation(BaseResourceCheck):
             return CheckResult.UNKNOWN
         spec = spec_list[0]
         if spec:
+            evaluated_keys_path = "spec"
+
+            template = spec.get("template")
+            if template and isinstance(template, list):
+                template = template[0]
+                template_spec = template.get("spec")
+                if template_spec and isinstance(template_spec, list):
+                    spec = template_spec[0]
+                    evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
             containers = spec.get("container")
             if not containers:
                 return CheckResult.UNKNOWN
@@ -34,7 +45,7 @@ class AllowPrivilegeEscalation(BaseResourceCheck):
                     context = container.get("security_context")[0]
                     if context.get("allow_privilege_escalation"):
                         if context.get("allow_privilege_escalation") == [True]:
-                            self.evaluated_keys = [f'spec/[0]/container/[{idx}]/security_context/[0]/'
+                            self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/security_context/[0]/'
                                                    f'allow_privilege_escalation']
                             return CheckResult.FAILED
             return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/kubernetes/AllowedCapabilities.py
+++ b/checkov/terraform/checks/resource/kubernetes/AllowedCapabilities.py
@@ -12,12 +12,23 @@ class AllowedCapabilities(BaseResourceCheck):
 
         id = "CKV_K8S_25"
 
-        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1',
+                               'kubernetes_deployment', 'kubernetes_deployment_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf.get('spec', [None])[0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
         if isinstance(spec, dict) and spec.get("container"):
             containers = spec.get("container")
 
@@ -31,8 +42,9 @@ class AllowedCapabilities(BaseResourceCheck):
                         if capabilities.get("add"):
                             add = capabilities.get("add")[0]
                             if add:
-                                self.evaluated_keys = [f'spec/[0]/container/[{idx}]/'
+                                self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/'
                                                        f'security_context/[0]/capabilities/add']
+
                                 return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/kubernetes/AllowedCapabilitiesSysAdmin.py
+++ b/checkov/terraform/checks/resource/kubernetes/AllowedCapabilitiesSysAdmin.py
@@ -10,12 +10,23 @@ class AllowedCapabilitiesSysAdmin(BaseResourceCheck):
         # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
         id = "CKV_K8S_39"
 
-        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1',
+                               'kubernetes_deployment', 'kubernetes_deployment_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf.get('spec', [None])[0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
         if isinstance(spec, dict) and spec.get("container"):
             containers = spec.get("container")
 
@@ -29,7 +40,7 @@ class AllowedCapabilitiesSysAdmin(BaseResourceCheck):
                         if capabilities.get("add") and isinstance(capabilities.get("add"), list):
                             add = capabilities.get("add")[0]
                             if "SYS_ADMIN" in add:
-                                self.evaluated_keys = [f'spec/[0]/container/[{idx}]/'
+                                self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/'
                                                        f'security_context/[0]/capabilities/add']
                                 return CheckResult.FAILED
         return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/kubernetes/CPULimits.py
+++ b/checkov/terraform/checks/resource/kubernetes/CPULimits.py
@@ -10,7 +10,8 @@ class CPULimits(BaseResourceCheck):
     def __init__(self) -> None:
         name = "CPU Limits should be set"
         id = "CKV_K8S_11"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1',
+                               'kubernetes_deployment', 'kubernetes_deployment_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
@@ -19,6 +20,15 @@ class CPULimits(BaseResourceCheck):
             self.evaluated_keys = [""]
             return CheckResult.FAILED
         spec = conf['spec'][0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
 
         containers = spec.get("container")
         if not containers:
@@ -32,11 +42,11 @@ class CPULimits(BaseResourceCheck):
                     limits = resources.get('limits')[0]
                     if isinstance(limits, dict) and limits.get('cpu'):
                         return CheckResult.PASSED
-                    self.evaluated_keys = [f'spec/[0]/container/[{idx}]/resources/[0]/limits']
+                    self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/resources/[0]/limits']
                     return CheckResult.FAILED
-                self.evaluated_keys = [f'spec/[0]/container/[{idx}]/resources']
+                self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/resources']
                 return CheckResult.FAILED
-            self.evaluated_keys = [f'spec/[0]/container/[{idx}]']
+            self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]']
             return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/kubernetes/CPURequests.py
+++ b/checkov/terraform/checks/resource/kubernetes/CPURequests.py
@@ -6,7 +6,8 @@ class CPURequests(BaseResourceCheck):
     def __init__(self):
         name = "CPU requests should be set"
         id = "CKV_K8S_10"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1',
+                               'kubernetes_deployment', 'kubernetes_deployment_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
@@ -15,6 +16,15 @@ class CPURequests(BaseResourceCheck):
             self.evaluated_keys = [""]
             return CheckResult.FAILED
         spec = conf['spec'][0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
 
         containers = spec.get("container")
         if containers is None:
@@ -28,11 +38,11 @@ class CPURequests(BaseResourceCheck):
                     limits = resources.get('requests')[0]
                     if isinstance(limits, dict) and limits.get('cpu'):
                         return CheckResult.PASSED
-                    self.evaluated_keys = [f'spec/[0]/container/[{idx}]/resources/[0]/requests']
+                    self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/resources/[0]/requests']
                     return CheckResult.FAILED
-                self.evaluated_keys = [f'spec/[0]/container/[{idx}]/resources']
+                self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/resources']
                 return CheckResult.FAILED
-            self.evaluated_keys = [f'spec/[0]/container/[{idx}]']
+            self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]']
             return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/kubernetes/ContainerSecurityContext.py
+++ b/checkov/terraform/checks/resource/kubernetes/ContainerSecurityContext.py
@@ -11,12 +11,23 @@ class ContainerSecurityContext(BaseResourceCheck):
         # Location: container .securityContext
         id = "CKV_K8S_30"
 
-        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1',
+                               'kubernetes_deployment', 'kubernetes_deployment_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf.get('spec', [None])[0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
         if isinstance(spec, dict) and spec.get("container"):
             containers = spec.get("container")
 
@@ -24,7 +35,7 @@ class ContainerSecurityContext(BaseResourceCheck):
                 if type(container) != dict:
                     return CheckResult.UNKNOWN
                 if not container.get("security_context"):
-                    self.evaluated_keys = [f'spec/[0]/container/[{idx}]/security_context']
+                    self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/security_context']
                     return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/tests/terraform/checks/resource/kubernetes/example_AllowPrivilegeEscalation/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_AllowPrivilegeEscalation/main.tf
@@ -92,7 +92,6 @@ resource "kubernetes_pod" "unknown" {
   }
 }
 
-
 #ignore as old tf
 resource "kubernetes_pod_v1" "unknown" {
   metadata {
@@ -187,6 +186,233 @@ resource "kubernetes_pod_v1" "unknown" {
   }
 }
 
+#ignore as old tf
+resource "kubernetes_deployment" "unknown" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx:1.7.9"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#ignore as old tf
+resource "kubernetes_deployment_v1" "unknown" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx:1.7.9"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
 
 resource "kubernetes_pod" "fail" {
   metadata {
@@ -368,6 +594,230 @@ resource "kubernetes_pod_v1" "fail" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged                 = true
+            allow_privilege_escalation = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged                 = true
+            allow_privilege_escalation = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -554,6 +1004,228 @@ resource "kubernetes_pod_v1" "pass" {
   }
 }
 
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 #set to false
 resource "kubernetes_pod" "pass2" {
   metadata {
@@ -676,6 +1348,167 @@ resource "kubernetes_pod_v1" "pass2" {
   }
 }
 
+resource "kubernetes_deployment" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged                 = false
+            allow_privilege_escalation = false
+          }
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged                 = false
+            allow_privilege_escalation = false
+          }
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
 
 resource "kubernetes_pod" "unknown_2" {
   metadata {
@@ -688,4 +1521,122 @@ resource "kubernetes_pod_v1" "unknown_2" {
   metadata {
     name = "terraform-example"
   }
+}
+
+resource "kubernetes_deployment" "unknown_2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+}
+
+resource "kubernetes_deployment_v1" "unknown_2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+}
+
+resource "kubernetes_deployment" "unknown_3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+  }
+
+}
+
+resource "kubernetes_deployment_v1" "unknown_3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+  }
+
+}
+
+resource "kubernetes_deployment" "unknown_4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+    }
+  }
+
+}
+
+resource "kubernetes_deployment_v1" "unknown_4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+    }
+  }
+
 }

--- a/tests/terraform/checks/resource/kubernetes/example_AllowedCapabilities/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_AllowedCapabilities/main.tf
@@ -184,6 +184,232 @@ resource "kubernetes_pod_v1" "ignore" {
   }
 }
 
+resource "kubernetes_deployment" "ignore" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx:1.7.9"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "ignore" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx:1.7.9"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 resource "kubernetes_pod" "fail" {
   metadata {
     name = "terraform-example"
@@ -376,6 +602,239 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            capabilities {
+              add = ["NET_BIND_SERVICE"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            capabilities {
+              add = ["NET_BIND_SERVICE"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            capabilities {
+              add = ["NET_BIND_SERVICE"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            capabilities {
+              add = ["NET_BIND_SERVICE"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
 
 resource "kubernetes_pod" "pass2" {
   metadata {
@@ -495,6 +954,166 @@ resource "kubernetes_pod_v1" "pass2" {
   }
 }
 
+resource "kubernetes_deployment" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            capabilities {
+              add = []
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            capabilities {
+              add = []
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 resource "kubernetes_pod" "pass" {
   metadata {
     name = "terraform-example"
@@ -608,5 +1227,163 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            capabilities {
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            capabilities {
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_AllowedCapabilitiesSysAdmin/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_AllowedCapabilitiesSysAdmin/main.tf
@@ -185,6 +185,234 @@ resource "kubernetes_pod_v1" "ignore" {
   }
 }
 
+resource "kubernetes_deployment" "ignore" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx:1.7.9"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ,
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "ignore" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx:1.7.9"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ,
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 resource "kubernetes_pod" "fail" {
   metadata {
@@ -379,63 +607,235 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
-
-resource "kubernetes_pod" "pass2" {
+resource "kubernetes_deployment" "fail" {
   metadata {
     name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
   }
 
   spec {
-    container {
-      image = "nginx:1.7.9"
-      name  = "example22"
+    replicas = 3
 
-      security_context {
-        capabilities {
-          add = []
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
         }
       }
 
-      env {
-        name  = "environment"
-        value = "test"
-      }
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
 
-      port {
-        container_port = 8080
-      }
+          security_context {
+            capabilities {
+              add = ["SYS_ADMIN"]
+            }
+          }
 
-      liveness_probe {
-        http_get  {
-          path = "/nginx_status"
-          port = 80
+          env {
+            name  = "environment"
+            value = "test"
+          }
 
-          http_header {
-            name  = "X-Custom-Header"
-            value = "Awesome"
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
           }
         }
 
-        initial_delay_seconds = 3
-        period_seconds        = 3
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            capabilities {
+              add = ["NET_BIND_SERVICE"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
       }
     }
 
-    dns_config {
-      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
-      searches    = ["example.com"]
-
-      option {
-        name  = "ndots"
-        value = 1
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
       }
 
-      option {
-        name = "use-vc"
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            capabilities {
+              add = ["SYS_ADMIN"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            capabilities {
+              add = ["NET_BIND_SERVICE"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
       }
     }
-
-    dns_policy = "None"
   }
 }
 
@@ -498,6 +898,7 @@ resource "kubernetes_pod" "pass2" {
     dns_policy = "None"
   }
 }
+
 
 resource "kubernetes_pod_v1" "pass2" {
   metadata {
@@ -555,6 +956,166 @@ resource "kubernetes_pod_v1" "pass2" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            capabilities {
+              add = []
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            capabilities {
+              add = []
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -671,5 +1232,163 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            capabilities {
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            capabilities {
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_CPULimits/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_CPULimits/main.tf
@@ -5,13 +5,33 @@ resource "kubernetes_pod" "fail2" {
   }
 }
 
-
 # fails no spec
 resource "kubernetes_pod_v1" "fail2" {
   metadata {
     name = "terraform-example"
   }
 }
+
+# fails no spec
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+# fails no spec
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
 
 # fails no resource
 resource "kubernetes_pod" "fail3" {
@@ -98,6 +118,135 @@ resource "kubernetes_pod_v1" "fail3" {
     dns_policy = "None"
   }
 }
+
+# fails no resource
+resource "kubernetes_deployment" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no resource
+resource "kubernetes_deployment_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 # fails no limits
 resource "kubernetes_pod" "fail" {
@@ -193,6 +342,143 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+# fails no limits
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no limits
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
 # fails no cpu limit
 resource "kubernetes_pod" "fail4" {
   metadata {
@@ -242,7 +528,6 @@ resource "kubernetes_pod" "fail4" {
   }
 }
 
-
 # fails no cpu limit
 resource "kubernetes_pod_v1" "fail4" {
   metadata {
@@ -291,6 +576,147 @@ resource "kubernetes_pod_v1" "fail4" {
     dns_policy = "None"
   }
 }
+
+# fails no cpu limit
+resource "kubernetes_deployment" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              memory = "1Gi"
+            }
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no cpu limit
+resource "kubernetes_deployment_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              memory = "1Gi"
+            }
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 resource "kubernetes_pod" "pass" {
   metadata {
@@ -392,6 +818,149 @@ resource "kubernetes_pod_v1" "pass" {
   }
 }
 
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              cpu = "500m"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              cpu = "500m"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
 resource "kubernetes_pod" "unknown" {
   metadata {
     name = "terraform-example"
@@ -443,5 +1012,101 @@ resource "kubernetes_pod_v1" "unknown" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "unknown" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "unknown" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_CPURequests/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_CPURequests/main.tf
@@ -12,6 +12,27 @@ resource "kubernetes_pod_v1" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+# fails no spec
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -95,6 +116,134 @@ resource "kubernetes_pod_v1" "fail3" {
     }
 
     dns_policy = "None"
+  }
+}
+
+# fails no resource
+resource "kubernetes_deployment" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no resource
+resource "kubernetes_deployment_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -192,6 +341,143 @@ resource "kubernetes_pod_v1" "fail" {
     dns_policy = "None"
   }
 }
+
+# fails no requests
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no requests
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 # fails no cpu limit
 resource "kubernetes_pod" "fail4" {
@@ -291,6 +577,147 @@ resource "kubernetes_pod_v1" "fail4" {
   }
 }
 
+# fails no cpu limit
+resource "kubernetes_deployment" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              memory = "1Gi"
+            }
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no cpu limit
+resource "kubernetes_deployment_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              memory = "1Gi"
+            }
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
 resource "kubernetes_pod" "pass" {
   metadata {
     name = "terraform-example"
@@ -388,5 +815,147 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              cpu = "500m"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              cpu = "500m"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_CPURequests/main2.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_CPURequests/main2.tf
@@ -12,6 +12,27 @@ resource "kubernetes_pod_v1" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+# fails no spec
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -97,6 +118,135 @@ resource "kubernetes_pod_v1" "fail3" {
     dns_policy = "None"
   }
 }
+
+# fails no resource
+resource "kubernetes_deployment" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no resource
+resource "kubernetes_deployment_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 # fails no requests
 resource "kubernetes_pod" "fail" {
@@ -189,6 +339,142 @@ resource "kubernetes_pod_v1" "fail" {
     }
 
     dns_policy = "None"
+  }
+}
+
+# fails no requests
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no requests
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -291,6 +577,146 @@ resource "kubernetes_pod_v1" "fail4" {
   }
 }
 
+# fails no cpu limit
+resource "kubernetes_deployment" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              memory = "1Gi"
+            }
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no cpu limit
+resource "kubernetes_deployment_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              memory = "1Gi"
+            }
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 resource "kubernetes_pod" "fail5" {
   metadata {
@@ -385,5 +811,143 @@ resource "kubernetes_pod_v1" "fail5" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "fail5" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = "x"
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail5" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = "x"
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_CPURequests/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_CPURequests/main3.tf
@@ -39,3 +39,80 @@ resource "kubernetes_pod_v1" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_deployment" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/tests/terraform/checks/resource/kubernetes/example_ContainerSecurityContext/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ContainerSecurityContext/main.tf
@@ -167,6 +167,217 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
 resource "kubernetes_pod" "pass" {
   metadata {
     name = "terraform-example"
@@ -269,5 +480,153 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+
+        container {
+          image             = "nginx"
+          image_pull_policy = "Never"
+          name              = "example"
+
+          security_context {
+            privileged                 = true
+            allow_privilege_escalation = true
+            capabilities {
+              add  = ["NET_RAW"]
+              drop = ["NET_BIND_SERVICE"]
+            }
+          }
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+            host_port      = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+
+        container {
+          image             = "nginx"
+          image_pull_policy = "Never"
+          name              = "example"
+
+          security_context {
+            privileged                 = true
+            allow_privilege_escalation = true
+            capabilities {
+              add  = ["NET_RAW"]
+              drop = ["NET_BIND_SERVICE"]
+            }
+          }
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+            host_port      = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/test_AllowPrivilegeEscalation.py
+++ b/tests/terraform/checks/resource/kubernetes/test_AllowPrivilegeEscalation.py
@@ -22,18 +22,24 @@ class TestAllowPrivilegeEscalation(unittest.TestCase):
             "kubernetes_pod.pass2",
             "kubernetes_pod_v1.pass",
             "kubernetes_pod_v1.pass2",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment.pass2",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_deployment_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod_v1.fail",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2 * 2)
-        self.assertEqual(summary["failed"], 1 * 2)
+        self.assertEqual(summary["passed"], 4 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_AllowedCapabilities.py
+++ b/tests/terraform/checks/resource/kubernetes/test_AllowedCapabilities.py
@@ -22,18 +22,24 @@ class TestAllowedCapabilities(unittest.TestCase):
             "kubernetes_pod.pass2",
             "kubernetes_pod_v1.pass",
             "kubernetes_pod_v1.pass2",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment.pass2",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_deployment_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod_v1.fail",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2 * 2)
-        self.assertEqual(summary["failed"], 1 * 2)
+        self.assertEqual(summary["passed"], 4 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_AllowedCapabilitiesSysAdmin.py
+++ b/tests/terraform/checks/resource/kubernetes/test_AllowedCapabilitiesSysAdmin.py
@@ -22,18 +22,24 @@ class TestAllowedCapabilitiesSysAdmin(unittest.TestCase):
             "kubernetes_pod.pass2",
             "kubernetes_pod_v1.pass",
             "kubernetes_pod_v1.pass2",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment.pass2",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_deployment_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod_v1.fail",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2 * 2)
-        self.assertEqual(summary["failed"], 1 * 2)
+        self.assertEqual(summary["passed"], 4 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_CPULimits.py
+++ b/tests/terraform/checks/resource/kubernetes/test_CPULimits.py
@@ -20,6 +20,8 @@ class TestCPULimits(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
@@ -31,13 +33,21 @@ class TestCPULimits(unittest.TestCase):
             "kubernetes_pod_v1.fail2",
             "kubernetes_pod_v1.fail3",
             "kubernetes_pod_v1.fail4",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment.fail3",
+            "kubernetes_deployment.fail4",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
+            "kubernetes_deployment_v1.fail3",
+            "kubernetes_deployment_v1.fail4",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1 * 2)
-        self.assertEqual(summary["failed"], 4 * 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 8 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_CPURequests.py
+++ b/tests/terraform/checks/resource/kubernetes/test_CPURequests.py
@@ -20,6 +20,8 @@ class TestCPURequests(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
@@ -33,13 +35,23 @@ class TestCPURequests(unittest.TestCase):
             "kubernetes_pod_v1.fail3",
             "kubernetes_pod_v1.fail4",
             "kubernetes_pod_v1.fail5",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment.fail3",
+            "kubernetes_deployment.fail4",
+            "kubernetes_deployment.fail5",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
+            "kubernetes_deployment_v1.fail3",
+            "kubernetes_deployment_v1.fail4",
+            "kubernetes_deployment_v1.fail5",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1 * 2)
-        self.assertEqual(summary["failed"], 9 * 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 18 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ContainerSecurityContext.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ContainerSecurityContext.py
@@ -20,18 +20,22 @@ class TestContainerSecurityContext(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod_v1.fail",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1 * 2)
-        self.assertEqual(summary["failed"], 1 * 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

This PR includes pods defined via `kubernetes_deployment` in pod checks . PR 1 of 4.

Fixes #3690

## New/Edited policies (Delete if not relevant)
* CKV_K8S_20
   Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_25
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_39
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_11
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_10
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_30
  Add resource: kubernetes_deployment, kubernetes_deployment_v1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
