### PR TITLE
feat(terraform): Mask secret values in Terraform plan file reports by resource

### DIFF
--- a/checkov/common/typing.py
+++ b/checkov/common/typing.py
@@ -13,7 +13,9 @@ _ScannerCallableAlias: TypeAlias = Callable[
     [str, "BaseCheck", "_SkippedCheck", "dict[str, Any]", str, str, "dict[str, Any]"], None
 ]
 
-ResourceAttributesToOmit: TypeAlias = Dict[str, str]
+_Resource: TypeAlias = str
+_Attribute: TypeAlias = str
+ResourceAttributesToOmit: TypeAlias = Dict[_Resource, _Attribute]
 
 
 class _CheckResult(TypedDict, total=False):

--- a/checkov/common/typing.py
+++ b/checkov/common/typing.py
@@ -13,7 +13,7 @@ _ScannerCallableAlias: TypeAlias = Callable[
     [str, "BaseCheck", "_SkippedCheck", "dict[str, Any]", str, str, "dict[str, Any]"], None
 ]
 
-ResourceAttributesToOmit: TypeAlias = dict[str, str]
+ResourceAttributesToOmit: TypeAlias = Dict[str, str]
 
 
 class _CheckResult(TypedDict, total=False):

--- a/checkov/common/typing.py
+++ b/checkov/common/typing.py
@@ -13,9 +13,7 @@ _ScannerCallableAlias: TypeAlias = Callable[
     [str, "BaseCheck", "_SkippedCheck", "dict[str, Any]", str, str, "dict[str, Any]"], None
 ]
 
-_Resource = str
-_Attribute = str
-ResourceAttributesToOmit = Dict[_Resource, _Attribute]
+ResourceAttributesToOmit: TypeAlias = dict[str, str]
 
 
 class _CheckResult(TypedDict, total=False):

--- a/checkov/common/typing.py
+++ b/checkov/common/typing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Dict
 from typing_extensions import TypeAlias, TypedDict
 
 if TYPE_CHECKING:
@@ -13,6 +13,9 @@ _ScannerCallableAlias: TypeAlias = Callable[
     [str, "BaseCheck", "_SkippedCheck", "dict[str, Any]", str, str, "dict[str, Any]"], None
 ]
 
+_Resource = str
+_Attribute = str
+ResourceAttributesToOmit = Dict[_Resource, _Attribute]
 
 class _CheckResult(TypedDict, total=False):
     result: "CheckResult" | tuple["CheckResult", dict[str, Any]]

--- a/checkov/common/typing.py
+++ b/checkov/common/typing.py
@@ -17,6 +17,7 @@ _Resource = str
 _Attribute = str
 ResourceAttributesToOmit = Dict[_Resource, _Attribute]
 
+
 class _CheckResult(TypedDict, total=False):
     result: "CheckResult" | tuple["CheckResult", dict[str, Any]]
     suppress_comment: str

--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -140,7 +140,7 @@ def omit_secret_value_from_checks(check: BaseCheck, check_result: dict[str, Chec
     censored_code_lines = []
 
     if CheckCategories.SECRETS in check.categories and check_result.get('result') == CheckResult.FAILED:
-        secrets.add(str(secret) for key, secret in entity_config.items() if key.startswith(f'{check.id}_secret'))
+        secrets.update([str(secret) for key, secret in entity_config.items() if key.startswith(f'{check.id}_secret')])
 
     if resource_attributes_to_omit and check.entity_type in resource_attributes_to_omit and \
             resource_attributes_to_omit[check.entity_type] in entity_config:

--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -143,9 +143,10 @@ def omit_secret_value_from_checks(check: BaseCheck, check_result: dict[str, Chec
         secrets.update([str(secret) for key, secret in entity_config.items() if key.startswith(f'{check.id}_secret')])
 
     if resource_attributes_to_omit and check.entity_type in resource_attributes_to_omit and \
-            resource_attributes_to_omit[check.entity_type] in entity_config:
-        secret = entity_config[resource_attributes_to_omit[check.entity_type]][0]
-        secrets.add(secret)
+            resource_attributes_to_omit.get(check.entity_type, None) in entity_config:
+        secret = entity_config.get(resource_attributes_to_omit.get(check.entity_type, {}), [])  # type:ignore[arg-type]
+        if isinstance(secret, list) and len(secret) != 0:
+            secrets.add(secret[0])
 
     if len(secrets) == 0:
         logging.debug(f"Secret was not saved in {check.id}, can't omit")

--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -144,11 +144,11 @@ def omit_secret_value_from_checks(check: BaseCheck, check_result: dict[str, Chec
 
     if resource_attributes_to_omit and check.entity_type in resource_attributes_to_omit and \
             resource_attributes_to_omit.get(check.entity_type) in entity_config:
-        secret = entity_config.get(resource_attributes_to_omit.get(check.entity_type, {}), [])  # type:ignore[arg-type]
-        if isinstance(secret, list) and len(secret) != 0:
+        secret = entity_config.get(resource_attributes_to_omit.get(check.entity_type, ''), [])
+        if isinstance(secret, list) and secret:
             secrets.add(secret[0])
 
-    if len(secrets) == 0:
+    if not secrets:
         logging.debug(f"Secret was not saved in {check.id}, can't omit")
         return entity_code_lines
 

--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -143,7 +143,7 @@ def omit_secret_value_from_checks(check: BaseCheck, check_result: dict[str, Chec
         secrets.update([str(secret) for key, secret in entity_config.items() if key.startswith(f'{check.id}_secret')])
 
     if resource_attributes_to_omit and check.entity_type in resource_attributes_to_omit and \
-            resource_attributes_to_omit.get(check.entity_type, None) in entity_config:
+            resource_attributes_to_omit.get(check.entity_type) in entity_config:
         secret = entity_config.get(resource_attributes_to_omit.get(check.entity_type, {}), [])  # type:ignore[arg-type]
         if isinstance(secret, list) and len(secret) != 0:
             secrets.add(secret[0])

--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -11,7 +11,7 @@ from checkov.common.models.enums import CheckCategories, CheckResult
 
 if TYPE_CHECKING:
     from checkov.common.checks.base_check import BaseCheck
-    from checkov.common.typing import _CheckResult
+    from checkov.common.typing import _CheckResult, ResourceAttributesToOmit
     from pycep.typing import ParameterAttributes, ResourceAttributes
 
 
@@ -109,7 +109,7 @@ def string_has_secrets(s: str, *categories: str) -> bool:
     return False
 
 
-def omit_multiple_secret_values_from_line(secrets: list[str], line_text: str) -> str:
+def omit_multiple_secret_values_from_line(secrets: set[str], line_text: str) -> str:
     censored_line = line_text
     for secret in secrets:
         censored_line = omit_secret_value_from_line(secret, censored_line)
@@ -133,20 +133,27 @@ def omit_secret_value_from_line(secret: str, line_text: str) -> str:
 
 def omit_secret_value_from_checks(check: BaseCheck, check_result: dict[str, CheckResult] | _CheckResult,
                                   entity_code_lines: list[tuple[int, str]],
-                                  entity_config: dict[str, Any] | ParameterAttributes | ResourceAttributes) -> \
+                                  entity_config: dict[str, Any] | ParameterAttributes | ResourceAttributes,
+                                  resource_attributes_to_omit: ResourceAttributesToOmit | None = None) -> \
         list[tuple[int, str]]:
-    if CheckCategories.SECRETS in check.categories and check_result.get('result') == CheckResult.FAILED:
-        censored_code_lines = []
-        secrets = [str(secret) for key, secret in entity_config.items() if key.startswith(f'{check.id}_secret')]
-        if not secrets:
-            logging.debug(f"Secret was not saved in {check.id}, can't omit")
-            return entity_code_lines
+    secrets = set()  # a set, to efficiently avoid duplicates in case the same secret is found in the following conditions
+    censored_code_lines = []
 
-        for idx, line in entity_code_lines:
-            censored_line = omit_multiple_secret_values_from_line(secrets, line)
-            censored_code_lines.append((idx, censored_line))
-    else:
-        censored_code_lines = entity_code_lines
+    if CheckCategories.SECRETS in check.categories and check_result.get('result') == CheckResult.FAILED:
+        secrets.add(str(secret) for key, secret in entity_config.items() if key.startswith(f'{check.id}_secret'))
+
+    if resource_attributes_to_omit and check.entity_type in resource_attributes_to_omit and \
+            resource_attributes_to_omit[check.entity_type] in entity_config:
+        secret = entity_config[resource_attributes_to_omit[check.entity_type]][0]
+        secrets.add(secret)
+
+    if len(secrets) == 0:
+        logging.debug(f"Secret was not saved in {check.id}, can't omit")
+        return entity_code_lines
+
+    for idx, line in entity_code_lines:
+        censored_line = omit_multiple_secret_values_from_line(secrets, line)
+        censored_code_lines.append((idx, censored_line))
 
     return censored_code_lines
 

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -129,9 +129,10 @@ class Runner(TerraformRunner):
                     if check.id in TF_LIFECYCLE_CHECK_IDS:
                         # can't be evaluated in TF plan
                         continue
-                    censored_code_lines = omit_secret_value_from_checks(check, check_result,
-                                                                        entity_code_lines,
-                                                                        entity_config,
+                    censored_code_lines = omit_secret_value_from_checks(check=check,
+                                                                        check_result=check_result,
+                                                                        entity_code_lines=entity_code_lines,
+                                                                        entity_config=entity_config,
                                                                         resource_attributes_to_omit=RESOURCE_ATTRIBUTES_TO_OMIT)
                     record = Record(check_id=check.id, bc_check_id=check.bc_id, check_name=check.name,
                                     check_result=check_result,

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -13,6 +13,7 @@ from checkov.terraform.graph_builder.local_graph import TerraformLocalGraph
 from checkov.common.checks_infra.registry import get_graph_checks_registry
 from checkov.common.graph.graph_builder.graph_components.attribute_names import CustomAttributes
 from checkov.common.output.record import Record
+from checkov.common.util.secrets import omit_secret_value_from_checks
 
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.output.report import Report
@@ -29,6 +30,12 @@ TF_LIFECYCLE_CHECK_IDS = {
     "CKV_AWS_233",
     "CKV_AWS_237",
     "CKV_GCP_82",
+}
+
+RESOURCE_ATTRIBUTES_TO_OMIT = {
+    'azurerm_key_vault_secret': 'value',
+    'aws_secretsmanager_secret_version': 'secret_string',
+     'google_kms_secret_ciphertext': 'plaintext',
 }
 
 
@@ -115,16 +122,20 @@ class Runner(TerraformRunner):
                 entity_lines_range = [entity_context.get('start_line'), entity_context.get('end_line')]
                 entity_code_lines = entity_context.get('code_lines')
                 entity_address = entity_context.get('address')
+                _, _, entity_config = registry.extract_entity_details(entity)
 
                 results = registry.scan(scanned_file, entity, [], runner_filter, report_type=CheckType.TERRAFORM_PLAN)
                 for check, check_result in results.items():
                     if check.id in TF_LIFECYCLE_CHECK_IDS:
                         # can't be evaluated in TF plan
                         continue
-
+                    censored_code_lines = omit_secret_value_from_checks(check, check_result,
+                                                                        entity_code_lines,
+                                                                        entity_config,
+                                                                        resource_attributes_to_omit=RESOURCE_ATTRIBUTES_TO_OMIT)
                     record = Record(check_id=check.id, bc_check_id=check.bc_id, check_name=check.name,
                                     check_result=check_result,
-                                    code_block=entity_code_lines, file_path=scanned_file,
+                                    code_block=censored_code_lines, file_path=scanned_file,
                                     file_line_range=entity_lines_range,
                                     resource=entity_id, resource_address=entity_address, evaluations=None,
                                     check_class=check.__class__.__module__, file_abs_path=full_file_path,

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -35,7 +35,7 @@ TF_LIFECYCLE_CHECK_IDS = {
 RESOURCE_ATTRIBUTES_TO_OMIT = {
     'azurerm_key_vault_secret': 'value',
     'aws_secretsmanager_secret_version': 'secret_string',
-     'google_kms_secret_ciphertext': 'plaintext',
+    'google_kms_secret_ciphertext': 'plaintext'
 }
 
 

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -36,7 +36,8 @@ RESOURCE_ATTRIBUTES_TO_OMIT = {
     'azurerm_key_vault_secret': 'value',
     'aws_secretsmanager_secret_version': 'secret_string',
     'google_kms_secret_ciphertext': 'plaintext',
-    'aws_ssm_parameter': 'value'
+    'aws_ssm_parameter': 'value',
+    'aws_db_instance': 'password'
 }
 
 

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -35,7 +35,8 @@ TF_LIFECYCLE_CHECK_IDS = {
 RESOURCE_ATTRIBUTES_TO_OMIT = {
     'azurerm_key_vault_secret': 'value',
     'aws_secretsmanager_secret_version': 'secret_string',
-    'google_kms_secret_ciphertext': 'plaintext'
+    'google_kms_secret_ciphertext': 'plaintext',
+    'aws_ssm_parameter': 'value'
 }
 
 

--- a/tests/common/utils/conftest.py
+++ b/tests/common/utils/conftest.py
@@ -59,49 +59,37 @@ def scan_result_success_response() -> Dict[str, Any]:
 
 
 @pytest.fixture
-def aws_instance_resource_config_with_secrets():
+def aws_provider_config_with_secrets():
     return {
-        '__end_line__': 23,
-        '__start_line__': 1,
-        'ami': ['ami-09a5b0b7edf08843d'],
-        'instance_type': ['t2.nano'],
-        'subnet_id': ['aws_subnet.web_subnet.id'],
-        'tags': [{'Name': '${data.aws_caller_identity.current.account_id}-acme-dev-ec2'}],
-        'user_data': ['#! /bin/bashsudo apt-get updatesudo apt-get install -y apache2sudo systemctl start apache2sudo systemctl enable apache2export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMAAAexport AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMAAAKEYexport AWS_DEFAULT_REGION=us-west-2echo "<h1>Deployed via Terraform</h1>" | sudo tee /var/www/html/index.html'],
-        'vpc_security_group_ids': [['aws_security_group.web-node.id']],
-        'CKV_AWS_46_secret': '#! /bin/bashsudo apt-get updatesudo apt-get install -y apache2sudo systemctl start apache2sudo systemctl enable apache2export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMAAAexport AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMAAAKEYexport AWS_DEFAULT_REGION=us-west-2echo "<h1>Deployed via Terraform</h1>" | sudo tee /var/www/html/index.html'
-    }
+            '__end_line__': 12,
+            '__start_line__': 7,
+            'access_key': ['AKIAIOSFODNN7EXAMPLE'],
+            'alias': ['plain_text_access_keys_provider'],
+            'region': ['us-west-1'],
+            'secret_key': ['wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'],
+            'CKV_AWS_41_secret_access_key': 'AKIAIOSFODNN7EXAMPLE',
+            'CKV_AWS_41_secret_secret_key': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+            }
 
 
 @pytest.fixture
-def aws_instance_resource_lines_with_secrets():
-    return [
-        (1, 'resource "aws_instance" "web_host" {\n'),
-        (2, '  # ec2 have plain text secrets in user data\n'),
-        (3, '  ami           = "${var.ami}"\n'),
-        (4, '  instance_type = "t2.nano"\n'),
-        (5, '\n'),
-        (6, '  vpc_security_group_ids = [\n'),
-        (7, '  "${aws_security_group.web-node.id}"]\n'),
-        (8, '  subnet_id = "${aws_subnet.web_subnet.id}"\n'),
-        (9, '  user_data = <<EOF\n'),
-        (10, '#! /bin/bash\n'),
-        (11, 'sudo apt-get update\n'),
-        (12, 'sudo apt-get install -y apache2\n'),
-        (13, 'sudo systemctl start apache2\n'),
-        (14, 'sudo systemctl enable apache2\n'),
-        (15, 'export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMAAA\n'),
-        (16, 'export AWS_SECRET_ACCESS_KEY=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\n'),
-        (17, 'export AWS_DEFAULT_REGION=us-west-2\n'),
-        (18, 'echo "<h1>Deployed via Terraform</h1>" | sudo tee /var/www/html/index.html\n'),
-        (19, 'EOF\n'),
-        (20, '  tags = {\n'),
-        (21, '    Name = "${local.resource_prefix.value}-ec2"\n'),
-        (22, '  }\n'),
-        (23, '}\n')
-    ]
+def aws_provider_lines_with_secrets():
+    return [(7, 'provider "aws" {\n'),
+            (8, '  alias      = "plain_text_access_keys_provider"\n'),
+            (9, '  region     = "us-west-1"\n'),
+            (10, '  access_key = "AKIAIOSFODNN7EXAMPLE"\n'),
+            (11, '  secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"\n'),
+            (12, '}\n')]
 
 
+@pytest.fixture
+def aws_provider_lines_without_secrets():
+    return [(7, 'provider "aws" {\n'),
+            (8, '  alias      = "plain_text_access_keys_provider"\n'),
+            (9, '  region     = "us-west-1"\n'),
+            (10, '  access_key = "AKIAI***************"\n'),
+            (11, '  secret_key = "wJalrXUtnF******************************"\n'),
+            (12, '}\n')]
 
 
 @pytest.fixture

--- a/tests/common/utils/conftest.py
+++ b/tests/common/utils/conftest.py
@@ -59,26 +59,72 @@ def scan_result_success_response() -> Dict[str, Any]:
 
 
 @pytest.fixture
+def aws_instance_resource_config_with_secrets():
+    return {
+        '__end_line__': 23,
+        '__start_line__': 1,
+        'ami': ['ami-09a5b0b7edf08843d'],
+        'instance_type': ['t2.nano'],
+        'subnet_id': ['aws_subnet.web_subnet.id'],
+        'tags': [{'Name': '${data.aws_caller_identity.current.account_id}-acme-dev-ec2'}],
+        'user_data': ['#! /bin/bashsudo apt-get updatesudo apt-get install -y apache2sudo systemctl start apache2sudo systemctl enable apache2export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMAAAexport AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMAAAKEYexport AWS_DEFAULT_REGION=us-west-2echo "<h1>Deployed via Terraform</h1>" | sudo tee /var/www/html/index.html'],
+        'vpc_security_group_ids': [['aws_security_group.web-node.id']],
+        'CKV_AWS_46_secret': '#! /bin/bashsudo apt-get updatesudo apt-get install -y apache2sudo systemctl start apache2sudo systemctl enable apache2export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMAAAexport AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMAAAKEYexport AWS_DEFAULT_REGION=us-west-2echo "<h1>Deployed via Terraform</h1>" | sudo tee /var/www/html/index.html'
+    }
+
+
+@pytest.fixture
+def aws_instance_resource_lines_with_secrets():
+    return [
+        (1, 'resource "aws_instance" "web_host" {\n'),
+        (2, '  # ec2 have plain text secrets in user data\n'),
+        (3, '  ami           = "${var.ami}"\n'),
+        (4, '  instance_type = "t2.nano"\n'),
+        (5, '\n'),
+        (6, '  vpc_security_group_ids = [\n'),
+        (7, '  "${aws_security_group.web-node.id}"]\n'),
+        (8, '  subnet_id = "${aws_subnet.web_subnet.id}"\n'),
+        (9, '  user_data = <<EOF\n'),
+        (10, '#! /bin/bash\n'),
+        (11, 'sudo apt-get update\n'),
+        (12, 'sudo apt-get install -y apache2\n'),
+        (13, 'sudo systemctl start apache2\n'),
+        (14, 'sudo systemctl enable apache2\n'),
+        (15, 'export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMAAA\n'),
+        (16, 'export AWS_SECRET_ACCESS_KEY=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\n'),
+        (17, 'export AWS_DEFAULT_REGION=us-west-2\n'),
+        (18, 'echo "<h1>Deployed via Terraform</h1>" | sudo tee /var/www/html/index.html\n'),
+        (19, 'EOF\n'),
+        (20, '  tags = {\n'),
+        (21, '    Name = "${local.resource_prefix.value}-ec2"\n'),
+        (22, '  }\n'),
+        (23, '}\n')
+    ]
+
+
+
+
+@pytest.fixture
 def tfplan_resource_config_with_secrets():
     return {
         'content_type': [''],
         'expiration_date': [None],
-        'id': ['https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02-primary-cs/352d0b63ac873c528170cb366b570da5'],
+        'id': ['https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02-primary-key/352d0b63ac873c528170cb366b570da5'],
         'key_vault_id': ['/subscriptions/resourceGroups/'],
-        'name': ['sb-nau2d-bsn00vn34-01-primary-cs'],
+        'name': ['test-123-abcdse-02-primary-key'],
         'not_before_date': [None],
         'resource_id': ['/subscriptions/resourceGroups/'],
         'resource_versionless_id': ['/subscriptions/resourceGroups/'],
         'tags': [{'__startline__': 45, '__endline__': 45, 'start_line': 44, 'end_line': 44}],
         'timeouts': [None],
-        'value': ['Endpoint=sb://te-st123-abcdse-02.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=IClnjeTb8fgd14LyV9m1qG0xvFfUyQY3qHq/slUIrk5='],
+        'value': ['IClnjeTb8fgd14LyV9m1qG0xvFfUyQY3qHq/slUIrk5='],
         'version': ['123d0b12ab123c123456ab123e120bc1'],
-        'versionless_id': ['https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02'],
+        'versionless_id': ['https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02'],
         '__startline__': [35],
         '__endline__': [50],
         'start_line': [34],
         'end_line': [49],
-        '__address__': 'module.test.azurerm_key_vault_secret.sb_primary_cs["te-st123-abcdse-02"]'}
+        '__address__': 'module.test.azurerm_key_vault_secret.te_primary_key["test-123-abcdse-02"]'}
 
 
 @pytest.fixture
@@ -86,18 +132,18 @@ def tfplan_resource_lines_with_secrets():
     return [(35, '                            {\n'),
             (36, '                                "content_type": "",\n'),
             (37, '                                "expiration_date": null,\n'),
-            (38, '                                "id": "https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02-primary-cs/352d0b63ac873c528170cb366b570da5",\n'),
-            (39, '                                "key_vault_id": "/subscriptions/resourceGroups/",\n'),
-            (40, '                                "name": "sb-nau2d-bsn00vn34-01-primary-cs",\n'),
+            (38, '                                "id": "https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02-primary-key/352d0b63ac873c528170cb366b570da5",\n'),
+            (39, '                                "key_vault_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
+            (40, '                                "name": "test-123-abcdse-02-primary-key",\n'),
             (41, '                                "not_before_date": null,\n'),
-            (42, '                                "resource_id": "/subscriptions/resourceGroups/",\n'),
-            (43, '                                "resource_versionless_id": "/subscriptions/resourceGroups/",\n'),
+            (42, '                                "resource_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
+            (43, '                                "resource_versionless_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
             (44, '                                "tags":\n'),
             (45, '                                {},\n'),
             (46, '                                "timeouts": null,\n'),
-            (47, '                                "value": "Endpoint=sb://te-st123-abcdse-02.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=IClnjeTb8fgd14LyV9m1qG0xvFfUyQY3qHq/slUIrk5=",\n'),
+            (47, '                                "value": "IClnjeTb8fgd14LyV9m1qG0xvFfUyQY3qHq/slUIrk5=",\n'),
             (48, '                                "version": "123d0b12ab123c123456ab123e120bc1",\n'),
-            (49, '                                "versionless_id": "https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02"\n')]
+            (49, '                                "versionless_id": "https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02"\n')]
 
 
 @pytest.fixture
@@ -105,14 +151,15 @@ def tfplan_resource_lines_without_secrets():
     return [(35, '                            {\n'),
             (36, '                                "content_type": "",\n'),
             (37, '                                "expiration_date": null,\n'),
-            (38, '                                "id": "https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02-primary-cs/352d0b63ac873c528170cb366b570da5",\n'),
-            (39, '                                "key_vault_id": "/subscriptions/resourceGroups/",\n'),
-            (40, '                                "name": "sb-nau2d-bsn00vn34-01-primary-cs",\n'),
+            (38, '                                "id": "https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02-primary-key/352d0b63ac873c528170cb366b570da5",\n'),
+            (39, '                                "key_vault_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
+            (40, '                                "name": "test-123-abcdse-02-primary-key",\n'),
             (41, '                                "not_before_date": null,\n'),
-            (42, '                                "resource_id": "/subscriptions/resourceGroups/",\n'),
-            (43, '                                "resource_versionless_id": "/subscriptions/resourceGroups/",\n'),
-            (44, '                                "tags":\n'), (45, '                                {},\n'),
+            (42, '                                "resource_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
+            (43, '                                "resource_versionless_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
+            (44, '                                "tags":\n'),
+            (45, '                                {},\n'),
             (46, '                                "timeouts": null,\n'),
-            (47, '                                "value": "Endpoint=sb://te-st123-abcdse-02.service***************************************************************************************************************************",\n'),
+            (47, '                                "value": "IClnjeTb8fg*********************************",\n'),
             (48, '                                "version": "123d0b12ab123c123456ab123e120bc1",\n'),
-            (49, '                                "versionless_id": "https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02"\n')]
+            (49, '                                "versionless_id": "https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02"\n')]

--- a/tests/common/utils/conftest.py
+++ b/tests/common/utils/conftest.py
@@ -79,6 +79,8 @@ def tfplan_resource_config_with_secrets():
         'start_line': [34],
         'end_line': [49],
         '__address__': 'module.test.azurerm_key_vault_secret.sb_primary_cs["te-st123-abcdse-02"]'}
+
+
 @pytest.fixture
 def tfplan_resource_lines_with_secrets():
     return [(35, '                            {\n'),
@@ -96,6 +98,7 @@ def tfplan_resource_lines_with_secrets():
             (47, '                                "value": "Endpoint=sb://te-st123-abcdse-02.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=IClnjeTb8fgd14LyV9m1qG0xvFfUyQY3qHq/slUIrk5=",\n'),
             (48, '                                "version": "123d0b12ab123c123456ab123e120bc1",\n'),
             (49, '                                "versionless_id": "https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02"\n')]
+
 
 @pytest.fixture
 def tfplan_resource_lines_without_secrets():

--- a/tests/common/utils/conftest.py
+++ b/tests/common/utils/conftest.py
@@ -56,3 +56,60 @@ def scan_result_success_response() -> Dict[str, Any]:
                    "anz3q7neGie2cS8HcBin/BL8U8U/AL0XOSX+jt75P82r6+RIV6DoZDXW14oKMNz5rR2TA6fr6j3WG52dFumrjvsG"
                    "sp7dAH12j5wbWz+sG1vfOD6+m3b/8HQd/FwVgXAAA=",
      'compressionMethod': 'gzip'}
+
+
+@pytest.fixture
+def tfplan_resource_config_with_secrets():
+    return {
+        'content_type': [''],
+        'expiration_date': [None],
+        'id': ['https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02-primary-cs/352d0b63ac873c528170cb366b570da5'],
+        'key_vault_id': ['/subscriptions/resourceGroups/'],
+        'name': ['sb-nau2d-bsn00vn34-01-primary-cs'],
+        'not_before_date': [None],
+        'resource_id': ['/subscriptions/resourceGroups/'],
+        'resource_versionless_id': ['/subscriptions/resourceGroups/'],
+        'tags': [{'__startline__': 45, '__endline__': 45, 'start_line': 44, 'end_line': 44}],
+        'timeouts': [None],
+        'value': ['Endpoint=sb://te-st123-abcdse-02.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=IClnjeTb8fgd14LyV9m1qG0xvFfUyQY3qHq/slUIrk5='],
+        'version': ['123d0b12ab123c123456ab123e120bc1'],
+        'versionless_id': ['https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02'],
+        '__startline__': [35],
+        '__endline__': [50],
+        'start_line': [34],
+        'end_line': [49],
+        '__address__': 'module.test.azurerm_key_vault_secret.sb_primary_cs["te-st123-abcdse-02"]'}
+@pytest.fixture
+def tfplan_resource_lines_with_secrets():
+    return [(35, '                            {\n'),
+            (36, '                                "content_type": "",\n'),
+            (37, '                                "expiration_date": null,\n'),
+            (38, '                                "id": "https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02-primary-cs/352d0b63ac873c528170cb366b570da5",\n'),
+            (39, '                                "key_vault_id": "/subscriptions/resourceGroups/",\n'),
+            (40, '                                "name": "sb-nau2d-bsn00vn34-01-primary-cs",\n'),
+            (41, '                                "not_before_date": null,\n'),
+            (42, '                                "resource_id": "/subscriptions/resourceGroups/",\n'),
+            (43, '                                "resource_versionless_id": "/subscriptions/resourceGroups/",\n'),
+            (44, '                                "tags":\n'),
+            (45, '                                {},\n'),
+            (46, '                                "timeouts": null,\n'),
+            (47, '                                "value": "Endpoint=sb://te-st123-abcdse-02.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=IClnjeTb8fgd14LyV9m1qG0xvFfUyQY3qHq/slUIrk5=",\n'),
+            (48, '                                "version": "123d0b12ab123c123456ab123e120bc1",\n'),
+            (49, '                                "versionless_id": "https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02"\n')]
+
+@pytest.fixture
+def tfplan_resource_lines_without_secrets():
+    return [(35, '                            {\n'),
+            (36, '                                "content_type": "",\n'),
+            (37, '                                "expiration_date": null,\n'),
+            (38, '                                "id": "https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02-primary-cs/352d0b63ac873c528170cb366b570da5",\n'),
+            (39, '                                "key_vault_id": "/subscriptions/resourceGroups/",\n'),
+            (40, '                                "name": "sb-nau2d-bsn00vn34-01-primary-cs",\n'),
+            (41, '                                "not_before_date": null,\n'),
+            (42, '                                "resource_id": "/subscriptions/resourceGroups/",\n'),
+            (43, '                                "resource_versionless_id": "/subscriptions/resourceGroups/",\n'),
+            (44, '                                "tags":\n'), (45, '                                {},\n'),
+            (46, '                                "timeouts": null,\n'),
+            (47, '                                "value": "Endpoint=sb://te-st123-abcdse-02.service***************************************************************************************************************************",\n'),
+            (48, '                                "version": "123d0b12ab123c123456ab123e120bc1",\n'),
+            (49, '                                "versionless_id": "https://te-st123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02"\n')]

--- a/tests/common/utils/test_secrets_utils.py
+++ b/tests/common/utils/test_secrets_utils.py
@@ -1,7 +1,7 @@
 from checkov.common.util.secrets import omit_secret_value_from_checks
 from checkov.common.models.enums import CheckResult
 from checkov.terraform.checks.resource.azure.SecretExpirationDate import SecretExpirationDate
-from checkov.terraform.checks.resource.aws.EC2Credentials import EC2Credentials
+from checkov.terraform.checks.provider.aws.credentials import AWSCredentials
 
 
 def test_omit_secret_value_from_checks_by_attribute(tfplan_resource_lines_with_secrets, tfplan_resource_config_with_secrets,
@@ -16,12 +16,11 @@ def test_omit_secret_value_from_checks_by_attribute(tfplan_resource_lines_with_s
                                          ) == tfplan_resource_lines_without_secrets
 
 
-def test_omit_secret_value_from_checks_by_secret(tfplan_resource_lines_with_secrets, tfplan_resource_config_with_secrets,
-                                    tfplan_resource_lines_without_secrets):
-    check = EC2Credentials()
-    check.entity_type = 'aws_instance'
+def test_omit_secret_value_from_checks_by_secret(aws_provider_lines_with_secrets, aws_provider_config_with_secrets,
+                                    aws_provider_lines_without_secrets):
+    check = AWSCredentials()
     check_result = {'result': CheckResult.FAILED}
 
-    assert omit_secret_value_from_checks(check, check_result, tfplan_resource_lines_with_secrets,
-                                         tfplan_resource_config_with_secrets
-                                         ) == tfplan_resource_lines_without_secrets
+    assert omit_secret_value_from_checks(check, check_result, aws_provider_lines_with_secrets,
+                                         aws_provider_config_with_secrets
+                                         ) == aws_provider_lines_without_secrets

--- a/tests/common/utils/test_secrets_utils.py
+++ b/tests/common/utils/test_secrets_utils.py
@@ -1,0 +1,15 @@
+from checkov.common.util.secrets import omit_secret_value_from_checks
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.azure.SecretExpirationDate import SecretExpirationDate
+
+
+def test_omit_secret_value_from_checks(tfplan_resource_lines_with_secrets, tfplan_resource_config_with_secrets,
+                                    tfplan_resource_lines_without_secrets):
+    check = SecretExpirationDate()
+    check.entity_type = 'azurerm_key_vault_secret'
+    check_result = {'result': CheckResult.FAILED}
+    resource_attributes_to_omit = {'azurerm_key_vault_secret': 'value'}
+
+    assert omit_secret_value_from_checks(check, check_result, tfplan_resource_lines_with_secrets,
+                                         tfplan_resource_config_with_secrets, resource_attributes_to_omit
+                                         ) == tfplan_resource_lines_without_secrets

--- a/tests/common/utils/test_secrets_utils.py
+++ b/tests/common/utils/test_secrets_utils.py
@@ -1,9 +1,10 @@
 from checkov.common.util.secrets import omit_secret_value_from_checks
 from checkov.common.models.enums import CheckResult
 from checkov.terraform.checks.resource.azure.SecretExpirationDate import SecretExpirationDate
+from checkov.terraform.checks.resource.aws.EC2Credentials import EC2Credentials
 
 
-def test_omit_secret_value_from_checks(tfplan_resource_lines_with_secrets, tfplan_resource_config_with_secrets,
+def test_omit_secret_value_from_checks_by_attribute(tfplan_resource_lines_with_secrets, tfplan_resource_config_with_secrets,
                                     tfplan_resource_lines_without_secrets):
     check = SecretExpirationDate()
     check.entity_type = 'azurerm_key_vault_secret'
@@ -12,4 +13,15 @@ def test_omit_secret_value_from_checks(tfplan_resource_lines_with_secrets, tfpla
 
     assert omit_secret_value_from_checks(check, check_result, tfplan_resource_lines_with_secrets,
                                          tfplan_resource_config_with_secrets, resource_attributes_to_omit
+                                         ) == tfplan_resource_lines_without_secrets
+
+
+def test_omit_secret_value_from_checks_by_secret(tfplan_resource_lines_with_secrets, tfplan_resource_config_with_secrets,
+                                    tfplan_resource_lines_without_secrets):
+    check = EC2Credentials()
+    check.entity_type = 'aws_instance'
+    check_result = {'result': CheckResult.FAILED}
+
+    assert omit_secret_value_from_checks(check, check_result, tfplan_resource_lines_with_secrets,
+                                         tfplan_resource_config_with_secrets
                                          ) == tfplan_resource_lines_without_secrets


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- This PR enables masking secret values that are not classified as secrets.
- The solution is a general one, implemented only in tf plan runner for now, for 3 types of resource & attributes that their values should be hidden (`azurerm_key_vault_secret`: `value`, `aws_secretsmanager_secret_version`: `secret_string`, `google_kms_secret_ciphertext`: `plaintext`).
- Can be extended to future runners by adding the `resource_attributes_to_omit` map when calling `omit_secret_value_from_checks()`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
