### PR TITLE
fix(terraform): handle empty enabled_cluster_log_types list

### DIFF
--- a/checkov/terraform/checks/resource/aws/EKSControlPlaneLogging.py
+++ b/checkov/terraform/checks/resource/aws/EKSControlPlaneLogging.py
@@ -19,7 +19,8 @@ class EKSControlPlaneLogging(BaseResourceCheck):
         :return: <CheckResult>
         """
         log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
-        if "enabled_cluster_log_types" in conf.keys() and conf["enabled_cluster_log_types"][0] is not None \
+        if "enabled_cluster_log_types" in conf.keys() and conf["enabled_cluster_log_types"] and \
+                conf["enabled_cluster_log_types"][0] is not None \
                 and all(elem in conf["enabled_cluster_log_types"][0] for elem in log_types):
             return CheckResult.PASSED
         return CheckResult.FAILED

--- a/tests/terraform/checks/resource/aws/test_EKSControlPlaneLogging.py
+++ b/tests/terraform/checks/resource/aws/test_EKSControlPlaneLogging.py
@@ -17,12 +17,17 @@ class TestEKSControlPlaneLogging(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-
     def test_success(self):
         resource_conf = {'name': ['testcluster'], 'enabled_cluster_log_types': [['api', 'audit', 'authenticator', 'controllerManager', 'scheduler']]}
 
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success(self):
+        resource_conf = {'name': ['testcluster'], 'enabled_cluster_log_types': []}
+
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

handle empty enabled_cluster_log_types list for check EKSControlPlaneLogging

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
