### PR TITLE
feat(terraform): Censor secrets from tfplan graph

### DIFF
--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -169,11 +169,10 @@ def omit_secret_value_from_definitions(definitions: Dict[str, DictNode],
         """
     found_secrets = False
     censored_definitions = definitions
-    for file in definitions:
-        for i, resource in enumerate(definitions[file].get('resource', [])):
+    for file, definition in definitions.items():
+        for i, resource in enumerate(definition.get('resource', [])):
             for resource_type in [r_type for r_type in resource if r_type in resource_attributes_to_omit]:
-                for resource_name in resource[resource_type]:
-                    resource_config = resource[resource_type][resource_name]
+                for resource_name, resource_config in resource[resource_type].items():
                     for attribute in [attribute for attribute in resource_config if
                                       attribute == resource_attributes_to_omit[resource_type]]:
                         if not found_secrets:

--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import copy
 import itertools
 import logging
 import re
 
 # secret categories for use as constants
-from typing import Any, TYPE_CHECKING
+from typing import Any, Dict, TYPE_CHECKING
 
 from checkov.common.models.enums import CheckCategories, CheckResult
 
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
     from checkov.common.checks.base_check import BaseCheck
     from checkov.common.typing import _CheckResult, ResourceAttributesToOmit
     from pycep.typing import ParameterAttributes, ResourceAttributes
+    from checkov.common.parsers.node import DictNode
 
 
 AWS = 'aws'
@@ -157,6 +159,34 @@ def omit_secret_value_from_checks(check: BaseCheck, check_result: dict[str, Chec
         censored_code_lines.append((idx, censored_line))
 
     return censored_code_lines
+
+
+def omit_secret_value_from_definitions(definitions: Dict[str, DictNode],
+                                       resource_attributes_to_omit: ResourceAttributesToOmit) -> Dict[str, DictNode]:
+    """
+        Mask secret values from definitions, as a way to mask these values in the created graph.
+        Should be used only in runners that have the resource_attributes_to_omit mapping
+        """
+    found_secrets = False
+    censored_definitions = definitions
+    for file in definitions:
+        for i, resource in enumerate(definitions[file].get('resource', [])):
+            for resource_type in [r_type for r_type in resource if r_type in resource_attributes_to_omit]:
+                for resource_name in resource[resource_type]:
+                    resource_config = resource[resource_type][resource_name]
+                    for attribute in [attribute for attribute in resource_config if
+                                      attribute == resource_attributes_to_omit[resource_type]]:
+                        if not found_secrets:
+                            found_secrets = True
+                            # The values in self.definitions shouldn't be changed so that checks' results
+                            # of checks that rely on the definitions values are not affected.
+                            # Hence, if secrets are found, we should censor them in a deep copy of self.definitions
+                            censored_definitions = copy.deepcopy(definitions)
+                        secret = resource_config[attribute][0]
+                        censored_value = omit_secret_value_from_line(secret, secret)
+                        censored_definitions[file]['resource'][i][resource_type][resource_name][attribute] = \
+                            [censored_value]
+    return censored_definitions
 
 
 def get_secrets_from_string(s: str, *categories: str) -> list[str]:

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -13,7 +13,7 @@ from checkov.terraform.graph_builder.local_graph import TerraformLocalGraph
 from checkov.common.checks_infra.registry import get_graph_checks_registry
 from checkov.common.graph.graph_builder.graph_components.attribute_names import CustomAttributes
 from checkov.common.output.record import Record
-from checkov.common.util.secrets import omit_secret_value_from_checks
+from checkov.common.util.secrets import omit_secret_value_from_checks, omit_secret_value_from_definitions
 
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.output.report import Report
@@ -80,7 +80,9 @@ class Runner(TerraformRunner):
             self.definitions, definitions_raw = create_definitions(root_folder, files, runner_filter, parsing_errors)
             self.context = build_definitions_context(self.definitions, definitions_raw)
             if CHECKOV_CREATE_GRAPH:
-                graph = self.graph_manager.build_graph_from_definitions(self.definitions, render_variables=False)
+                censored_definitions = omit_secret_value_from_definitions(definitions=self.definitions,
+                                                                          resource_attributes_to_omit=RESOURCE_ATTRIBUTES_TO_OMIT)
+                graph = self.graph_manager.build_graph_from_definitions(censored_definitions, render_variables=False)
                 self.graph_manager.save_graph(graph)
 
         if external_checks_dir:

--- a/tests/common/utils/conftest.py
+++ b/tests/common/utils/conftest.py
@@ -150,4 +150,96 @@ def tfplan_resource_lines_without_secrets():
             (46, '                                "timeouts": null,\n'),
             (47, '                                "value": "IClnjeTb8fg*********************************",\n'),
             (48, '                                "version": "123d0b12ab123c123456ab123e120bc1",\n'),
-            (49, '                                "versionless_id": "https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02"\n')]
+            (49,
+             '                                "versionless_id": "https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02"\n')]
+
+
+@pytest.fixture
+def tfplan_definitions_with_secrets():
+    return {'/Users/arielk/dev/terragoat/tfplan.json': {
+        'resource': [
+            {'azurerm_key_vault_secret': {
+                'test_123': {
+                    'content_type': [''],
+                    'expiration_date': [None],
+                    'id': [
+                        'https://test-123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02-primary-cs/t3stK3yR4nd0mN0tR34l'],
+                    'key_vault_id': ['abcd/subscriptions/1234/resourceGroups/xyz'], 'name': ['test-123-abcdse-02'],
+                    'not_before_date': [None], 'resource_id': ['abcd/subscriptions/1234/resourceGroups/xyz'],
+                    'resource_versionless_id': ['abcd/subscriptions/1234/resourceGroups/xyz'],
+                    'tags': [{'__startline__': 45, '__endline__': 45, 'start_line': 44, 'end_line': 44}],
+                    'timeouts': [None], 'value': ['t3stK3yR4nd0mN0tR34l/syQIyk9='],
+                    'version': ['t3stK3yR4nd0mN0tR34l'],
+                    'versionless_id': ['https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02'],
+                    '__startline__': [35], '__endline__': [50], 'start_line': [34], 'end_line': [49],
+                    '__address__': 'module.test.azurerm_key_vault_secret.te_primary_cs["te-st123-abcdse-02"]'}}},
+            {'azurerm_key_vault_secret': {
+                'test_01_key': {
+                    'content_type': [''],
+                    'expiration_date': [None],
+                    'id': ['https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02-primary-key/t3stK3yR4nd0mN0tR34l'],
+                    'key_vault_id': ['abcd/subscriptions/1234/resourceGroups/xyz'],
+                    'name': ['test-123-abcdse-02-primary-key'],
+                    'not_before_date': [None],
+                    'resource_id': ['abcd/subscriptions/1234/resourceGroups/xyz'],
+                    'resource_versionless_id': ['abcd/subscriptions/1234/resourceGroups/xyz'],
+                    'tags': [
+                        {'__startline__': 77,
+                         '__endline__': 77,
+                         'start_line': 76,
+                         'end_line': 76}],
+                    'timeouts': [None],
+                    'value': ['t3stK3yR4nd0mN0tR34l/syQIyk9='],
+                    'version': ['t3stK3yR4nd0mN0tR34l'],
+                    'versionless_id': ['https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02-primary-key'],
+                    '__startline__': [67],
+                    '__endline__': [82],
+                    'start_line': [66],
+                    'end_line': [81],
+                    '__address__': 'module.test.azurerm_key_vault_secret.te_primary_key["test-123-abcdse-02"]'}}}]}}
+
+
+@pytest.fixture
+def tfplan_definitions_without_secrets():
+    return {'/Users/arielk/dev/terragoat/tfplan.json': {
+        'resource': [
+            {'azurerm_key_vault_secret': {
+                'test_123': {
+                    'content_type': [''],
+                    'expiration_date': [None],
+                    'id': [
+                        'https://test-123-abcdse-02.vault.azure.net/secrets/te-st123-abcdse-02-primary-cs/t3stK3yR4nd0mN0tR34l'],
+                    'key_vault_id': ['abcd/subscriptions/1234/resourceGroups/xyz'], 'name': ['test-123-abcdse-02'],
+                    'not_before_date': [None], 'resource_id': ['abcd/subscriptions/1234/resourceGroups/xyz'],
+                    'resource_versionless_id': ['abcd/subscriptions/1234/resourceGroups/xyz'],
+                    'tags': [{'__startline__': 45, '__endline__': 45, 'start_line': 44, 'end_line': 44}],
+                    'timeouts': [None],
+                    'value': ['t3stK3y**********************'],
+                    'version': ['t3stK3yR4nd0mN0tR34l'],
+                    'versionless_id': ['https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02'],
+                    '__startline__': [35], '__endline__': [50], 'start_line': [34], 'end_line': [49],
+                    '__address__': 'module.test.azurerm_key_vault_secret.te_primary_cs["te-st123-abcdse-02"]'}}},
+            {'azurerm_key_vault_secret': {
+                'test_01_key': {
+                    'content_type': [''],
+                    'expiration_date': [None],
+                    'id': ['https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02-primary-key/t3stK3yR4nd0mN0tR34l'],
+                    'key_vault_id': ['abcd/subscriptions/1234/resourceGroups/xyz'],
+                    'name': ['test-123-abcdse-02-primary-key'],
+                    'not_before_date': [None],
+                    'resource_id': ['abcd/subscriptions/1234/resourceGroups/xyz'],
+                    'resource_versionless_id': ['abcd/subscriptions/1234/resourceGroups/xyz'],
+                    'tags': [
+                        {'__startline__': 77,
+                         '__endline__': 77,
+                         'start_line': 76,
+                         'end_line': 76}],
+                    'timeouts': [None],
+                    'value': ['t3stK3y**********************'],
+                    'version': ['t3stK3yR4nd0mN0tR34l'],
+                    'versionless_id': ['https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02-primary-key'],
+                    '__startline__': [67],
+                    '__endline__': [82],
+                    'start_line': [66],
+                    'end_line': [81],
+                    '__address__': 'module.test.azurerm_key_vault_secret.te_primary_key["test-123-abcdse-02"]'}}}]}}

--- a/tests/common/utils/test_secrets_utils.py
+++ b/tests/common/utils/test_secrets_utils.py
@@ -1,11 +1,12 @@
-from checkov.common.util.secrets import omit_secret_value_from_checks
+from checkov.common.util.secrets import omit_secret_value_from_checks, omit_secret_value_from_definitions
 from checkov.common.models.enums import CheckResult
 from checkov.terraform.checks.resource.azure.SecretExpirationDate import SecretExpirationDate
 from checkov.terraform.checks.provider.aws.credentials import AWSCredentials
 
 
-def test_omit_secret_value_from_checks_by_attribute(tfplan_resource_lines_with_secrets, tfplan_resource_config_with_secrets,
-                                    tfplan_resource_lines_without_secrets):
+def test_omit_secret_value_from_checks_by_attribute(tfplan_resource_lines_with_secrets,
+                                                    tfplan_resource_config_with_secrets,
+                                                    tfplan_resource_lines_without_secrets):
     check = SecretExpirationDate()
     check.entity_type = 'azurerm_key_vault_secret'
     check_result = {'result': CheckResult.FAILED}
@@ -24,3 +25,11 @@ def test_omit_secret_value_from_checks_by_secret(aws_provider_lines_with_secrets
     assert omit_secret_value_from_checks(check, check_result, aws_provider_lines_with_secrets,
                                          aws_provider_config_with_secrets
                                          ) == aws_provider_lines_without_secrets
+
+
+def test_omit_secret_value_from_definitions_by_attribute(tfplan_definitions_with_secrets,
+                                                         tfplan_definitions_without_secrets):
+    resource_attributes_to_omit = {'azurerm_key_vault_secret': 'value'}
+    censored_definitions = omit_secret_value_from_definitions(tfplan_definitions_with_secrets,
+                                                              resource_attributes_to_omit)
+    assert censored_definitions == tfplan_definitions_without_secrets


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Follows the changes in https://github.com/bridgecrewio/checkov/pull/3868, and adds the masking of the values to the graph in addition to the reports and checks metadata

We want secret values to be masked from graphs as well as from reports. This change checks for every tfplan definitions if they include secrets, by the resource attributes to omit mapping, and creates a censored version of the definitions as input for the graph creation if needed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
