### PR TITLE
fix(terraform): reduce parsing time for large TF plan files

### DIFF
--- a/checkov/cloudformation/parser/cfn_yaml.py
+++ b/checkov/cloudformation/parser/cfn_yaml.py
@@ -230,40 +230,42 @@ def load(filename: Path, content_type: ContentType) -> Tuple[DictNode, List[Tupl
     """
     Load the given YAML file
     """
+    file_path = filename if isinstance(filename, Path) else Path(filename)
+
     if platform.system() == "Windows":
         try:
-            content = str(from_path(filename).best())
+            content = str(from_path(file_path).best())
         except UnicodeDecodeError as e:
-            LOGGER.error(f"Encoding for file {filename} could not be detected or read. Please try encoding the file as UTF-8.")
+            LOGGER.error(f"Encoding for file {file_path} could not be detected or read. Please try encoding the file as UTF-8.")
             raise e
     else:
-        file_path = filename if isinstance(filename, Path) else Path(filename)
         try:
             content = file_path.read_text()
         except UnicodeDecodeError:
-            LOGGER.info(f"Encoding for file {filename} is not UTF-8, trying to detect it")
-            content = str(from_path(filename).best())
+            LOGGER.info(f"Encoding for file {file_path} is not UTF-8, trying to detect it")
+            content = str(from_path(file_path).best())
 
     if content_type == ContentType.CFN and "Resources" not in content:
-        logging.debug(f'File {filename} is expected to be a CFN template but has no Resources attribute')
+        logging.debug(f'File {file_path} is expected to be a CFN template but has no Resources attribute')
         return {}, []
     elif content_type == ContentType.SLS and "provider" not in content:
-        logging.debug(f'File {filename} is expected to be an SLS template but has no provider attribute')
+        logging.debug(f'File {file_path} is expected to be an SLS template but has no provider attribute')
         return {}, []
     elif content_type == ContentType.TFPLAN and "planned_values" not in content:
-        logging.debug(f'File {filename} is expected to be a TFPLAN file but has no planned_values attribute')
+        logging.debug(f'File {file_path} is expected to be a TFPLAN file but has no planned_values attribute')
         return {}, []
 
     file_lines = [(idx + 1, line) for idx, line in enumerate(content.splitlines(keepends=True))]
 
-    if content_type == ContentType.TFPLAN:
+    if file_path.suffix == ".json":
         file_size = len(content)
         if file_size > MAX_IAC_FILE_SIZE:
-            # large files take too much time, when parsed with `pyyaml`, compared to a normal 'json.loads()'
+            # large JSON files take too much time, when parsed with `pyyaml`, compared to a normal 'json.loads()'
             # with start/end line numbers of 0 takes only a few seconds
             logging.info(
-                f"File {filename} has a size of {file_size} which is bigger than the supported 50mb, "
-                "therefore file lines will default to 0"
+                f"File {file_path} has a size of {file_size} which is bigger than the supported 50mb, "
+                "therefore file lines will default to 0."
+                "This limit can be adjusted via the environment variable 'CHECKOV_MAX_IAC_FILE_SIZE'."
             )
             return json.loads(content, cls=SimpleDecoder), file_lines
 

--- a/checkov/common/parsers/json/decoder.py
+++ b/checkov/common/parsers/json/decoder.py
@@ -12,6 +12,32 @@ from checkov.common.parsers.node import StrNode, DictNode, ListNode
 from checkov.common.parsers.json.errors import NullError, DuplicateError, DecodeError
 
 
+class SimpleDecoder(JSONDecoder):
+    def __init__(
+        self,
+        *,
+        object_hook: Callable[[dict[str, Any]], Any] | None = None,
+        parse_float: Callable[[str], Any] | None = None,
+        parse_int: Callable[[str], Any] | None = None,
+        parse_constant: Callable[[str], Any] | None = None,
+        strict: bool = True,
+        object_pairs_hook: Callable[[list[tuple[str, Any]]], Any] | None = None,
+    ) -> None:
+        super().__init__(
+            object_hook=self.object_hook,
+            parse_float=parse_float,
+            parse_int=parse_int,
+            parse_constant=parse_constant,
+            strict=strict,
+            object_pairs_hook=object_pairs_hook,
+        )
+
+    def object_hook(self, obj: dict[str, Any]) -> Any:
+        obj["start_line"] = 0
+        obj["end_line"] = 0
+        return obj
+
+
 class Mark:
     """Mark of line and column"""
     __slots__ = ("column", "line")

--- a/checkov/common/util/consts.py
+++ b/checkov/common/util/consts.py
@@ -1,3 +1,5 @@
+import os
+
 DEFAULT_EXTERNAL_MODULES_DIR = ".external_modules"
 RESOLVED_MODULE_ENTRY_NAME = "__resolved__"
 START_LINE = '__startline__'
@@ -20,3 +22,5 @@ PARSE_ERROR_FAIL_FLAG = 'CKV_PARSE_ERROR_FAIL'
 
 PRISMA_PLATFORM = 'Prisma Cloud Code Security'
 BRIDGECREW_PLATFORM = 'Bridgecrew'
+
+MAX_IAC_FILE_SIZE = int(os.getenv('CHECKOV_MAX_IAC_FILE_SIZE', '50_000_000'))  # 50 MB is default limit

--- a/checkov/terraform/context_parsers/tf_plan/__init__.py
+++ b/checkov/terraform/context_parsers/tf_plan/__init__.py
@@ -3,7 +3,6 @@ from typing import Dict
 
 from checkov.cloudformation.parser.cfn_yaml import ContentType
 from checkov.cloudformation.parser import cfn_yaml
-from checkov.common.parsers.node import DictNode
 
 LOGGER = logging.getLogger(__name__)
 
@@ -12,17 +11,24 @@ def parse(filename, out_parsing_errors: Dict[str, str]):
     """
         Decode filename into an object
     """
+    logging.debug(f"[tf_plan] - Parsing file {filename}")
+
     try:
-        (template, template_lines) = cfn_yaml.load(filename, ContentType.TFPLAN)
+        template, template_lines = cfn_yaml.load(filename, ContentType.TFPLAN)
     except Exception as e:
+        logging.debug(f"[tf_plan] - Failed to parse file {filename}", exc_info=True)
         out_parsing_errors[filename] = str(e)
         return None, None
 
     if (
         template is not None
-        and isinstance(template, DictNode)
+        and isinstance(template, dict)
         and 'terraform_version' in template
         and 'planned_values' in template
     ):
+        logging.debug(f"[tf_plan] - Successfully parsed file {filename}")
+
         return template, template_lines
+
+    logging.debug(f"[tf_plan] - Missing required fields in file {filename}")
     return None, None

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -49,7 +49,10 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
 
     def build_graph(self, render_variables: bool) -> None:
         self._create_vertices()
+        logging.info(f"[TerraformLocalGraph] created {len(self.vertices)} vertices")
         self._build_edges()
+        logging.info(f"[TerraformLocalGraph] created {len(self.edges)} edges")
+
         self.calculate_encryption_attribute(ENCRYPTION_BY_RESOURCE_TYPE)
         if render_variables:
             logging.info(f"Rendering variables, graph has {len(self.vertices)} vertices and {len(self.edges)} edges")

--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -111,7 +111,7 @@ def _prepare_resource_block(
     if mode == "managed":
         expressions = conf.get("expressions") if conf else None
 
-        resource_conf = _hclify(resource.get("values", {}), expressions)
+        resource_conf = _hclify(resource.get("values", {"start_line": 0, "end_line": 0}), expressions)
         resource_address = resource.get("address")
         resource_conf[TF_PLAN_RESOURCE_ADDRESS] = resource_address
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- Added a `json.laods()` fallback for TF plan files, which are bigger than 50mb (the created ticket says 100mb, but currently it takes ~40sec to parse a 100mb file, compared to ~2-3sec via `json.loads`)
- Added a couple of logs for better troubleshooting
- Interestingly we also have a custom JSON parser, but it performs worse compared to the YAML loader 🤷 
- Added some small performance improvements in the TF edge creation, which makes it ~20% faster for TF plan files and ~10% for HCL files 🚀 

Fixes #3754 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
