### PR TITLE
platform(sca): Fix licenses delimiter

### DIFF
--- a/checkov/common/output/cyclonedx.py
+++ b/checkov/common/output/cyclonedx.py
@@ -221,7 +221,7 @@ class CycloneDX:
         licenses = resource.vulnerability_details.get("licenses")
         if licenses:
             license_choices = [
-                LicenseChoice(license_=License(license_name=license)) for license in licenses.split(", ")
+                LicenseChoice(license_=License(license_name=license)) for license in licenses
             ]
 
         purl = PackageURL(

--- a/checkov/common/sca/output.py
+++ b/checkov/common/sca/output.py
@@ -114,7 +114,7 @@ def create_report_cve_record(
     file_abs_path: str,
     check_class: str,
     vulnerability_details: dict[str, Any],
-    licenses: dict[str, str],
+    licenses: List[str],
     runner_filter: RunnerFilter | None = None,
     sca_details: SCADetails | None = None,
     scan_data_format: ScanDataFormat = ScanDataFormat.FROM_TWISTCLI

--- a/checkov/common/sca/output.py
+++ b/checkov/common/sca/output.py
@@ -114,7 +114,7 @@ def create_report_cve_record(
     file_abs_path: str,
     check_class: str,
     vulnerability_details: dict[str, Any],
-    licenses: str,
+    licenses: dict[str, str],
     runner_filter: RunnerFilter | None = None,
     sca_details: SCADetails | None = None,
     scan_data_format: ScanDataFormat = ScanDataFormat.FROM_TWISTCLI
@@ -258,7 +258,7 @@ def add_to_reports_cves_and_packages(
             file_abs_path=scanned_file_path,
             check_class=check_class or "",
             vulnerability_details=vulnerability,
-            licenses=", ".join(licenses_per_package_map[get_package_alias(package_name, package_version)]) or "Unknown",
+            licenses=licenses_per_package_map[get_package_alias(package_name, package_version)] or [],
             runner_filter=runner_filter,
             sca_details=sca_details,
             scan_data_format=scan_data_format,
@@ -292,10 +292,7 @@ def add_to_reports_cves_and_packages(
                     vulnerability_details={
                         "package_name": package["name"],
                         "package_version": package["version"],
-                        "licenses": ", ".join(
-                            licenses_per_package_map[get_package_alias(package["name"], package["version"])]
-                        )
-                        or "Unknown",
+                        "licenses": licenses_per_package_map[get_package_alias(package["name"], package["version"])] or [],
                         "package_type": get_package_type(package["name"], package["version"], sca_details),
                     },
                 )

--- a/checkov/common/sca/output.py
+++ b/checkov/common/sca/output.py
@@ -114,7 +114,7 @@ def create_report_cve_record(
     file_abs_path: str,
     check_class: str,
     vulnerability_details: dict[str, Any],
-    licenses: List[str],
+    licenses: list[str],
     runner_filter: RunnerFilter | None = None,
     sca_details: SCADetails | None = None,
     scan_data_format: ScanDataFormat = ScanDataFormat.FROM_TWISTCLI

--- a/tests/common/output/test_cyclonedx_report.py
+++ b/tests/common/output/test_cyclonedx_report.py
@@ -85,7 +85,7 @@ def test_valid_cyclonedx_image_bom():
         file_abs_path=file_abs_path,
         check_class=check_class,
         vulnerability_details=vulnerability,
-        licenses="BSD-3-Clause",
+        licenses=["BSD-3-Clause"],
         sca_details=image_details,
     )
     report = Report(check_type='sca_image')
@@ -164,7 +164,7 @@ def test_sca_packages_cyclonedx_bom():
         file_abs_path=file_abs_path,
         check_class=check_class,
         vulnerability_details=vulnerability_details,
-        licenses='OSI_BDS',
+        licenses=['OSI_BDS'],
     )
 
     report = Report(CheckType.SCA_PACKAGE)
@@ -179,7 +179,7 @@ def test_sca_packages_cyclonedx_bom():
             vulnerability_details={
                 "package_name": "testpkg",
                 "package_version": "1.1.1",
-                "licenses": "MIT"
+                "licenses": ["MIT"]
             }
         )
     )
@@ -223,7 +223,7 @@ def test_create_library_component_maven_package() -> None:
         vulnerability_details={
             "package_name": package["name"],
             "package_version": package["version"],
-            "licenses": "Unknown",
+            "licenses": [],
             "package_type": 'jar',
         },
     )
@@ -249,7 +249,7 @@ def test_create_library_component_maven_package_without_group_name() -> None:
         vulnerability_details={
             "package_name": package["name"],
             "package_version": package["version"],
-            "licenses": "Unknown",
+            "licenses": [],
             "package_type": 'jar',
         },
     )


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

On creating the BOM report, the delimiter was a comma character, it cause an issue because there are some licenses that contain comma characters.

Fixes # (issue)

Instead of encode and decode the licenses to string, just pass them as a list.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
