### PR TITLE
feat(terraform): add CKV_AWS_282 to ensure that Redshift Serverless namespace is encrypted by KMS

### DIFF
--- a/checkov/terraform/checks/resource/aws/RedshiftServerlessNamespaceKMSKey.py
+++ b/checkov/terraform/checks/resource/aws/RedshiftServerlessNamespaceKMSKey.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.common.models.consts import ANY_VALUE
+
+
+class RedshiftServerlessNamespaceKMSKey(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that Redshift Serverless namespace is encrypted by KMS using a customer managed key (CMK)"
+        id = "CKV_AWS_282"
+        supported_resources = ('aws_redshiftserverless_namespace',)
+        categories = (CheckCategories.ENCRYPTION,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "kms_key_id"
+
+    def get_expected_value(self) -> Any:
+        return ANY_VALUE
+
+
+check = RedshiftServerlessNamespaceKMSKey()

--- a/tests/terraform/checks/resource/aws/example_RedshiftServerlessNamespaceKMSKey/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RedshiftServerlessNamespaceKMSKey/main.tf
@@ -1,0 +1,8 @@
+resource "aws_redshiftserverless_namespace" "fail" {
+  namespace_name = "test-fail-namespace"
+}
+
+resource "aws_redshiftserverless_namespace" "pass" {
+  namespace_name = "test-pass-namespace"
+  kms_key_id = aws_kms_key.example.arn
+}

--- a/tests/terraform/checks/resource/aws/test_RedshiftServerlessNamespaceKMSKey.py
+++ b/tests/terraform/checks/resource/aws/test_RedshiftServerlessNamespaceKMSKey.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.RedshiftServerlessNamespaceKMSKey import check
+from checkov.terraform.runner import Runner
+
+
+class TestRedshiftServerlessNamespaceKMSKey(unittest.TestCase):
+    def test(self) -> None:
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_RedshiftServerlessNamespaceKMSKey"
+        report = runner.run(
+            root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
+        )
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_redshiftserverless_namespace.pass",
+        }
+        failing_resources = {
+            "aws_redshiftserverless_namespace.fail",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Added new policy

## New/Edited policies
CKV_AWS_282 - checks that `aws_redshiftserverless_namespace` has a `kms_key_id` set

### Description
We want to make sure that `aws_redshiftserverless_namespace` is encrypted.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
