### PR TITLE
fix(terraform): fix a TF plan issue with CKV_AWS_274

### DIFF
--- a/checkov/terraform/checks/resource/aws/IAMManagedAdminPolicy.py
+++ b/checkov/terraform/checks/resource/aws/IAMManagedAdminPolicy.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
@@ -7,7 +11,7 @@ ADMIN_POLICY_ARN = f"arn:aws:iam::aws:policy/{ADMIN_POLICY_NAME}"
 
 
 class IAMManagedAdminPolicy(BaseResourceCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         # This is the full description of your check
         description = "Disallow IAM roles, users, and groups from using the AWS AdministratorAccess policy"
 
@@ -27,10 +31,10 @@ class IAMManagedAdminPolicy(BaseResourceCheck):
         categories = (CheckCategories.IAM,)
         super().__init__(name=description, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
         if self.entity_type == "aws_iam_role":
             if "managed_policy_arns" in conf.keys():
-                if ADMIN_POLICY_ARN in conf.get("managed_policy_arns")[0]:
+                if ADMIN_POLICY_ARN in conf["managed_policy_arns"][0]:
                     return CheckResult.FAILED
 
         elif self.entity_type in (
@@ -39,7 +43,8 @@ class IAMManagedAdminPolicy(BaseResourceCheck):
             "aws_iam_user_policy_attachment",
             "aws_iam_group_policy_attachment",
         ):
-            if conf.get("policy_arn")[0] == ADMIN_POLICY_ARN:
+            policy_arn = conf.get("policy_arn")
+            if policy_arn and policy_arn[0] == ADMIN_POLICY_ARN:
                 return CheckResult.FAILED
 
         return CheckResult.PASSED

--- a/tests/terraform/checks/resource/aws/example_IAMManagedAdminPolicy/IAMManagedAdminPolicy.tf
+++ b/tests/terraform/checks/resource/aws/example_IAMManagedAdminPolicy/IAMManagedAdminPolicy.tf
@@ -56,6 +56,10 @@ resource "aws_iam_group_policy_attachment" "pass5" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
 }
 
+resource "aws_iam_role_policy_attachment" "pass6" {
+  role       = aws_iam_role.fail1.name
+#  policy_arn = ""  # not valid, just to simulate a TF plan behaviour
+}
 
 # Data
 

--- a/tests/terraform/checks/resource/aws/test_IAMManagedAdminPolicy.py
+++ b/tests/terraform/checks/resource/aws/test_IAMManagedAdminPolicy.py
@@ -23,6 +23,7 @@ class TestIAMManagedAdminPolicy(unittest.TestCase):
             "aws_iam_role_policy_attachment.pass3",
             "aws_iam_user_policy_attachment.pass4",
             "aws_iam_group_policy_attachment.pass5",
+            "aws_iam_role_policy_attachment.pass6",
         }
 
         failing_resources = {
@@ -36,8 +37,8 @@ class TestIAMManagedAdminPolicy(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 5)
-        self.assertEqual(summary["failed"], 5)
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- in some cases `policy_arn` can be non existent, when a TF plan file is created, it will be populated after the apply

Fixes #3744 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
