### PR TITLE
feat(terraform): Handle omitting multiline secrets for tfplan

### DIFF
--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -23,7 +23,7 @@ GCP = 'gcp'
 GENERAL = 'general'
 ALL = 'all'
 
-MULTILINE_REGEX = re.compile('.*\n.*')
+NEWLINE_REGEX = re.compile('\n')
 
 # Taken from various git-secrets forks that add Azure and GCP support to base AWS.
 # The groups here are the result of running git secrets --register-[aws|azure|gcp]
@@ -212,4 +212,4 @@ def get_secrets_from_string(s: str, *categories: str) -> list[str]:
 
 
 def parse_multiline_secret_strings(secret: str) -> str:
-    return secret.replace('\n', '\\n') if re.match(MULTILINE_REGEX, secret) else secret
+    return re.sub(NEWLINE_REGEX, '\\\\n', secret)

--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -211,5 +211,5 @@ def get_secrets_from_string(s: str, *categories: str) -> list[str]:
     return secrets
 
 
-def parse_multiline_secret_strings(secret: str):
+def parse_multiline_secret_strings(secret: str) -> str:
     return secret.replace('\n', '\\n') if re.match(MULTILINE_REGEX, secret) else secret

--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -210,5 +210,6 @@ def get_secrets_from_string(s: str, *categories: str) -> list[str]:
             secrets.extend(matches)
     return secrets
 
+
 def parse_multiline_secret_strings(secret: str):
     return secret.replace('\n', '\\n') if re.match(MULTILINE_REGEX, secret) else secret

--- a/tests/common/utils/conftest.py
+++ b/tests/common/utils/conftest.py
@@ -153,6 +153,67 @@ def tfplan_resource_lines_without_secrets():
             (49,
              '                                "versionless_id": "https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02"\n')]
 
