### PR TITLE
feat(openapi): pre-validate OpenAPI JSON files

### DIFF
--- a/checkov/arm/parser/__init__.py
+++ b/checkov/arm/parser/__init__.py
@@ -20,7 +20,7 @@ def parse(filename: str) -> tuple[dict[str, Any], tuple[int, str]] | tuple[None,
     template = None
     template_lines = None
     try:
-        (template, template_lines) = cfn_yaml.load(filename)
+        template, template_lines = cfn_yaml.load(filename)
     except IOError as e:
         if e.errno == 2:
             LOGGER.error(f"Template file not found: {filename}")
@@ -35,7 +35,9 @@ def parse(filename: str) -> tuple[dict[str, Any], tuple[int, str]] | tuple[None,
     except ScannerError as err:
         if err.problem in ("found character '\\t' that cannot start any token", "found unknown escape character"):
             try:
-                (template, template_lines) = json_parse(filename, allow_nulls=False)
+                result = json_parse(filename, allow_nulls=False)
+                if result:
+                    template, template_lines = result
             except Exception:
                 LOGGER.error(f"Template {filename} is malformed: {err.problem}")
                 LOGGER.error(f"Tried to parse {filename} as JSON", exc_info=True)

--- a/checkov/cloudformation/parser/__init__.py
+++ b/checkov/cloudformation/parser/__init__.py
@@ -52,14 +52,18 @@ def parse(
     except ScannerError as err:
         if err.problem in ["found character '\\t' that cannot start any token", "found unknown escape character"]:
             try:
-                (template, template_lines) = json_parse(filename, allow_nulls=False)
+                result = json_parse(filename, allow_nulls=False)
+                if result:
+                    template, template_lines = result
             except Exception as json_err:  # pylint: disable=W0703
                 error = f"Template {filename} is malformed: {err.problem}. Tried to parse {filename} as JSON but got error: {json_err}"
                 LOGGER.info(error)
     except YAMLError as err:
         if hasattr(err, 'problem') and err.problem in ["expected ',' or '}', but got '<scalar>'"]:
             try:
-                (template, template_lines) = json_parse(filename, allow_nulls=False)
+                result = json_parse(filename, allow_nulls=False)
+                if result:
+                    template, template_lines = result
             except Exception as json_err:  # pylint: disable=W0703
                 error = f"Template {filename} is malformed: {err.problem}. Tried to parse {filename} as JSON but got error: {json_err}"
                 LOGGER.info(error)

--- a/checkov/common/parsers/json/__init__.py
+++ b/checkov/common/parsers/json/__init__.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 from charset_normalizer import from_path
 
@@ -16,31 +17,35 @@ from checkov.common.parsers.json.errors import DecodeError
 LOGGER = logging.getLogger(__name__)
 
 
-def load(filename: str, allow_nulls: bool = True) -> tuple[dict[str, Any], list[tuple[int, str]]]:
+def load(
+    filename: str | Path, allow_nulls: bool = True, content: str | None = None
+) -> tuple[dict[str, Any], list[tuple[int, str]]]:
     """
     Load the given JSON file
     """
 
     try:
-        with open(filename) as fp:
-            content = fp.read()
+        if not content:
+            file_path = filename if isinstance(filename, Path) else Path(filename)
+            content = file_path.read_text()
     except UnicodeDecodeError:
         LOGGER.info(f"Encoding for file {filename} is not UTF-8, trying to detect it")
         content = str(from_path(filename).best())  # type:ignore[arg-type]  # somehow str is not recognized as PathLike
 
     file_lines = [(idx + 1, line) for idx, line in enumerate(content.splitlines(keepends=True))]
 
-    return (json.loads(content, cls=Decoder, allow_nulls=allow_nulls), file_lines)
+    return json.loads(content, cls=Decoder, allow_nulls=allow_nulls), file_lines
 
 
 def parse(
-    filename: str, allow_nulls: bool = True, out_parsing_errors: Dict[str, str] | None = None
-) -> tuple[dict[str, Any] | list[dict[str, Any]] | None, list[tuple[int, str]] | None]:
-    template = None
-    template_lines = None
+    filename: str,
+    allow_nulls: bool = True,
+    out_parsing_errors: dict[str, str] | None = None,
+    file_content: str | None = None,
+) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
     error: Exception | None = None
     try:
-        (template, template_lines) = load(filename, allow_nulls)
+        return load(filename=filename, allow_nulls=allow_nulls, content=file_content)
     except DecodeError as e:
         logging.debug(f'Got DecodeError parsing file {filename}', exc_info=True)
         error = e
@@ -60,4 +65,4 @@ def parse(
             out_parsing_errors = {}
         out_parsing_errors[filename] = str(error)
 
-    return (template, template_lines)
+    return None

--- a/checkov/common/parsers/yaml/loader.py
+++ b/checkov/common/parsers/yaml/loader.py
@@ -38,7 +38,7 @@ def load(filename: str | Path, content: str | None = None) -> tuple[list[dict[st
 
     template = loads(content)
 
-    return (template, file_lines)
+    return template, file_lines
 
 
 class SafeLineLoader(SafeLoader):

--- a/checkov/common/parsers/yaml/parser.py
+++ b/checkov/common/parsers/yaml/parser.py
@@ -17,7 +17,7 @@ def parse(
     template_lines = None
     try:
         if filename.endswith(".yaml") or filename.endswith(".yml"):
-            (template, template_lines) = loader.load(filename, file_content)
+            template, template_lines = loader.load(filename, file_content)
 
         if template and template_lines:
             if isinstance(template, list):
@@ -30,22 +30,20 @@ def parse(
             return None
     except IOError as e:
         if e.errno == 2:
-            logger.error('Template file not found: %s', filename)
+            logger.error(f"Template file not found: {filename}")
             return None
         elif e.errno == 21:
-            logger.error('Template references a directory, not a file: %s',
-                         filename)
+            logger.error(f"Template references a directory, not a file: {filename}")
             return None
         elif e.errno == 13:
-            logger.error('Permission denied when accessing template file: %s',
-                         filename)
+            logger.error(f"Permission denied when accessing template file: {filename}")
             return None
     except UnicodeDecodeError:
-        logger.error('Cannot read file contents: %s', filename)
+        logger.error(f"Cannot read file contents: {filename}")
         return None
     except YAMLError:
         if filename.endswith(".yaml") or filename.endswith(".yml"):
-            logger.debug('Cannot read file contents: %s - is it a yaml?', filename)
+            logger.debug(f"Cannot read file contents: {filename} - is it a yaml?")
         return None
 
     return None

--- a/checkov/json_doc/runner.py
+++ b/checkov/json_doc/runner.py
@@ -20,14 +20,13 @@ class Runner(ObjectRunner):
         from checkov.json_doc.registry import registry
         return registry
 
-    def _parse_file(  # type:ignore[override]  # expected behaviour but should be aligned
+    def _parse_file(
         self, f: str, file_content: str | None = None
-    ) -> tuple[dict[str, Any] | list[dict[str, Any]] | None, list[tuple[int, str]] | None] | None:
+    ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         if not f.endswith(".json"):
             return None
 
-        content: tuple[dict[str, Any] | list[dict[str, Any]] | None, list[tuple[int, str]] | None] = parse(f)
-        return content
+        return parse(filename=f, file_content=file_content)
 
     def get_start_end_lines(self, end: int, result_config: dict[str, Any], start: int) -> tuple[int, int]:
         if not isinstance(result_config, DictNode):

--- a/checkov/openapi/runner.py
+++ b/checkov/openapi/runner.py
@@ -46,14 +46,13 @@ class Runner(YamlRunner, JsonRunner):
         func: _ParseFormatJsonCallable | _ParseFormatYamlCallable,
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         try:
-            if f.endswith(".json"):
-                parsed_file = func(self, f, None)
-            elif f.endswith(".yml") or f.endswith(".yaml"):
-                content = self.load_yaml_file(f)
-                valid_openapi_file = self.pre_validate_file(content)
-                if not valid_openapi_file:
-                    return None
-                parsed_file = func(self, f, content)
+            content = self.load_file(f)
+            valid_openapi_file = self.pre_validate_file(content)
+            if not valid_openapi_file:
+                return None
+
+            parsed_file = func(self, f, content)
+
             if isinstance(parsed_file, tuple) and self.is_valid(parsed_file[0]):
                 return parsed_file  # type:ignore[return-value]  # is_valid checks for being not empty
         except ValueError:
@@ -95,7 +94,7 @@ class Runner(YamlRunner, JsonRunner):
     def get_resource(self, file_path: str, key: str, supported_entities: Iterable[str], definitions: dict[str, Any] | None = None) -> str:
         return ",".join(supported_entities)
 
-    def load_yaml_file(self, filename: str | Path) -> str:
+    def load_file(self, filename: str | Path) -> str:
         file_path = filename if isinstance(filename, Path) else Path(filename)
         content = file_path.read_text()
         return content

--- a/tests/openapi/runner/test_runner.py
+++ b/tests/openapi/runner/test_runner.py
@@ -17,13 +17,12 @@ class TestRunnerValid(unittest.TestCase):
         checks = ["CKV_OPENAPI_1", "CKV_OPENAPI_4", "CKV_OPENAPI_3"]
         report = runner.run(
             root_folder=valid_dir_path,
-            runner_filter=RunnerFilter(framework='openapi', checks=checks)
+            runner_filter=RunnerFilter(framework=['openapi'], checks=checks)
         )
         self.assertEqual(len(report.failed_checks), 12)
         self.assertEqual(report.parsing_errors, [])
         self.assertEqual(len(report.passed_checks), 6)
         self.assertEqual(report.skipped_checks, [])
-        report.print_console()
 
     def test_runner_honors_enforcement_rules(self) -> None:
         current_dir = os.path.dirname(__file__)
@@ -51,9 +50,8 @@ class TestRunnerValid(unittest.TestCase):
         runner = Runner()
         report = runner.run(
             root_folder=valid_dir_path,
-            runner_filter=RunnerFilter(framework='openapi')
+            runner_filter=RunnerFilter(framework=['openapi'])
         )
-        report.print_console()
 
     def test_pre_validate_non_openapi_file(self) -> None:
         runner = Runner()
@@ -73,7 +71,7 @@ class TestRunnerValid(unittest.TestCase):
         result = runner.pre_validate_file(file_content)
         self.assertFalse(result)
 
-    def test_pre_validate_openapi_file(self) -> None:
+    def test_pre_validate_openapi_yaml_file(self) -> None:
         runner = Runner()
         file_content = """
             'openapi: 3.0.0
@@ -92,6 +90,41 @@ class TestRunnerValid(unittest.TestCase):
         result = runner.pre_validate_file(file_content)
         self.assertTrue(result)
 
+    def test_pre_validate_openapi_json_file(self) -> None:
+        runner = Runner()
+        file_content = json.dumps(
+            {
+                "openapi": "3.0.0",
+                "info": {
+                    "title": "test",
+                    "version": "1.0.0"
+                },
+                "components": {
+                    "securitySchemes": {
+                        "encryptedScheme": {
+                            "type": "oauth2"
+                        }
+                    }
+                },
+                "paths": {
+                    "/": {
+                        "get": {
+                            "security": [
+                                {
+                                    "encryptedScheme": [
+                                        "write",
+                                        "read"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        )
+        result = runner.pre_validate_file(file_content)
+        self.assertTrue(result)
+
     def test_runner_results_consistency(self) -> None:
         current_dir = os.path.dirname(__file__)
         valid_dir_path = os.path.join(current_dir, "resources")
@@ -100,7 +133,7 @@ class TestRunnerValid(unittest.TestCase):
         checks = ["CKV_OPENAPI_1", "CKV_OPENAPI_4", "CKV_OPENAPI_3"]
         report = runner.run(
             root_folder=valid_dir_path,
-            runner_filter=RunnerFilter(framework='openapi', checks=checks)
+            runner_filter=RunnerFilter(framework=['openapi'], checks=checks)
         )
         self.assertEqual(len(report.failed_checks), 12)
         self.assertEqual(report.parsing_errors, [])


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- aligned the processing of OpenAPI YAML and JSON files to do a simple pre-validation step
- adjusted the JSOn parsing to have the same return type as the YAML one
- removed a couple of round brackets, which are not needed

Fixes #3755 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
