### PR TITLE
feat(general): add source to contributor metrics report

### DIFF
--- a/checkov/contributor_metrics.py
+++ b/checkov/contributor_metrics.py
@@ -9,9 +9,9 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def report_contributor_metrics(repository: str, bc_integration: BcPlatformIntegration) -> None:  # ignore: type
+def report_contributor_metrics(repository: str, source: str, bc_integration: BcPlatformIntegration) -> None:  # ignore: type
     logging.debug(f"Attempting to get log history for repository {repository}")
-    request_body = parse_gitlog(repository)
+    request_body = parse_gitlog(repository, source)
     if request_body:
         response = request_wrapper(
             "POST", f"{bc_integration.api_url}/api/v1/contributors/report",
@@ -23,7 +23,7 @@ def report_contributor_metrics(repository: str, bc_integration: BcPlatformIntegr
             logging.info(f"Failed to upload contributor metrics with: {response.status_code} - {response.reason}")
 
 
-def parse_gitlog(repository: str) -> dict[str, Any] | None:
+def parse_gitlog(repository: str, source: str) -> dict[str, Any] | None:
     process = subprocess.Popen(['git', 'shortlog', '-ne', '--all', '--since', '"90 days ago"', '--pretty=commit-%ct', '--reverse'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # nosec
     out, err = process.communicate()
     if err:
@@ -31,7 +31,7 @@ def parse_gitlog(repository: str) -> dict[str, Any] | None:
         return None
     # split per contributor
     list_of_contributors = out.decode('utf-8').split('\n\n')
-    return {"repository": repository,
+    return {"repository": repository, "source": source,
             "contributors": list(map(lambda contributor: process_contributor(contributor),
                                      list(filter(lambda x: x, list_of_contributors))
                                      ))

--- a/checkov/contributor_metrics.py
+++ b/checkov/contributor_metrics.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def report_contributor_metrics(repository: str, source: str, bc_integration: BcPlatformIntegration) -> None:  # ignore: type
-    logging.debug(f"Attempting to get log history for repository {repository}")
+    logging.debug(f"Attempting to get log history for repository {repository} under source {source}")
     request_body = parse_gitlog(repository, source)
     if request_body:
         response = request_wrapper(

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -255,7 +255,7 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
             logger.debug(f"Should run contributor metrics report: {should_run_contributor_metrics}")
             if should_run_contributor_metrics:
                 try:        # collect contributor info and upload
-                    report_contributor_metrics(config.repo_id, bc_integration)
+                    report_contributor_metrics(config.repo_id, source.name, bc_integration)
                 except Exception as e:
                     logger.warning(f"Unable to report contributor metrics due to: {e}")
 

--- a/tests/test_contributor_metrics.py
+++ b/tests/test_contributor_metrics.py
@@ -32,7 +32,9 @@ def test_parse_gitlog(mock_subproc_popen):
     process_mock.configure_mock(**attrs)
     mock_subproc_popen.return_value = process_mock
 
-    result = parse_gitlog("my_repo")
-    assert result == {"repository": "my_repo", "contributors": ["Fake User <fake1@paloaltonetworks.com> 1666516907",
+    result = parse_gitlog("my_repo", "jenkins")
+    assert result == {"repository": "my_repo",
+                      "source": "jenkins",
+                      "contributors": ["Fake User <fake1@paloaltonetworks.com> 1666516907",
                                                                 "dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com> 1667819806",
                                                                 "Fake User <fake2@paloaltonetworks.com> 1667216980"]}


### PR DESCRIPTION
This PR adds source to contributor metrics report in order for the persistence to differentiate between repositories under different sources.


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
