### PR TITLE
Inverse the order management of Integration Classes

### DIFF
--- a/checkov/common/bridgecrew/integration_features/base_integration_feature.py
+++ b/checkov/common/bridgecrew/integration_features/base_integration_feature.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+from checkov.common.bridgecrew.integration_features.integration_feature_enum import IntegrationFeature
 from checkov.common.bridgecrew.integration_features.integration_feature_registry import integration_feature_registry
 
 if TYPE_CHECKING:
@@ -11,9 +12,10 @@ if TYPE_CHECKING:
 
 
 class BaseIntegrationFeature(ABC):
-    def __init__(self, bc_integration: BcPlatformIntegration, order: int) -> None:
+
+    def __init__(self, bc_integration: BcPlatformIntegration, integration_name: IntegrationFeature) -> None:
         self.bc_integration = bc_integration
-        self.order = order
+        self.integration_name = integration_name
         integration_feature_registry.register(self)
         self.integration_feature_failures = False
 

--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 from checkov.common.bridgecrew.integration_features.base_integration_feature import BaseIntegrationFeature
+from checkov.common.bridgecrew.integration_features.integration_feature_enum import IntegrationFeature
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.bridgecrew.severities import Severities
 from checkov.common.checks_infra.checks_parser import NXGraphCheckParser
@@ -24,7 +25,7 @@ CFN_RESOURCE_TYPE_IDENTIFIER = re.compile(r"^[a-zA-Z0-9]+::[a-zA-Z0-9]+::[a-zA-Z
 
 class CustomPoliciesIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
-        super().__init__(bc_integration=bc_integration, order=1)  # must be after policy metadata and before suppression integration
+        super().__init__(bc_integration=bc_integration, integration_name=IntegrationFeature.CUSTOM_POLICIES)
         self.platform_policy_parser = NXGraphCheckParser()
         self.policies_url = f"{self.bc_integration.api_url}/api/v1/policies/table/data"
         self.bc_cloned_checks: dict[str, list[dict[str, Any]]] = defaultdict(list)

--- a/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/fixes_integration.py
@@ -7,6 +7,7 @@ from itertools import groupby
 from typing import TYPE_CHECKING, Any
 
 from checkov.common.bridgecrew.integration_features.base_integration_feature import BaseIntegrationFeature
+from checkov.common.bridgecrew.integration_features.integration_feature_enum import IntegrationFeature
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as metadata_integration
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.util.data_structures_utils import merge_dicts
@@ -22,7 +23,7 @@ SUPPORTED_FIX_FRAMEWORKS = ['terraform', 'cloudformation']
 
 class FixesIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
-        super().__init__(bc_integration=bc_integration, order=10)
+        super().__init__(bc_integration=bc_integration, integration_name=IntegrationFeature.FIXES)
         self.fixes_url = f"{self.bc_integration.api_url}/api/v1/fixes/checkov"
 
     def is_valid(self) -> bool:

--- a/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from checkov.common.checks_infra.registry import get_graph_checks_registry
 from checkov.common.bridgecrew.integration_features.base_integration_feature import BaseIntegrationFeature
+from checkov.common.bridgecrew.integration_features.integration_feature_enum import IntegrationFeature
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.bridgecrew.severities import Severities, get_severity
 from checkov.common.checks.base_check_registry import BaseCheckRegistry
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 
 class PolicyMetadataIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
-        super().__init__(bc_integration=bc_integration, order=0)
+        super().__init__(bc_integration=bc_integration, integration_name=IntegrationFeature.POLICY_METADATA)
         self.check_metadata: dict[str, Any] = {}
         self.bc_to_ckv_id_mapping: dict[str, str] = {}
         self.pc_to_ckv_id_mapping: dict[str, str] = {}

--- a/checkov/common/bridgecrew/integration_features/features/repo_config_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/repo_config_integration.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from checkov.common.bridgecrew.code_categories import CodeCategoryConfiguration, CodeCategoryType
 from checkov.common.bridgecrew.integration_features.base_integration_feature import BaseIntegrationFeature
+from checkov.common.bridgecrew.integration_features.integration_feature_enum import IntegrationFeature
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.bridgecrew.severities import Severities, BcSeverities
 
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
 
 class RepoConfigIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
-        super().__init__(bc_integration=bc_integration, order=0)
+        super().__init__(bc_integration=bc_integration, integration_name=IntegrationFeature.REPO_CONFIG)
         self.skip_paths: set[str] = set()
         self.enforcement_rule: dict[str, Any] = {}
         self.code_category_configs: dict[str, CodeCategoryConfiguration] = {}

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Pattern, Any
 from checkov.common.bridgecrew.check_type import CheckType
 
 from checkov.common.bridgecrew.integration_features.base_integration_feature import BaseIntegrationFeature
+from checkov.common.bridgecrew.integration_features.integration_feature_enum import IntegrationFeature
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import \
     integration as metadata_integration
 from checkov.common.bridgecrew.platform_integration import bc_integration
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 
 class SuppressionsIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
-        super().__init__(bc_integration=bc_integration, order=2)  # must be after the custom policies integration
+        super().__init__(bc_integration=bc_integration, integration_name=IntegrationFeature.SUPPRESSIONS)
         self.suppressions: dict[str, list[dict[str, Any]]] = {}
         self.suppressions_url = f"{self.bc_integration.api_url}/api/v1/suppressions"
 

--- a/checkov/common/bridgecrew/integration_features/integration_feature_enum.py
+++ b/checkov/common/bridgecrew/integration_features/integration_feature_enum.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class IntegrationFeature(Enum):
+    CUSTOM_POLICIES = "CUSTOM_POLICIES"
+    FIXES = "FIXES"
+    POLICY_METADATA = "POLICY_METADATA"
+    REPO_CONFIG = "REPO_CONFIG"
+    SUPPRESSIONS = "SUPPRESSIONS"

--- a/checkov/common/bridgecrew/integration_features/integration_feature_registry.py
+++ b/checkov/common/bridgecrew/integration_features/integration_feature_registry.py
@@ -3,19 +3,29 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from checkov.common.bridgecrew.integration_features.integration_feature_enum import IntegrationFeature
+
 if TYPE_CHECKING:
     from checkov.common.bridgecrew.integration_features.base_integration_feature import BaseIntegrationFeature
     from checkov.common.output.report import Report
 
 
 class IntegrationFeatureRegistry:
+    __integrations_order__ = {
+        IntegrationFeature.POLICY_METADATA: 0,
+        IntegrationFeature.REPO_CONFIG: 0,
+        IntegrationFeature.CUSTOM_POLICIES: 1,  # must be after policy metadata and before suppression integration
+        IntegrationFeature.SUPPRESSIONS: 2,  # must be after the custom policies integration
+        IntegrationFeature.FIXES: 10
+    }
+
     def __init__(self) -> None:
         self.features: list[BaseIntegrationFeature] = []
 
     def register(self, integration_feature: BaseIntegrationFeature) -> None:
-        logging.debug(f"Adding the IntegrationFeatureRegistry {integration_feature} with order {integration_feature.order}")
+        logging.debug(f"Adding the IntegrationFeatureRegistry {integration_feature}")
         self.features.append(integration_feature)
-        self.features.sort(key=lambda f: f.order)
+        self.features.sort(key=lambda f: self.__integrations_order__.get(f.integration_name, 20))
         logging.debug("self.features after the sort:")
         logging.debug(self.features)
 


### PR DESCRIPTION
So far the order of the integration classes in the feature registry depends on the order we set in each class. Instead, it will be managed by the registry itself

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
