### PR TITLE
fix(terraform): fix false positive for write ACL yaml check

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/S3PublicACLWrite.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/S3PublicACLWrite.yaml
@@ -53,12 +53,33 @@ definition:
                         - aws_s3_bucket_acl
                       attribute: access_control_policy.grant
                       operator: not_exists
-                    - cond_type: attribute
-                      resource_types:
-                        - aws_s3_bucket_acl
-                      attribute: access_control_policy.grant.*.grantee.uri
-                      operator: not_equals
-                      value: "http://acs.amazonaws.com/groups/global/AllUsers"
+                    - or:
+                      - cond_type: attribute
+                        resource_types:
+                          - aws_s3_bucket_acl
+                        attribute: access_control_policy.grant.*.grantee.uri
+                        operator: not_equals
+                        value: "http://acs.amazonaws.com/groups/global/AllUsers"
+                      - not:
+                        - or:
+                          - cond_type: attribute
+                            resource_types:
+                              - aws_s3_bucket_acl
+                            attribute: access_control_policy.grant.*.permission
+                            operator: equals
+                            value: "WRITE"
+                          - cond_type: attribute
+                            resource_types:
+                              - aws_s3_bucket_acl
+                            attribute: access_control_policy.grant.*.permission
+                            operator: equals
+                            value: "FULL_CONTROL"
+                          - cond_type: attribute
+                            resource_types:
+                              - aws_s3_bucket_acl
+                            attribute: access_control_policy.grant.*.permission
+                            operator: equals
+                            value: "WRITE_ACP"
     - and:
       - cond_type: filter
         attribute: resource_type

--- a/tests/terraform/graph/checks/resources/S3PublicACLWrite/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3PublicACLWrite/expected.yaml
@@ -7,6 +7,7 @@ pass:
   - "aws_s3_bucket.unknown_var_v4_legacy"
   - "aws_s3_bucket.no_grant"
   - "aws_s3_bucket.grant_onwer"
+  - "aws_s3_bucket.bucket_with_read_acl"
 fail:
   - "aws_s3_bucket.public_read_write"
   - "aws_s3_bucket.public_read_write_v4"

--- a/tests/terraform/graph/checks/resources/S3PublicACLWrite/main.tf
+++ b/tests/terraform/graph/checks/resources/S3PublicACLWrite/main.tf
@@ -127,3 +127,21 @@ resource "aws_s3_bucket_acl" "grant_public_write_all" {
     }
   }
 }
+
+# pass
+resource "aws_s3_bucket" "bucket_with_read_acl" {
+  bucket = "abc"
+}
+
+resource "aws_s3_bucket_acl" "acl_for_bucket_with_read_acl" {
+  bucket = aws_s3_bucket.bucket_with_read_acl.id
+  access_control_policy {
+    grant {
+      grantee {
+        uri   = "http://acs.amazonaws.com/groups/global/AllUsers"
+        type = "Group"
+      }
+      permission = "READ"
+    }
+  }
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixes an issue with the yaml check for the write ACL on S3 resulting in a false positive for the following ACL:

```
resource "aws_s3_bucket_acl" "acl" {
  bucket = aws_s3_bucket.b.id
  access_control_policy {
    grant {
      grantee {
        uri   = "http://acs.amazonaws.com/groups/global/AllUsers"
        type = "Group"
      }
      permission = "READ"
    }
  }
}
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
