### PR TITLE
fix(general): skip scanning VCS configuration if only files are passed in

### DIFF
--- a/checkov/bitbucket/runner.py
+++ b/checkov/bitbucket/runner.py
@@ -33,10 +33,13 @@ class Runner(JsonRunner):
 
         self.prepare_data()
 
-        report = super().run(root_folder=self.bitbucket.bitbucket_conf_dir_path, external_checks_dir=external_checks_dir,
-                             files=files,
-                             runner_filter=runner_filter, collect_skip_comments=collect_skip_comments)
-        # JsonRunner._change_files_path_to_relative(report)
+        report = super().run(
+            root_folder=self.bitbucket.bitbucket_conf_dir_path,
+            external_checks_dir=external_checks_dir,
+            files=None,  # ignore file scans
+            runner_filter=runner_filter,
+            collect_skip_comments=collect_skip_comments,
+        )
 
         return report
 

--- a/checkov/github/runner.py
+++ b/checkov/github/runner.py
@@ -33,9 +33,13 @@ class Runner(JsonRunner):
 
         self.prepare_data()
 
-        report = super().run(root_folder=self.github.github_conf_dir_path, external_checks_dir=external_checks_dir,
-                             files=files,
-                             runner_filter=runner_filter, collect_skip_comments=collect_skip_comments)
+        report = super().run(
+            root_folder=self.github.github_conf_dir_path,
+            external_checks_dir=external_checks_dir,
+            files=None,  # ignore file scans
+            runner_filter=runner_filter,
+            collect_skip_comments=collect_skip_comments,
+        )
         JsonRunner._change_files_path_to_relative(report)  # type:ignore[arg-type]  # report can only be of type Report, not a list
         return report
 

--- a/checkov/gitlab/runner.py
+++ b/checkov/gitlab/runner.py
@@ -35,7 +35,7 @@ class Runner(JsonRunner):
         report = super().run(
             root_folder=self.gitlab.gitlab_conf_dir_path,
             external_checks_dir=external_checks_dir,
-            files=files,
+            files=None,  # ignore file scans
             runner_filter=runner_filter,
             collect_skip_comments=collect_skip_comments,
         )

--- a/tests/bitbucket/test_runner.py
+++ b/tests/bitbucket/test_runner.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from checkov.bitbucket.runner import Runner
@@ -69,6 +70,25 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.parsing_errors, [])
         self.assertEqual(len(report.passed_checks), 1)
         self.assertEqual(report.skipped_checks, [])
+
+    @mock.patch.dict(os.environ, {"CKV_BITBUCKET_CONFIG_FETCH_DATA": "False", "PYCHARM_HOSTED": "1"}, clear=True)
+    def test_runner_files_ignore(self):
+        # given
+        test_file = Path(__file__).parent / "resources/bitbucket_conf/pass/branch_restrictions.json"
+        checks = ["CKV_BITBUCKET_1"]
+
+        # when
+        report = Runner().run(
+            files=[str(test_file)],
+            runner_filter=RunnerFilter(checks=checks)
+        )
+
+        # then
+        # even it points to a file with scannable content, it should skip it
+        self.assertEqual(len(report.passed_checks), 0)
+        self.assertEqual(len(report.failed_checks), 0)
+        self.assertEqual(len(report.parsing_errors), 0)
+        self.assertEqual(len(report.skipped_checks), 0)
 
 
 if __name__ == "__main__":

--- a/tests/github/test_runner.py
+++ b/tests/github/test_runner.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from checkov.common.bridgecrew.check_type import CheckType
@@ -139,6 +140,25 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.parsing_errors, [])
         self.assertEqual(len(report.passed_checks), 3)
         self.assertEqual(report.skipped_checks, [])
+
+    @mock.patch.dict(os.environ, {"CKV_GITHUB_CONFIG_FETCH_DATA": "False", "PYCHARM_HOSTED": "1"}, clear=True)
+    def test_runner_files_ignore(self):
+        # given
+        test_file = Path(__file__).parent / "resources/github_conf/pass/org_security.json"
+        checks = ["CKV_GITHUB_1", "CKV_GITHUB_2", "CKV_GITHUB_3"]
+
+        # when
+        report = Runner().run(
+            files=[str(test_file)],
+            runner_filter=RunnerFilter(checks=checks)
+        )
+
+        # then
+        # even it points to a file with scannable content, it should skip it
+        self.assertEqual(len(report.passed_checks), 0)
+        self.assertEqual(len(report.failed_checks), 0)
+        self.assertEqual(len(report.parsing_errors), 0)
+        self.assertEqual(len(report.skipped_checks), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- currently we scan any json file passed in via `-f` flag vor VCS configuration, which we shouldn't do 😄 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
