### PR TITLE
feat(terraform): include pods of kubernetes_deployment in kubernetes_pod checks (3/4)

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/MemoryLimits.py
+++ b/checkov/terraform/checks/resource/kubernetes/MemoryLimits.py
@@ -6,7 +6,8 @@ class MemoryLimits(BaseResourceCheck):
     def __init__(self):
         name = "Memory Limits should be set"
         id = "CKV_K8S_12"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
@@ -15,6 +16,15 @@ class MemoryLimits(BaseResourceCheck):
             self.evaluated_keys = [""]
             return CheckResult.FAILED
         spec = conf['spec'][0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
 
         containers = spec.get("container")
         if containers is None:
@@ -28,11 +38,11 @@ class MemoryLimits(BaseResourceCheck):
                     limits = resources.get('limits')[0]
                     if isinstance(limits, dict) and limits.get('memory'):
                         return CheckResult.PASSED
-                    self.evaluated_keys = [f'spec/[0]/container/[{idx}]/resources/[0]/limits']
+                    self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/resources/[0]/limits']
                     return CheckResult.FAILED
-                self.evaluated_keys = [f'spec/[0]/container/[{idx}]/resources']
+                self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/resources']
                 return CheckResult.FAILED
-            self.evaluated_keys = [f'spec/[0]/container/[{idx}]']
+            self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]']
             return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/kubernetes/MinimiseCapabilities.py
+++ b/checkov/terraform/checks/resource/kubernetes/MinimiseCapabilities.py
@@ -9,12 +9,23 @@ class MinimiseCapabilities(BaseResourceCheck):
         name = "Minimise the admission of containers with capabilities assigned"
         id = "CKV_K8S_37"
 
-        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
+        supported_resources = ['kubernetes_pod', "kubernetes_pod_v1",
+                               'kubernetes_deployment', 'kubernetes_deployment_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf.get('spec', [None])[0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
         if isinstance(spec, dict) and spec.get("container"):
             containers = spec.get("container")
 
@@ -28,11 +39,11 @@ class MinimiseCapabilities(BaseResourceCheck):
                         if capabilities.get("drop") and isinstance(capabilities.get("drop"), list):
                             drop = capabilities.get("drop")[0]
                             if not any(item in ("ALL", "all") for item in drop):
-                                self.evaluated_keys = [f'spec/[0]/container/[{idx}]/'
+                                self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/'
                                                        f'security_context/[0]/capabilities/drop']
                                 return CheckResult.FAILED
                         else:
-                            self.evaluated_keys = [f'spec/[0]/container/[{idx}]/'
+                            self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/'
                                                    f'security_context/[0]/capabilities']
                             return CheckResult.FAILED
         return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/kubernetes/PrivilegedContainer.py
+++ b/checkov/terraform/checks/resource/kubernetes/PrivilegedContainer.py
@@ -10,12 +10,23 @@ class PrivilegedContainers(BaseResourceCheck):
         name = "Do not admit privileged containers"
         id = "CKV_K8S_16"
 
-        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
+        supported_resources = ['kubernetes_pod', "kubernetes_pod_v1",
+                               'kubernetes_deployment', 'kubernetes_deployment_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf['spec'][0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
         if spec.get("container"):
             containers = spec.get("container")
 
@@ -25,7 +36,7 @@ class PrivilegedContainers(BaseResourceCheck):
                 if container.get("security_context"):
                     context = container.get("security_context")[0]
                     if context.get("privileged") == [True]:
-                        self.evaluated_keys = [f'spec/[0]/container/[{idx}]/security_context/[0]/privileged']
+                        self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/security_context/[0]/privileged']
                         return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/kubernetes/ReadinessProbe.py
+++ b/checkov/terraform/checks/resource/kubernetes/ReadinessProbe.py
@@ -9,16 +9,29 @@ class ReadinessProbe(BaseResourceValueCheck):
     def __init__(self):
         name = "Readiness Probe Should be Configured"
         id = "CKV_K8S_9"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
                          missing_block_result=CheckResult.FAILED)
 
     def get_inspected_key(self) -> str:
+        if "kubernetes_deployment" == self.entity_type or "kubernetes_deployment_v1" == self.entity_type:
+            return "spec/[0]/template/[0]/spec/[0]/container/[0]/readiness_probe/[0]"
         return "spec/[0]/container/[0]/readiness_probe/[0]"
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf.get('spec', [None])[0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
         if isinstance(spec, dict) and spec:
             containers = spec.get("container")
             if containers is None:
@@ -28,7 +41,7 @@ class ReadinessProbe(BaseResourceValueCheck):
                     return CheckResult.UNKNOWN
                 if container.get("readiness_probe"):
                     return CheckResult.PASSED
-                self.evaluated_keys = [f'spec/[0]/container/[{idx}]']
+                self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]']
                 return CheckResult.FAILED
 
         return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/kubernetes/ReadonlyRootFilesystem.py
+++ b/checkov/terraform/checks/resource/kubernetes/ReadonlyRootFilesystem.py
@@ -8,12 +8,21 @@ class ReadonlyRootFilesystem(BaseResourceCheck):
         name = "Use read-only filesystem for containers where possible"
         id = "CKV_K8S_22"
 
-        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
+        supported_resources = ['kubernetes_pod', "kubernetes_pod_v1",
+                               'kubernetes_deployment', 'kubernetes_deployment_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
         spec = conf.get('spec', [None])[0]
+        evaluated_keys_path = "spec"
+
+        if spec.get("template") and isinstance(spec.get("template"), list):
+            template = spec.get("template")[0]
+            if template.get("spec") and isinstance(template.get("spec"), list):
+                spec = template.get("spec")[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
         if isinstance(spec, dict) and spec.get("container"):
             containers = spec.get("container")
 
@@ -23,7 +32,7 @@ class ReadonlyRootFilesystem(BaseResourceCheck):
                 if container.get("security_context"):
                     context = container.get("security_context")[0]
                     if context.get("read_only_root_filesystem") != [True]:
-                        self.evaluated_keys = [f'spec/[0]/container/[{idx}]/security_context/[0]/read_only_root_filesystem']
+                        self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/security_context/[0]/read_only_root_filesystem']
                         return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/tests/terraform/checks/resource/kubernetes/example_HostPort/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_HostPort/main3.tf
@@ -39,3 +39,79 @@ resource "kubernetes_pod_v1" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_deployment" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_ImageDigest/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ImageDigest/main3.tf
@@ -40,3 +40,81 @@ resource "kubernetes_pod_v1" "examplePod" {
   }
 }
 
+
+resource "kubernetes_deployment" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_ImagePullPolicyAlways/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ImagePullPolicyAlways/main3.tf
@@ -39,3 +39,81 @@ resource "kubernetes_pod_v1" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_deployment" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main.tf
@@ -12,6 +12,27 @@ resource "kubernetes_pod_v1" "fail2" {
   }
 }
 
+
+# fails no spec
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+# fails no spec
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -95,6 +116,134 @@ resource "kubernetes_pod_v1" "fail3" {
     }
 
     dns_policy = "None"
+  }
+}
+
+# fails no resource
+resource "kubernetes_deployment" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no resource
+resource "kubernetes_deployment_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -192,6 +341,143 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+# fails no limits
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no limits
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
 # fails no cpu limit
 resource "kubernetes_pod" "fail4" {
   metadata {
@@ -238,6 +524,146 @@ resource "kubernetes_pod" "fail4" {
     }
 
     dns_policy = "None"
+  }
+}
+
+# fails no cpu limit
+resource "kubernetes_deployment" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              cpu = "500m"
+            }
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no cpu limit
+resource "kubernetes_deployment_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              cpu = "500m"
+            }
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -387,5 +813,147 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              memory = "1Gi"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              memory = "1Gi"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main2.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main2.tf
@@ -12,6 +12,26 @@ resource "kubernetes_pod_v1" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+# fails no spec
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -98,6 +118,135 @@ resource "kubernetes_pod_v1" "fail3" {
   }
 }
 
