### PR TITLE
feat(terraform): Add CKV_AWS_276 to ensure that API Gateway Method Settings data_trace_enabled is not set to True

### DIFF
--- a/checkov/terraform/checks/resource/aws/APIGatewayMethodSettingsDataTrace.py
+++ b/checkov/terraform/checks/resource/aws/APIGatewayMethodSettingsDataTrace.py
@@ -3,12 +3,11 @@ from checkov.common.models.enums import CheckCategories
 
 
 class APIGatewayMethodSettingsDataTrace(BaseResourceNegativeValueCheck):
-
     def __init__(self):
         name = "Ensure Data Trace is not enabled in API Gateway Method Settings"
         id = "CKV_AWS_276"
-        supported_resources = ['aws_api_gateway_method_settings']
-        categories = [CheckCategories.LOGGING]
+        supported_resources = ('aws_api_gateway_method_settings',)
+        categories = (CheckCategories.LOGGING,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):

--- a/checkov/terraform/checks/resource/aws/APIGatewayMethodSettingsDataTrace.py
+++ b/checkov/terraform/checks/resource/aws/APIGatewayMethodSettingsDataTrace.py
@@ -1,0 +1,21 @@
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class APIGatewayMethodSettingsDataTrace(BaseResourceNegativeValueCheck):
+
+    def __init__(self):
+        name = "Ensure Data Trace is not enabled in API Gateway Method Settings"
+        id = "CKV_AWS_276"
+        supported_resources = ['aws_api_gateway_method_settings']
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "settings/[0]/data_trace_enabled"
+
+    def get_forbidden_values(self):
+        return [True]
+
+
+check = APIGatewayMethodSettingsDataTrace()

--- a/tests/terraform/checks/resource/aws/example_APIGatewayMethodSettingsDataTrace/main.tf
+++ b/tests/terraform/checks/resource/aws/example_APIGatewayMethodSettingsDataTrace/main.tf
@@ -1,0 +1,25 @@
+resource "aws_api_gateway_method_settings" "fail" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_stage.test.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    data_trace_enabled = true
+  }
+}
+
+resource "aws_api_gateway_method_settings" "pass_explicit" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_stage.test.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    data_trace_enabled = false
+  }
+}
+
+resource "aws_api_gateway_method_settings" "pass_implicit" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_stage.test.stage_name
+  method_path = "path1/GET"
+}

--- a/tests/terraform/checks/resource/aws/test_APIGatewayMethodSettingsDataTrace.py
+++ b/tests/terraform/checks/resource/aws/test_APIGatewayMethodSettingsDataTrace.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.aws.APIGatewayMethodSettingsDataTrace import check
+
+
+class TestAPIGatewayMethodSettingsDataTrace(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_APIGatewayMethodSettingsDataTrace")
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_api_gateway_method_settings.pass_explicit",
+            "aws_api_gateway_method_settings.pass_implicit",
+        }
+        failing_resources = {
+            "aws_api_gateway_method_settings.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Added a new check that data_trace_enabled in API Gateway Method Settings is not set to True 
Not recommended to be enabled by AWS as seen [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)

Fixes #3693 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
