### PR TITLE
fix: Clear details before next check run to avoid duplications in output

### DIFF
--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -163,7 +163,7 @@ class Record:
             detail_buffer = [colored(f"\tDetails: {self.details[0]}\n", "blue")]
 
             for t in self.details[1:]:
-                detail_buffer.append(colored(f"\t\t{t}\n", "blue"))
+                detail_buffer.append(colored(f"\t         {t}\n", "blue"))
 
             detail = "".join(detail_buffer)
 

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -403,9 +403,9 @@ class Runner(ImageReferencerMixin, BaseRunner):
                         severity=check.severity,
                         bc_category=check.bc_category,
                         benchmarks=check.benchmarks,
-                        details=check.details
+                        details=check.details.copy()
                     )
-
+                    check.details.clear()
                     if CHECKOV_CREATE_GRAPH:
                         breadcrumb = self.breadcrumbs.get(record.file_path, {}).get(
                             '.'.join([entity_type, entity_name]))


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

When a check is executed multiple times, details messages added for an execution result were being added in the output of each execution. They were not just showed in the report of the specific execution for a resource.
This PR solves this by copying and clearing the details list after each execution.
It also fixes an indenting issue.

Before:

<img width="789" alt="image" src="https://user-images.githubusercontent.com/75026603/197236828-3d7c0a8a-a33b-4acd-bd94-bcbed3ddcf3d.png">


After: 

<img width="760" alt="image" src="https://user-images.githubusercontent.com/75026603/197236925-46000cad-c41d-41d1-8e4e-629c05c4c56a.png">

Fixes # (issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