+# fails no resource
+resource "kubernetes_deployment" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no resource
+resource "kubernetes_deployment_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
 # fails no limits
 resource "kubernetes_pod" "fail" {
   metadata {
@@ -144,6 +293,143 @@ resource "kubernetes_pod" "fail" {
     dns_policy = "None"
   }
 }
+
+# fails no limits
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no limits
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 # fails no limits
 resource "kubernetes_pod_v1" "fail" {
@@ -285,6 +571,142 @@ resource "kubernetes_pod_v1" "fail4" {
     dns_policy = "None"
   }
 }
+# fails no cpu limit
+resource "kubernetes_deployment" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = "x"
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no cpu limit
+resource "kubernetes_deployment_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = "x"
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 resource "kubernetes_pod" "pass" {
   metadata {
@@ -383,5 +805,147 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              memory = "1Gi"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            limits = {
+              memory = "1Gi"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryLimits/main3.tf
@@ -39,3 +39,79 @@ resource "kubernetes_pod_v1" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_deployment" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main.tf
@@ -12,6 +12,26 @@ resource "kubernetes_pod_v1" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name   = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+# fails no spec
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name   = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -95,6 +115,134 @@ resource "kubernetes_pod_v1" "fail3" {
     }
 
     dns_policy = "None"
+  }
+}
+
+# fails no resource
+resource "kubernetes_deployment" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no resource
+resource "kubernetes_deployment_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -192,6 +340,142 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+# fails no requests
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no requests
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 # fails no memory requests
 resource "kubernetes_pod" "fail4" {
   metadata {
@@ -238,6 +522,146 @@ resource "kubernetes_pod" "fail4" {
     }
 
     dns_policy = "None"
+  }
+}
+
+# fails no memory requests
+resource "kubernetes_deployment" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              cpu = "500m"
+            }
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no memory requests
+resource "kubernetes_deployment_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              cpu = "500m"
+            }
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -388,5 +812,147 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              memory = "1Gi"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              memory = "1Gi"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main2.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main2.tf
@@ -12,6 +12,27 @@ resource "kubernetes_pod_v1" "fail2" {
   }
 }
 
+# fails no spec
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+# fails no spec
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+}
+
+
 # fails no resource
 resource "kubernetes_pod" "fail3" {
   metadata {
@@ -98,6 +119,134 @@ resource "kubernetes_pod_v1" "fail3" {
   }
 }
 
+# fails no resource
+resource "kubernetes_deployment" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no resource
+resource "kubernetes_deployment_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 # fails no requests
 resource "kubernetes_pod" "fail" {
   metadata {
@@ -142,6 +291,142 @@ resource "kubernetes_pod" "fail" {
     }
 
     dns_policy = "None"
+  }
+}
+
+# fails no requests
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no requests
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -285,6 +570,142 @@ resource "kubernetes_pod_v1" "fail4" {
     dns_policy = "None"
   }
 }
