### PR TITLE
fix(bicep): ignore unresolvable properties for Bicep storage account checks

### DIFF
--- a/checkov/bicep/checks/resource/azure/StorageAccountAzureServicesAccessEnabled.py
+++ b/checkov/bicep/checks/resource/azure/StorageAccountAzureServicesAccessEnabled.py
@@ -18,6 +18,9 @@ class StorageAccountAzureServicesAccessEnabled(BaseResourceCheck):
         self.evaluated_keys = ["properties/networkAcls/defaultAction"]
         properties = conf.get("properties")
         if properties:
+            if not isinstance(properties, dict):
+                return CheckResult.UNKNOWN
+
             nacls = properties.get("networkAcls")
             if nacls:
                 default_action = nacls.get("defaultAction")

--- a/checkov/bicep/checks/resource/azure/StorageAccountsTransportEncryption.py
+++ b/checkov/bicep/checks/resource/azure/StorageAccountsTransportEncryption.py
@@ -19,6 +19,9 @@ class StorageAccountsTransportEncryption(BaseResourceCheck):
         self.evaluated_keys = ["properties/supportsHttpsTrafficOnly"]
         properties = conf.get("properties")
         if properties:
+            if not isinstance(properties, dict):
+                return CheckResult.UNKNOWN
+
             https_only = properties.get("supportsHttpsTrafficOnly")
             if https_only is True:
                 return CheckResult.PASSED

--- a/tests/bicep/checks/resource/azure/example_StorageAccountAzureServicesAccessEnabled/main.bicep
+++ b/tests/bicep/checks/resource/azure/example_StorageAccountAzureServicesAccessEnabled/main.bicep
@@ -72,3 +72,16 @@ resource denyAndBypassNone 'Microsoft.Storage/storageAccounts@2019-06-01' = {
     }
   }
 }
+
+// unknown
+
+resource unknown 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: diagStorageAccountName
+  location: location
+  sku: {
+    name: storageAccountType
+  }
+  kind: 'StorageV2'
+
+  properties: storageAccountProperties
+}

--- a/tests/bicep/checks/resource/azure/example_StorageAccountsTransportEncryption/main.bicep
+++ b/tests/bicep/checks/resource/azure/example_StorageAccountsTransportEncryption/main.bicep
@@ -45,3 +45,17 @@ resource disabled 'Microsoft.Storage/storageAccounts@2019-06-01' = {
     supportsHttpsTrafficOnly: false
   }
 }
+
+// unknown
+
+resource unknown 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: diagStorageAccountName
+  location: location
+  sku: {
+    name: storageAccountType
+  }
+  kind: 'StorageV2'
+
+  properties: storageAccountProperties
+}
+

--- a/tests/bicep/checks/resource/azure/test_StorageAccountAzureServicesAccessEnabled.py
+++ b/tests/bicep/checks/resource/azure/test_StorageAccountAzureServicesAccessEnabled.py
@@ -29,10 +29,11 @@ def test_examples():
     passed_check_resources = {c.resource for c in report.passed_checks}
     failed_check_resources = {c.resource for c in report.failed_checks}
 
-    assert summary["passed"] == 3
-    assert summary["failed"] == 2
+    assert summary["passed"] == len(passing_resources)
+    assert summary["failed"] == len(failing_resources)
     assert summary["skipped"] == 0
     assert summary["parsing_errors"] == 0
+    assert summary["resource_count"] == len(passing_resources) + len(failing_resources) + 1  # unknown
 
     assert passed_check_resources == passing_resources
     assert failed_check_resources == failing_resources

--- a/tests/bicep/checks/resource/azure/test_StorageAccountsTransportEncryption.py
+++ b/tests/bicep/checks/resource/azure/test_StorageAccountsTransportEncryption.py
@@ -28,10 +28,11 @@ def test_examples():
     passed_check_resources = {c.resource for c in report.passed_checks}
     failed_check_resources = {c.resource for c in report.failed_checks}
 
-    assert summary["passed"] == 2
-    assert summary["failed"] == 2
+    assert summary["passed"] == len(passing_resources)
+    assert summary["failed"] == len(failing_resources)
     assert summary["skipped"] == 0
     assert summary["parsing_errors"] == 0
+    assert summary["resource_count"] == len(passing_resources) + len(failing_resources) + 1  # unknown
 
     assert passed_check_resources == passing_resources
     assert failed_check_resources == failing_resources


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- returning result `UNKNOWN` if `properties` can't be resolved

Fixes #3916 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
