### PR TITLE
feat(general): add range_includes and inverted operator

### DIFF
--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -44,7 +44,9 @@ from checkov.common.checks_infra.solvers import (
     IntersectsAttributeSolver,
     NotIntersectsAttributeSolver,
     EqualsIgnoreCaseAttributeSolver,
-    NotEqualsIgnoreCaseAttributeSolver
+    NotEqualsIgnoreCaseAttributeSolver,
+    RangeIncludesAttributeSolver,
+    RangeNotIncludesAttributeSolver
 )
 from checkov.common.checks_infra.solvers.connections_solvers.connection_one_exists_solver import \
     ConnectionOneExistsSolver
@@ -96,7 +98,9 @@ operators_to_attributes_solver_classes: dict[str, Type[BaseAttributeSolver]] = {
     "intersects": IntersectsAttributeSolver,
     "not_intersects": NotIntersectsAttributeSolver,
     "equals_ignore_case": EqualsIgnoreCaseAttributeSolver,
-    "not_equals_ignore_case": NotEqualsIgnoreCaseAttributeSolver
+    "not_equals_ignore_case": NotEqualsIgnoreCaseAttributeSolver,
+    "range_includes": RangeIncludesAttributeSolver,
+    "range_not_includes": RangeNotIncludesAttributeSolver
 }
 
 operators_to_complex_solver_classes: dict[str, Type[BaseComplexSolver]] = {

--- a/checkov/common/checks_infra/solvers/attribute_solvers/__init__.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/__init__.py
@@ -32,3 +32,5 @@ from checkov.common.checks_infra.solvers.attribute_solvers.intersects_attribute_
 from checkov.common.checks_infra.solvers.attribute_solvers.not_intersects_attribute_solver import NotIntersectsAttributeSolver  # noqa
 from checkov.common.checks_infra.solvers.attribute_solvers.equals_ignore_case_attribute_solver import EqualsIgnoreCaseAttributeSolver  # noqa
 from checkov.common.checks_infra.solvers.attribute_solvers.not_equals_ignore_case_attribute_solver import NotEqualsIgnoreCaseAttributeSolver  # noqa
+from checkov.common.checks_infra.solvers.attribute_solvers.range_includes_attribute_solver import RangeIncludesAttributeSolver  # noqa
+from checkov.common.checks_infra.solvers.attribute_solvers.range_not_includes_attribute_solver import RangeNotIncludesAttributeSolver  # noqa

--- a/checkov/common/checks_infra/solvers/attribute_solvers/range_includes_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/range_includes_attribute_solver.py
@@ -30,12 +30,12 @@ class RangeIncludesAttributeSolver(BaseAttributeSolver):
         try:
             attr = force_int(attr)
             return attr == self.value
-        except ValueError as e:
+        except ValueError:
             if '-' in attr:
                 try:
                     [start, end] = [force_int(a for a in attr.split('-'))]
                     return start <= self.value <= end
-                except ValueError as e:
+                except ValueError:
                     # Occurs if there are not two entries or if one is not an int, in which case we just give up
                     pass
 

--- a/checkov/common/checks_infra/solvers/attribute_solvers/range_includes_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/range_includes_attribute_solver.py
@@ -1,0 +1,42 @@
+from typing import Optional, Any, Dict, List
+from checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver import BaseAttributeSolver
+from checkov.common.graph.checks_infra.enums import Operators
+from checkov.common.util.type_forcers import force_int
+
+
+class RangeIncludesAttributeSolver(BaseAttributeSolver):
+    operator = Operators.RANGE_INCLUDES  # noqa: CCE003  # a static attribute
+
+    def __init__(
+        self, resource_types: List[str], attribute: Optional[str], value: Any, is_jsonpath_check: bool = False
+    ) -> None:
+        super().__init__(resource_types, attribute, force_int(value), is_jsonpath_check)
+
+    def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
+        if vertex.get(attribute) is None:  # type:ignore[arg-type]  # due to attribute can be None
+            return False
+
+        attr = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
+
+        # expects one of the following values:
+        # - an actual int
+        # - a string that parses to an int
+        # - *
+        # - a string range like '1000-2000'
+
+        if attr == '*':
+            return True
+
+        try:
+            attr = force_int(attr)
+            return attr == self.value
+        except ValueError as e:
+            if '-' in attr:
+                try:
+                    [start, end] = [force_int(a for a in attr.split('-'))]
+                    return start <= self.value <= end
+                except ValueError as e:
+                    # Occurs if there are not two entries or if one is not an int, in which case we just give up
+                    pass
+
+        return False

--- a/checkov/common/checks_infra/solvers/attribute_solvers/range_not_includes_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/range_not_includes_attribute_solver.py
@@ -1,0 +1,10 @@
+from typing import Optional, Any, Dict
+from checkov.common.checks_infra.solvers.attribute_solvers.range_includes_attribute_solver import RangeIncludesAttributeSolver
+from checkov.common.graph.checks_infra.enums import Operators
+
+
+class RangeNotIncludesAttributeSolver(RangeIncludesAttributeSolver):
+    operator = Operators.RANGE_NOT_INCLUDES  # noqa: CCE003  # a static attribute
+
+    def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
+        return not super()._get_operation(vertex, attribute)

--- a/checkov/common/graph/checks_infra/enums.py
+++ b/checkov/common/graph/checks_infra/enums.py
@@ -64,3 +64,5 @@ class Operators:
     NOT_INTERSECTS = 'not_intersects'
     EQUALS_IGNORE_CASE = 'equals_ignore_case'
     NOT_EQUALS_IGNORE_CASE = 'not_equals_ignore_case'
+    RANGE_INCLUDES = 'range_includes'
+    RANGE_NOT_INCLUDES = 'range_not_includes'

--- a/docs/3.Custom Policies/YAML Custom Policies.md
+++ b/docs/3.Custom Policies/YAML Custom Policies.md
@@ -123,8 +123,10 @@ definition:
 | Is True                      | `is_true`                      |
 | Intersects                   | `intersects`                   |
 | Not Intersects               | `not_intersects`               |
-| Equals Ignore Case           | `equals_ignore case`           |
-| Not Equals Ignore Case       | `not_equals_ignore case`       |
+| Equals Ignore Case           | `equals_ignore_case`           |
+| Not Equals Ignore Case       | `not_equals_ignore_case`       |
+| Range Includes               | `range_includes`               |
+| Range Not Includes           | `range_not_includes`           |
 
 All those operators are supporting JSONPath attribute expression by adding the `jsonpath_` prefix to the operator, for example - `jsonpath_length_equals`
 

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/JsonPathRangeIncludesInt.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/JsonPathRangeIncludesInt.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "JsonPathRangeIncludesInt"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "test"
+  attribute: "range"
+  operator: "jsonpath_range_includes"
+  value: 3000
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/JsonPathRangeIncludesString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/JsonPathRangeIncludesString.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "JsonPathRangeIncludesString"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "test"
+  attribute: "range"
+  operator: "jsonpath_range_includes"
+  value: "3000"
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/RangeIncludesInt.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/RangeIncludesInt.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "RangeIncludesInt"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "test"
+  attribute: "range"
+  operator: "range_includes"
+  value: 3000
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/RangeIncludesString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/RangeIncludesString.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "RangeIncludesString"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "test"
+  attribute: "range"
+  operator: "range_includes"
+  value: "3000"
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/resources/main.tf
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/resources/main.tf
@@ -1,0 +1,55 @@
+resource "test" "pass1" {
+  range = "*"
+}
+
+resource "test" "pass2" {
+  range = 3000
+}
+
+resource "test" "pass3" {
+  range = "3000"
+}
+
+resource "test" "pass4" {
+  range = "3000-4000"
+}
+
+resource "test" "pass5" {
+  range = "2000-3000"
+}
+
+resource "test" "pass6" {
+  range = "2000-4000"
+}
+
+resource "test" "fail1" {
+  range = 2000
+}
+
+resource "test" "fail2" {
+  range = "2000"
+}
+
+resource "test" "fail3" {
+  range = "1000-2000"
+}
+
+resource "test" "fail4" {
+  range = "4000-5000"
+}
+
+resource "test" "fail5" {
+  # no range
+}
+
+resource "test" "fail6" {
+  range = "abc"
+}
+
+resource "test" "fail7" {
+  range = "abc-123"
+}
+
+resource "test" "fail8" {
+  range = "1000-5000-6000"
+}

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/test_solver.py
@@ -1,0 +1,49 @@
+import os
+
+from tests.terraform.graph.checks_infra.test_base import TestBaseSolver
+
+TEST_DIRNAME = os.path.dirname(os.path.realpath(__file__))
+
+
+class TestRangeIncludesSolver(TestBaseSolver):
+    def setUp(self):
+        self.checks_dir = TEST_DIRNAME
+        super(TestRangeIncludesSolver, self).setUp()
+
+    def test_range_includes_int_solver(self):
+        root_folder = 'resources'
+        check_id = "RangeIncludesInt"
+        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6']
+        should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7', 'test.fail8']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_range_includes_string_solver(self):
+        root_folder = 'resources'
+        check_id = "RangeIncludesString"
+        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6']
+        should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7',
+                       'test.fail8']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_range_includes_int_jsonpath_solver(self):
+        root_folder = 'resources'
+        check_id = "JsonPathRangeIncludesInt"
+        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6']
+        should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7', 'test.fail8']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_range_includes_string_jsonpath_solver(self):
+        root_folder = 'resources'
+        check_id = "JsonPathRangeIncludesString"
+        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6']
+        should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7',
+                       'test.fail8']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/JsonPathRangeNotIncludesInt.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/JsonPathRangeNotIncludesInt.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "JsonPathRangeNotIncludesInt"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "test"
+  attribute: "range"
+  operator: "jsonpath_range_not_includes"
+  value: 3000
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/JsonPathRangeNotIncludesString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/JsonPathRangeNotIncludesString.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "JsonPathRangeNotIncludesString"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "test"
+  attribute: "range"
+  operator: "jsonpath_range_not_includes"
+  value: "3000"
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/RangeNotIncludesInt.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/RangeNotIncludesInt.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "RangeNotIncludesInt"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "test"
+  attribute: "range"
+  operator: "range_not_includes"
+  value: 3000
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/RangeNotIncludesString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/RangeNotIncludesString.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "RangeNotIncludesString"
+scope:
+  provider: "AWS"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "test"
+  attribute: "range"
+  operator: "range_not_includes"
+  value: "3000"
+

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/resources/main.tf
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/resources/main.tf
@@ -1,0 +1,55 @@
+resource "test" "pass1" {
+  range = "*"
+}
+
+resource "test" "pass2" {
+  range = 3000
+}
+
+resource "test" "pass3" {
+  range = "3000"
+}
+
+resource "test" "pass4" {
+  range = "3000-4000"
+}
+
+resource "test" "pass5" {
+  range = "2000-3000"
+}
+
+resource "test" "pass6" {
+  range = "2000-4000"
+}
+
+resource "test" "fail1" {
+  range = 2000
+}
+
+resource "test" "fail2" {
+  range = "2000"
+}
+
+resource "test" "fail3" {
+  range = "1000-2000"
+}
+
+resource "test" "fail4" {
+  range = "4000-5000"
+}
+
+resource "test" "fail5" {
+  # no range
+}
+
+resource "test" "fail6" {
+  range = "abc"
+}
+
+resource "test" "fail7" {
+  range = "abc-123"
+}
+
+resource "test" "fail8" {
+  range = "1000-5000-6000"
+}

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/test_solver.py
@@ -1,0 +1,50 @@
+import os
+
+from tests.terraform.graph.checks_infra.test_base import TestBaseSolver
+
+TEST_DIRNAME = os.path.dirname(os.path.realpath(__file__))
+
+
+class TestRangeNotIncludesSolver(TestBaseSolver):
+    def setUp(self):
+        self.checks_dir = TEST_DIRNAME
+        super(TestRangeNotIncludesSolver, self).setUp()
+
+    def test_range_not_includes_int_solver(self):
+        root_folder = 'resources'
+        check_id = "RangeNotIncludesInt"
+        should_fail = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6']
+        should_pass = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7', 'test.fail8']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_range_not_includes_string_solver(self):
+        root_folder = 'resources'
+        check_id = "RangeNotIncludesString"
+        should_fail = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6']
+        should_pass = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7',
+                       'test.fail8']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_range_not_includes_int_jsonpath_solver(self):
+        root_folder = 'resources'
+        check_id = "JsonPathRangeNotIncludesInt"
+        should_fail = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6']
+        should_pass = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7',
+                       'test.fail8']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_range_not_includes_string_jsonpath_solver(self):
+        root_folder = 'resources'
+        check_id = "JsonPathRangeNotIncludesString"
+        should_fail = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6']
+        should_pass = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7',
+                       'test.fail8']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Adds `range_includes` and `range_not_includes` operators that understand the different ways you can specify ports in SG rules (`*`, `1234`, `"1234"`, `"1234-5678"`)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