+# fails no memory requests
+resource "kubernetes_deployment" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = "x"
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+# fails no memory requests
+resource "kubernetes_deployment_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = "x"
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 resource "kubernetes_pod" "pass" {
   metadata {
@@ -383,5 +804,147 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              memory = "1Gi"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          resources {
+            requests = {
+              memory = "1Gi"
+            }
+
+          }
+
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MemoryRequests/main3.tf
@@ -40,3 +40,79 @@ resource "kubernetes_pod_v1" "examplePod" {
   }
 }
 
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_MinimiseCapabilities/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_MinimiseCapabilities/main.tf
@@ -171,6 +171,220 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+
+        container {
+          image             = "nginx"
+          image_pull_policy = "Never"
+          name              = "example"
+
+          security_context {
+            privileged                 = true
+            allow_privilege_escalation = true
+            capabilities {
+              add  = ["NET_RAW"]
+              drop = ["NET_BIND_SERVICE"]
+            }
+          }
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+            host_port      = 8080
+          }
+
+          # resources = {
+          #   requests = {
+          #     memory = "50Mi"
+          #   }
+          #   limits ={
+          #     memory = "50Mi"
+          #   }
+          # }
+          # liveness_probe {
+          #   http_get {
+          #     path = "/nginx_status"
+          #     port = 80
+
+          #     http_header {
+          #       name  = "X-Custom-Header"
+          #       value = "Awesome"
+          #     }
+          #   }
+
+          #   initial_delay_seconds = 3
+          #   period_seconds        = 3
+          # }
+        }
+        # readiness_probe {
+        #     failure_threshold = 3
+        #     http_get {
+        #       path = "/health"
+        #       port = "10254"
+        #       scheme = "http"
+        #     }
+        #     period_seconds = 10
+        #     success_threshold = 1
+        #     timeout_seconds = 10
+        #   }
+        # }
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+
+        container {
+          image             = "nginx"
+          image_pull_policy = "Never"
+          name              = "example"
+
+          security_context {
+            privileged                 = true
+            allow_privilege_escalation = true
+            capabilities {
+              add  = ["NET_RAW"]
+              drop = ["NET_BIND_SERVICE"]
+            }
+          }
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+            host_port      = 8080
+          }
+
+          # resources = {
+          #   requests = {
+          #     memory = "50Mi"
+          #   }
+          #   limits ={
+          #     memory = "50Mi"
+          #   }
+          # }
+          # liveness_probe {
+          #   http_get {
+          #     path = "/nginx_status"
+          #     port = 80
+
+          #     http_header {
+          #       name  = "X-Custom-Header"
+          #       value = "Awesome"
+          #     }
+          #   }
+
+          #   initial_delay_seconds = 3
+          #   period_seconds        = 3
+          # }
+        }
+        # readiness_probe {
+        #     failure_threshold = 3
+        #     http_get {
+        #       path = "/health"
+        #       port = "10254"
+        #       scheme = "http"
+        #     }
+        #     period_seconds = 10
+        #     success_threshold = 1
+        #     timeout_seconds = 10
+        #   }
+        # }
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 resource "kubernetes_pod" "fail2" {
   metadata {
     name = "terraform-example"
@@ -338,6 +552,218 @@ resource "kubernetes_pod_v1" "fail2" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+
+        container {
+          image             = "nginx"
+          image_pull_policy = "Never"
+          name              = "example"
+
+          security_context {
+            privileged                 = true
+            allow_privilege_escalation = true
+            capabilities {
+              add = ["NET_RAW"]
+            }
+          }
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+            host_port      = 8080
+          }
+
+          # resources = {
+          #   requests = {
+          #     memory = "50Mi"
+          #   }
+          #   limits ={
+          #     memory = "50Mi"
+          #   }
+          # }
+          # liveness_probe {
+          #   http_get {
+          #     path = "/nginx_status"
+          #     port = 80
+
+          #     http_header {
+          #       name  = "X-Custom-Header"
+          #       value = "Awesome"
+          #     }
+          #   }
+
+          #   initial_delay_seconds = 3
+          #   period_seconds        = 3
+          # }
+        }
+        # readiness_probe {
+        #     failure_threshold = 3
+        #     http_get {
+        #       path = "/health"
+        #       port = "10254"
+        #       scheme = "http"
+        #     }
+        #     period_seconds = 10
+        #     success_threshold = 1
+        #     timeout_seconds = 10
+        #   }
+        # }
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+
+        container {
+          image             = "nginx"
+          image_pull_policy = "Never"
+          name              = "example"
+
+          security_context {
+            privileged                 = true
+            allow_privilege_escalation = true
+            capabilities {
+              add = ["NET_RAW"]
+            }
+          }
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+            host_port      = 8080
+          }
+
+          # resources = {
+          #   requests = {
+          #     memory = "50Mi"
+          #   }
+          #   limits ={
+          #     memory = "50Mi"
+          #   }
+          # }
+          # liveness_probe {
+          #   http_get {
+          #     path = "/nginx_status"
+          #     port = 80
+
+          #     http_header {
+          #       name  = "X-Custom-Header"
+          #       value = "Awesome"
+          #     }
+          #   }
+
+          #   initial_delay_seconds = 3
+          #   period_seconds        = 3
+          # }
+        }
+        # readiness_probe {
+        #     failure_threshold = 3
+        #     http_get {
+        #       path = "/health"
+        #       port = "10254"
+        #       scheme = "http"
+        #     }
+        #     period_seconds = 10
+        #     success_threshold = 1
+        #     timeout_seconds = 10
+        #   }
+        # }
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -510,5 +936,219 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+
+        container {
+          image             = "nginx"
+          image_pull_policy = "Never"
+          name              = "example"
+
+          security_context {
+            privileged                 = true
+            allow_privilege_escalation = true
+            capabilities {
+              add  = ["NET_RAW"]
+              drop = ["ALL"]
+            }
+          }
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+            host_port      = 8080
+          }
+
+          # resources = {
+          #   requests = {
+          #     memory = "50Mi"
+          #   }
+          #   limits ={
+          #     memory = "50Mi"
+          #   }
+          # }
+          # liveness_probe {
+          #   http_get {
+          #     path = "/nginx_status"
+          #     port = 80
+
+          #     http_header {
+          #       name  = "X-Custom-Header"
+          #       value = "Awesome"
+          #     }
+          #   }
+
+          #   initial_delay_seconds = 3
+          #   period_seconds        = 3
+          # }
+        }
+        # readiness_probe {
+        #     failure_threshold = 3
+        #     http_get {
+        #       path = "/health"
+        #       port = "10254"
+        #       scheme = "http"
+        #     }
+        #     period_seconds = 10
+        #     success_threshold = 1
+        #     timeout_seconds = 10
+        #   }
+        # }
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+
+        container {
+          image             = "nginx"
+          image_pull_policy = "Never"
+          name              = "example"
+
+          security_context {
+            privileged                 = true
+            allow_privilege_escalation = true
+            capabilities {
+              add  = ["NET_RAW"]
+              drop = ["ALL"]
+            }
+          }
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+            host_port      = 8080
+          }
+
+          # resources = {
+          #   requests = {
+          #     memory = "50Mi"
+          #   }
+          #   limits ={
+          #     memory = "50Mi"
+          #   }
+          # }
+          # liveness_probe {
+          #   http_get {
+          #     path = "/nginx_status"
+          #     port = 80
+
+          #     http_header {
+          #       name  = "X-Custom-Header"
+          #       value = "Awesome"
+          #     }
+          #   }
+
+          #   initial_delay_seconds = 3
+          #   period_seconds        = 3
+          # }
+        }
+        # readiness_probe {
+        #     failure_threshold = 3
+        #     http_get {
+        #       path = "/health"
+        #       port = "10254"
+        #       scheme = "http"
+        #     }
+        #     period_seconds = 10
+        #     success_threshold = 1
+        #     timeout_seconds = 10
+        #   }
+        # }
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_PrivilegedContainers/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_PrivilegedContainers/main.tf
@@ -92,6 +92,232 @@ resource "kubernetes_pod" "fail_container" {
   }
 }
 
