### PR TITLE
break(terraform): adjust the check result return for dependant variables to unknown in  Python based checks

### DIFF
--- a/checkov/terraform/checks/resource/base_resource_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_value_check.py
@@ -58,8 +58,8 @@ class BaseResourceValueCheck(BaseResourceCheck):
                 # Key is found on the configuration - if it accepts any value, the check is PASSED
                 return CheckResult.PASSED
             if self._is_variable_dependant(value):
-                # If the tested attribute is variable-dependant, then result is PASSED
-                return CheckResult.PASSED
+                # If the tested attribute is variable-dependant, then result is UNKNOWN
+                return CheckResult.UNKNOWN
             if value in expected_values:
                 return CheckResult.PASSED
             if get_referenced_vertices_in_value(value=value, aliases={}, resources_types=[]):
@@ -80,8 +80,8 @@ class BaseResourceValueCheck(BaseResourceCheck):
                             if sub_conf in self.get_expected_values():
                                 return CheckResult.PASSED
                             if self._is_variable_dependant(sub_conf):
-                                # If the tested attribute is variable-dependant, then result is PASSED
-                                return CheckResult.PASSED
+                                # If the tested attribute is variable-dependant, then result is UNKNOWN
+                                return CheckResult.UNKNOWN
 
         return self.missing_block_result
 

--- a/checkov/terraform/checks/resource/github/SecretsEncrypted.py
+++ b/checkov/terraform/checks/resource/github/SecretsEncrypted.py
@@ -23,7 +23,7 @@ class SecretsEncrypted(BaseResourceNegativeValueCheck):
     def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
         plaintext = conf.get("plaintext_value")
         if plaintext and self._is_variable_dependant(plaintext[0]):
-            return CheckResult.PASSED
+            return CheckResult.UNKNOWN
 
         return super().scan_resource_conf(conf)
 

--- a/tests/terraform/checks/resource/azure/test_StorageSyncPublicAccessDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_StorageSyncPublicAccessDisabled.py
@@ -45,7 +45,7 @@ class TestStorageSyncPublicAccessDisabled(unittest.TestCase):
               name                = "example-storage-sync"
               resource_group_name = azurerm_resource_group.test.name
               location            = azurerm_resource_group.test.location
-              incoming_traffic_policy = AllowVirtualNetworksOnly
+              incoming_traffic_policy = "AllowVirtualNetworksOnly"
               tags = {
                 foo = "bar"
               }

--- a/tests/terraform/checks/resource/github/test_SecretsEncrypted.py
+++ b/tests/terraform/checks/resource/github/test_SecretsEncrypted.py
@@ -21,7 +21,6 @@ class TestSecretsEncrypted(unittest.TestCase):
             "github_actions_environment_secret.pass",
             "github_actions_organization_secret.pass",
             "github_actions_secret.pass",
-            "github_actions_secret.value_ref",
         }
         failing_resources = {
             "github_actions_environment_secret.fail",
@@ -32,10 +31,12 @@ class TestSecretsEncrypted(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 4)
-        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
+        # github_actions_secret.value_ref is dependent on azuread_service_principal_password.gh_actions
+        self.assertEqual(summary["resource_count"], 8)  # 2 extra
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)

--- a/tests/terraform/checks/resource/test_base_resource_value_check.py
+++ b/tests/terraform/checks/resource/test_base_resource_value_check.py
@@ -58,7 +58,7 @@ class Test(unittest.TestCase):
     def test_string_contains_var_static(self):
         result = self._check(TestStaticCheck(),
                              {"foo": "something-${var.whatever}"})
-        self.assertEqual(result, CheckResult.PASSED)
+        self.assertEqual(result, CheckResult.UNKNOWN)
 
     def test_var_any(self):
         result = self._check(TestAnyCheck(),
@@ -68,7 +68,7 @@ class Test(unittest.TestCase):
     def test_var_static(self):
         result = self._check(TestStaticCheck(),
                              {"foo": "${var.whatever}"})
-        self.assertEqual(result, CheckResult.PASSED)
+        self.assertEqual(result, CheckResult.UNKNOWN)
 
     def test_local_any(self):
         result = self._check(TestAnyCheck(),
@@ -78,7 +78,7 @@ class Test(unittest.TestCase):
     def test_local_static(self):
         result = self._check(TestStaticCheck(),
                              {"foo": "${local.whatever}"})
-        self.assertEqual(result, CheckResult.PASSED)
+        self.assertEqual(result, CheckResult.UNKNOWN)
 
     def test_resource_any(self):
         result = self._check(TestAnyCheck(),
@@ -88,7 +88,7 @@ class Test(unittest.TestCase):
     def test_resource_static(self):
         result = self._check(TestStaticCheck(),
                              {"foo": "${aws_s3_bucket.foo.bucket}"})
-        self.assertEqual(result, CheckResult.PASSED)
+        self.assertEqual(result, CheckResult.UNKNOWN)
 
     @staticmethod
     def _check(check, data):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- changed return to `UNKNOWN` to align with #3689

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
