### PR TITLE
fix(helm): undo file_abs_path manipulation for helm files

### DIFF
--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -336,7 +336,6 @@ class Runner(BaseRunner):
 def fix_report_paths(report: Report, tmp_dir: str) -> None:
     for check in itertools.chain(report.failed_checks, report.passed_checks):
         check.repo_file_path = check.repo_file_path.replace(tmp_dir, '', 1)
-        check.file_abs_path = check.file_abs_path.replace(tmp_dir, '', 1)
     report.resources = {r.replace(tmp_dir, '', 1) for r in report.resources}
 
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Helm files in checkov report are missing root dir prefix, which is causing issues in producing BOM report

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
