### PR TITLE
fix(github): print the result again in GHA

### DIFF
--- a/github_action_resources/entrypoint.sh
+++ b/github_action_resources/entrypoint.sh
@@ -140,8 +140,12 @@ fi
 
 CHECKOV_EXIT_CODE=$?
 
+# print to console
+echo "${CHECKOV_RESULTS}"
+
 CHECKOV_RESULTS="${CHECKOV_RESULTS//$'\\n'/''}"
 
+# save output to GitHub files for further usage
 { echo "CHECKOV_RESULTS<<EOF"; echo "${CHECKOV_RESULTS:0:65536}"; echo "EOF"; } >> $GITHUB_ENV
 { echo "results<<EOF"; echo "$CHECKOV_RESULTS"; echo "EOF"; } >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- the mitigation of the deprecation of `set-output` had a side-effect of not printing the result to console anymore, therefore I added an extra print/echo statement

Fixes bridgecrewio/checkov-action#108

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
