### PR TITLE
docs(general): Update Jenkins page to use Checkov image

### DIFF
--- a/docs/4.Integrations/Jenkins.md
+++ b/docs/4.Integrations/Jenkins.md
@@ -58,7 +58,7 @@ Below is a simple example integration with Jenkins using the Checkov container i
 
    ```groovy
    sh "pipenv run pip install checkov"
-   sh "checkov -d . --use-enforcement-rules -o cli -o junitxml --output-file-path console,results.xml --repo-id example/terragoat --branch master"
+   sh "pipenv run checkov -d . --use-enforcement-rules -o cli -o junitxml --output-file-path console,results.xml --repo-id example/terragoat --branch master"
    ```
 
 

--- a/docs/4.Integrations/Jenkins.md
+++ b/docs/4.Integrations/Jenkins.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 # Integrate Checkov with Jenkins
 
-This simple integration into Jenkins will result in build failures whenever developers create and modify infrastructure as code monitored by Checkov. To prevent developer frustration from failed builds, we recommend training and encouraging usage of Checkov's inline suppressions.
+Below is a simple example integration with Jenkins using the Checkov container image. This will result in build failures whenever developers create and modify infrastructure as code with misconfigurations. To prevent developer frustration from failed builds, we recommend training and encouraging usage of Checkov's inline suppressions.
 
 ## Tutorial
 
@@ -17,44 +17,48 @@ This simple integration into Jenkins will result in build failures whenever deve
 
 2. Add new a stage into the pipeline definition using a `pipeline script`
 
+    ```groovy
+    pipeline {
+        agent any
+        
+        stages {
+            stage('Checkout') {
+                steps {
+                    git branch: 'master', url: 'https://github.com/bridgecrewio/terragoat'
+                    stash includes: '**/*', name: 'terragoat'
+                }
+            }
+            stage('Checkov') {
+                steps {
+                    script {
+                        docker.image('bridgecrew/checkov:latest').inside("--entrypoint=''") {
+                            unstash 'terragoat'
+                            try {
+                                sh 'checkov -d . --use-enforcement-rules -o cli -o junitxml --output-file-path console,results.xml --repo-id example/terragoat --branch master'
+                                junit skipPublishingChecks: true, testResults: 'results.xml'
+                            } catch (err) {
+                                junit skipPublishingChecks: true, testResults: 'results.xml'
+                                throw err
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        options {
+            preserveStashes()
+            timestamps()
+        }
+    }
+    ```
+
+
+
+   Alternatively, add the following script to install and run Checkov without an image:
+
    ```groovy
-   pipeline {
-       agent {
-           docker {
-               image 'kennethreitz/pipenv:latest'
-               args '-u root --privileged -v /var/run/docker.sock:/var/run/docker.sock'
-               label 'agent'
-           }
-       }
-       stages {
-           stage('test') {
-               steps {
-                   checkout([$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github', url: 'git@github.com:bridgecrewio/checkov.git']]])
-                   script {
-                       sh "pipenv install"
-                       sh "pipenv run pip install checkov"
-                       sh "pipenv run checkov --directory tests/terraform/runner/resources/example -o junitxml > result.xml || true"
-                       junit "result.xml"
-                   }
-
-
-               }
-           }
-       }
-       options {
-           preserveStashes()
-           timestamps()
-           ansiColor('xterm')
-       }
-   }
-   ```
-
-
-
-   Modify the directory parameter to enable Checkov on the project terraform directory:
-
-   ```groovy
-   sh "pipenv run checkov --directory $TERRAFORM_MAIN_DIRECTORY_HERE -o junitxml > result.xml || true"
+   sh "pipenv run pip install checkov"
+   sh "checkov -d . --use-enforcement-rules -o cli -o junitxml --output-file-path console,results.xml --repo-id example/terragoat --branch master"
    ```
 
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Updating Jenkins docs page to use the Checkov image instead of the no longer supported pipenv image.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules