### PR TITLE
fix(terraform): Add or condition for TLS 1.3 policy, supporting CKV_AWS_103

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/AppLoadBalancerTLS12.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/AppLoadBalancerTLS12.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: "CKV_AWS_103"
-  name: "Ensure that load balancer is using TLS 1.2"
+  name: "Ensure that load balancer is using at least TLS 1.2"
   category: "NETWORKING"
 definition:
   or:
@@ -39,6 +39,13 @@ definition:
               attribute: "ssl_policy"
               operator: "starting_with"
               value: "ELBSecurityPolicy-TLS-1-2"
+            - cond_type: "attribute"
+              resource_types:
+                - "aws_lb_listener"
+                - "aws_alb_listener"
+              attribute: "ssl_policy"
+              operator: "starting_with"
+              value: "ELBSecurityPolicy-TLS13"
     - and:
         - cond_type: "attribute"
           resource_types:

--- a/tests/terraform/graph/checks/resources/AppLoadBalancerTLS12/expected.yaml
+++ b/tests/terraform/graph/checks/resources/AppLoadBalancerTLS12/expected.yaml
@@ -3,6 +3,7 @@ pass:
   - "aws_lb_listener.tcp"
   - "aws_lb_listener.udp"
   - "aws_lb_listener.tcp_udp"
+  - "aws_lb_listener.tls_1_3"
   - "aws_lb_listener.tls_fs_1_2"
   - "aws_lb_listener.https_fs_1_2"
   - "aws_alb_listener.https_fs_1_2"

--- a/tests/terraform/graph/checks/resources/AppLoadBalancerTLS12/main.tf
+++ b/tests/terraform/graph/checks/resources/AppLoadBalancerTLS12/main.tf
@@ -49,6 +49,19 @@ resource "aws_lb_listener" "tcp_udp" {
   }
 }
 
+resource "aws_lb_listener" "tls_1_3" {
+  load_balancer_arn = var.aws_lb_arn
+  protocol          = "TLS"
+  port              = "8080"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = var.aws_lb_target_group_arn
+  }
+}
+
 resource "aws_lb_listener" "tls_fs_1_2" {
   load_balancer_arn = var.aws_lb_arn
   protocol          = "TLS"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

This adds a condition to check that listener policies for the TLS 1.3 policy announced [here](https://aws.amazon.com/about-aws/whats-new/2021/10/aws-network-load-balancer-supports-tls-1-3/) are indeed "at least" TLS 1.2.

Fixes #3570

## New/Edited policies

*CKV_AWS_103* is edited to confirm that policy `ELBSecurityPolicy-TLS13-1-2-2021-06` is at least TLS 1.2.

## Checklist:

- [✓] My code follows the style guidelines of this project
- [✓] I have performed a self-review of my own code
- [✓] I have commented my code, particularly in hard-to-understand areas
- [✓] I have made corresponding changes to the documentation
- [✓] I have added tests that prove my feature, policy, or fix is effective and works
- [✓] New and existing tests pass locally with my changes
- [✓] Any dependent changes have been merged and published in downstream modules
