### PR TITLE
fix(kubernetes): handle empty spec object in k8s templates

### DIFF
--- a/checkov/kubernetes/checks/resource/base_root_container_check.py
+++ b/checkov/kubernetes/checks/resource/base_root_container_check.py
@@ -35,7 +35,13 @@ class BaseK8sRootContainerCheck(BaseK8Check):
             if "spec" in conf:
                 spec = conf["spec"]
         elif conf['kind'] == 'CronJob':
-            if "spec" in conf and "jobTemplate" in conf["spec"] and "spec" in conf["spec"]["jobTemplate"] and conf["spec"]["jobTemplate"]["spec"] and "template" in conf["spec"]["jobTemplate"]["spec"] and "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
+            if "spec" in conf and \
+                    isinstance(conf["spec"], dict) and \
+                    "jobTemplate" in conf["spec"] and \
+                    "spec" in conf["spec"]["jobTemplate"] and \
+                    conf["spec"]["jobTemplate"]["spec"] and \
+                    "template" in conf["spec"]["jobTemplate"]["spec"] and \
+                    "spec" in conf["spec"]["jobTemplate"]["spec"]["template"]:
                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
         else:
             inner_spec = self.get_inner_entry(conf, "spec")

--- a/checkov/kubernetes/checks/resource/base_spec_check.py
+++ b/checkov/kubernetes/checks/resource/base_spec_check.py
@@ -50,6 +50,6 @@ class BaseK8Check(BaseCheck):
     @staticmethod
     def get_inner_entry(conf: Dict[str, Any], entry_name: str) -> Dict[str, Any]:
         spec = {}
-        if conf.get("spec") and conf.get("spec").get("template"):
+        if conf.get("spec") and isinstance(conf["spec"], dict) and conf.get("spec").get("template"):
             spec = conf.get("spec").get("template").get(entry_name, {})
         return spec

--- a/checkov/kubernetes/checks/resource/k8s/Seccomp.py
+++ b/checkov/kubernetes/checks/resource/k8s/Seccomp.py
@@ -37,7 +37,7 @@ class Seccomp(BaseK8Check):
                 metadata = conf["metadata"]
         elif conf['kind'] == 'CronJob':
             if "spec" in conf:
-                if "jobTemplate" in conf["spec"]:
+                if isinstance(conf["spec"], dict) and "jobTemplate" in conf["spec"]:
                     if "spec" in conf["spec"]["jobTemplate"]:
                         if conf["spec"]["jobTemplate"]["spec"] and "template" in conf["spec"]["jobTemplate"]["spec"]:
                             if "metadata" in conf["spec"]["jobTemplate"]["spec"]["template"]:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

handle failing checks due to unexpected empty spec object.
no UT for this specific case wasn't added since a YAML with null value is not parsed in checkov (considered as a parsing error)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
