### PR TITLE
feat(terraform): include pods of kubernetes_deployment in kubernetes_pod checks (2/4)

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/DropCapabilities.py
+++ b/checkov/terraform/checks/resource/kubernetes/DropCapabilities.py
@@ -11,7 +11,8 @@ class DropCapabilities(BaseResourceCheck):
         name = "Minimize the admission of containers with the NET_RAW capability"
         id = "CKV_K8S_28"
 
-        supported_resources = ('kubernetes_pod', 'kubernetes_pod_v1')
+        supported_resources = ('kubernetes_pod', 'kubernetes_pod_v1',
+                               'kubernetes_deployment', 'kubernetes_deployment_v1', )
         categories = (CheckCategories.GENERAL_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
@@ -20,6 +21,16 @@ class DropCapabilities(BaseResourceCheck):
             self.evaluated_keys = [""]
             return CheckResult.FAILED
         spec = conf['spec'][0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
         if spec.get("container"):
             containers = spec.get("container")
 
@@ -39,13 +50,13 @@ class DropCapabilities(BaseResourceCheck):
                             if not dropped:
                                 return CheckResult.FAILED
                         else:
-                            self.evaluated_keys = [f"spec/[0]/container/{idx}/security_context/[0]/capabilities"]
+                            self.evaluated_keys = [f"{evaluated_keys_path}/[0]/container/{idx}/security_context/[0]/capabilities"]
                             return CheckResult.FAILED
                     else:
-                        self.evaluated_keys = [f"spec/[0]/container/{idx}/security_context"]
+                        self.evaluated_keys = [f"{evaluated_keys_path}/[0]/container/{idx}/security_context"]
                         return CheckResult.FAILED
                 else:
-                    self.evaluated_keys = [f"spec/[0]/container/{idx}"]
+                    self.evaluated_keys = [f"{evaluated_keys_path}/[0]/container/{idx}"]
                     return CheckResult.FAILED
             return CheckResult.PASSED
         return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/kubernetes/HostPort.py
+++ b/checkov/terraform/checks/resource/kubernetes/HostPort.py
@@ -16,7 +16,8 @@ class HostPort(BaseResourceCheck):
                """
         name = "Do not specify hostPort unless absolutely necessary"
         id = "CKV_K8S_26"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
@@ -26,7 +27,18 @@ class HostPort(BaseResourceCheck):
             return CheckResult.FAILED
 
         spec = conf.get('spec')[0]
+        evaluated_keys_path = "spec"
+
         if spec:
+
+            template = spec.get("template")
+            if template and isinstance(template, list):
+                template = template[0]
+                template_spec = template.get("spec")
+                if template_spec and isinstance(template_spec, list):
+                    spec = template_spec[0]
+                    evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
             containers = spec.get("container")
             if containers is None:
                 return CheckResult.UNKNOWN
@@ -36,7 +48,7 @@ class HostPort(BaseResourceCheck):
                 if container.get("port"):
                     for idy, port in enumerate(container["port"]):
                         if "host_port" in port:
-                            self.evaluated_keys = [f"spec/[0]/container/[{idx}]/port/[{idy}]/host_port"]
+                            self.evaluated_keys = [f"{evaluated_keys_path}/[0]/container/[{idx}]/port/[{idy}]/host_port"]
                             return CheckResult.FAILED
                 return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/kubernetes/ImageDigest.py
+++ b/checkov/terraform/checks/resource/kubernetes/ImageDigest.py
@@ -15,13 +15,24 @@ class ImageDigest(BaseResourceCheck):
          """
         name = "Image should use digest"
         id = "CKV_K8S_43"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf.get('spec')[0]
         if spec:
+            evaluated_keys_path = "spec"
+
+            template = spec.get("template")
+            if template and isinstance(template, list):
+                template = template[0]
+                template_spec = template.get("spec")
+                if template_spec and isinstance(template_spec, list):
+                    spec = template_spec[0]
+                    evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
             containers = spec.get("container")
             if containers is None:
                 return CheckResult.UNKNOWN
@@ -31,7 +42,7 @@ class ImageDigest(BaseResourceCheck):
                 if container.get("image") and isinstance(container.get("image"), list):
                     name = container.get("image")[0]
                     if "@" not in name:
-                        self.evaluated_keys = [f'spec/[0]/container/[{idx}]/image']
+                        self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/image']
                         return CheckResult.FAILED
             return CheckResult.PASSED
         return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/kubernetes/ImagePullPolicyAlways.py
+++ b/checkov/terraform/checks/resource/kubernetes/ImagePullPolicyAlways.py
@@ -14,13 +14,24 @@ class ImagePullPolicyAlways(BaseResourceCheck):
         """
         name = "Image Pull Policy should be Always"
         id = "CKV_K8S_15"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf.get('spec', [None])[0]
         if isinstance(spec, dict) and spec:
+            evaluated_keys_path = "spec"
+
+            template = spec.get("template")
+            if template and isinstance(template, list):
+                template = template[0]
+                template_spec = template.get("spec")
+                if template_spec and isinstance(template_spec, list):
+                    spec = template_spec[0]
+                    evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
             containers = spec.get("container")
             if containers is None:
                 return CheckResult.UNKNOWN
@@ -36,7 +47,7 @@ class ImagePullPolicyAlways(BaseResourceCheck):
                         name = container.get("image")[0]
                         if "latest" in name:
                             break
-                self.evaluated_keys = [f'spec/[0]/container/[{idx}]']
+                self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]']
                 return CheckResult.FAILED
             return CheckResult.PASSED
         return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/kubernetes/ImageTagFixed.py
+++ b/checkov/terraform/checks/resource/kubernetes/ImageTagFixed.py
@@ -12,32 +12,44 @@ class ImageTagFixed(BaseResourceCheck):
          """
         name = "Image Tag should be fixed - not latest or blank"
         id = "CKV_K8S_14"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf.get('spec', [None])[0]
-        if isinstance(spec, dict) and spec.get("container"):
-            containers = spec.get("container")
-            for idx, container in enumerate(containers):
-                if not isinstance(container, dict):
-                    return CheckResult.UNKNOWN
-                if container.get("image"):
-                    name = container.get("image")[0]
-                    if ":" in name:
-                        if name.split(":")[1] in ("latest", ""):
-                            self.evaluated_keys = [f'spec/[0]/container/[{idx}]/image']
-                            return CheckResult.FAILED
-                        continue
-                    if "@" in name:
-                        continue
-                    self.evaluated_keys = [f'spec/[0]/container/[{idx}]/image']
+        if isinstance(spec, dict) and spec:
+            evaluated_keys_path = "spec"
+
+            template = spec.get("template")
+            if template and isinstance(template, list):
+                template = template[0]
+                template_spec = template.get("spec")
+                if template_spec and isinstance(template_spec, list):
+                    spec = template_spec[0]
+                    evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
+            if spec.get("container"):
+                containers = spec.get("container")
+                for idx, container in enumerate(containers):
+                    if not isinstance(container, dict):
+                        return CheckResult.UNKNOWN
+                    if container.get("image"):
+                        name = container.get("image")[0]
+                        if ":" in name:
+                            if name.split(":")[1] in ("latest", ""):
+                                self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/image']
+                                return CheckResult.FAILED
+                            continue
+                        if "@" in name:
+                            continue
+                        self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/image']
+                        return CheckResult.FAILED
+                    self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]']
                     return CheckResult.FAILED
-                self.evaluated_keys = [f'spec/[0]/container/[{idx}]']
-                return CheckResult.FAILED
-            return CheckResult.PASSED
-        return CheckResult.FAILED
+                return CheckResult.PASSED
+            return CheckResult.FAILED
 
 
 check = ImageTagFixed()

--- a/checkov/terraform/checks/resource/kubernetes/LivenessProbe.py
+++ b/checkov/terraform/checks/resource/kubernetes/LivenessProbe.py
@@ -9,7 +9,8 @@ class LivenessProbe(BaseResourceValueCheck):
     def __init__(self):
         name = "Liveness Probe Should be Configured"
         id = "CKV_K8S_8"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
                          missing_block_result=CheckResult.FAILED)
@@ -19,7 +20,18 @@ class LivenessProbe(BaseResourceValueCheck):
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf.get('spec', [None])[0]
-        if spec and isinstance(spec, dict):
+
+        if isinstance(spec, dict) and spec:
+            evaluated_keys_path = "spec"
+
+            template = spec.get("template")
+            if template and isinstance(template, list):
+                template = template[0]
+                template_spec = template.get("spec")
+                if template_spec and isinstance(template_spec, list):
+                    spec = template_spec[0]
+                    evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
             containers = spec.get("container")
             if containers is None:
                 return CheckResult.UNKNOWN
@@ -28,7 +40,7 @@ class LivenessProbe(BaseResourceValueCheck):
                     return CheckResult.UNKNOWN
                 if container.get("liveness_probe"):
                     return CheckResult.PASSED
-                self.evaluated_keys = [f'spec/[0]/container/[{idx}]']
+                self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]']
                 return CheckResult.FAILED
 
         return CheckResult.FAILED

--- a/tests/terraform/checks/resource/kubernetes/example_DropCapabilities/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_DropCapabilities/main.tf
@@ -12,6 +12,26 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+# fails no spec
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+# fails no spec
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
 #no capabilities
 resource "kubernetes_pod" "fail4" {
   metadata {
@@ -132,6 +152,169 @@ resource "kubernetes_pod_v1" "fail4" {
   }
 }
 
+#no capabilities
+resource "kubernetes_deployment" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          security_context {
+
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#no capabilities
+resource "kubernetes_deployment_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          security_context {
+
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
 #no context
 resource "kubernetes_pod" "fail5" {
   metadata {
@@ -241,6 +424,159 @@ resource "kubernetes_pod_v1" "fail5" {
     dns_policy = "None"
   }
 }
+
+#no context
+resource "kubernetes_deployment" "fail5" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#no context
+resource "kubernetes_deployment_v1" "fail5" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 #doesnt drop any or net_raw
 resource "kubernetes_pod" "fail2" {
@@ -434,6 +770,239 @@ resource "kubernetes_pod_v1" "fail2" {
   }
 }
 
+#doesnt drop any or net_raw
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          security_context {
+            capabilities {
+              add = ["NET_BIND_SERVICE"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example2"
+
+          security_context {
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          security_context {
+            capabilities {
+              add = ["NET_BIND_SERVICE"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example2"
+
+          security_context {
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 #wrong drop
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -557,6 +1126,239 @@ resource "kubernetes_pod_v1" "fail3" {
   }
 }
 
+#wrong drop
+resource "kubernetes_deployment" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          security_context {
+            capabilities {
+              add = ["NET_BIND_SERVICE"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example2"
+
+          security_context {
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#wrong drop
+resource "kubernetes_deployment_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          security_context {
+            capabilities {
+              add = ["NET_BIND_SERVICE"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example2"
+
+          security_context {
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
 
 resource "kubernetes_pod" "pass" {
   metadata {
@@ -653,7 +1455,6 @@ resource "kubernetes_pod" "pass" {
   }
 }
 
-
 resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
@@ -746,5 +1547,237 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          security_context {
+            capabilities {
+              drop = ["NET_BIND_SERVICE", "ALL"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example2"
+
+          security_context {
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          security_context {
+            capabilities {
+              drop = ["NET_BIND_SERVICE", "ALL"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example2"
+
+          security_context {
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_HostPort/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_HostPort/main.tf
@@ -12,6 +12,26 @@ resource "kubernetes_pod_v1" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+# fails no spec
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail" {
   metadata {
@@ -97,6 +117,135 @@ resource "kubernetes_pod_v1" "fail" {
     }
 
     dns_policy = "None"
+  }
+}
+
+# fails no resource
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+            host_port      = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+            host_port      = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -197,5 +346,147 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              cpu = "500m"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              cpu = "500m"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_ImageDigest/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ImageDigest/main.tf
@@ -186,6 +186,234 @@ resource "kubernetes_pod_v1" "unknown" {
   }
 }
 
+#not set
+resource "kubernetes_deployment" "unknown" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#not set
+resource "kubernetes_deployment_v1" "unknown" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 #not set modern
 resource "kubernetes_pod" "fail" {
   metadata {
@@ -274,6 +502,230 @@ resource "kubernetes_pod" "fail" {
     }
 
     dns_policy = "None"
+  }
+}
+
+#not set modern
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx"
+          name  = "example22"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#not set modern
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx"
+          name  = "example22"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -477,4 +929,152 @@ resource "kubernetes_pod_v1" "pass" {
   }
 }
 
+#digest
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
 
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#digest
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_ImagePullPolicyAlways/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ImagePullPolicyAlways/main.tf
@@ -186,6 +186,238 @@ resource "kubernetes_pod_v1" "unknown" {
   }
 }
 
+#not set
+resource "kubernetes_deployment" "unknown" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ,
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+
+    }
+  }
+}
+
+#not set
+resource "kubernetes_deployment_v1" "unknown" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ,
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+
+    }
+  }
+}
+
 #not set modern
 resource "kubernetes_pod" "fail" {
   metadata {
@@ -241,6 +473,164 @@ resource "kubernetes_pod" "fail" {
     }
 
     dns_policy = "None"
+  }
+}
+
+#not set modern
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx"
+          name  = "example22"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#not set modern
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx"
+          name  = "example22"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -417,6 +807,163 @@ resource "kubernetes_pod_v1" "fail2" {
     dns_policy = "None"
   }
 }
+#latest but specified wrong
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image             = "nginx:latest"
+          image_pull_policy = "Never"
+          name              = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#latest but specified wrong
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image             = "nginx:latest"
+          image_pull_policy = "Never"
+          name              = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
 
 #latest so pass
 resource "kubernetes_pod" "pass" {
@@ -472,6 +1019,162 @@ resource "kubernetes_pod" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+#latest so pass
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:latest"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#latest so pass
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:latest"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -647,5 +1350,165 @@ resource "kubernetes_pod_v1" "pass2" {
     }
 
     dns_policy = "None"
+  }
+}
+
+#happy path
+resource "kubernetes_deployment" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image             = "nginx:1.7.9"
+          image_pull_policy = "Always"
+          name              = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#happy path
+resource "kubernetes_deployment_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image             = "nginx:1.7.9"
+          image_pull_policy = "Always"
+          name              = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_ImageTagFixed/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ImageTagFixed/main.tf
@@ -186,6 +186,234 @@ resource "kubernetes_pod_v1" "unknown" {
   }
 }
 
+#not set
+resource "kubernetes_deployment" "unknown" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#not set
+resource "kubernetes_deployment_v1" "unknown" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 #not set modern
 resource "kubernetes_pod" "fail" {
   metadata {
@@ -368,6 +596,230 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+#not set modern
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx"
+          name  = "example22"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#not set modern
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx"
+          name  = "example22"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 #latest
 resource "kubernetes_pod" "fail2" {
   metadata {
@@ -545,6 +997,228 @@ resource "kubernetes_pod_v1" "fail2" {
     }
 
     dns_policy = "None"
+  }
+}
+
+#latest
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:latest"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#latest
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:latest"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -730,6 +1404,231 @@ resource "kubernetes_pod_v1" "pass" {
   }
 }
 
+#regular
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#regular
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
 #digest
 resource "kubernetes_pod" "pass2" {
   metadata {
@@ -901,5 +1800,221 @@ resource "kubernetes_pod_v1" "pass2" {
     }
 
     dns_policy = "None"
+  }
+}
+
+#digest
+resource "kubernetes_deployment" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#digest
+resource "kubernetes_deployment_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_LivenessProbe/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_LivenessProbe/main.tf
@@ -104,6 +104,154 @@ resource "kubernetes_pod_v1" "pass" {
   }
 }
 
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 resource "kubernetes_pod" "fail" {
   metadata {
     name = "terraform-example"
@@ -179,5 +327,126 @@ resource "kubernetes_pod_v1" "fail" {
     }
 
     dns_policy = "None"
+  }
+}
+
+
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_LivenessProbe/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_LivenessProbe/main3.tf
@@ -40,3 +40,42 @@ resource "kubernetes_pod_v1" "examplePod" {
   }
 }
 
+
+resource "kubernetes_deployment" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/tests/terraform/checks/resource/kubernetes/test_DropCapabilities.py
+++ b/tests/terraform/checks/resource/kubernetes/test_DropCapabilities.py
@@ -20,6 +20,8 @@ class TestDropCapabilities(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
@@ -33,13 +35,23 @@ class TestDropCapabilities(unittest.TestCase):
             "kubernetes_pod_v1.fail3",
             "kubernetes_pod_v1.fail4",
             "kubernetes_pod_v1.fail5",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment.fail3",
+            "kubernetes_deployment.fail4",
+            "kubernetes_deployment.fail5",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
+            "kubernetes_deployment_v1.fail3",
+            "kubernetes_deployment_v1.fail4",
+            "kubernetes_deployment_v1.fail5",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1 * 2)
-        self.assertEqual(summary["failed"], 5 * 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 10 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_HostPort.py
+++ b/tests/terraform/checks/resource/kubernetes/test_HostPort.py
@@ -20,6 +20,8 @@ class TestHostPort(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
@@ -27,13 +29,17 @@ class TestHostPort(unittest.TestCase):
             "kubernetes_pod.fail2",
             "kubernetes_pod_v1.fail",
             "kubernetes_pod_v1.fail2",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1 * 2)
-        self.assertEqual(summary["failed"], 2 * 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 4 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ImageDigest.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ImageDigest.py
@@ -20,18 +20,22 @@ class TestImageDigest(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod_v1.fail",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1 * 2)
-        self.assertEqual(summary["failed"], 1 * 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ImagePullPolicyAlways.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ImagePullPolicyAlways.py
@@ -22,6 +22,10 @@ class TestImagePullPolicyAlways(unittest.TestCase):
             "kubernetes_pod.pass2",
             "kubernetes_pod_v1.pass",
             "kubernetes_pod_v1.pass2",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment.pass2",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_deployment_v1.pass2",
         }
 
         failing_resources = {
@@ -29,13 +33,17 @@ class TestImagePullPolicyAlways(unittest.TestCase):
             "kubernetes_pod.fail2",
             "kubernetes_pod_v1.fail",
             "kubernetes_pod_v1.fail2",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2 * 2)
-        self.assertEqual(summary["failed"], 2 * 2)
+        self.assertEqual(summary["passed"], 4 * 2)
+        self.assertEqual(summary["failed"], 4 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ImageTagFixed.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ImageTagFixed.py
@@ -22,6 +22,10 @@ class TestImageTagFixed(unittest.TestCase):
             "kubernetes_pod.pass2",
             "kubernetes_pod_v1.pass",
             "kubernetes_pod_v1.pass2",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment.pass2",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_deployment_v1.pass2",
         }
 
         failing_resources = {
@@ -29,13 +33,17 @@ class TestImageTagFixed(unittest.TestCase):
             "kubernetes_pod.fail2",
             "kubernetes_pod_v1.fail",
             "kubernetes_pod_v1.fail2",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2 * 2)
-        self.assertEqual(summary["failed"], 2 * 2)
+        self.assertEqual(summary["passed"], 4 * 2)
+        self.assertEqual(summary["failed"], 4 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_LivenessProbe.py
+++ b/tests/terraform/checks/resource/kubernetes/test_LivenessProbe.py
@@ -20,18 +20,22 @@ class TestLivenessProbe(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod_v1.fail",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1 * 2)
-        self.assertEqual(summary["failed"], 1 * 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

This PR includes pods defined via `kubernetes_deployment` in pod checks . PR 2 of 4.

Fixes #3690

## New/Edited policies (Delete if not relevant)
* CKV_K8S_28
   Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_26
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_43
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_15
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_14
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_8
  Add resource: kubernetes_deployment, kubernetes_deployment_v1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules