### PR TITLE
feat(github): split repo and org webhooks to separate files

### DIFF
--- a/checkov/github/dal.py
+++ b/checkov/github/dal.py
@@ -79,7 +79,7 @@ class Github(BaseVCSDAL):
         if organization_webhooks:
             for idx, item in enumerate(organization_webhooks):
                 path = str(self.github_conf_file_paths["org_webhooks"])
-                BaseVCSDAL.persist(path=path.replace(".json", str(idx) + ".json"), conf=[item])
+                BaseVCSDAL.persist(path=path.replace(".json", str(idx) + ".json"), conf=[item])    # type: ignore
 
     def get_organization_webhooks(self) -> dict[str, Any] | None:
         data = self._request(endpoint="orgs/{}/hooks".format(self.org), allowed_status_codes=[200])
@@ -111,7 +111,7 @@ class Github(BaseVCSDAL):
         if repository_webhooks:
             for idx, item in enumerate(repository_webhooks):
                 path = str(self.github_conf_file_paths["repository_webhooks"])
-                BaseVCSDAL.persist(path=path.replace(".json", str(idx) + ".json"), conf=[item])
+                BaseVCSDAL.persist(path=path.replace(".json", str(idx) + ".json"), conf=[item])    # type: ignore
 
     def get_organization_security(self) -> dict[str, str] | None:
         if not self._organization_security:

--- a/checkov/github/dal.py
+++ b/checkov/github/dal.py
@@ -77,7 +77,9 @@ class Github(BaseVCSDAL):
     def persist_organization_webhooks(self) -> None:
         organization_webhooks = self.get_organization_webhooks()
         if organization_webhooks:
-            BaseVCSDAL.persist(path=self.github_conf_file_paths["org_webhooks"], conf=organization_webhooks)
+            for idx, item in enumerate(organization_webhooks):
+                path = str(self.github_conf_file_paths["org_webhooks"])
+                BaseVCSDAL.persist(path=path.replace(".json", str(idx) + ".json"), conf=[item])
 
     def get_organization_webhooks(self) -> dict[str, Any] | None:
         data = self._request(endpoint="orgs/{}/hooks".format(self.org), allowed_status_codes=[200])
@@ -107,7 +109,9 @@ class Github(BaseVCSDAL):
     def persist_repository_webhooks(self) -> None:
         repository_webhooks = self.get_repository_webhooks()
         if repository_webhooks:
-            BaseVCSDAL.persist(path=self.github_conf_file_paths["repository_webhooks"], conf=repository_webhooks)
+            for idx, item in enumerate(repository_webhooks):
+                path = str(self.github_conf_file_paths["repository_webhooks"])
+                BaseVCSDAL.persist(path=path.replace(".json", str(idx) + ".json"), conf=[item])
 
     def get_organization_security(self) -> dict[str, str] | None:
         if not self._organization_security:


### PR DESCRIPTION
## Description

This PR splits multiple vcs webhooks into separate files so each one appears as new check violation.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
