### PR TITLE
fix(general): remove filter value validation

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -630,6 +630,7 @@ class BcPlatformIntegration:
             logging.debug(f'Prisma filter URL: {self.prisma_policy_filters_url}')
             request = self.http.request("GET", self.prisma_policy_filters_url, headers=headers)  # type:ignore[no-untyped-call]
             policy_filters: dict[str, dict[str, Any]] = json.loads(request.data.decode("utf8"))
+            logging.debug(f'Prisma filter suggestion response: {policy_filters}')
             return policy_filters
         except Exception:
             logging.warning(f"Failed to get prisma build policy metadata from {self.platform_run_config_url}", exc_info=True)
@@ -637,6 +638,9 @@ class BcPlatformIntegration:
 
     @staticmethod
     def is_valid_policy_filter(policy_filter: dict[str, str], valid_filters: dict[str, dict[str, Any]] | None = None) -> bool:
+        """
+        Validates only the filter names
+        """
         valid_filters = valid_filters or {}
 
         if not policy_filter:
@@ -646,10 +650,7 @@ class BcPlatformIntegration:
         for filter_name, filter_value in policy_filter.items():
             if filter_name not in valid_filters.keys():
                 logging.warning(f"Invalid filter name: {filter_name}")
-                return False
-            elif filter_value not in valid_filters[filter_name].get('options', []):
-                logging.warning(f"Invalid filter value: {filter_value}")
-                logging.warning(f"Available options: {valid_filters[filter_name].get('options')}")
+                logging.warning(f"Available filter names: {'. '.join(valid_filters.keys())}")
                 return False
             elif filter_name == 'policy.subtype' and filter_value != 'build':
                 logging.warning(f"Filter value not allowed: {filter_value}")

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -650,7 +650,7 @@ class BcPlatformIntegration:
         for filter_name, filter_value in policy_filter.items():
             if filter_name not in valid_filters.keys():
                 logging.warning(f"Invalid filter name: {filter_name}")
-                logging.warning(f"Available filter names: {'. '.join(valid_filters.keys())}")
+                logging.warning(f"Available filter names: {', '.join(valid_filters.keys())}")
                 return False
             elif filter_name == 'policy.subtype' and filter_value != 'build':
                 logging.warning(f"Filter value not allowed: {filter_value}")

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -151,8 +151,6 @@ class TestBCApiUrl(unittest.TestCase):
                                                         valid_filters=mock_prisma_policy_filter_response()))
         self.assertFalse(instance.is_valid_policy_filter(policy_filter={'policy.label': 'CODE', 'not': 'allowed'},
                                                         valid_filters=mock_prisma_policy_filter_response()))
-        self.assertFalse(instance.is_valid_policy_filter(policy_filter={'policy.label': ['A', 'B']},
-                                                         valid_filters=mock_prisma_policy_filter_response()))
         self.assertFalse(instance.is_valid_policy_filter(policy_filter={},
                                                          valid_filters=mock_prisma_policy_filter_response()))
         self.assertFalse(instance.is_valid_policy_filter(policy_filter={'policy.label': ['A', 'B']}, valid_filters={}))


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Removes validation of prisma metadata filter values since https://prisma.pan.dev/api/cloud/cspm/policy#operation/get-policy-filters-and-options only returns recently used values. 

Fixes #3475

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
