### PR TITLE
fix(general): Custom Policies integration must run before Suppresion integration

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -24,7 +24,7 @@ CFN_RESOURCE_TYPE_IDENTIFIER = re.compile(r"^[a-zA-Z0-9]+::[a-zA-Z0-9]+::[a-zA-Z
 
 class CustomPoliciesIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
-        super().__init__(bc_integration=bc_integration, order=2)  # must be after policy metadata
+        super().__init__(bc_integration=bc_integration, order=1)  # must be after policy metadata and before suppression integration
         self.platform_policy_parser = NXGraphCheckParser()
         self.policies_url = f"{self.bc_integration.api_url}/api/v1/policies/table/data"
         self.bc_cloned_checks: dict[str, list[dict[str, Any]]] = defaultdict(list)

--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -24,7 +24,7 @@ CFN_RESOURCE_TYPE_IDENTIFIER = re.compile(r"^[a-zA-Z0-9]+::[a-zA-Z0-9]+::[a-zA-Z
 
 class CustomPoliciesIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
-        super().__init__(bc_integration=bc_integration, order=1)  # must be after policy metadata
+        super().__init__(bc_integration=bc_integration, order=2)  # must be after policy metadata
         self.platform_policy_parser = NXGraphCheckParser()
         self.policies_url = f"{self.bc_integration.api_url}/api/v1/policies/table/data"
         self.bc_cloned_checks: dict[str, list[dict[str, Any]]] = defaultdict(list)

--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -100,6 +100,10 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
         bc_check_ids = [record.bc_check_id for record in records]
         for idx, bc_check_id in enumerate(bc_check_ids):
             cloned_policies = self.bc_cloned_checks.get(bc_check_id, [])  # type:ignore[arg-type]  # bc_check_id can be None
+            logging.debug('Cloned policies to be deep copied:')
+            logging.debug(cloned_policies)
+            logging.debug('From origin policy:')
+            logging.debug(records[idx].get_unique_string())
             for cloned_policy in cloned_policies:
                 new_record = deepcopy(records[idx])
                 new_record.check_id = cloned_policy['id']

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -86,11 +86,11 @@ class SuppressionsIntegration(BaseIntegrationFeature):
 
             applied_suppression = self._check_suppressions(check, relevant_suppressions) if relevant_suppressions else None
             if applied_suppression:
-                logging.debug('Applying suppresion to the following check:')
-                logging.debug(check.check_id)
+                suppress_comment = applied_suppression['comment']
+                logging.debug(f'Applying suppression to the check {check.check_id} with the comment: {suppress_comment}')
                 check.check_result = {
                     'result': CheckResult.SKIPPED,
-                    'suppress_comment': applied_suppression['comment']
+                    'suppress_comment': suppress_comment
                 }
                 scan_report.skipped_checks.append(check)
             elif check.check_result['result'] == CheckResult.FAILED:

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -60,6 +60,8 @@ class SuppressionsIntegration(BaseIntegrationFeature):
             self.suppressions = {policy_id: list(sup) for policy_id, sup in
                                  groupby(suppressions, key=lambda s: s['checkovPolicyId'])}
             logging.debug(f'Found {len(self.suppressions)} valid suppressions from the platform.')
+            logging.debug(f'The found suppressions are:')
+            logging.debug(self.suppressions)
         except Exception:
             self.integration_feature_failures = True
             logging.debug("Scanning without applying suppressions configured in the platform.", exc_info=True)
@@ -84,6 +86,8 @@ class SuppressionsIntegration(BaseIntegrationFeature):
 
             applied_suppression = self._check_suppressions(check, relevant_suppressions) if relevant_suppressions else None
             if applied_suppression:
+                logging.debug('Applying suppresion to the following check:')
+                logging.debug(check.check_id)
                 check.check_result = {
                     'result': CheckResult.SKIPPED,
                     'suppress_comment': applied_suppression['comment']

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 class SuppressionsIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
-        super().__init__(bc_integration=bc_integration, order=1)  # must be after the policy metadata
+        super().__init__(bc_integration=bc_integration, order=2)  # must be after the custom policies integration
         self.suppressions: dict[str, list[dict[str, Any]]] = {}
         self.suppressions_url = f"{self.bc_integration.api_url}/api/v1/suppressions"
 

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -60,7 +60,7 @@ class SuppressionsIntegration(BaseIntegrationFeature):
             self.suppressions = {policy_id: list(sup) for policy_id, sup in
                                  groupby(suppressions, key=lambda s: s['checkovPolicyId'])}
             logging.debug(f'Found {len(self.suppressions)} valid suppressions from the platform.')
-            logging.debug(f'The found suppressions are:')
+            logging.debug('The found suppression rules are:')
             logging.debug(self.suppressions)
         except Exception:
             self.integration_feature_failures = True

--- a/checkov/common/bridgecrew/integration_features/integration_feature_registry.py
+++ b/checkov/common/bridgecrew/integration_features/integration_feature_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -12,8 +13,11 @@ class IntegrationFeatureRegistry:
         self.features: list[BaseIntegrationFeature] = []
 
     def register(self, integration_feature: BaseIntegrationFeature) -> None:
+        logging.debug(f"Adding the IntegrationFeatureRegistry {integration_feature} with order {integration_feature.order}")
         self.features.append(integration_feature)
         self.features.sort(key=lambda f: f.order)
+        logging.debug("self.features after the sort:")
+        logging.debug(self.features)
 
     def run_pre_scan(self) -> None:
         for integration in self.features:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
Let's assume we have an OOTB policy with a suppression rule for it, and a clone of it.
If by any chance Suppression integration is loaded into the list before Custom Policies, the OOTB policy will be suppressed, and then the clone would be as well.

Currently the order ID of these 2 integrations is the same, so we rely on the mercy of the `globs` method to load the files in the right order, in the file `checkov/common/bridgecrew/integration_features/features/__init__.py` 
https://stackoverflow.com/questions/6773584/how-are-glob-globs-return-values-ordered
https://stackoverflow.com/a/6774404


[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
