### PR TITLE
platform(general): rationalize policy metadata error handling behavior

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -562,6 +562,7 @@ class BcPlatformIntegration:
             logging.debug(f"Got customer run config from {platform_type} platform")
         except Exception:
             logging.warning(f"Failed to get the customer run config from {self.platform_run_config_url}", exc_info=True)
+            raise
 
     def get_prisma_build_policies(self, policy_filter: str) -> None:
         """
@@ -666,7 +667,7 @@ class BcPlatformIntegration:
             platform_type = PRISMA_PLATFORM if self.is_prisma_integration() else BRIDGECREW_PLATFORM
             logging.debug(f"Got checkov mappings and guidelines from {platform_type} platform")
         except Exception:
-            logging.warning(f"Failed to get the checkov mappings and guidelines from {self.guidelines_api_url}",
+            logging.warning(f"Failed to get the checkov mappings and guidelines from {self.guidelines_api_url}. Skips using BC_* IDs will not work.",
                             exc_info=True)
 
     def onboarding(self) -> None:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -277,7 +277,7 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
 
     try:
         bc_integration.get_platform_run_config()
-    except Exception as e:
+    except Exception:
         if not config.include_all_checkov_policies:
             # stack trace gets printed in the exception handlers above
             # include_all_checkov_policies will always be set when there is no API key, so we don't need to worry about it here


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

This change causes checkov to fail if the user uses a platform API key, but the connection itself fails (e.g. SSL or auth error), and they don't use `--include-all-checkov-checks`.

Today, the behavior is that the policy metadata download will fail with an error, but then the run will proceed. However, Checkov thinks all the policies are local policies, and does not run any of them (by design when using an API key). The result is blank output (minus the connection error message in the logs). This causes issues primarily in the IDEs, where there is no error message popup from the failed run, so it just looks like nothing happened.

This change will cause the run to actually fail if no policies are going to get evaluated.

It also handles some general conflicting logic with the use of `--skip-download`, which causes similar behavior (but without an error).

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works  *(I tested all the cases locally)*
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
