### PR TITLE
fix(sca): fix related resource id for helm and kustomize

### DIFF
--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -43,6 +43,16 @@ def enable_image_referencer(
     return False
 
 
+def fix_related_resource_ids(report: Report | None, tmp_dir: str) -> None:
+    """Remove tmp dir prefix from 'relatedResourceId'"""
+
+    if report and report.image_cached_results:
+        for cached_result in report.image_cached_results:
+            related_resource_id = cached_result.get("relatedResourceId")
+            if related_resource_id and isinstance(related_resource_id, str):
+                cached_result["relatedResourceId"] = related_resource_id.replace(tmp_dir, "", 1)
+
+
 class Image:
     def __init__(self, file_path: str, name: str, start_line: int, end_line: int,
                  related_resource_id: str | None = None) -> None:

--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -13,6 +13,7 @@ import yaml
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.graph.checks_infra.registry import BaseRegistry
 from checkov.common.graph.db_connectors.networkx.networkx_db_connector import NetworkxConnector
+from checkov.common.images.image_referencer import fix_related_resource_ids
 from checkov.common.output.report import Report
 from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.runners.base_runner import BaseRunner, filter_ignored_paths
@@ -62,12 +63,19 @@ class K8sHelmRunner(k8_runner):
             chart_results = super().run(root_folder, external_checks_dir=external_checks_dir, runner_filter=runner_filter)
 
             if isinstance(chart_results, list):
-                helm_report = next(chart_result for chart_result in chart_results if chart_result.check_type == self.check_type)
+                helm_report = next(
+                    chart_result for chart_result in chart_results if chart_result.check_type == self.check_type
+                )
+                sca_image_report = next(
+                    chart_result for chart_result in chart_results if chart_result.check_type == CheckType.SCA_IMAGE
+                )
             else:
                 helm_report = chart_results
+                sca_image_report = None
 
             if root_folder is not None:
-                fix_report_paths(helm_report, root_folder)
+                fix_report_paths(report=helm_report, tmp_dir=root_folder)
+                fix_related_resource_ids(report=sca_image_report, tmp_dir=root_folder)
 
             return chart_results
         except Exception:

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -15,6 +15,7 @@ import yaml
 from typing import Optional, Dict, Any, TextIO, TYPE_CHECKING
 
 from checkov.common.graph.graph_builder import CustomAttributes
+from checkov.common.images.image_referencer import fix_related_resource_ids
 from checkov.common.output.record import Record
 from checkov.common.output.report import Report
 from checkov.common.bridgecrew.check_type import CheckType
@@ -48,6 +49,25 @@ class K8sKustomizeRunner(K8sRunner):
         self.check_type = CheckType.KUSTOMIZE
         self.report_mutator_data: "dict[str, dict[str, Any]]" = {}
         self.pbar.turn_off_progress_bar()
+
+    def run(
+        self,
+        root_folder: str | None,
+        external_checks_dir: list[str] | None = None,
+        files: list[str] | None = None,
+        runner_filter: RunnerFilter | None = None,
+        collect_skip_comments: bool = True
+    ) -> Report | list[Report]:
+        results = super().run(root_folder, external_checks_dir=external_checks_dir, runner_filter=runner_filter)
+
+        sca_image_report = None
+        if isinstance(results, list):
+            sca_image_report = next(result for result in results if result.check_type == CheckType.SCA_IMAGE)
+
+        if root_folder is not None:
+            fix_related_resource_ids(report=sca_image_report, tmp_dir=root_folder)
+
+        return results
 
     def set_external_data(
         self,

--- a/tests/helm/test_runner_image_referencer.py
+++ b/tests/helm/test_runner_image_referencer.py
@@ -117,3 +117,13 @@ def test_deployment_resources(mocker: MockerFixture, image_cached_result, licens
     assert len(sca_image_report.failed_checks) == 1
     assert len(sca_image_report.skipped_checks) == 0
     assert len(sca_image_report.parsing_errors) == 0
+    assert len(sca_image_report.image_cached_results) == 1
+
+    assert sca_image_report.image_cached_results[0]["dockerImageName"] == image_name
+    assert (
+        sca_image_report.image_cached_results[0]["relatedResourceId"]
+        == "/hello-world/templates/deployment.yaml:Deployment.default.release-name-hello-world"
+    )
+    assert sca_image_report.image_cached_results[0]["packages"] == [
+        {"type": "os", "name": "zlib", "version": "1.2.12-r1", "licenses": ["Zlib"]}
+    ]

--- a/tests/kustomize/test_runner_image_referencer.py
+++ b/tests/kustomize/test_runner_image_referencer.py
@@ -121,3 +121,13 @@ def test_deployment_resources(mocker: MockerFixture, image_cached_result, licens
     assert len(sca_image_report.failed_checks) == 1
     assert len(sca_image_report.skipped_checks) == 0
     assert len(sca_image_report.parsing_errors) == 0
+    assert len(sca_image_report.image_cached_results) == 1
+
+    assert sca_image_report.image_cached_results[0]["dockerImageName"] == image_name
+    assert (
+        sca_image_report.image_cached_results[0]["relatedResourceId"]
+        == "/image_referencer/overlays/prod/Deployment-default-prod-wordpress.yaml:Deployment.default.prod-wordpress"
+    )
+    assert sca_image_report.image_cached_results[0]["packages"] == [
+        {"type": "os", "name": "zlib", "version": "1.2.12-r1", "licenses": ["Zlib"]}
+    ]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- removed the temp folder prefix from the related resource id field in helm and kustomize Image Referencer reports

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
