### PR TITLE
fix(cloudformation): only parse valid tag key-pairs in CloudFormation

### DIFF
--- a/checkov/cloudformation/cfn_utils.py
+++ b/checkov/cloudformation/cfn_utils.py
@@ -17,6 +17,7 @@ from checkov.runner_filter import RunnerFilter
 from checkov.common.models.consts import YAML_COMMENT_MARK
 
 CF_POSSIBLE_ENDINGS = frozenset([".yml", ".yaml", ".json", ".template"])
+TAG_FIELD_NAMES = ("Key", "Value")
 
 
 def get_resource_tags(entity: Dict[StrNode, DictNode], registry: Registry = cfn_registry) -> Optional[Dict[str, str]]:
@@ -43,8 +44,12 @@ def get_resource_tags(entity: Dict[StrNode, DictNode], registry: Registry = cfn_
 
 
 def parse_entity_tags(tags: Union[ListNode, Dict[str, Any]]) -> Optional[Dict[str, str]]:
-    if isinstance(tags, ListNode):
-        tag_dict = {get_entity_value_as_string(tag["Key"]): get_entity_value_as_string(tag["Value"]) for tag in tags}
+    if isinstance(tags, list):
+        tag_dict = {
+            get_entity_value_as_string(tag["Key"]): get_entity_value_as_string(tag["Value"])
+            for tag in tags
+            if all(field in tag for field in TAG_FIELD_NAMES)
+        }
         return tag_dict
     elif isinstance(tags, dict):
         tag_dict = {

--- a/tests/cloudformation/runner/test_runner.py
+++ b/tests/cloudformation/runner/test_runner.py
@@ -183,20 +183,25 @@ class TestRunnerValid(unittest.TestCase):
         entity = {resource_name: resource}
         entity_tags = cfn_utils.get_resource_tags(entity)
 
-        self.assertIsNone(entity_tags)
+        self.assertDictEqual(
+            entity_tags,
+            {
+                "Name": "TF-FulfillmentServer",
+                "terraform-server-tag-key": "terraform-server-tag-value",
+            }
+        )
 
         resource_name = 'EKSClusterNodegroup'
         resource = definitions['Resources'][resource_name]
         entity = {resource_name: resource}
         entity_tags = cfn_utils.get_resource_tags(entity)
 
-        self.assertEqual(len(entity_tags), 1)
-        tags = {
-            'Name': '{\'Ref\': \'ClusterName\'}-EKS-{\'Ref\': \'NodeGroupName\'}'
-        }
-
-        for name, value in tags.items():
-            self.assertEqual(entity_tags[name], value)
+        self.assertDictEqual(
+            entity_tags,
+            {
+                'Name': '{\'Ref\': \'ClusterName\'}-EKS-{\'Ref\': \'NodeGroupName\'}',
+            }
+        )
 
     def test_wrong_check_imports(self):
         wrong_imports = ["arm", "dockerfile", "helm", "kubernetes", "serverless", "terraform"]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- in CloudFormation it is allowed to use intrinsic functions like `If`, therefore only valid tag key-pairs are parsed and others are just skipped

Fixes #3829 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