+@pytest.fixture
+def tfplan_resource_config_with_multiline_secret():
+    return {
+        'content_type': [''],
+        'expiration_date': [None],
+        'id': ['https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02-primary-key/352d0b63ac873c528170cb366b570da5'],
+        'key_vault_id': ['/subscriptions/resourceGroups/'],
+        'name': ['test-123-abcdse-02-primary-key'],
+        'not_before_date': [None],
+        'resource_id': ['/subscriptions/resourceGroups/'],
+        'resource_versionless_id': ['/subscriptions/resourceGroups/'],
+        'tags': [{'__startline__': 45, '__endline__': 45, 'start_line': 44, 'end_line': 44}],
+        'timeouts': [None],
+        'value': ['-----BEGIN RSA PRIVATE KEY-----\ndGhpcyBpcyBhIHBzc3dvcmQgdmVyeSB2ZXJ5IGxvbmchIQphbmQgaXQgY2FuIGJlCmRlY2lwaGxsZWQKb25seQppZiB5b3UKZGVjb2RlIGl0Ck1BR0lD\nndGhpcyBpcyBhIHBzc3dvcmQgdmVyeSB2ZXJ5IGxvbmchIQphbmQgaXQgY2FuIGJlCmRlY2lwaGxsZWQKb25seQppZiB5b3UKZGVjb2RlIGl0Ck1BR0lD\n-----END RSA PRIVATE KEY-----\n'],
+        'version': ['123d0b12ab123c123456ab123e120bc1'],
+        'versionless_id': ['https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02'],
+        '__startline__': [35],
+        '__endline__': [50],
+        'start_line': [34],
+        'end_line': [49],
+        '__address__': 'module.test.azurerm_key_vault_secret.te_primary_key["test-123-abcdse-02"]'}
+
+
+@pytest.fixture
+def tfplan_resource_lines_with_multiline_secret():
+    return [(35, '                            {\n'),
+            (36, '                                "content_type": "",\n'),
+            (37, '                                "expiration_date": null,\n'),
+            (38, '                                "id": "https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02-primary-key/352d0b63ac873c528170cb366b570da5",\n'),
+            (39, '                                "key_vault_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
+            (40, '                                "name": "test-123-abcdse-02-primary-key",\n'),
+            (41, '                                "not_before_date": null,\n'),
+            (42, '                                "resource_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
+            (43, '                                "resource_versionless_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
+            (44, '                                "tags":\n'),
+            (45, '                                {},\n'),
+            (46, '                                "timeouts": null,\n'),
+            (47, '                                "value": "-----BEGIN RSA PRIVATE KEY-----\\ndGhpcyBpcyBhIHBzc3dvcmQgdmVyeSB2ZXJ5IGxvbmchIQphbmQgaXQgY2FuIGJlCmRlY2lwaGxsZWQKb25seQppZiB5b3UKZGVjb2RlIGl0Ck1BR0lD\\nndGhpcyBpcyBhIHBzc3dvcmQgdmVyeSB2ZXJ5IGxvbmchIQphbmQgaXQgY2FuIGJlCmRlY2lwaGxsZWQKb25seQppZiB5b3UKZGVjb2RlIGl0Ck1BR0lD\\n-----END RSA PRIVATE KEY-----\\n",\n'),
+            (48, '                                "version": "123d0b12ab123c123456ab123e120bc1",\n'),
+            (49, '                                "versionless_id": "https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02"\n')]
+
+
+@pytest.fixture
+def tfplan_resource_lines_without_multiline_secret():
+    return [(35, '                            {\n'),
+            (36, '                                "content_type": "",\n'),
+            (37, '                                "expiration_date": null,\n'),
+            (38, '                                "id": "https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02-primary-key/352d0b63ac873c528170cb366b570da5",\n'),
+            (39, '                                "key_vault_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
+            (40, '                                "name": "test-123-abcdse-02-primary-key",\n'),
+            (41, '                                "not_before_date": null,\n'),
+            (42, '                                "resource_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
+            (43, '                                "resource_versionless_id": "abcd/subscriptions/123/resourceGroups/abcd",\n'),
+            (44, '                                "tags":\n'),
+            (45, '                                {},\n'),
+            (46, '                                "timeouts": null,\n'),
+            (47, '                                "value": "-----BEGIN RSA PRIVATE KEY-----\\ndGhpcyBpcyBhIHBzc3dvcmQgdmVyeSB2ZXJ5IGxvbm**********************************************************************************************************************************************************************************************************************************",\n'),
+            (48, '                                "version": "123d0b12ab123c123456ab123e120bc1",\n'),
+            (49,
+             '                                "versionless_id": "https://test-123-abcdse-02.vault.azure.net/secrets/test-123-abcdse-02"\n')]
+
 
 @pytest.fixture
 def tfplan_definitions_with_secrets():

--- a/tests/common/utils/test_secrets_utils.py
+++ b/tests/common/utils/test_secrets_utils.py
@@ -16,6 +16,18 @@ def test_omit_secret_value_from_checks_by_attribute(tfplan_resource_lines_with_s
                                          tfplan_resource_config_with_secrets, resource_attributes_to_omit
                                          ) == tfplan_resource_lines_without_secrets
 
+def test_omit_multiline_secret_value_from_checks_by_attribute(tfplan_resource_lines_with_multiline_secret,
+                                                    tfplan_resource_config_with_multiline_secret,
+                                                    tfplan_resource_lines_without_multiline_secret):
+    check = SecretExpirationDate()
+    check.entity_type = 'azurerm_key_vault_secret'
+    check_result = {'result': CheckResult.FAILED}
+    resource_attributes_to_omit = {'azurerm_key_vault_secret': 'value'}
+
+    assert omit_secret_value_from_checks(check, check_result, tfplan_resource_lines_with_multiline_secret,
+                                         tfplan_resource_config_with_multiline_secret, resource_attributes_to_omit
+                                         ) == tfplan_resource_lines_without_multiline_secret
+
 
 def test_omit_secret_value_from_checks_by_secret(aws_provider_lines_with_secrets, aws_provider_config_with_secrets,
                                     aws_provider_lines_without_secrets):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

multiline secrets like this one were not omitted
```
value: "-----BEGIN RSA PRIVATE KEY-----
<BASE64_KEY>
-----END RSA PRIVATE KEY-----"
```
Now they are

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
