### PR TITLE
fix(terraform): render list entries via modules correctly

### DIFF
--- a/checkov/common/graph/graph_builder/graph_components/blocks.py
+++ b/checkov/common/graph/graph_builder/graph_components/blocks.py
@@ -145,7 +145,9 @@ class Block:
             previous_breadcrumbs.append(BreadcrumbMetadata(change_origin_id, attribute_at_dest))
 
         # update the numbered attributes, if the new value is a list
-        if isinstance(attribute_value, list):
+        if attribute_value and isinstance(attribute_value, list) and isinstance(self.attributes[attribute_key][0], list):
+            # sometimes the attribute_value is a list and replaces the whole value of the key, which makes it a normal value
+            # ex. attribute_value = ["xyz"] and self.attributes[attribute_key][0] = "xyz"
             for idx, value in enumerate(attribute_value):
                 self.attributes[f"{attribute_key}.{idx}"] = value
 

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -14,6 +14,7 @@ from checkov.common.graph.graph_builder import reserved_attribute_names
 from checkov.common.graph.graph_builder.graph_components.attribute_names import CustomAttributes
 from checkov.common.graph.graph_builder.local_graph import LocalGraph
 from checkov.common.graph.graph_builder.utils import calculate_hash, join_trimmed_strings, filter_sub_keys
+from checkov.common.util.type_forcers import force_int
 from checkov.terraform.checks.utils.dependency_path_handler import unify_dependency_path
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 from checkov.terraform.graph_builder.graph_components.blocks import TerraformBlock
@@ -474,21 +475,54 @@ def update_dictionary_attribute(
         config: Union[List[Any], Dict[str, Any]], key_to_update: str, new_value: Any
 ) -> Union[List[Any], Dict[str, Any]]:
     key_parts = key_to_update.split(".")
+
     if isinstance(config, dict):
-        if config.get(key_parts[0]) is not None:
-            key = key_parts[0]
+        key = key_parts[0]
+        inner_config = config.get(key)
+
+        if inner_config is not None:
             if len(key_parts) == 1:
-                if isinstance(config[key], list) and not isinstance(new_value, list):
+                if isinstance(inner_config, list) and not isinstance(new_value, list):
                     new_value = [new_value]
                 config[key] = new_value
                 return config
             else:
-                config[key] = update_dictionary_attribute(config[key], ".".join(key_parts[1:]), new_value)
+                config[key] = update_dictionary_attribute(inner_config, ".".join(key_parts[1:]), new_value)
         else:
             for key in config:
                 config[key] = update_dictionary_attribute(config[key], key_to_update, new_value)
     if isinstance(config, list):
-        for i, config_value in enumerate(config):
-            config[i] = update_dictionary_attribute(config_value, key_to_update, new_value)
+        return update_list_attribute(
+            config=config,
+            key_parts=key_parts,
+            key_to_update=key_to_update,
+            new_value=new_value,
+        )
+    return config
+
+
+def update_list_attribute(
+    config: list[Any], key_parts: list[str], key_to_update: str, new_value: Any
+) -> list[Any] | dict[str, Any]:
+    """Updates a list attribute in the given config"""
+
+    if not config:
+        # happens when we can't correctly evaluate something, because of strange defaults or 'for_each' blocks
+        return config
+
+    if len(key_parts) == 1:
+        idx = force_int(key_parts[0])
+        inner_config = config[0]
+
+        if idx is not None and isinstance(inner_config, list):
+            if not inner_config:
+                # happens when config = [[]]
+                return config
+
+            inner_config[idx] = new_value
+            return config
+
+    for i, config_value in enumerate(config):
+        config[i] = update_dictionary_attribute(config=config_value, key_to_update=key_to_update, new_value=new_value)
 
     return config

--- a/tests/terraform/graph/variable_rendering/test_resources/list_entry_module_var/module/main.tf
+++ b/tests/terraform/graph/variable_rendering/test_resources/list_entry_module_var/module/main.tf
@@ -1,0 +1,26 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "cidr_sg" {
+  type    = string
+  default = "0.0.0.0/0"
+}
+
+resource "aws_security_group" "sg" {
+  name            = "example"
+  vpc_id          = var.vpc_id
+
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "TCP"
+    cidr_blocks     = [var.cidr_sg]
+  }
+  egress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "TCP"
+    cidr_blocks     = ["10.0.0.0/16", var.cidr_sg]
+  }
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- the example in linked issue explains the problem pretty well. we actually render the value, but we don't pass to the config attribute, therefore we still think it is unrendered, when we run any checks against it.
- during implementation I encountered various side effects, that's why I needed to write more code than expected

Fixes #3766 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
