### PR TITLE
feat(terraform): PC Policy Team Yaml Policies Check-in

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/EC2InstanceHasIAMRoleAttached.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/EC2InstanceHasIAMRoleAttached.yaml
@@ -1,10 +1,7 @@
 metadata:
   id: "CKV2_AWS_41"
   name: "Ensure an IAM role is attached to EC2 instance"
-  guidelines: "AWS provides Identity Access Management (IAM) roles to securely access AWS services and resources. The role is an identity with permission policies that define what the identity can and cannot do in AWS. As a best practice, create IAM roles and attach the role to manage EC2 instance permissions securely instead of distributing or sharing keys or passwords."
   category: "IAM"
-scope:
-  provider: "aws"
 definition:
   cond_type: "attribute"
   resource_types:

--- a/checkov/terraform/checks/graph_checks/aws/EC2InstanceHasIAMRoleAttached.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/EC2InstanceHasIAMRoleAttached.yaml
@@ -1,0 +1,13 @@
+metadata:
+  id: "CKV_AWS_EC2_ROLE_1"
+  name: "Ensure an IAM role is attached to EC2 instance"
+  guidelines: "AWS provides Identity Access Management (IAM) roles to securely access AWS services and resources. The role is an identity with permission policies that define what the identity can and cannot do in AWS. As a best practice, create IAM roles and attach the role to manage EC2 instance permissions securely instead of distributing or sharing keys or passwords."
+  category: "IAM"
+scope:
+  provider: "aws"
+definition:
+  cond_type: "attribute"
+  resource_types:
+  - "aws_instance"
+  attribute: "iam_instance_profile"
+  operator: "exists"

--- a/checkov/terraform/checks/graph_checks/aws/EC2InstanceHasIAMRoleAttached.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/EC2InstanceHasIAMRoleAttached.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: "CKV_AWS_EC2_ROLE_1"
+  id: "CKV2_AWS_41"
   name: "Ensure an IAM role is attached to EC2 instance"
   guidelines: "AWS provides Identity Access Management (IAM) roles to securely access AWS services and resources. The role is an identity with permission policies that define what the identity can and cannot do in AWS. As a best practice, create IAM roles and attach the role to manage EC2 instance permissions securely instead of distributing or sharing keys or passwords."
   category: "IAM"

--- a/checkov/terraform/checks/graph_checks/gcp/CloudFunctionSecureHTTPTrigger.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/CloudFunctionSecureHTTPTrigger.yaml
@@ -1,10 +1,7 @@
 metadata:
   id: "CKV2_GCP_10"
-  name: "GCP Cloud Function HTTP trigger is secured"
-  guidelines: "This policy identifies GCP Cloud Functions for which the HTTP trigger is not secured. When you configure HTTP functions to be triggered only with HTTPS, user requests will be redirected to use the HTTPS protocol, which is more secure. It is recommended to set the 'Trigger Security level' to 'SECURE_ALWAYS' for configuring HTTP triggers while deploying your function"
+  name: "Ensure GCP Cloud Function HTTP trigger is secured"
   category: "NETWORKING"
-scope:
-  provider: "gcp"
 definition:
   cond_type: "attribute"
   resource_types:

--- a/checkov/terraform/checks/graph_checks/gcp/CloudFunctionSecureHTTPTrigger.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/CloudFunctionSecureHTTPTrigger.yaml
@@ -1,0 +1,14 @@
+metadata:
+  id: "CKV_GCP_FUNCTION_1"
+  name: "GCP Cloud Function HTTP trigger is secured"
+  guidelines: "This policy identifies GCP Cloud Functions for which the HTTP trigger is not secured. When you configure HTTP functions to be triggered only with HTTPS, user requests will be redirected to use the HTTPS protocol, which is more secure. It is recommended to set the 'Trigger Security level' to 'SECURE_ALWAYS' for configuring HTTP triggers while deploying your function"
+  category: "NETWORKING"
+scope:
+  provider: "gcp"
+definition:
+  cond_type: "attribute"
+  resource_types:
+  - "google_cloudfunctions_function"
+  attribute: "https_trigger_security_level"
+  operator: "equals"
+  value: "SECURE_ALWAYS"

