### PR TITLE
fix(terraform): Handled nested unrendered vars

### DIFF
--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -57,9 +57,21 @@ class BaseAttributeSolver(BaseSolver):
         # if this value contains an underendered variable, then we cannot evaluate value checks,
         # and will return None (for UNKNOWN)
         # handle edge cases in some policies that explicitly look for blank values
-        if self.is_value_attribute_check and self._is_variable_dependant(attr_val, vertex['source_']) \
-                and self.value != '':
-            return None
+        # we also need to check the attribute stack - e.g., if they are looking for tags.component, but tags = local.tags,
+        # then we actually need to see if tags is variable dependent as well
+        attr_parts = self.attribute.split('.')  # type:ignore[union-attr]  # due to attribute can be None (but not really)
+        attr_to_check = None
+        for attr in attr_parts:
+            attr_to_check = f'{attr_to_check}.{attr}' if attr_to_check else attr
+            value_to_check = vertex.get(attr_to_check)
+
+            # we can only check is_attribute_value_check when evaluating the full attribute
+            # for example, if we have a policy that says "tags.component exists", and tags = local.tags, then
+            # we need to check if tags is variable dependent even though this is a not value_attribute check
+            if (attr_to_check != self.attribute or self.is_value_attribute_check) \
+                    and self._is_variable_dependant(value_to_check, vertex['source_']) \
+                    and self.value != '':
+                return None
 
         if self.attribute and (self.is_jsonpath_check or re.match(WILDCARD_PATTERN, self.attribute)):
             attribute_matches = self.get_attribute_matches(vertex)

--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -53,7 +53,6 @@ class BaseAttributeSolver(BaseSolver):
         return passed_vertices, failed_vertices, unknown_vertices
 
     def get_operation(self, vertex: Dict[str, Any]) -> Optional[bool]:
-        attr_val = vertex.get(self.attribute)   # type:ignore[arg-type]  # due to attribute can be None
         # if this value contains an underendered variable, then we cannot evaluate value checks,
         # and will return None (for UNKNOWN)
         # handle edge cases in some policies that explicitly look for blank values

--- a/tests/terraform/runner/resources/unrendered_vars/bucket_equals.yaml
+++ b/tests/terraform/runner/resources/unrendered_vars/bucket_equals.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "BUCKET_EQUALS"
+  name: "Ensure S3 bucket name is xyz"
+  category: "general"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "aws_s3_bucket"
+  attribute: "bucket"
+  operator: "equals"
+  value: "xyz"

--- a/tests/terraform/runner/resources/unrendered_vars/bucket_exists.yaml
+++ b/tests/terraform/runner/resources/unrendered_vars/bucket_exists.yaml
@@ -1,0 +1,10 @@
+metadata:
+  id: "BUCKET_EXISTS"
+  name: "Ensure S3 bucket name is present"
+  category: "general"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "aws_s3_bucket"
+  attribute: "bucket"
+  operator: "exists"

--- a/tests/terraform/runner/resources/unrendered_vars/component_equals.yaml
+++ b/tests/terraform/runner/resources/unrendered_vars/component_equals.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "COMPONENT_EQUALS"
+  name: "Ensure S3 bucket has a component tag"
+  category: "general"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "aws_s3_bucket"
+  attribute: "tags.component"
+  operator: "equals"
+  value: "xyz"

--- a/tests/terraform/runner/resources/unrendered_vars/component_exists.yaml
+++ b/tests/terraform/runner/resources/unrendered_vars/component_exists.yaml
@@ -1,0 +1,10 @@
+metadata:
+  id: "COMPONENT_EXISTS"
+  name: "Ensure S3 bucket has a component tag"
+  category: "general"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "aws_s3_bucket"
+  attribute: "tags.component"
+  operator: "exists"

--- a/tests/terraform/runner/resources/unrendered_vars/nested.tf
+++ b/tests/terraform/runner/resources/unrendered_vars/nested.tf
@@ -1,0 +1,40 @@
+
+variable "tags_without_component" {
+  default = {
+    something = "something"
+  }
+}
+
+variable "tags_with_component" {
+  default = {
+    component = "xyz"
+  }
+}
+
+variable "component" {
+  default = "xyz"
+}
+
+resource "aws_s3_bucket" "unknown_nested_unknown" {
+  tags = var.unknown_tags
+}
+
+resource "aws_s3_bucket" "unknown_nested_2_pass" {
+  tags = {
+    component = var.unknown_component
+  }
+}
+
+resource "aws_s3_bucket" "known_nested_pass" {
+  tags = var.tags_with_component
+}
+
+resource "aws_s3_bucket" "known_nested_2_pass" {
+  tags = {
+    component = var.component
+  }
+}
+
+resource "aws_s3_bucket" "known_nested_fail" {
+  tags = var.tags_without_component
+}

--- a/tests/terraform/runner/resources/unrendered_vars/simple.tf
+++ b/tests/terraform/runner/resources/unrendered_vars/simple.tf
@@ -1,0 +1,11 @@
+variable "bucket" {
+  default = "xyz"
+}
+
+resource "aws_s3_bucket" "unknown_simple" {
+  bucket = var.unknown_bucket
+}
+
+resource "aws_s3_bucket" "known_simple_pass" {
+  bucket = var.bucket
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Adds logic to handle unrendered variables for custom policies that use nested attributes, like checking for a specific tag.

Previously, `tags.component equals ...` for `tags = local.unrendered_var` would fail because the value of that attribute is `None`, and this doesn't get picked up as an unrendered var. The fix is to check each attribute part (first `tags`, then `tags.component`) to see if it maps to an unrendered var.

Additionally, , a policy like `tags.component exists` would fail for `tags = local.unrendered_var`, because of the `is_value_attribute_check` condition. This PR modifies that behavior to only care about `is_value_attribute_check` when we are evaluating the literal attribute in the policy (`tags.component`, not just `tags`).

This PR also adds some explicit tests for simple and nested unrendered variables for conditions with and without `value`, since it seemed like those were missing. (They are just reflected in changed results of other tests for other things).

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
