### PR TITLE
feat(general): sign and push checkov image to GitHub registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,8 +242,15 @@ jobs:
     runs-on: [self-hosted, public, linux, x64]
     needs: bump-version
     environment: release
+    permissions:
+      packages: write
+      id-token: write  # Enable OIDC
+    env:
+      DH_IMAGE_NAME: bridgecrew/checkov
+      GHCR_IMAGE_NAME: ghcr.io/${{ github.repository }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3
+      - uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b  # v2
       - name: Get release version
         id: versions
         run: |
@@ -251,14 +258,57 @@ jobs:
           checkov_major_version=$(echo "${checkov_version}" | head -c1)
           echo "version=$checkov_version" >> $GITHUB_OUTPUT
           echo "major_version=$checkov_major_version" >> $GITHUB_OUTPUT
-      - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@742a180fa47f3adfb5115902ae4955acc6ad769b  # v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a  # v2
         with:
-          name: bridgecrew/checkov
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          buildoptions: "--no-cache"
-          tags: "latest,${{ steps.versions.outputs.version }},${{ steps.versions.outputs.major_version }}"
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a  # v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        id: docker_push
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5  # v3
+        with:
+          context: .
+          no-cache: true
+          push: true
+          tags: |
+            ${{ env.DH_IMAGE_NAME }}:latest
+            ${{ env.DH_IMAGE_NAME }}:${{ steps.versions.outputs.major_version }}
+            ${{ env.DH_IMAGE_NAME }}:${{ steps.versions.outputs.version }}
+            ${{ env.GHCR_IMAGE_NAME }}:latest
+            ${{ env.GHCR_IMAGE_NAME }}:${{ steps.versions.outputs.major_version }}
+            ${{ env.GHCR_IMAGE_NAME }}:${{ steps.versions.outputs.version }}
+      - name: Generate SBOM
+        continue-on-error: true
+        uses: bridgecrewio/checkov-action@master  # use latest and greatest
+        with:
+          api-key: ${{ secrets.BC_API_KEY }}
+          docker_image: ${{ env.DH_IMAGE_NAME }}:${{ steps.versions.outputs.version }}
+          dockerfile_path: Dockerfile
+          output_format: cyclonedx_json
+          output_file_path: cyclonedx.json,
+      - name: Sign and attest image
+        run: |
+          # sign image
+          cosign sign ${{ env.DH_IMAGE_NAME }}@${{ steps.docker_push.outputs.digest }}
+          cosign sign -f ${{ env.GHCR_IMAGE_NAME }}@${{ steps.docker_push.outputs.digest }}
+          
+          # attest SBOM
+          cosign attest \
+            --type cyclonedx \
+            --predicate cyclonedx.json \
+            ${{ env.DH_IMAGE_NAME }}@${{ steps.docker_push.outputs.digest }}
+          cosign attest -f \
+            --type cyclonedx \
+            --predicate cyclonedx.json \
+            ${{ env.GHCR_IMAGE_NAME }}@${{ steps.docker_push.outputs.digest }}
+        env:
+          COSIGN_EXPERIMENTAL: 1  # needed for keyless signing
   publish-checkov-k8s-dockerhub:
     runs-on: [self-hosted, public, linux, x64]
     needs: bump-version

--- a/docs/4.Integrations/Docker.md
+++ b/docs/4.Integrations/Docker.md
@@ -13,3 +13,19 @@ docker run --tty --volume /user/tf:/tf --workdir /tf bridgecrew/checkov --direct
 ```
 
 If you are using Python 3.6 (which is the default version in Ubuntu 18.04) Checkov will not work and it will fail with `ModuleNotFoundError: No module named 'dataclasses'`. In this case, you can use the Docker version instead.\n\nIn certain cases, when redirecting `docker run --tty` output to a file - for example, if you want to save the Checkov JUnit output to a file - will cause extra control characters to be printed. This can break file parsing. If you encounter this, remove the --tty flag.
+
+## Signed images
+
+Docker images are keyless signed with `cosign` and attested with a `CycloneDX` formatted SBOM.
+
+### Verify image
+
+```shell
+COSIGN_EXPERIMENTAL=1 cosign verify bridgecrew/checkov | jq .
+```
+
+### Verify attestation
+
+```shell
+COSIGN_EXPERIMENTAL=1 cosign verify-attestation --type cyclonedx bridgecrew/checkov | jq -r .payload | base64 -D | jq .
+```


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- changed `elgohr/Publish-Docker-Github-Action` to the official `docker/login-action` and `docker/build-push-action` GHA
- `checkov` Docker image is also pushed to GitHub Container Registry
- created a SBOM with our own `bridgecrewio/checkov-action` GHA, it is on purpose set to `master` branch, so we don't need to update the hash all the time, except we want
- signed the image with `cosign` and attested it with created SBOM

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