+resource "kubernetes_deployment" "fail_container" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx:1.7.9"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail_container" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx:1.7.9"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 resource "kubernetes_pod_v1" "fail_container" {
   metadata {
@@ -275,6 +501,229 @@ resource "kubernetes_pod" "fail" {
     dns_policy = "None"
   }
 }
+
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 resource "kubernetes_pod_v1" "fail" {
   metadata {
@@ -544,6 +993,227 @@ resource "kubernetes_pod_v1" "fail2" {
   }
 }
 
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
 resource "kubernetes_pod" "pass" {
   metadata {
     name = "terraform-example"
@@ -633,6 +1303,229 @@ resource "kubernetes_pod" "pass" {
     dns_policy = "None"
   }
 }
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 resource "kubernetes_pod_v1" "pass" {
   metadata {
@@ -896,3 +1789,216 @@ resource "kubernetes_pod_v1" "pass2" {
   }
 }
 
+resource "kubernetes_deployment" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/example_ReadinessProbe/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ReadinessProbe/main.tf
@@ -129,6 +129,178 @@ resource "kubernetes_pod_v1" "pass" {
   }
 }
 
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
+          readiness_probe {
+            failure_threshold = 3
+            http_get {
+              path   = "/health"
+              port   = "10254"
+              scheme = "http"
+            }
+            period_seconds    = 10
+            success_threshold = 1
+            timeout_seconds   = 10
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
+          readiness_probe {
+            failure_threshold = 3
+            http_get {
+              path   = "/health"
+              port   = "10254"
+              scheme = "http"
+            }
+            period_seconds    = 10
+            success_threshold = 1
+            timeout_seconds   = 10
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 resource "kubernetes_pod" "fail" {
   metadata {
     name = "terraform-example"
@@ -232,5 +404,153 @@ resource "kubernetes_pod_v1" "fail" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_ReadinessProbe/main3.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ReadinessProbe/main3.tf
@@ -39,3 +39,80 @@ resource "kubernetes_pod_v1" "examplePod" {
     }
   }
 }
+
+resource "kubernetes_deployment" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "examplePod" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        security_context {
+        }
+        selector {
+          match_labels = {
+            test = "MyExampleApp"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/tests/terraform/checks/resource/kubernetes/example_ReadonlyRootFilesystem/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ReadonlyRootFilesystem/main.tf
@@ -185,6 +185,232 @@ resource "kubernetes_pod_v1" "fail_container" {
   }
 }
 
+resource "kubernetes_deployment" "fail_container" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx:1.7.9"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail_container" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container = [
+          {
+            image = "nginx:1.7.9"
+            name  = "example22"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          },
+          {
+            image = "nginx:1.7.9"
+            name  = "example22222"
+
+            security_context = {
+              privileged = true
+            }
+
+            env = {
+              name  = "environment"
+              value = "test"
+            }
+
+            port = {
+              container_port = 8080
+            }
+
+            liveness_probe = {
+              http_get = {
+                path = "/nginx_status"
+                port = 80
+
+                http_header = {
+                  name  = "X-Custom-Header"
+                  value = "Awesome"
+                }
+              }
+
+              initial_delay_seconds = 3
+              period_seconds        = 3
+            }
+          }
+        ]
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 #missing
 resource "kubernetes_pod" "fail" {
   metadata {
@@ -273,6 +499,230 @@ resource "kubernetes_pod" "fail" {
     }
 
     dns_policy = "None"
+  }
+}
+
+#missing
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#missing
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -548,6 +998,231 @@ resource "kubernetes_pod_v1" "fail2" {
   }
 }
 
+#false
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged                = false
+            read_only_root_filesystem = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#false
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged                = false
+            read_only_root_filesystem = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          security_context {
+            privileged = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+
 resource "kubernetes_pod" "pass" {
   metadata {
     name = "terraform-example"
@@ -663,3 +1338,161 @@ resource "kubernetes_pod_v1" "pass" {
     dns_policy = "None"
   }
 }
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged                = false
+            read_only_root_filesystem = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22"
+
+          security_context {
+            privileged                = false
+            read_only_root_filesystem = true
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+

--- a/tests/terraform/checks/resource/kubernetes/test_MemoryLimits.py
+++ b/tests/terraform/checks/resource/kubernetes/test_MemoryLimits.py
@@ -20,6 +20,8 @@ class TestMemoryLimits(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
@@ -31,13 +33,21 @@ class TestMemoryLimits(unittest.TestCase):
             "kubernetes_pod_v1.fail2",
             "kubernetes_pod_v1.fail3",
             "kubernetes_pod_v1.fail4",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment.fail3",
+            "kubernetes_deployment.fail4",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
+            "kubernetes_deployment_v1.fail3",
+            "kubernetes_deployment_v1.fail4",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2 * 2)
-        self.assertEqual(summary["failed"], 8 * 2)
+        self.assertEqual(summary["passed"], 4 * 2)
+        self.assertEqual(summary["failed"], 16 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_MemoryRequests.py
+++ b/tests/terraform/checks/resource/kubernetes/test_MemoryRequests.py
@@ -20,6 +20,8 @@ class TestMemoryRequests(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
@@ -31,13 +33,21 @@ class TestMemoryRequests(unittest.TestCase):
             "kubernetes_pod_v1.fail2",
             "kubernetes_pod_v1.fail3",
             "kubernetes_pod_v1.fail4",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment.fail3",
+            "kubernetes_deployment.fail4",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
+            "kubernetes_deployment_v1.fail3",
+            "kubernetes_deployment_v1.fail4",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2 * 2)
-        self.assertEqual(summary["failed"], 8 * 2)
+        self.assertEqual(summary["passed"], 4 * 2)
+        self.assertEqual(summary["failed"], 16 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_MinimiseCapabilities.py
+++ b/tests/terraform/checks/resource/kubernetes/test_MinimiseCapabilities.py
@@ -20,6 +20,8 @@ class TestMinimiseCapabilities(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
@@ -27,13 +29,17 @@ class TestMinimiseCapabilities(unittest.TestCase):
             "kubernetes_pod.fail2",
             "kubernetes_pod_v1.fail",
             "kubernetes_pod_v1.fail2",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1 * 2)
-        self.assertEqual(summary["failed"], 2 * 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 4 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_PrivilegedContainers.py
+++ b/tests/terraform/checks/resource/kubernetes/test_PrivilegedContainers.py
@@ -22,6 +22,10 @@ class TestPrivilegedContainer(unittest.TestCase):
             "kubernetes_pod.pass2",
             "kubernetes_pod_v1.pass",
             "kubernetes_pod_v1.pass2",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment.pass2",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_deployment_v1.pass2",
         }
 
         failing_resources = {
@@ -29,13 +33,17 @@ class TestPrivilegedContainer(unittest.TestCase):
             "kubernetes_pod.fail2",
             "kubernetes_pod_v1.fail",
             "kubernetes_pod_v1.fail2",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2 * 2)
-        self.assertEqual(summary["failed"], 2 * 2)
+        self.assertEqual(summary["passed"], 4 * 2)
+        self.assertEqual(summary["failed"], 4 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ReadinessProbe.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ReadinessProbe.py
@@ -20,18 +20,22 @@ class TestReadinessProbe(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod_v1.fail",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1 * 2)
-        self.assertEqual(summary["failed"], 1 * 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ReadonlyRootFilesystem.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ReadonlyRootFilesystem.py
@@ -20,6 +20,8 @@ class TestReadonlyRootFilesystem(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
@@ -27,13 +29,17 @@ class TestReadonlyRootFilesystem(unittest.TestCase):
             "kubernetes_pod.fail2",
             "kubernetes_pod_v1.fail",
             "kubernetes_pod_v1.fail2",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1 * 2)
-        self.assertEqual(summary["failed"], 2 * 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 4 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

This PR includes pods defined via `kubernetes_deployment` in pod checks . PR 3 of 4.

Fixes #3690

## New/Edited policies (Delete if not relevant)
* CKV_K8S_12
   Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_13
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_37
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_16
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_9
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_22
  Add resource: kubernetes_deployment, kubernetes_deployment_v1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules