### PR TITLE
feat(terraform): include pods of kubernetes_deployment in kubernetes_pod checks (4/4)

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/Secrets.py
+++ b/checkov/terraform/checks/resource/kubernetes/Secrets.py
@@ -9,7 +9,8 @@ class Secrets(BaseResourceCheck):
         name = "Prefer using secrets as files over secrets as environment variables"
         id = "CKV_K8S_35"
 
-        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1']
+        supported_resources = ['kubernetes_pod', "kubernetes_pod_v1",
+                               'kubernetes_deployment', 'kubernetes_deployment_v1']
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
@@ -18,6 +19,16 @@ class Secrets(BaseResourceCheck):
             self.evaluated_keys = [""]
             return CheckResult.FAILED
         spec = conf['spec'][0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
+
         containers = spec.get("container")
         if containers:
 
@@ -33,14 +44,14 @@ class Secrets(BaseResourceCheck):
                                 value_from = env.get("value_from")[0]
                                 if value_from.get("secret_key_ref"):
                                     self.evaluated_keys = \
-                                        [f"spec/[0]/container/[{idx}]/env/[{idy}]/value_from/secret_key_ref"]
+                                        [f"{evaluated_keys_path}/[0]/container/[{idx}]/env/[{idy}]/value_from/secret_key_ref"]
                                     return CheckResult.FAILED
                 if container.get("env_from") and isinstance(container.get("env_from"), list):
                     env_from = container.get("env_from")[0]
                     for idy, ef in enumerate(env_from):
                         if "secret_ref" in ef:
                             self.evaluated_keys = \
-                                [f"spec/[0]/container/[{idx}]/env_from/[{idy}]/secret_ref"]
+                                [f"{evaluated_keys_path}/[0]/container/[{idx}]/env_from/[{idy}]/secret_ref"]
                             return CheckResult.FAILED
             return CheckResult.PASSED
 

--- a/checkov/terraform/checks/resource/kubernetes/ShareHostIPC.py
+++ b/checkov/terraform/checks/resource/kubernetes/ShareHostIPC.py
@@ -11,11 +11,14 @@ class ShareHostIPC(BaseResourceNegativeValueCheck):
         # CIS-1.5 5.2.3
         name = "Do not admit containers wishing to share the host IPC namespace"
         id = "CKV_K8S_18"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):
+        if "kubernetes_deployment" == self.entity_type or "kubernetes_deployment_v1" == self.entity_type:
+            return "spec/[0]/template/[0]/spec/[0]/host_ipc"
         return "spec/[0]/host_ipc"
 
     def get_forbidden_values(self) -> List[Any]:

--- a/checkov/terraform/checks/resource/kubernetes/ShareHostPID.py
+++ b/checkov/terraform/checks/resource/kubernetes/ShareHostPID.py
@@ -11,12 +11,15 @@ class ShareHostPID(BaseResourceValueCheck):
         # CIS-1.5 5.2.2
         name = "Do not admit containers wishing to share the host process ID namespace"
         id = "CKV_K8S_17"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
                          missing_block_result=CheckResult.PASSED)
 
     def get_inspected_key(self) -> str:
+        if "kubernetes_deployment" == self.entity_type or "kubernetes_deployment_v1" == self.entity_type:
+            return "spec/[0]/template/[0]/spec/[0]/host_pid"
         return "spec/[0]/host_pid"
 
     def get_expected_value(self) -> Any:

--- a/checkov/terraform/checks/resource/kubernetes/SharedHostNetworkNamespace.py
+++ b/checkov/terraform/checks/resource/kubernetes/SharedHostNetworkNamespace.py
@@ -11,12 +11,15 @@ class SharedHostNetworkNamespace(BaseResourceValueCheck):
         # CIS-1.5 5.2.4
         name = "Do not admit containers wishing to share the host network namespace"
         id = "CKV_K8S_19"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1"]
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
                          missing_block_result=CheckResult.PASSED)
 
     def get_inspected_key(self) -> str:
+        if "kubernetes_deployment" == self.entity_type or "kubernetes_deployment_v1" == self.entity_type:
+            return "spec/[0]/template/[0]/spec/[0]/host_network"
         return "spec/[0]/host_network"
 
     def get_expected_value(self) -> Any:

--- a/checkov/terraform/checks/resource/kubernetes/Tiller.py
+++ b/checkov/terraform/checks/resource/kubernetes/Tiller.py
@@ -10,7 +10,8 @@ class Tiller(BaseResourceCheck):
     def __init__(self) -> None:
         name = "Ensure that Tiller (Helm v2) is not deployed"
         id = "CKV_K8S_34"
-        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1"]
+        supported_resources = ["kubernetes_pod", "kubernetes_pod_v1",
+                               "kubernetes_deployment", "kubernetes_deployment_v1"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
@@ -32,6 +33,29 @@ class Tiller(BaseResourceCheck):
             self.evaluated_keys = [""]
             return CheckResult.FAILED
         spec = conf['spec'][0]
+        evaluated_keys_path = "spec"
+
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            metadata = template.get("metadata")
+            if metadata and isinstance(metadata, list):
+                metadata = metadata[0]
+
+                if metadata.get("labels") and isinstance(metadata.get("labels"), list) and isinstance(metadata.get("labels")[0], dict):
+                    labels = metadata.get("labels")[0]
+                    self.evaluated_keys = [f"{evaluated_keys_path}/[0]/template/[0]/metadata/[0]/labels"]
+                    if labels.get("app") == "helm":
+                        self.evaluated_keys = [f"{evaluated_keys_path}/[0]/template/[0]/metadata/[0]/labels/[0]/app"]
+                        return CheckResult.FAILED
+                    elif labels.get("name") == "tiller":
+                        self.evaluated_keys = [f"{evaluated_keys_path}/[0]/template/[0]/metadata/[0]/labels/[0]/name"]
+                        return CheckResult.FAILED
+
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+                evaluated_keys_path = f'{evaluated_keys_path}/[0]/template/[0]/spec'
 
         containers = spec.get("container")
         if not containers:
@@ -42,7 +66,7 @@ class Tiller(BaseResourceCheck):
             if container.get("image") and isinstance(container.get("image"), list):
                 image = container.get("image")[0]
                 if "tiller" in image:
-                    self.evaluated_keys = [f'spec/[0]/container/[{idx}]/image']
+                    self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]/image']
                     return CheckResult.FAILED
 
         return CheckResult.PASSED

