### PR TITLE
fix(kubernetes): fixed unexpected list object

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/CPURequests.py
+++ b/checkov/kubernetes/checks/resource/k8s/CPURequests.py
@@ -18,6 +18,8 @@ class CPURequests(BaseK8sContainerCheck):
             if not isinstance(res, dict):
                 return CheckResult.UNKNOWN
             requests = res.get("requests")
+            if not isinstance(requests, dict):
+                return CheckResult.UNKNOWN
             if requests and requests.get("cpu"):
                 return CheckResult.PASSED
         return CheckResult.FAILED

--- a/checkov/kubernetes/checks/resource/k8s/MemoryRequests.py
+++ b/checkov/kubernetes/checks/resource/k8s/MemoryRequests.py
@@ -18,6 +18,8 @@ class MemoryRequests(BaseK8sContainerCheck):
             if not isinstance(res, dict):
                 return CheckResult.UNKNOWN
             requests = res.get("requests")
+            if not isinstance(requests, dict):
+                return CheckResult.UNKNOWN
             if requests and requests.get("memory"):
                 return CheckResult.PASSED
         return CheckResult.FAILED

--- a/tests/kubernetes/checks/example_Requests_Limits/pod-requests-limits-UNKNOWN2.yaml
+++ b/tests/kubernetes/checks/example_Requests_Limits/pod-requests-limits-UNKNOWN2.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+spec:
+  containers:
+  - name: db
+    image: mysql
+    env:
+    - name: MYSQL_ROOT_PASSWORD
+      value: "password"
+    resources:
+      requests:
+      - memory: "64Mi"
+        cpu: "250m"
+        ephemeral-storage: "2Gi"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+        ephemeral-storage: "4Gi"

--- a/tests/kubernetes/checks/test_CPULimits.py
+++ b/tests/kubernetes/checks/test_CPULimits.py
@@ -16,7 +16,7 @@ class TestCPULimits(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/kubernetes/checks/test_MemoryLimits.py
+++ b/tests/kubernetes/checks/test_MemoryLimits.py
@@ -16,7 +16,7 @@ class TestMemoryLimits(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

fixed a case when `requests` object in template is a list instead of a dict

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