--- a/checkov/terraform/checks/graph_checks/gcp/CloudFunctionSecureHTTPTrigger.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/CloudFunctionSecureHTTPTrigger.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: "CKV_GCP_FUNCTION_1"
+  id: "CKV2_GCP_10"
   name: "GCP Cloud Function HTTP trigger is secured"
   guidelines: "This policy identifies GCP Cloud Functions for which the HTTP trigger is not secured. When you configure HTTP functions to be triggered only with HTTPS, user requests will be redirected to use the HTTPS protocol, which is more secure. It is recommended to set the 'Trigger Security level' to 'SECURE_ALWAYS' for configuring HTTP triggers while deploying your function"
   category: "NETWORKING"

--- a/checkov/terraform/checks/graph_checks/gcp/GCRContainerVulnerabilityScanningEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCRContainerVulnerabilityScanningEnabled.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: "CKV_GCR_1"
+  id: "CKV2_GCP_11"
   name: "GCP GCR Container Vulnerability Scanning is enabled"
   guidelines: "This policy identifies GCP accounts where GCR Container Vulnerability Scanning is not enabled. GCR Container Analysis and other third party products allow images stored in GCR to be scanned for known vulnerabilities. Vulnerabilities in software packages can be exploited by hackers or malicious users to obtain unauthorized access to local cloud resources. It is recommended to enable vulnerability scanning for images stored in Google Container Registry."
   category: "SECURITY"

--- a/checkov/terraform/checks/graph_checks/gcp/GCRContainerVulnerabilityScanningEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCRContainerVulnerabilityScanningEnabled.yaml
@@ -1,17 +1,8 @@
 metadata:
   id: "CKV2_GCP_11"
-  name: "GCP GCR Container Vulnerability Scanning is enabled"
-  guidelines: "This policy identifies GCP accounts where GCR Container Vulnerability Scanning is not enabled. GCR Container Analysis and other third party products allow images stored in GCR to be scanned for known vulnerabilities. Vulnerabilities in software packages can be exploited by hackers or malicious users to obtain unauthorized access to local cloud resources. It is recommended to enable vulnerability scanning for images stored in Google Container Registry."
-  category: "SECURITY"
-scope:
-  provider: "gcp"
+  name: "Ensure GCP GCR Container Vulnerability Scanning is enabled"
+  category: "GENERAL_SECURITY"
 definition:
-  cond_type: "attribute"
-  resource_types:
-  - "google_project_services"
-  - "google_project_service"
-  attribute: "iam_instance_profile"
-  operator: "exists"
   or:
     - cond_type: "attribute"
       resource_types:

--- a/checkov/terraform/checks/graph_checks/gcp/GCRContainerVulnerabilityScanningEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCRContainerVulnerabilityScanningEnabled.yaml
@@ -3,16 +3,9 @@ metadata:
   name: "Ensure GCP GCR Container Vulnerability Scanning is enabled"
   category: "GENERAL_SECURITY"
 definition:
-  or:
-    - cond_type: "attribute"
-      resource_types:
-      - "google_project_services"
-      attribute: "services"
-      operator: "contains"
-      value: "containerscanning.googleapis.com"
-    - cond_type: "attribute"
-      resource_types:
-      - "google_project_service"
-      attribute: "service"
-      operator: "contains"
-      value: "containerscanning.googleapis.com"
+  cond_type: "attribute"
+  resource_types:
+    - "google_project_services"
+  attribute: "services"
+  operator: "contains"
+  value: "containerscanning.googleapis.com"

--- a/checkov/terraform/checks/graph_checks/gcp/GCRContainerVulnerabilityScanningEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCRContainerVulnerabilityScanningEnabled.yaml
@@ -1,0 +1,27 @@
+metadata:
+  id: "CKV_GCR_1"
+  name: "GCP GCR Container Vulnerability Scanning is enabled"
+  guidelines: "This policy identifies GCP accounts where GCR Container Vulnerability Scanning is not enabled. GCR Container Analysis and other third party products allow images stored in GCR to be scanned for known vulnerabilities. Vulnerabilities in software packages can be exploited by hackers or malicious users to obtain unauthorized access to local cloud resources. It is recommended to enable vulnerability scanning for images stored in Google Container Registry."
+  category: "SECURITY"
+scope:
+  provider: "gcp"
+definition:
+  cond_type: "attribute"
+  resource_types:
+  - "google_project_services"
+  - "google_project_service"
+  attribute: "iam_instance_profile"
+  operator: "exists"
+  or:
+    - cond_type: "attribute"
+      resource_types:
+      - "google_project_services"
+      attribute: "services"
+      operator: "contains"
+      value: "containerscanning.googleapis.com"
+    - cond_type: "attribute"
+      resource_types:
+      - "google_project_service"
+      attribute: "service"
+      operator: "contains"
+      value: "containerscanning.googleapis.com"

--- a/tests/terraform/graph/checks/resources/CloudFunctionSecureHTTPTrigger/expected.yaml
+++ b/tests/terraform/graph/checks/resources/CloudFunctionSecureHTTPTrigger/expected.yaml
@@ -1,0 +1,5 @@
+pass:
+  - "google_cloudfunctions_function.pass"
+fail:
+  - "google_cloudfunctions_function.fail_1"
+  - "google_cloudfunctions_function.fail_2"

--- a/tests/terraform/graph/checks/resources/CloudFunctionSecureHTTPTrigger/main.tf
+++ b/tests/terraform/graph/checks/resources/CloudFunctionSecureHTTPTrigger/main.tf
@@ -1,0 +1,49 @@
+resource "google_cloudfunctions_function" "pass" {
+  name        = "function-test"
+  description = "My function"
+  runtime     = "nodejs16"
+
+  available_memory_mb          = 128
+  source_archive_bucket        = google_storage_bucket.bucket.name
+  source_archive_object        = google_storage_bucket_object.archive.name
+  trigger_http                 = true
+  https_trigger_security_level = "SECURE_ALWAYS"
+  timeout                      = 60
+  entry_point                  = "helloGET"
+  labels = {
+    my-label = "my-label-value"
+  }
+}
+
+resource "google_cloudfunctions_function" "fail_1" {
+  name        = "function-test"
+  description = "My function"
+  runtime     = "nodejs16"
+
+  available_memory_mb          = 128
+  source_archive_bucket        = google_storage_bucket.bucket.name
+  source_archive_object        = google_storage_bucket_object.archive.name
+  trigger_http                 = true
+  https_trigger_security_level = "SECURE_OPTIONAL"
+  timeout                      = 60
+  entry_point                  = "helloGET"
+  labels = {
+    my-label = "my-label-value"
+  }
+}
+
+resource "google_cloudfunctions_function" "fail_2" {
+  name        = "function-test"
+  description = "My function"
+  runtime     = "nodejs16"
+
+  available_memory_mb          = 128
+  source_archive_bucket        = google_storage_bucket.bucket.name
+  source_archive_object        = google_storage_bucket_object.archive.name
+  trigger_http                 = true
+  timeout                      = 60
+  entry_point                  = "helloGET"
+  labels = {
+    my-label = "my-label-value"
+  }
+}

--- a/tests/terraform/graph/checks/resources/EC2InstanceHasIAMRoleAttached/expected.yaml
+++ b/tests/terraform/graph/checks/resources/EC2InstanceHasIAMRoleAttached/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "aws_instance.pass"
+fail:
+  - "aws_instance.fail"

--- a/tests/terraform/graph/checks/resources/EC2InstanceHasIAMRoleAttached/main.tf
+++ b/tests/terraform/graph/checks/resources/EC2InstanceHasIAMRoleAttached/main.tf
@@ -1,0 +1,28 @@
+resource "aws_instance" "pass" {
+  ami           = "ami-005e54dee72cc1d00" # us-west-2
+  instance_type = "t2.micro"
+  iam_instance_profile = "test"
+
+  network_interface {
+    network_interface_id = aws_network_interface.foo.id
+    device_index         = 0
+  }
+
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+}
+
+resource "aws_instance" "fail" {
+  ami           = "ami-005e54dee72cc1d00"
+  instance_type = "t2.micro"
+
+  network_interface {
+    network_interface_id = aws_network_interface.foo.id
+    device_index         = 0
+  }
+
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+}

--- a/tests/terraform/graph/checks/resources/GCRContainerVulnerabilityScanningEnabled/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCRContainerVulnerabilityScanningEnabled/expected.yaml
@@ -1,0 +1,6 @@
+pass:
+  - "google_project_services.pass_1"
+  - "google_project_service.pass_2"
+fail:
+  - "google_project_services.fail_1"
+  - "google_project_service.fail_2"

--- a/tests/terraform/graph/checks/resources/GCRContainerVulnerabilityScanningEnabled/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCRContainerVulnerabilityScanningEnabled/expected.yaml
@@ -1,6 +1,4 @@
 pass:
   - "google_project_services.pass_1"
-  - "google_project_service.pass_2"
 fail:
   - "google_project_services.fail_1"
-  - "google_project_service.fail_2"

--- a/tests/terraform/graph/checks/resources/GCRContainerVulnerabilityScanningEnabled/main.tf
+++ b/tests/terraform/graph/checks/resources/GCRContainerVulnerabilityScanningEnabled/main.tf
@@ -3,31 +3,7 @@ resource "google_project_services" "pass_1" {
   services   = ["iam.googleapis.com", "cloudresourcemanager.googleapis.com", "containerscanning.googleapis.com"]
 }
 
-resource "google_project_service" "pass_2" {
-  project = "your-project-id"
-  service = "containerscanning.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
-}
-
 resource "google_project_services" "fail_1" {
   project = "your-project-id"
   services   = ["iam.googleapis.com", "cloudresourcemanager.googleapis.com"]
-}
-
-resource "google_project_service" "fail_2" {
-  project = "your-project-id"
-  service = "cloudresourcemanager.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
 }

--- a/tests/terraform/graph/checks/resources/GCRContainerVulnerabilityScanningEnabled/main.tf
+++ b/tests/terraform/graph/checks/resources/GCRContainerVulnerabilityScanningEnabled/main.tf
@@ -1,0 +1,33 @@
+resource "google_project_services" "pass_1" {
+  project = "your-project-id"
+  services   = ["iam.googleapis.com", "cloudresourcemanager.googleapis.com", "containerscanning.googleapis.com"]
+}
+
+resource "google_project_service" "pass_2" {
+  project = "your-project-id"
+  service = "containerscanning.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}
+
+resource "google_project_services" "fail_1" {
+  project = "your-project-id"
+  services   = ["iam.googleapis.com", "cloudresourcemanager.googleapis.com"]
+}
+
+resource "google_project_service" "fail_2" {
+  project = "your-project-id"
+  service = "cloudresourcemanager.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -47,6 +47,9 @@ class TestYamlPolicies(unittest.TestCase):
     def test_SGAttachedToResource(self):
         self.go("SGAttachedToResource")
 
+    def test_EC2InstanceHasIAMRoleAttached(self):
+        self.go("EC2InstanceHasIAMRoleAttached") 
+
     def test_StorageContainerActivityLogsNotPublic(self):
         self.go("StorageContainerActivityLogsNotPublic")
 
@@ -86,6 +89,9 @@ class TestYamlPolicies(unittest.TestCase):
     def test_GCPProjectHasNoLegacyNetworks(self):
         self.go("GCPProjectHasNoLegacyNetworks")
 
+    def test_GCRContainerVulnerabilityScanningEnabled(self):
+        self.go("GCRContainerVulnerabilityScanningEnabled")    
+
     def test_AzureDataFactoriesEncryptedWithCustomerManagedKey(self):
         self.go("AzureDataFactoriesEncryptedWithCustomerManagedKey")
 
@@ -103,6 +109,9 @@ class TestYamlPolicies(unittest.TestCase):
 
     def test_GCPLogBucketsConfiguredUsingLock(self):
         self.go("GCPLogBucketsConfiguredUsingLock")
+
+    def test_CloudFunctionSecureHTTPTrigger(self):
+        self.go("CloudFunctionSecureHTTPTrigger")    
 
     def test_GCPAuditLogsConfiguredForAllServicesAndUsers(self):
         self.go("GCPAuditLogsConfiguredForAllServicesAndUsers")


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR has 3 Yaml - based checks with detailed description below

**Checkov Title:** Ensure an IAM role is attached to EC2 instance

PC Title - AWS EC2 Instance IAM Role not enabled

PC Policy ID - 8f2a2ff7-b484-463d-95df-aecd038f62b0

Compliance Standard - ACSC Information Security Manual (ISM)-ISM-1566, API Auto Clone of PIPEDA-4.7.3, APRA (CPS 234) Information Security-CPS234-14, APRA (CPS 234) Information Security-CPS234-23, APRA (CPS 234) Information Security-CPS234-27, APRA (CPS 234) Information Security-CPS234-34, Australian Cyber Security Centre (ACSC) Essential Eight-Restrict administrative privileges, Australian Energy Sector Cyber Security Framework (AESCSF)-IAM-2D, Australian Energy Sector Cyber Security Framework (AESCSF)-IAM-2F, Brazilian Data Protection Law (LGPD)-Article 49, CCPA 2018-1798.150(a)(1), CIS Controls v7.1-19.2, CIS Controls v8-6.8, CIS v1.2.0 (AWS)-1.19, CIS v1.3.0 (AWS)-1.18, CIS v1.4.0 (AWS)-1.18, CIS v1.5.0 (AWS) - Level 2-1.18, CSA CCM v.4.0.1-DSP-17, CSA CCM v.4.0.1-IAM-04, CSA CCM v.4.0.1-IAM-05, CSA CCM v.4.0.1-IAM-09, CSA CCM v.4.0.1-IAM-16, Copy of 1Copy of Brazilian Data Protection Law (LGPD)-Article 49, Copy of APRA (CPS 234) Information Security-CPS234-14, Copy of APRA (CPS 234) Information Security-CPS234-23, Copy of APRA (CPS 234) Information Security-CPS234-27, Copy of APRA (CPS 234) Information Security-CPS234-34, Copy of Brazilian Data Protection Law (LGPD)-Article 49, CyberSecurity Law of the People's Republic of China-Article 30, CyberSecurity Law of the People's Republic of China-Article 31, CyberSecurity Law of the People's Republic of China-Article 41, CyberSecurity Law of the People's Republic of China-Article 43, CyberSecurity Law of the People's Republic of China-Article 44, CyberSecurity Law of the People's Republic of China-Article 45, Cybersecurity Maturity Model Certification (CMMC) v.1.02-AC.2.007, Cybersecurity Maturity Model Certification (CMMC) v.2.0 (Level 1)-AC.L1-3.1.2, FFIEC-D1.R.St.B.1, FFIEC-D3.PC.Am.B.1, FFIEC-D3.PC.Am.B.2, FFIEC-D3.PC.Am.B.4, HITRUST CSF v.9.6.0-11.a, HITRUST v.9.4.2-Control Reference:01.c, ISO/IEC 27002:2013-18.1.3, ISO/IEC 27002:2013-18.1.4, ISO/IEC 27002:2013-6.1.2, ISO/IEC 27002:2013-9.1.1, ISO/IEC 27002:2013-9.1.2, ISO/IEC 27002:2013-9.2.3, ISO/IEC 27002:2013-9.2.5, ISO/IEC 27017:2015-9.2.3, ISO/IEC 27017:2015-9.2.5, ISO/IEC 27018:2019-9.2.3, ISO/IEC 27018:2019-9.2.5, MAS TRM 2021-9.1.1, MITRE ATT&CK v10.0-T1098 - Account Manipulation, MITRE ATT&CK v6.3-T1098, MITRE ATT&CK v6.3-T1098, MITRE ATT&CK v8.2-T1098, MLPS 2.0-8.2.4.1, NIST 800-53 Rev 5-Access Enforcement | Role-based Access Control, NIST 800-53 Rev4-AC-3 (7), NIST CSF-PR.AC-4, NIST SP 800-171 Revision 2-3.1.5, NIST SP 800-172-3.1.2e, PCI DSS v3.2.1-7.1, PCI DSS v3.2.1-7.1.2, PCI DSS v4.0-10.3.1, PCI DSS v4.0-7.1.1, PCI DSS v4.0-7.2.1, PCI DSS v4.0-7.2.2, PCI DSS v4.0-7.2.4, PCI DSS v4.0-7.2.6, PCI DSS v4.0-7.3.1, PCI DSS v4.0-7.3.2, PIPEDA-4.7.3, Risk Management in Technology (RMiT)-10.55, TestCompliance-CPS234-14, TestCompliance-CPS234-23, TestCompliance-CPS234-27, TestCompliance-CPS234-34

Remediation Steps:
The most common setup is the AWS default that allows for EC2 access to AWS Services. For most, this is a great way to realize flexible, yet secure, EC2 access enabled for your instances. Select this when you launch EC2 instances to automatically inherit these permissions.

IAM
   1. Go to the AWS console IAM dashboard.
   2. In the navigation pane, choose Roles, Create new role.
   3. Under 'Choose the service that will use this role' select EC2, then 'Next:Permissions.'
   4. On the Attach permissions policies page, select an AWS managed policy that grants your instance access to the 
   resources that they need, then 'Next:Tags.'
   5. Add tags (optional), the select 'Next:Review.'
   6. On the Create role and Review page, type a name for the role and choose Create role.

EC2
   1. Go to the AWS console EC2 dashboard.
   2. Select Running Instances.
   3. Check the instance you want to modify.
   4. From the Actions pull down menu, select Instance Settings and Attach/Replace IAM Role.
   5. On the Attach/Replace IAM Role page, under the IAM role pull down menu, choose the role created in the IAM steps 
   above.

**Checkov Title:** GCP Cloud Function HTTP trigger is secured

PC Policy ID - 4eab897c-f9a8-439d-b3d5-ac48f5d827e7

PC Policy Title - GCP Cloud Function HTTP trigger is not secured

Compliance Standard - ACSC Information Security Manual (ISM)-ISM-0469, ACSC Information Security Manual (ISM)-ISM-1552, CIS Controls v7.1-14.4, CIS Controls v7.1-16.5, CIS Controls v8-3.10, FFIEC-D1.RM.Au.B.2, New Zealand Information Security Manual (NZISM v3.4)-17.4, PCI DSS v4.0-2.2.7, PCI DSS v4.0-4.1.1, PCI DSS v4.0-4.2.1, PCI DSS v4.0-4.2.1.2, PCI DSS v4.0-4.2.2, PCI DSS v4.0-8.3.2

Remediation Steps:
   1. Login to GCP console
   2. Navigate to 'Cloud Functions' service (Left Panel)
   3. Click on the alerting function
   4. Click on 'EDIT'
   5. Under section 'Trigger', click on 'EDIT'
   7. Select the checkbox against the field 'Require HTTPS'
   8. Click on 'SAVE'
   9. Click on 'NEXT'
   10. Click on 'DEPLOY'

**Checkov Title:** GCP GCR Container Vulnerability Scanning is enabled

PC Policy ID - 0367679b-7384-4d67-9673-22e6ba99719e

PC Policy Title - GCP GCR Container Vulnerability Scanning is disabled

Compliance Standard - ACSC Information Security Manual (ISM)-ISM-1698, Australian Energy Sector Cyber Security Framework (AESCSF)-TVM-AP2, CIS Controls v7.1-3.1, CIS Controls v7.1-3.2, CIS Controls v8-10.4, CSA CCM v.4.0.1-A&A-03, CSA CCM v.4.0.1-AIS-01, CSA CCM v.4.0.1-AIS-02, CSA CCM v.4.0.1-AIS-04, CSA CCM v.4.0.1-CCC-01, CSA CCM v.4.0.1-DSP-01, CSA CCM v.4.0.1-DSP-04, CSA CCM v.4.0.1-GRC-03, CSA CCM v.4.0.1-IVS-04, CSA CCM v.4.0.1-TVM-01, CSA CCM v.4.0.1-TVM-07, CSA CCM v.4.0.1-TVM-08, CSA CCM v.4.0.1-TVM-09, CSA CCM v.4.0.1-TVM-10, CSA CCM v.4.0.1-UEM-03, CSA CCM v.4.0.1-UEM-06, HITRUST v.9.4.2-Control Reference:10.m, ISO/IEC 27002:2013-12.1.1, ISO/IEC 27002:2013-12.1.2, ISO/IEC 27002:2013-12.6.1, ISO/IEC 27002:2013-14.1.1, ISO/IEC 27002:2013-14.1.2, ISO/IEC 27002:2013-14.2.1, ISO/IEC 27002:2013-14.2.2, ISO/IEC 27002:2013-14.2.4, ISO/IEC 27002:2013-16.1.2, ISO/IEC 27002:2013-16.1.3, ISO/IEC 27002:2013-18.2.1, ISO/IEC 27002:2013-5.1.1, ISO/IEC 27002:2013-5.1.2, ISO/IEC 27002:2013-8.2.1, ISO/IEC 27017:2015-12.1.2, ISO/IEC 27017:2015-14.1.1, ISO/IEC 27017:2015-14.1.2, ISO/IEC 27017:2015-14.2.1, ISO/IEC 27017:2015-14.2.5, ISO/IEC 27017:2015-5.1.1, ISO/IEC 27018:2019-12.1.2, ISO/IEC 27018:2019-18.2.1, NIST CSF-DE.AE-4, NIST CSF-DE.CM-8, NIST CSF-ID.RA-1, NIST CSF-ID.RA-3, NIST CSF-ID.RA-4, NIST CSF-ID.RA-5, NIST CSF-PR.IP-1, NIST CSF-RS.AN-2, NIST CSF-RS.MI-3, NIST SP 800-171 Revision 2-3.11.1, NIST SP 800-171 Revision 2-3.11.2, NIST SP 800-172-3.12.1e, New Zealand Information Security Manual (NZISM v3.4)-12.4, PCI DSS v3.2.1-6.1, PCI DSS v3.2.1-6.2, PCI DSS v4.0-5.3.3

Remediation Steps:
    1. Login to the GCP console
    2. For the reported account, navigate to the GCP service 'Container Registry'(Left Panel)
    3. Select the tab 'Settings'
    4. To enable the vulnerability scanning, click on the 'TURN ON' button.