--- a/tests/terraform/checks/resource/kubernetes/example_Secrets/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_Secrets/main.tf
@@ -129,6 +129,180 @@ resource "kubernetes_pod_v1" "fail" {
     dns_policy = "None"
   }
 }
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+
+            value_from {
+
+              secret_key_ref {
+                key = "hjjhjh"
+              }
+            }
+          }
+
+          env_from {
+            secret_ref {
+              name = "wwww"
+            }
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+
+            value_from {
+
+              secret_key_ref {
+                key = "hjjhjh"
+              }
+            }
+          }
+
+          env_from {
+            secret_ref {
+              name = "wwww"
+            }
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
  resource "kubernetes_pod" "fail2" {
   metadata {
@@ -237,6 +411,156 @@ resource "kubernetes_pod_v1" "fail2" {
     dns_policy = "None"
   }
 }
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env_from {
+            secret_ref {
+              name = "wwww"
+            }
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env_from {
+            secret_ref {
+              name = "wwww"
+            }
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
  resource "kubernetes_pod" "pass" {
   metadata {
@@ -283,6 +607,144 @@ resource "kubernetes_pod_v1" "fail2" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -446,6 +908,160 @@ resource "kubernetes_pod_v1" "pass2" {
   }
 }
 
+resource "kubernetes_deployment" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+
+            value_from {
+            }
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+
+            value_from {
+            }
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 resource "kubernetes_pod" "pass3" {
   metadata {
     name = "terraform-example"
@@ -545,5 +1161,149 @@ resource "kubernetes_pod_v1" "pass3" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env_from {
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env_from {
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/example_ShareHostIPC/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ShareHostIPC/main.tf
@@ -113,6 +113,162 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_ipc = true
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 resource "kubernetes_pod" "pass" {
   metadata {
     name = "terraform-example"
@@ -171,6 +327,158 @@ resource "kubernetes_pod" "pass" {
   }
 }
 
+resource "kubernetes_deployment" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
@@ -226,6 +534,164 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        host_pid = false
+        host_ipc = false
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        host_pid = false
+        host_ipc = false
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 

--- a/tests/terraform/checks/resource/kubernetes/example_ShareHostPID/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ShareHostPID/main.tf
@@ -113,6 +113,162 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        host_pid = true
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 resource "kubernetes_pod" "pass" {
   metadata {
     name = "terraform-example"
@@ -170,6 +326,158 @@ resource "kubernetes_pod" "pass" {
   }
 }
 
+resource "kubernetes_deployment" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 resource "kubernetes_pod_v1" "pass" {
   metadata {
     name = "terraform-example"
@@ -224,6 +532,162 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        host_pid = false
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+
+        host_pid = false
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 

--- a/tests/terraform/checks/resource/kubernetes/example_SharedHostNetworkNamespace/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_SharedHostNetworkNamespace/main.tf
@@ -106,6 +106,156 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_network = true
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_network = true
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 resource "kubernetes_pod" "pass" {
   metadata {
     name = "terraform-example"
@@ -157,6 +307,154 @@ resource "kubernetes_pod" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+resource "kubernetes_deployment" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -213,6 +511,157 @@ resource "kubernetes_pod_v1" "pass" {
     dns_policy = "None"
   }
 }
+
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_network = false
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        host_network = false
+        container {
+          image = "nginx:1.7.9"
+          name  = "example"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 
 resource "kubernetes_pod" "pass2" {
   metadata {

--- a/tests/terraform/checks/resource/kubernetes/example_Tiller/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_Tiller/main.tf
@@ -183,6 +183,224 @@ resource "kubernetes_pod_v1" "fail" {
   }
 }
 
+#image is tiller
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        app = "app"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "app"
+        }
+      }
+
+      spec {
+        container {
+          image = "tiller-image"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#image is tiller
+resource "kubernetes_deployment_v1" "fail" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        app = "app"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "app"
+        }
+      }
+
+      spec {
+        container {
+          image = "tiller-image"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
 #label is tiller
 resource "kubernetes_pod" "fail2" {
   metadata {
@@ -351,6 +569,452 @@ resource "kubernetes_pod_v1" "fail2" {
       }
     }
 
+    #app is helm
+    resource "kubernetes_deployment" "fail3" {
+      metadata {
+        name = "terraform-example"
+        labels = {
+          app = "helm"
+        }
+      }
+
+      spec {
+        replicas = 3
+
+        selector {
+          match_labels = {
+            app = "nginx"
+          }
+        }
+
+        template {
+          metadata {
+            labels = {
+              app = "nginx"
+            }
+          }
+
+          spec {
+            container {
+              image = "nuthin-dodgy"
+              name  = "example22"
+
+              env {
+                name  = "environment"
+                value = "test"
+              }
+
+              port {
+                container_port = 8080
+              }
+
+              liveness_probe {
+                http_get {
+                  path = "/nginx_status"
+                  port = 80
+
+                  http_header {
+                    name  = "X-Custom-Header"
+                    value = "Awesome"
+                  }
+                }
+
+                initial_delay_seconds = 3
+                period_seconds        = 3
+              }
+            }
+
+            container {
+              image = "nginx:1.7.9"
+              name  = "example22222"
+
+              resources {
+                requests = {
+                  cpu    = "250m"
+                  memory = "50Mi"
+                }
+              }
+
+              env {
+                name  = "environment"
+                value = "test"
+              }
+
+              port {
+                container_port = 8080
+              }
+
+              liveness_probe {
+                http_get {
+                  path = "/nginx_status"
+                  port = 80
+
+                  http_header {
+                    name  = "X-Custom-Header"
+                    value = "Awesome"
+                  }
+                }
+
+                initial_delay_seconds = 3
+                period_seconds        = 3
+              }
+            }
+
+
+            dns_config {
+              nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+              searches    = ["example.com"]
+
+              option {
+                name  = "ndots"
+                value = 1
+              }
+
+              option {
+                name = "use-vc"
+              }
+            }
+
+            dns_policy = "None"
+          }
+        }
+      }
+    }
+
+    #app is helm
+    resource "kubernetes_deployment_v1" "fail3" {
+      metadata {
+        name = "terraform-example"
+        labels = {
+          app = "helm"
+        }
+      }
+
+      spec {
+        replicas = 3
+
+        selector {
+          match_labels = {
+            app = "nginx"
+          }
+        }
+
+        template {
+          metadata {
+            labels = {
+              app = "nginx"
+            }
+          }
+
+          spec {
+            container {
+              image = "nuthin-dodgy"
+              name  = "example22"
+
+              env {
+                name  = "environment"
+                value = "test"
+              }
+
+              port {
+                container_port = 8080
+              }
+
+              liveness_probe {
+                http_get {
+                  path = "/nginx_status"
+                  port = 80
+
+                  http_header {
+                    name  = "X-Custom-Header"
+                    value = "Awesome"
+                  }
+                }
+
+                initial_delay_seconds = 3
+                period_seconds        = 3
+              }
+            }
+
+            container {
+              image = "nginx:1.7.9"
+              name  = "example22222"
+
+              resources {
+                requests = {
+                  cpu    = "250m"
+                  memory = "50Mi"
+                }
+              }
+
+              env {
+                name  = "environment"
+                value = "test"
+              }
+
+              port {
+                container_port = 8080
+              }
+
+              liveness_probe {
+                http_get {
+                  path = "/nginx_status"
+                  port = 80
+
+                  http_header {
+                    name  = "X-Custom-Header"
+                    value = "Awesome"
+                  }
+                }
+
+                initial_delay_seconds = 3
+                period_seconds        = 3
+              }
+            }
+
+
+            dns_config {
+              nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+              searches    = ["example.com"]
+
+              option {
+                name  = "ndots"
+                value = 1
+              }
+
+              option {
+                name = "use-vc"
+              }
+            }
+
+            dns_policy = "None"
+          }
+        }
+      }
+    }
+
+    #app is helm
+    resource "kubernetes_deployment" "fail5" {
+      metadata {
+        name = "terraform-example"
+        labels = {
+          app = "nginx"
+        }
+      }
+
+      spec {
+        replicas = 3
+
+        selector {
+          match_labels = {
+            app = "helm"
+          }
+        }
+
+        template {
+          metadata {
+            labels = {
+              app = "helm"
+            }
+          }
+
+          spec {
+            container {
+              image = "nuthin-dodgy"
+              name  = "example22"
+
+              env {
+                name  = "environment"
+                value = "test"
+              }
+
+              port {
+                container_port = 8080
+              }
+
+              liveness_probe {
+                http_get {
+                  path = "/nginx_status"
+                  port = 80
+
+                  http_header {
+                    name  = "X-Custom-Header"
+                    value = "Awesome"
+                  }
+                }
+
+                initial_delay_seconds = 3
+                period_seconds        = 3
+              }
+            }
+
+            container {
+              image = "nginx:1.7.9"
+              name  = "example22222"
+
+              resources {
+                requests = {
+                  cpu    = "250m"
+                  memory = "50Mi"
+                }
+              }
+
+              env {
+                name  = "environment"
+                value = "test"
+              }
+
+              port {
+                container_port = 8080
+              }
+
+              liveness_probe {
+                http_get {
+                  path = "/nginx_status"
+                  port = 80
+
+                  http_header {
+                    name  = "X-Custom-Header"
+                    value = "Awesome"
+                  }
+                }
+
+                initial_delay_seconds = 3
+                period_seconds        = 3
+              }
+            }
+
+
+            dns_config {
+              nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+              searches    = ["example.com"]
+
+              option {
+                name  = "ndots"
+                value = 1
+              }
+
+              option {
+                name = "use-vc"
+              }
+            }
+
+            dns_policy = "None"
+          }
+        }
+      }
+    }
+
+    resource "kubernetes_deployment_v1" "fail5" {
+      metadata {
+        name = "terraform-example"
+        labels = {
+          app = "nginx"
+        }
+      }
+
+      spec {
+        replicas = 3
+
+        selector {
+          match_labels = {
+            app = "helm"
+          }
+        }
+
+        template {
+          metadata {
+            labels = {
+              app = "helm"
+            }
+          }
+
+          spec {
+            container {
+              image = "nuthin-dodgy"
+              name  = "example22"
+
+              env {
+                name  = "environment"
+                value = "test"
+              }
+
+              port {
+                container_port = 8080
+              }
+
+              liveness_probe {
+                http_get {
+                  path = "/nginx_status"
+                  port = 80
+
+                  http_header {
+                    name  = "X-Custom-Header"
+                    value = "Awesome"
+                  }
+                }
+
+                initial_delay_seconds = 3
+                period_seconds        = 3
+              }
+            }
+
+            container {
+              image = "nginx:1.7.9"
+              name  = "example22222"
+
+              resources {
+                requests = {
+                  cpu    = "250m"
+                  memory = "50Mi"
+                }
+              }
+
+              env {
+                name  = "environment"
+                value = "test"
+              }
+
+              port {
+                container_port = 8080
+              }
+
+              liveness_probe {
+                http_get {
+                  path = "/nginx_status"
+                  port = 80
+
+                  http_header {
+                    name  = "X-Custom-Header"
+                    value = "Awesome"
+                  }
+                }
+
+                initial_delay_seconds = 3
+                period_seconds        = 3
+              }
+            }
+
+
+            dns_config {
+              nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+              searches    = ["example.com"]
+
+              option {
+                name  = "ndots"
+                value = 1
+              }
+
+              option {
+                name = "use-vc"
+              }
+            }
+
+            dns_policy = "None"
+          }
+        }
+      }
+    }
 
 
     dns_config {
@@ -368,6 +1032,454 @@ resource "kubernetes_pod_v1" "fail2" {
     }
 
     dns_policy = "None"
+  }
+}
+
+#label is tiller
+resource "kubernetes_deployment" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      name = "tiller"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        name = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          name = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nuthin-dodgy"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#label is tiller
+resource "kubernetes_deployment_v1" "fail2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      name = "tiller"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        name = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          name = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nuthin-dodgy"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#label is tiller
+resource "kubernetes_deployment" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      name = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        name = "tiller"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          name = "tiller"
+        }
+      }
+
+      spec {
+        container {
+          image = "nuthin-dodgy"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#label is tiller
+resource "kubernetes_deployment_v1" "fail4" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      name = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        name = "tiller"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          name = "tiller"
+        }
+      }
+
+      spec {
+        container {
+          image = "nuthin-dodgy"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }
 
@@ -560,6 +1672,454 @@ resource "kubernetes_pod_v1" "fail3" {
 }
 
 #app is helm
+resource "kubernetes_deployment" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      app = "helm"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        name = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          name = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nuthin-dodgy"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#app is helm
+resource "kubernetes_deployment_v1" "fail3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      app = "helm"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        name = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          name = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nuthin-dodgy"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#app is helm
+resource "kubernetes_deployment" "fail5" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        app = "helm"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "helm"
+        }
+      }
+
+      spec {
+        container {
+          image = "nuthin-dodgy"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#app is helm
+resource "kubernetes_deployment_v1" "fail5" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        app = "helm"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "helm"
+        }
+      }
+
+      spec {
+        container {
+          image = "nuthin-dodgy"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#app is helm
 resource "kubernetes_pod" "pass" {
   metadata {
    name="terraform-example"
@@ -740,5 +2300,231 @@ resource "kubernetes_pod_v1" "pass" {
     }
 
     dns_policy = "None"
+  }
+}
+
+#app is helm
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nuthin-dodgy"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}
+
+#app is helm
+resource "kubernetes_deployment_v1" "pass" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nuthin-dodgy"
+          name  = "example22"
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        container {
+          image = "nginx:1.7.9"
+          name  = "example22222"
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
   }
 }

--- a/tests/terraform/checks/resource/kubernetes/test_Secrets.py
+++ b/tests/terraform/checks/resource/kubernetes/test_Secrets.py
@@ -24,6 +24,12 @@ class TestSecrets(unittest.TestCase):
             "kubernetes_pod_v1.pass",
             "kubernetes_pod_v1.pass2",
             "kubernetes_pod_v1.pass3",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment.pass2",
+            "kubernetes_deployment.pass3",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_deployment_v1.pass2",
+            "kubernetes_deployment_v1.pass3",
         }
 
         failing_resources = {
@@ -31,13 +37,17 @@ class TestSecrets(unittest.TestCase):
             "kubernetes_pod.fail2",
             "kubernetes_pod_v1.fail",
             "kubernetes_pod_v1.fail2",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 3 * 2)
-        self.assertEqual(summary["failed"], 2 * 2)
+        self.assertEqual(summary["passed"], 6 * 2)
+        self.assertEqual(summary["failed"], 4 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ShareHostIPC.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ShareHostIPC.py
@@ -22,18 +22,24 @@ class TestShareHostIPC(unittest.TestCase):
             "kubernetes_pod.pass2",
             "kubernetes_pod_v1.pass",
             "kubernetes_pod_v1.pass2",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment.pass2",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_deployment_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod_v1.fail",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2 * 2)
-        self.assertEqual(summary["failed"], 1 * 2)
+        self.assertEqual(summary["passed"], 4 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ShareHostNetworkNamespace.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ShareHostNetworkNamespace.py
@@ -22,18 +22,24 @@ class TestSharedHostNetworkNamespace(unittest.TestCase):
             "kubernetes_pod.pass2",
             "kubernetes_pod_v1.pass",
             "kubernetes_pod_v1.pass2",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment.pass2",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_deployment_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod_v1.fail",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2 * 2)
-        self.assertEqual(summary["failed"], 1 * 2)
+        self.assertEqual(summary["passed"], 4 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_ShareHostPID.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ShareHostPID.py
@@ -22,18 +22,24 @@ class TestShareHostPID(unittest.TestCase):
             "kubernetes_pod.pass2",
             "kubernetes_pod_v1.pass",
             "kubernetes_pod_v1.pass2",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment.pass2",
+            "kubernetes_deployment_v1.pass",
+            "kubernetes_deployment_v1.pass2",
         }
 
         failing_resources = {
             "kubernetes_pod.fail",
             "kubernetes_pod_v1.fail",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment_v1.fail",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2 * 2)
-        self.assertEqual(summary["failed"], 1 * 2)
+        self.assertEqual(summary["passed"], 4 * 2)
+        self.assertEqual(summary["failed"], 2 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/checks/resource/kubernetes/test_Tiller.py
+++ b/tests/terraform/checks/resource/kubernetes/test_Tiller.py
@@ -20,6 +20,8 @@ class TestTiller(unittest.TestCase):
         passing_resources = {
             "kubernetes_pod.pass",
             "kubernetes_pod_v1.pass",
+            "kubernetes_deployment.pass",
+            "kubernetes_deployment_v1.pass",
         }
 
         failing_resources = {
@@ -29,13 +31,23 @@ class TestTiller(unittest.TestCase):
             "kubernetes_pod_v1.fail",
             "kubernetes_pod_v1.fail2",
             "kubernetes_pod_v1.fail3",
+            "kubernetes_deployment.fail",
+            "kubernetes_deployment.fail2",
+            "kubernetes_deployment.fail3",
+            "kubernetes_deployment.fail4",
+            "kubernetes_deployment.fail5",
+            "kubernetes_deployment_v1.fail",
+            "kubernetes_deployment_v1.fail2",
+            "kubernetes_deployment_v1.fail3",
+            "kubernetes_deployment_v1.fail4",
+            "kubernetes_deployment_v1.fail5",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1 * 2)
-        self.assertEqual(summary["failed"], 3 * 2)
+        self.assertEqual(summary["passed"], 2 * 2)
+        self.assertEqual(summary["failed"], 8 * 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

This PR includes pods defined via `kubernetes_deployment` in pod checks . PR 4 of 4.

Fixes #3690

## New/Edited policies (Delete if not relevant)
* CKV_K8S_35
   Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_18
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_17
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_19
  Add resource: kubernetes_deployment, kubernetes_deployment_v1
* CKV_K8S_34
  Add resource: kubernetes_deployment, kubernetes_deployment_v1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules