### PR TITLE
chore: Stop bundling optional dependency pyston and move to extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,10 @@ setup(
             "GitPython==3.1.7",
             "bandit",
             "jsonschema",
+        ],
+        "pyston": [
+            "pyston-autoload==2.3.5; python_version < '3.11' and (sys_platform == 'linux' or sys_platform == 'darwin') and platform_machine == 'x86_64'",
+            "pyston==2.3.5; python_version < '3.11' and (sys_platform == 'linux' or sys_platform == 'darwin') and platform_machine == 'x86_64'",
         ]
     },
     install_requires=[
@@ -70,8 +74,6 @@ setup(
         "prettytable>=3.0.0",
         "pycep-parser==0.3.9",
         "charset-normalizer",
-        "pyston-autoload==2.3.5; python_version < '3.11' and (sys_platform == 'linux' or sys_platform == 'darwin') and platform_machine == 'x86_64'",
-        "pyston==2.3.5; python_version < '3.11' and (sys_platform == 'linux' or sys_platform == 'darwin') and platform_machine == 'x86_64'",
         "schema",
         "requests>=2.26.0",
     ],


### PR DESCRIPTION
## Description

This fixes checkov install on alpine and probably others where the version markers are unable to omit [musl](https://www.musl-libc.org/) and similarly incompatible install targets.

checkov can still bundle pyston by installing/requiring `checkov[pyston]`

Fixes #3649 

This can be tested by cloning this pr on a failing machine and doing `pip install .` and `pip install .[pyston]`.

Some reasons for why this change is a good one:
- Allows more users (like alpine users) to install the latest checkov using pip, without patches.
- Pyston is working to upstream their change into cpython, so bundling pyston will provide less value over time, once these patches hit cpython. See https://blog.pyston.org/2022/09/29/announcing-3-7-3-10-support-and-a-new-direction/ .