### PR TITLE
fix(terraform): OCI Security Group Control Problem

### DIFF
--- a/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/oci/AbsSecurityGroupUnrestrictedIngress.py
@@ -30,10 +30,10 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
 
     def scan_protocol_conf(self, protocol_name):
         """ scan tcp_options configuration"""
-        if 'source_port_range' not in protocol_name[0]:
+        if 'destination_port_range' not in protocol_name[0]:
             return False
-        max_port = force_int(protocol_name[0]['source_port_range'][0]['max'][0])
-        min_port = force_int(protocol_name[0]['source_port_range'][0]['min'][0])
+        max_port = force_int(protocol_name[0]['destination_port_range'][0]['max'][0])
+        min_port = force_int(protocol_name[0]['destination_port_range'][0]['min'][0])
         if max_port and min_port and min_port <= self.port <= max_port:
             return False
         return True

--- a/tests/terraform/checks/resource/oci/example_SecurityGroupUnrestrictedIngress22/main.tf
+++ b/tests/terraform/checks/resource/oci/example_SecurityGroupUnrestrictedIngress22/main.tf
@@ -6,7 +6,7 @@ resource "oci_core_network_security_group_security_rule" "pass" {
     source = "0.0.0.0/0"
 
     tcp_options {
-        source_port_range {
+        destination_port_range {
             max = 22
             min = 22
         }
@@ -28,7 +28,7 @@ resource "oci_core_network_security_group_security_rule" "pass2" {
     source_type = "CIDR_BLOCK"
 
     tcp_options {
-        source_port_range {
+        destination_port_range {
             max = 25
             min = 25
         }
@@ -43,7 +43,7 @@ resource "oci_core_network_security_group_security_rule" "pass3" {
     source_type = "CIDR_BLOCK"
 
     tcp_options {
-        source_port_range {
+        destination_port_range {
             max = 21
             min = 1
         }
@@ -59,7 +59,7 @@ resource "oci_core_network_security_group_security_rule" "fail" {
     source_type = "CIDR_BLOCK"
 
     tcp_options {
-        source_port_range {
+        destination_port_range {
             max = 22
             min = 22
         }
@@ -74,7 +74,7 @@ resource "oci_core_network_security_group_security_rule" "fail1" {
     source_type = "CIDR_BLOCK"
 
     tcp_options {
-        source_port_range {
+        destination_port_range {
             max = 25
             min = 21
         }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
AbsSecurtiGroupUnrestictedIngress  is comparing "source_port_range"  instead of   "destination_port_range" which is not a true way to control access policy. 

Fixes #3932

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
