### PR TITLE
feat(terraform): NSGRulePortAccessRestricted - Remove the condition for dynamic blocks

### DIFF
--- a/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
+++ b/checkov/terraform/checks/resource/azure/NSGRulePortAccessRestricted.py
@@ -28,10 +28,6 @@ class NSGRulePortAccessRestricted(BaseResourceCheck):
         return False
 
     def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
-        if "dynamic" in conf:
-            self.evaluated_keys = ["dynamic"]
-            return CheckResult.UNKNOWN
-
         rule_confs = [conf]
         evaluated_key_prefix = ""
         if "security_rule" in conf:

--- a/tests/terraform/checks/resource/azure/example_NSGRuleRDPAccessRestricted/main.tf
+++ b/tests/terraform/checks/resource/azure/example_NSGRuleRDPAccessRestricted/main.tf
@@ -165,3 +165,39 @@ resource "azurerm_network_security_rule" "range_prefix_lower_case" {
   destination_port_range = "3000-4000"
   source_address_prefix  = "internet"
 }
+
+resource "azurerm_network_security_group" "snet_nsgs" {
+  count               = "${length(local.subnets)}"
+  name                = "${local.root}-snet-${lookup(local.subnets[count.index], "name")}-nsg"
+  location            = "${azurerm_resource_group.net_rg.location}"
+  resource_group_name = "${azurerm_resource_group.net_rg.name}"
+  tags                = "${local.tags}"
+
+
+  dynamic "security_rule" {
+    for_each = [for s in local.subnets[count.index].nsg_rules : {
+      name                       = s.name
+      priority                   = s.priority
+      direction                  = s.direction
+      access                     = s.access
+      protocol                   = s.protocol
+      source_port_range          = s.source_port_range
+      destination_port_range     = s.destination_port_range
+      source_address_prefix      = s.source_address_prefix
+      destination_address_prefix = s.destination_address_prefix
+      description                = s.description
+    }]
+    content {
+      name                       = security_rule.value.name
+      priority                   = security_rule.value.priority
+      direction                  = security_rule.value.direction
+      access                     = security_rule.value.access
+      protocol                   = security_rule.value.protocol
+      source_port_range          = security_rule.value.source_port_range
+      destination_port_range     = security_rule.value.destination_port_range
+      source_address_prefix      = security_rule.value.source_address_prefix
+      destination_address_prefix = security_rule.value.destination_address_prefix
+      description                = security_rule.value.description
+    }
+  }
+}

--- a/tests/terraform/checks/resource/azure/test_NSGRuleRDPAccessRestricted.py
+++ b/tests/terraform/checks/resource/azure/test_NSGRuleRDPAccessRestricted.py
@@ -21,6 +21,7 @@ class TestNSGRuleRDPAccessRestricted(unittest.TestCase):
             "azurerm_network_security_rule.https",
             "azurerm_network_security_rule.rdp_restricted_prefixes",
             "azurerm_network_security_group.rdp_restricted",
+            "azurerm_network_security_group.snet_nsgs"
         }
         failing_resources = {
             "azurerm_network_security_rule.all",
@@ -35,7 +36,7 @@ class TestNSGRuleRDPAccessRestricted(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["passed"], 4)
         self.assertEqual(summary["failed"], 7)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
From this PR - [Here](https://github.com/bridgecrewio/checkov/issues/488) we are skipping the check for resources with dynamic blocks, now with the support of dynamic blocks, we can remove the condition.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
