### PR TITLE
fix(arm): CKV_AZURE_9 & CKV_AZURE_10 - Scan fails if protocol value is a wildcard

### DIFF
--- a/checkov/arm/checks/resource/NSGRulePortAccessRestricted.py
+++ b/checkov/arm/checks/resource/NSGRulePortAccessRestricted.py
@@ -45,7 +45,7 @@ class NSGRulePortAccessRestricted(BaseResourceCheck):
                 if "properties" in rule:
                     if "access" in rule["properties"] and rule["properties"]["access"].lower() == "allow":
                         if "direction" in rule["properties"] and rule["properties"]["direction"].lower() == "inbound":
-                            if "protocol" in rule["properties"] and rule["properties"]["protocol"].lower() == "tcp":
+                            if "protocol" in rule["properties"] and rule["properties"]["protocol"].lower() in ("tcp", "*"):
                                 if "destinationPortRanges" in rule["properties"]:
                                     portRanges.extend(rule["properties"]["destinationPortRanges"])
                                 if "destinationPortRange" in rule["properties"]:

--- a/tests/arm/checks/resource/example_NSGRuleRDPAccessRestricted/NSGRulePortAccessRestricted-FAILED.json
+++ b/tests/arm/checks/resource/example_NSGRuleRDPAccessRestricted/NSGRulePortAccessRestricted-FAILED.json
@@ -123,6 +123,30 @@
       }
     },
     {
+      "comments": "Wildcard protocol rule",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "*",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",

--- a/tests/arm/checks/resource/example_NSGRuleSSHAccessRestricted/NSGRulePortAccessRestricted-FAILED.json
+++ b/tests/arm/checks/resource/example_NSGRuleSSHAccessRestricted/NSGRulePortAccessRestricted-FAILED.json
@@ -123,6 +123,30 @@
       }
     },
     {
+      "comments": "Wildcard protocl rule",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-22",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "22",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",

--- a/tests/arm/checks/resource/test_NSGRuleRDPAccessRestricted.py
+++ b/tests/arm/checks/resource/test_NSGRuleRDPAccessRestricted.py
@@ -17,7 +17,7 @@ class TestNSGRuleRDPAccessRestricted(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 2)
-        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['failed'], 3)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/arm/checks/resource/test_NSGRuleSSHAccessRestricted.py
+++ b/tests/arm/checks/resource/test_NSGRuleSSHAccessRestricted.py
@@ -17,7 +17,7 @@ class TestNSGRuleSSHAccessRestricted(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 2)
-        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['failed'], 3)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Allows for wildcards for protocol in bicep/arm for network security groups. Fixes missing findings for CKV_AZURE_9 & CKV_AZURE_10

Fixes #3749

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
