### PR TITLE
feat(terraform): Adding yaml based build time policies for corresponding PC run time policies

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/AWSConfigRecorderEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/AWSConfigRecorderEnabled.yaml
@@ -1,0 +1,29 @@
+metadata:
+  id: "CKV2_AWS_45"
+  name: "Ensure AWS Config recorder is enabled"
+  category: "LOGGING"
+definition:
+  and:
+    - cond_type: filter
+      attribute: resource_type
+      operator: within
+      value:
+        - aws_config_configuration_recorder_status
+    - cond_type: connection
+      resource_types:
+        - aws_config_configuration_recorder_status
+      connected_resource_types:
+        - aws_config_configuration_recorder
+      operator: exists
+    - cond_type: attribute
+      resource_types:
+        - aws_config_configuration_recorder
+      attribute: recording_group.all_supported
+      operator: not_equals
+      value: "false"
+    - cond_type: attribute
+      resource_types:
+        - aws_config_configuration_recorder_status
+      attribute: is_enabled
+      operator: equals
+      value: "true"

--- a/checkov/terraform/checks/graph_checks/aws/CLoudFrontS3OriginConfigWithOAI.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/CLoudFrontS3OriginConfigWithOAI.yaml
@@ -1,0 +1,30 @@
+metadata:
+  id: "CKV2_AWS_46"
+  name: "Ensure AWS Cloudfront Distribution with S3 have Origin Access set to enabled"
+  category: "APPLICATION_SECURITY"
+definition:
+  or:
+    - and:
+        - cond_type: filter
+          attribute: resource_type
+          operator: within
+          value:
+            - aws_cloudfront_distribution
+        - cond_type: connection
+          resource_types:
+            - aws_cloudfront_distribution
+          connected_resource_types:
+            - aws_s3_bucket
+          operator: not_exists
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_distribution
+      attribute: "origin.*.s3_origin_config"
+      operator: "exists"
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_distribution
+      attribute: "origin.*.origin_access_control_id"
+      operator: "exists"         
+        
+    

--- a/checkov/terraform/checks/graph_checks/aws/CloudFrontWebACLConfiguredWIthLog4jVulnerability.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/CloudFrontWebACLConfiguredWIthLog4jVulnerability.yaml
@@ -1,0 +1,30 @@
+metadata:
+  id: "CKV2_AWS_47"
+  name: "Ensure AWS CloudFront attached WAFv2 WebACL is configured with AMR for Log4j Vulnerability"
+  category: "APPLICATION_SECURITY"
+definition:
+  and:
+    - cond_type: filter
+      attribute: resource_type
+      operator: within
+      value:
+        - aws_cloudfront_distribution
+    - cond_type: connection
+      resource_types:
+        - aws_cloudfront_distribution
+      connected_resource_types:
+        - aws_wafv2_web_acl
+      operator: exists
+    - cond_type: attribute
+      resource_types:
+        - aws_wafv2_web_acl
+      attribute: rule.*.statement.managed_rule_group_statement.name
+      operator: contains
+      value: "AWSManagedRulesAnonymousIpList"
+    - cond_type: attribute
+      resource_types:
+        - aws_wafv2_web_acl
+      attribute: rule.*.statement.managed_rule_group_statement.name
+      operator: contains
+      value: "AWSManagedRulesKnownBadInputsRuleSet"
+      

--- a/checkov/terraform/checks/graph_checks/aws/ConfigRecorderRecordsAllGlobalResources.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/ConfigRecorderRecordsAllGlobalResources.yaml
@@ -1,0 +1,29 @@
+metadata:
+  id: "CKV2_AWS_48"
+  name: "Ensure AWS Config must record all possible resources"
+  category: "LOGGING"
+definition:
+  and:
+    - cond_type: filter
+      attribute: resource_type
+      operator: within
+      value:
+        - aws_config_configuration_recorder_status
+    - cond_type: connection
+      resource_types:
+        - aws_config_configuration_recorder_status
+      connected_resource_types:
+        - aws_config_configuration_recorder
+      operator: exists
+    - cond_type: attribute
+      resource_types:
+        - aws_config_configuration_recorder
+      attribute: recording_group.include_global_resource_types
+      operator: equals
+      value: "true"
+    - cond_type: attribute
+      resource_types:
+        - aws_config_configuration_recorder_status
+      attribute: is_enabled
+      operator: equals
+      value: "true"

--- a/checkov/terraform/checks/graph_checks/aws/DMSEndpointHaveSSLConfigured.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/DMSEndpointHaveSSLConfigured.yaml
@@ -1,0 +1,55 @@
+metadata:
+  id: "CKV2_AWS_49"
+  name: "Ensure AWS Database Migration Service endpoint have SSL configured"
+  category: "NETWORKING"
+definition:
+  or:
+    - and:
+        - cond_type: "attribute"
+          resource_types:
+          - "aws_dms_endpoint"
+          attribute: "endpoint_type"
+          operator: "equals"
+          value: "source"
+        - or:
+            - cond_type: "attribute"
+              resource_types:
+              - "aws_dms_endpoint"
+              attribute: "engine_name"
+              operator: "subset"
+              value: 
+                - "s3"
+                - "azuredb"
+            - cond_type: "attribute"
+              resource_types:
+              - "aws_dms_endpoint"
+              attribute: "ssl_mode"
+              operator: "not_equals"
+              value: "none" 
+    - and:
+        - cond_type: "attribute"
+          resource_types:
+          - "aws_dms_endpoint"
+          attribute: "endpoint_type"
+          operator: "equals"
+          value: "target"
+        - or:
+            - cond_type: "attribute"
+              resource_types:
+              - "aws_dms_endpoint"
+              attribute: "engine_name"
+              operator: "subset"
+              value: 
+                - "dynamodb"
+                - "kinesis"
+                - "neptune"
+                - "redshift"
+                - "s3"
+                - "elasticsearch"
+                - "kafka"
+            - cond_type: "attribute"
+              resource_types:
+              - "aws_dms_endpoint"
+              attribute: "ssl_mode"
+              operator: "not_equals"
+              value: "none"

--- a/checkov/terraform/checks/graph_checks/aws/ElastiCacheRedisConfiguredAutomaticFailOver.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/ElastiCacheRedisConfiguredAutomaticFailOver.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "CKV2_AWS_50"
+  name: "Ensure AWS ElastiCache Redis cluster with Multi-AZ Automatic Failover feature set to enabled"
+  category: "GENERAL"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "aws_elasticache_replication_group"
+  attribute: "automatic_failover_enabled"
+  operator: "equals"
+  value: "true"

--- a/tests/terraform/graph/checks/resources/AWSConfigRecorderEnabled/expected.yaml
+++ b/tests/terraform/graph/checks/resources/AWSConfigRecorderEnabled/expected.yaml
@@ -1,0 +1,5 @@
+fail:
+  - "aws_config_configuration_recorder_status.fail_1"
+  - "aws_config_configuration_recorder_status.fail_2"
+pass:
+  - "aws_config_configuration_recorder_status.pass"

--- a/tests/terraform/graph/checks/resources/AWSConfigRecorderEnabled/main.tf
+++ b/tests/terraform/graph/checks/resources/AWSConfigRecorderEnabled/main.tf
@@ -1,0 +1,38 @@
+resource "aws_config_configuration_recorder" "pass_recorder" {
+  name     = "example"
+  role_arn = aws_iam_role.r.arn
+
+  recording_group {
+    include_global_resource_types = true
+  }
+  
+}
+
+resource "aws_config_configuration_recorder_status" "pass" {
+  name       = aws_config_configuration_recorder.pass_recorder.name
+  is_enabled = true
+}
+
+resource "aws_config_configuration_recorder" "fail_recorder_1" {
+  name     = "example"
+  role_arn = aws_iam_role.r.arn
+  
+}
+
+resource "aws_config_configuration_recorder_status" "fail_1" {
+  name       = aws_config_configuration_recorder.fail_recorder_1.name
+  is_enabled = false
+}
+
+resource "aws_config_configuration_recorder" "fail_recorder_2" {
+  name     = "example"
+  role_arn = aws_iam_role.r.arn
+  recording_group {
+    all_supported = false
+  }
+}
+
+resource "aws_config_configuration_recorder_status" "fail_2" {
+  name       = aws_config_configuration_recorder.fail_recorder_2.name
+  is_enabled = false
+}

--- a/tests/terraform/graph/checks/resources/CLoudFrontS3OriginConfigWithOAI/expected.yaml
+++ b/tests/terraform/graph/checks/resources/CLoudFrontS3OriginConfigWithOAI/expected.yaml
@@ -1,0 +1,5 @@
+fail:
+  - "aws_cloudfront_distribution.fail"
+pass:
+  - "aws_cloudfront_distribution.pass_1"
+  - "aws_cloudfront_distribution.pass_2"

--- a/tests/terraform/graph/checks/resources/CLoudFrontS3OriginConfigWithOAI/main.tf
+++ b/tests/terraform/graph/checks/resources/CLoudFrontS3OriginConfigWithOAI/main.tf
@@ -1,0 +1,336 @@
+
+resource "aws_s3_bucket" "b" {
+  bucket = "mybucket"
+
+  tags = {
+    Name = "My bucket"
+  }
+}
+
+resource "aws_cloudfront_distribution" "pass_1" {
+  
+
+  origin {
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_id   = "failoverS3"
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.default.cloudfront_access_identity_path
+    }
+    
+  }
+
+  
+
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "mylogs.s3.amazonaws.com"
+    prefix          = "myprefix"
+  }
+
+  aliases = ["mysite.example.com", "yoursite.example.com"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  ordered_cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  # Cache behavior with precedence 1
+  ordered_cache_behavior {
+    path_pattern     = "/content/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  tags = {
+    Environment = "production"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+  web_acl_id = aws_wafv2_web_acl.example.arn
+}
+
+resource "aws_cloudfront_distribution" "pass_2" {
+  
+
+  origin {
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_id   = "failoverS3"
+    origin_access_control_id = aws_cloudfront_origin_access_control.default.id
+    
+  }
+
+  
+
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "mylogs.s3.amazonaws.com"
+    prefix          = "myprefix"
+  }
+
+  aliases = ["mysite.example.com", "yoursite.example.com"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  ordered_cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  # Cache behavior with precedence 1
+  ordered_cache_behavior {
+    path_pattern     = "/content/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  tags = {
+    Environment = "production"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+  web_acl_id = aws_wafv2_web_acl.example.arn
+}
+
+resource "aws_cloudfront_distribution" "fail" {
+  
+
+  origin {
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_id   = "failoverS3"
+    
+  }
+
+  
+
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "mylogs.s3.amazonaws.com"
+    prefix          = "myprefix"
+  }
+
+  aliases = ["mysite.example.com", "yoursite.example.com"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  ordered_cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  # Cache behavior with precedence 1
+  ordered_cache_behavior {
+    path_pattern     = "/content/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  tags = {
+    Environment = "production"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+  web_acl_id = aws_wafv2_web_acl.example.arn
+}

--- a/tests/terraform/graph/checks/resources/CloudFrontWebACLConfiguredWIthLog4jVulnerability/expected.yaml
+++ b/tests/terraform/graph/checks/resources/CloudFrontWebACLConfiguredWIthLog4jVulnerability/expected.yaml
@@ -1,0 +1,6 @@
+fail:
+  - "aws_cloudfront_distribution.fail_1"
+  - "aws_cloudfront_distribution.fail_2"
+  - "aws_cloudfront_distribution.fail_3"
+pass:
+  - "aws_cloudfront_distribution.pass"

--- a/tests/terraform/graph/checks/resources/CloudFrontWebACLConfiguredWIthLog4jVulnerability/main.tf
+++ b/tests/terraform/graph/checks/resources/CloudFrontWebACLConfiguredWIthLog4jVulnerability/main.tf
@@ -1,0 +1,492 @@
+
+resource "aws_cloudfront_distribution" "pass" {
+  origin {
+    domain_name              = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.default.id
+    origin_id                = local.s3_origin_id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  aliases = ["mysite.example.com", "yoursite.example.com"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  ordered_cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  tags = {
+    Environment = "production"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+  web_acl_id = aws_wafv2_web_acl.pass_acl.arn
+}
+
+resource "aws_wafv2_web_acl" "pass_acl" {
+  name        = "managed-rule-example"
+  description = "Example of a managed rule."
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAnonymousIpList"
+        vendor_name = "AWS"
+
+        excluded_rule {
+          name = "SizeRestrictions_QUERYSTRING"
+        }
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = ["US", "NL"]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
+    name     = "rule-2"
+    priority = 2
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+
+        excluded_rule {
+          name = "SizeRestrictions_QUERYSTRING"
+        }
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = ["US", "NL"]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_cloudfront_distribution" "fail_1" {
+  origin {
+    domain_name              = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.default.id
+    origin_id                = local.s3_origin_id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  aliases = ["mysite.example.com", "yoursite.example.com"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  ordered_cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  tags = {
+    Environment = "production"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+
+resource "aws_cloudfront_distribution" "fail_2" {
+  origin {
+    domain_name              = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.default.id
+    origin_id                = local.s3_origin_id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  aliases = ["mysite.example.com", "yoursite.example.com"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  ordered_cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  tags = {
+    Environment = "production"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+  web_acl_id = aws_wafv2_web_acl.fail_2_acl.arn
+}
+
+resource "aws_wafv2_web_acl" "fail_2_acl" {
+  name        = "managed-rule-example"
+  description = "Example of a managed rule."
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAnonymousIpList"
+        vendor_name = "AWS"
+
+        excluded_rule {
+          name = "SizeRestrictions_QUERYSTRING"
+        }
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = ["US", "NL"]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_cloudfront_distribution" "fail_3" {
+  origin {
+    domain_name              = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.default.id
+    origin_id                = local.s3_origin_id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  aliases = ["mysite.example.com", "yoursite.example.com"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  ordered_cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  tags = {
+    Environment = "production"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+  web_acl_id = aws_wafv2_web_acl.fail_3_acl.arn
+}
+
+resource "aws_wafv2_web_acl" "fail_3_acl" {
+  name        = "managed-rule-example"
+  description = "Example of a managed rule."
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-2"
+    priority = 2
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+
+        excluded_rule {
+          name = "SizeRestrictions_QUERYSTRING"
+        }
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = ["US", "NL"]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}

--- a/tests/terraform/graph/checks/resources/ConfigRecorderRecordsAllGlobalResources/expected.yaml
+++ b/tests/terraform/graph/checks/resources/ConfigRecorderRecordsAllGlobalResources/expected.yaml
@@ -1,0 +1,5 @@
+fail:
+  - "aws_config_configuration_recorder_status.fail_1"
+  - "aws_config_configuration_recorder_status.fail_2"
+pass:
+  - "aws_config_configuration_recorder_status.pass"

--- a/tests/terraform/graph/checks/resources/ConfigRecorderRecordsAllGlobalResources/main.tf
+++ b/tests/terraform/graph/checks/resources/ConfigRecorderRecordsAllGlobalResources/main.tf
@@ -1,0 +1,38 @@
+resource "aws_config_configuration_recorder" "pass_recorder" {
+  name     = "example"
+  role_arn = aws_iam_role.r.arn
+
+  recording_group {
+    include_global_resource_types = true
+  }
+  
+}
+
+resource "aws_config_configuration_recorder_status" "pass" {
+  name       = aws_config_configuration_recorder.pass_recorder.name
+  is_enabled = true
+}
+
+resource "aws_config_configuration_recorder" "fail_recorder_1" {
+  name     = "example"
+  role_arn = aws_iam_role.r.arn
+  
+}
+
+resource "aws_config_configuration_recorder_status" "fail_1" {
+  name       = aws_config_configuration_recorder.fail_recorder_1.name
+  is_enabled = false
+}
+
+resource "aws_config_configuration_recorder" "fail_recorder_2" {
+  name     = "example"
+  role_arn = aws_iam_role.r.arn
+  recording_group {
+    include_global_resource_types = false
+  }
+}
+
+resource "aws_config_configuration_recorder_status" "fail_2" {
+  name       = aws_config_configuration_recorder.fail_recorder_2.name
+  is_enabled = true
+}

--- a/tests/terraform/graph/checks/resources/DMSEndpointHaveSSLConfigured/expected.yaml
+++ b/tests/terraform/graph/checks/resources/DMSEndpointHaveSSLConfigured/expected.yaml
@@ -1,0 +1,8 @@
+fail:
+  - "aws_dms_endpoint.fail_source"
+  - "aws_dms_endpoint.fail_target"
+pass:
+  - "aws_dms_endpoint.pass_source_1"
+  - "aws_dms_endpoint.pass_source_2"
+  - "aws_dms_endpoint.pass_target_1"
+  - "aws_dms_endpoint.pass_target_2"

--- a/tests/terraform/graph/checks/resources/DMSEndpointHaveSSLConfigured/main.tf
+++ b/tests/terraform/graph/checks/resources/DMSEndpointHaveSSLConfigured/main.tf
@@ -1,0 +1,89 @@
+resource "aws_dms_endpoint" "pass_source_1" {
+  certificate_arn             = "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+  database_name               = "test"
+  endpoint_id                 = "test-dms-endpoint-tf"
+  endpoint_type               = "source"
+  engine_name                 = "aurora"
+  extra_connection_attributes = ""
+  kms_key_arn                 = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+  password                    = "test"
+  port                        = 3306
+  server_name                 = "test"
+  ssl_mode                    = "require"
+  username = "test"
+}
+
+resource "aws_dms_endpoint" "pass_source_2" {
+  certificate_arn             = "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+  database_name               = "test"
+  endpoint_id                 = "test-dms-endpoint-tf"
+  endpoint_type               = "source"
+  engine_name                 = "s3"
+  extra_connection_attributes = ""
+  kms_key_arn                 = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+  password                    = "test"
+  port                        = 3306
+  server_name                 = "none"
+  ssl_mode                    = "none"
+  username = "test"
+}
+
+resource "aws_dms_endpoint" "pass_target_1" {
+  certificate_arn             = "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+  database_name               = "test"
+  endpoint_id                 = "test-dms-endpoint-tf"
+  endpoint_type               = "target"
+  engine_name                 = "aurora"
+  extra_connection_attributes = ""
+  kms_key_arn                 = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+  password                    = "test"
+  port                        = 3306
+  server_name                 = "none"
+  ssl_mode                    = "require"
+  username = "test"
+}
+
+resource "aws_dms_endpoint" "pass_target_2" {
+  certificate_arn             = "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+  database_name               = "test"
+  endpoint_id                 = "test-dms-endpoint-tf"
+  endpoint_type               = "target"
+  engine_name                 = "s3"
+  extra_connection_attributes = ""
+  kms_key_arn                 = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+  password                    = "test"
+  port                        = 3306
+  server_name                 = "none"
+  ssl_mode                    = "none"
+  username = "test"
+}
+
+resource "aws_dms_endpoint" "fail_source" {
+  certificate_arn             = "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+  database_name               = "test"
+  endpoint_id                 = "test-dms-endpoint-tf"
+  endpoint_type               = "source"
+  engine_name                 = "aurora"
+  extra_connection_attributes = ""
+  kms_key_arn                 = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+  password                    = "test"
+  port                        = 3306
+  server_name                 = "test"
+  ssl_mode                    = "none"
+  username = "test"
+}
+
+resource "aws_dms_endpoint" "fail_target" {
+  certificate_arn             = "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+  database_name               = "test"
+  endpoint_id                 = "test-dms-endpoint-tf"
+  endpoint_type               = "target"
+  engine_name                 = "aurora"
+  extra_connection_attributes = ""
+  kms_key_arn                 = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+  password                    = "test"
+  port                        = 3306
+  server_name                 = "none"
+  ssl_mode                    = "none"
+  username = "test"
+}

--- a/tests/terraform/graph/checks/resources/ElastiCacheRedisConfiguredAutomaticFailOver/expected.yaml
+++ b/tests/terraform/graph/checks/resources/ElastiCacheRedisConfiguredAutomaticFailOver/expected.yaml
@@ -1,0 +1,5 @@
+fail:
+  - "aws_elasticache_replication_group.fail_1"
+  - "aws_elasticache_replication_group.fail_2"
+pass:
+  - "aws_elasticache_replication_group.pass"

--- a/tests/terraform/graph/checks/resources/ElastiCacheRedisConfiguredAutomaticFailOver/main.tf
+++ b/tests/terraform/graph/checks/resources/ElastiCacheRedisConfiguredAutomaticFailOver/main.tf
@@ -1,0 +1,31 @@
+resource "aws_elasticache_replication_group" "pass" {
+  automatic_failover_enabled  = true
+  preferred_cache_cluster_azs = ["us-west-2a", "us-west-2b"]
+  replication_group_id        = "tf-rep-group-1"
+  description                 = "example description"
+  node_type                   = "cache.m4.large"
+  num_cache_clusters          = 2
+  parameter_group_name        = "default.redis3.2"
+  port                        = 6379
+}
+
+resource "aws_elasticache_replication_group" "fail_1" {
+  preferred_cache_cluster_azs = ["us-west-2a", "us-west-2b"]
+  replication_group_id        = "tf-rep-group-1"
+  description                 = "example description"
+  node_type                   = "cache.m4.large"
+  num_cache_clusters          = 2
+  parameter_group_name        = "default.redis3.2"
+  port                        = 6379
+}
+
+resource "aws_elasticache_replication_group" "fail_2" {
+  automatic_failover_enabled  = false
+  preferred_cache_cluster_azs = ["us-west-2a", "us-west-2b"]
+  replication_group_id        = "tf-rep-group-1"
+  description                 = "example description"
+  node_type                   = "cache.m4.large"
+  num_cache_clusters          = 2
+  parameter_group_name        = "default.redis3.2"
+  port                        = 6379
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -68,6 +68,24 @@ class TestYamlPolicies(unittest.TestCase):
     def test_VAconfiguredToSendReports(self):
         self.go("VAconfiguredToSendReports")
 
+    def test_AWSConfigRecorderEnabled():
+        self.go("AWSConfigRecorderEnabled")
+
+    def test_CLoudFrontS3OriginConfigWithOAI():
+        self.go("CLoudFrontS3OriginConfigWithOAI")
+
+    def test_CloudFrontWebACLConfiguredWIthLog4jVulnerability():
+        self.go("CloudFrontWebACLConfiguredWIthLog4jVulnerability")
+
+    def test_ConfigRecorderRecordsAllGlobalResources():
+        self.go("ConfigRecorderRecordsAllGlobalResources")
+
+    def test_DMSEndpointHaveSSLConfigured():
+        self.go("DMSEndpointHaveSSLConfigured")
+
+    def test_ElastiCacheRedisConfiguredAutomaticFailOver():
+        self.go("ElastiCacheRedisConfiguredAutomaticFailOver")  
+
     def test_VAconfiguredToSendReportsToAdmins(self):
         self.go("VAconfiguredToSendReportsToAdmins")
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license

This PR has 6 Yaml - based checks with detailed description below

Checkov Title: Ensure AWS Config recorder is enabled

PC Policy ID - ca5c571e-6930-44af-a47b-ebde3ac20ca5

PC Policy Title - AWS Config recording is disabled

Compliance Standard - ACSC Information Security Manual (ISM)-ISM-0109, ACSC Information Security Manual (ISM)-ISM-1228, API Auto Clone of PIPEDA-4.1.4, APRA (CPS 234) Information Security-CPS234-23, APRA (CPS 234) Information Security-CPS234-27, APRA (CPS 234) Information Security-CPS234-34, APRA (CPS 234) Information Security-CPS234-35, APRA (CPS 234) Information Security-CPS234-36, AWS Foundational Security Best Practices standard-Inventory, Australian Energy Sector Cyber Security Framework (AESCSF)-SA-1B, Brazilian Data Protection Law (LGPD)-Article 31, Brazilian Data Protection Law (LGPD)-Article 48, CCPA 2018-1798.150(a)(1), CIS Controls v7.1-12.5, CIS Controls v7.1-6.2, CIS Controls v8-13.6, CIS Controls v8-8.2, CIS v1.2.0 (AWS)-2.5, CIS v1.3.0 (AWS)-3.5, CIS v1.4.0 (AWS)-3.5, CIS v1.5.0 (AWS) - Level 2-3.5, CSA CCM v3.0.1-AAC-01, CSA CCM v3.0.1-AAC-02, CSA CCM v3.0.1-AIS-01, CSA CCM v3.0.1-DCS-01, CSA CCM v3.0.1-GRM-01, CSA CCM v3.0.1-IAM-13, CSA CCM v3.0.1-IVS-02, CSA CCM v3.0.1-IVS-05, CSA CCM v3.0.1-IVS-07, CSA CCM v3.0.1-MOS-09, CSA CCM v3.0.1-MOS-19, CSA CCM v3.0.1-TVM-02, Copy of 1Copy of Brazilian Data Protection Law (LGPD)-Article 31, Copy of 1Copy of Brazilian Data Protection Law (LGPD)-Article 48, Copy of APRA (CPS 234) Information Security-CPS234-23, Copy of APRA (CPS 234) Information Security-CPS234-27, Copy of APRA (CPS 234) Information Security-CPS234-34, Copy of APRA (CPS 234) Information Security-CPS234-35, Copy of APRA (CPS 234) Information Security-CPS234-36, Copy of Brazilian Data Protection Law (LGPD)-Article 31, Copy of Brazilian Data Protection Law (LGPD)-Article 48, CyberSecurity Law of the People's Republic of China-Article 55, CyberSecurity Law of the People's Republic of China-Article 56, Cybersecurity Maturity Model Certification (CMMC) v.1.02-AU.3.046, FFIEC-D2.MA.Ma.B.1, FFIEC-D3.DC.Ev.B.1, Fedramp (Moderate)-CM-02 (02), GDPR-Article 30, GDPR-Article 32, GDPR-Article 46, HITRUST CSF v.9.6.0-09.aa, HITRUST CSF v.9.6.0-09.ab, HITRUST CSF v.9.6.0-09.m, HITRUST CSF v9.3-Control Reference:05.h, HITRUST CSF v9.3-Control Reference:06.g, HITRUST CSF v9.3-Control Reference:06.h, HITRUST CSF v9.3-Control Reference:10.k, HITRUST CSF v9.3-Control Reference:10.m, HITRUST CSF v9.3-Control Reference:11.b, HITRUST v.9.4.2-Control Reference:09.ab, HITRUST v.9.4.2-Control Reference:09.ac, ISO 27001:2013-A.12.5.1, ISO 27001:2013-A.14.1.3, MAS TRM 2021-7.5.7, MLPS 2.0-8.1.5.4, NIST 800-171 Rev1-3.11.3, NIST 800-171 Rev1-3.4.1, NIST 800-171 Rev1-3.4.2, NIST 800-53 Rev 5-Baseline Configuration | Automation Support for Accuracy and Currency, NIST 800-53 Rev 5-Configuration Settings, NIST 800-53 Rev 5-Continuous Monitoring, NIST 800-53 Rev 5-System Component Inventory | Assessed Configurations and Approved Deviations, NIST 800-53 Rev 5-Vulnerability Monitoring and Scanning, NIST 800-53 Rev4-CA-7d, NIST 800-53 Rev4-CM-2 (2), NIST 800-53 Rev4-CM-6c, NIST 800-53 Rev4-CM-6d, NIST 800-53 Rev4-CM-8 (6), NIST 800-53 Rev4-RA-5b.1, NIST CSF-DE.AE-1, NIST CSF-DE.AE-2, NIST CSF-DE.AE-3, NIST CSF-DE.CM-1, NIST CSF-DE.CM-2, NIST CSF-DE.CM-3, NIST CSF-DE.CM-6, NIST CSF-DE.CM-7, NIST CSF-DE.DP-1, NIST CSF-DE.DP-2, NIST CSF-DE.DP-3, NIST CSF-DE.DP-4, NIST CSF-DE.DP-5, NIST CSF-ID.RA-1, NIST CSF-ID.RA-3, NIST CSF-ID.RA-5, NIST CSF-PR.DS-2, NIST CSF-PR.IP-1, NIST CSF-PR.IP-7, NIST CSF-PR.IP-8, NIST CSF-RS.AN-1, NIST CSF-RS.CO-3, NIST CSF-RS.MI-3, NIST SP 800-171 Revision 2-3.3.4, NIST SP 800-172-3.14.2e, PCI DSS v3.2.1-10.2.3, PCI DSS v3.2.1-10.6, PCI DSS v4.0-10.2.1, PCI DSS v4.0-10.2.1.1, PCI DSS v4.0-10.2.1.2, PCI DSS v4.0-10.2.1.3, PCI DSS v4.0-10.2.1.4, PCI DSS v4.0-10.2.1.5, PCI DSS v4.0-10.2.1.6, PCI DSS v4.0-10.2.1.7, PCI DSS v4.0-10.2.2, PCI DSS v4.0-5.3.4, PCI DSS v4.0-6.4.1, PCI DSS v4.0-6.4.2, PIPEDA-4.1.4, Risk Management in Technology (RMiT)-10.61, Risk Management in Technology (RMiT)-10.66, SOC 2-CC6.1, SOC 2-CC6.6, SOC 2-CC7.2, SOC 2-CC7.3, SOC 2-CC7.4, SOC 2-CC7.5, SOC 2-CC8.1, TestCompliance-CPS234-23, TestCompliance-CPS234-27, TestCompliance-CPS234-34, TestCompliance-CPS234-35, TestCompliance-CPS234-36, custom_3002_compliance_standard-S3R3, custom_config-S1R1

Remediation Steps:

1. Sign in to the AWS Management Console
2. Select the specific region from the top down, for which the alert is generated
3. Navigate to service 'Config' from the 'Services' dropdown.

If AWS Config set up exists,

- a. Go to Settings
- b. Click on 'Turn On' button under 'Recording is Off' section,
- c. provide required information for bucket and role with proper permission

If AWS Config set up doesn't exist

- a. Click on 'Get Started'
- b. For Step 1, Tick the check box for 'Record all resources supported in this region' under section 'Resource types to record'
- c. Under section 'Amazon S3 bucket', select bucket with permission to Config services
- d. Under section 'AWS Config role', select a role with permission to Config services
- e. Click on 'Next'
- f. For Step 2, Select required rule and click on 'Next' otherwise click on 'Skip'
- g. For Step 3, Review the created 'Settings' and click on 'Confirm'

Checkov Title: Ensure AWS Config must record all possible resources

PC Policy ID - 4c64a4d6-1b96-4004-8a11-f215aa8ee3ce

PC Policy Title - AWS Config must record all possible resources

Compliance Standard - ACSC Information Security Manual (ISM)-ISM-0109, ACSC Information Security Manual (ISM)-ISM-1228, APRA (CPS 234) Information Security-CPS234-23, APRA (CPS 234) Information Security-CPS234-27, APRA (CPS 234) Information Security-CPS234-34, Australian Energy Sector Cyber Security Framework (AESCSF)-SA-1B, Brazilian Data Protection Law (LGPD)-Article 31, Brazilian Data Protection Law (LGPD)-Article 48, CIS Controls v7.1-12.5, CIS Controls v7.1-6.2, CIS Controls v8-13.6, CIS Controls v8-8.2, CSA CCM v3.0.1-AAC-01, CSA CCM v3.0.1-AAC-02, CSA CCM v3.0.1-AIS-01, CSA CCM v3.0.1-GRM-01, CSA CCM v3.0.1-IAM-13, CSA CCM v3.0.1-IVS-05, CSA CCM v3.0.1-IVS-07, CSA CCM v3.0.1-MOS-19, CSA CCM v3.0.1-TVM-02, Copy of 1Copy of Brazilian Data Protection Law (LGPD)-Article 31, Copy of 1Copy of Brazilian Data Protection Law (LGPD)-Article 48, Copy of APRA (CPS 234) Information Security-CPS234-23, Copy of APRA (CPS 234) Information Security-CPS234-27, Copy of APRA (CPS 234) Information Security-CPS234-34, Copy of Brazilian Data Protection Law (LGPD)-Article 31, Copy of Brazilian Data Protection Law (LGPD)-Article 48, CyberSecurity Law of the People's Republic of China-Article 55, CyberSecurity Law of the People's Republic of China-Article 56, Cybersecurity Maturity Model Certification (CMMC) v.1.02-AU.3.046, FFIEC-D2.MA.Ma.B.1, FFIEC-D3.DC.Ev.B.1, Fedramp (Moderate)-CM-02 (02), GDPR-Article 30, GDPR-Article 32, GDPR-Article 46, HITRUST CSF v.9.6.0-09.aa, HITRUST CSF v.9.6.0-09.ab, HITRUST CSF v.9.6.0-09.m, HITRUST CSF v9.3-Control Reference:05.h, HITRUST CSF v9.3-Control Reference:06.g, HITRUST CSF v9.3-Control Reference:06.h, HITRUST CSF v9.3-Control Reference:10.k, HITRUST CSF v9.3-Control Reference:10.m, HITRUST CSF v9.3-Control Reference:11.b, HITRUST v.9.4.2-Control Reference:09.ab, HITRUST v.9.4.2-Control Reference:09.ac, ISO 27001:2013-A.12.5.1, ISO 27001:2013-A.14.1.3, MAS TRM 2021-7.5.7, MLPS 2.0-8.1.5.4, MLPS 2.0-8.2.3.3, NIST 800-171 Rev1-3.11.2, NIST 800-171 Rev1-3.11.3, NIST 800-171 Rev1-3.12.1, NIST 800-171 Rev1-3.12.2, NIST 800-171 Rev1-3.12.3, NIST 800-171 Rev1-3.12.4, NIST 800-171 Rev1-3.4.1, NIST 800-171 Rev1-3.4.2, NIST 800-53 Rev 5-Baseline Configuration | Automation Support for Accuracy and Currency, NIST 800-53 Rev 5-Configuration Settings, NIST 800-53 Rev 5-Continuous Monitoring, NIST 800-53 Rev 5-Vulnerability Monitoring and Scanning, NIST 800-53 Rev4-CA-7d, NIST 800-53 Rev4-CM-2 (2), NIST 800-53 Rev4-CM-6c, NIST 800-53 Rev4-CM-6d, NIST 800-53 Rev4-RA-5b.1, NIST CSF-DE.AE-1, NIST CSF-DE.AE-2, NIST CSF-DE.AE-3, NIST CSF-DE.CM-1, NIST CSF-DE.CM-2, NIST CSF-DE.CM-3, NIST CSF-DE.CM-6, NIST CSF-DE.DP-1, NIST CSF-DE.DP-2, NIST CSF-DE.DP-3, NIST CSF-DE.DP-4, NIST CSF-DE.DP-5, NIST CSF-ID.RA-1, NIST CSF-ID.RA-3, NIST CSF-ID.RA-5, NIST CSF-PR.DS-2, NIST CSF-PR.IP-7, NIST CSF-PR.IP-8, NIST CSF-RS.CO-3, NIST CSF-RS.MI-3, NIST SP 800-171 Revision 2-3.3.4, NIST SP 800-172-3.4.2e, PCI DSS v3.2.1-10.2.3, PCI DSS v3.2.1-10.6, PCI DSS v4.0-10.2.1, PCI DSS v4.0-10.2.1.1, PCI DSS v4.0-10.2.1.2, PCI DSS v4.0-10.2.1.3, PCI DSS v4.0-10.2.1.4, PCI DSS v4.0-10.2.1.5, PCI DSS v4.0-10.2.1.6, PCI DSS v4.0-10.2.1.7, PCI DSS v4.0-10.2.2, PCI DSS v4.0-5.3.4, PCI DSS v4.0-6.4.1, PCI DSS v4.0-6.4.2, SOC 2-CC6.1, SOC 2-CC6.6, SOC 2-CC7.2, SOC 2-CC7.3, SOC 2-CC7.4, SOC 2-CC7.5, SOC 2-CC8.1, TestCompliance-CPS234-23, TestCompliance-CPS234-27, TestCompliance-CPS234-34

Remediation Steps:

1. Login to the AWS and navigate to the 'Config' service
2. Change to the respective region and in the navigation pane, click on 'Settings'
3. Review the 'All resources' and Check the 2 options (3.a and 3.b)
3.a Record all resources supported in this region
3.b Include global resources (e.g., AWS IAM resources)

Checkov Title: Ensure AWS Cloudfront Distribution with S3 have Origin Access set to enabled

PC Policy ID - b0aac456-7422-47fc-9144-9b150bd18a9d

PC Policy Title - AWS Cloudfront Distribution with S3 have Origin Access set to disabled

Compliance Standard - APRA (CPS 234) Information Security-CPS234-23, APRA (CPS 234) Information Security-CPS234-27, APRA (CPS 234) Information Security-CPS234-34, AWS Foundational Security Best Practices standard-Secure access management, Brazilian Data Protection Law (LGPD)-Article 34, CIS Controls v7.1-5.1, CIS Controls v8-4.6, CSA CCM v.4.0.1-AIS-01, CSA CCM v.4.0.1-AIS-02, CSA CCM v.4.0.1-AIS-04, CSA CCM v.4.0.1-CCC-01, CSA CCM v.4.0.1-GRC-03, CSA CCM v.4.0.1-IVS-04, CSA CCM v.4.0.1-UEM-06, Copy of 1Copy of Brazilian Data Protection Law (LGPD)-Article 34, Copy of APRA (CPS 234) Information Security-CPS234-23, Copy of APRA (CPS 234) Information Security-CPS234-27, Copy of APRA (CPS 234) Information Security-CPS234-34, Copy of Brazilian Data Protection Law (LGPD)-Article 34, Cybersecurity Maturity Model Certification (CMMC) v.1.02-CM.2.062, HITRUST CSF v.9.6.0-10.k, HITRUST CSF v.9.6.0-10.m, HITRUST v.9.4.2-Control Reference:10.a, ISO/IEC 27002:2013-12.1.2, ISO/IEC 27002:2013-14.1.1, ISO/IEC 27002:2013-14.1.2, ISO/IEC 27002:2013-14.2.1, ISO/IEC 27002:2013-14.2.2, ISO/IEC 27017:2015-12.1.2, ISO/IEC 27017:2015-14.1.1, ISO/IEC 27017:2015-14.1.2, ISO/IEC 27017:2015-14.2.1, ISO/IEC 27017:2015-14.2.5, ISO/IEC 27017:2015-5.1.1, ISO/IEC 27018:2019-12.1.2, MAS TRM 2021-7.2.1, MAS TRM 2021-7.2.2, NIST 800-53 Rev 5-Boundary Protection | Connections to Public Networks, NIST 800-53 Rev4-CA-3 (4), NIST CSF-PR.IP-1, NIST SP 800-171 Revision 2-3.4.2, NIST SP 800-172-3.4.1e, NIST SP 800-172-3.4.2e, PCI DSS v3.2.1-6.3, TestCompliance-CPS234-23, TestCompliance-CPS234-27, TestCompliance-CPS234-34

Remediation Steps:

1. Sign in to the AWS Console
2. Go to CloudFront
3. Choose the reported Distribution
4. Click on Distribution Settings
5. Click on 'Origins and Origin Groups
6. Select the S3 bucket and click on Edit
7. On the 'Restrict Bucket Access', Select Yes
8. Click on 'Yes, Edit'

Checkov Title: Ensure AWS CloudFront attached WAFv2 WebACL is configured with AMR for Log4j Vulnerability

PC Policy ID - 955b15c5-fd5c-4b27-892e-fc14d50045eb

PC Policy Title - AWS CloudFront attached WAFv2 WebACL is not configured with AMR for Log4j Vulnerability

Compliance Standard - ACSC Information Security Manual (ISM)-ISM-1028, ACSC Information Security Manual (ISM)-ISM-1030, ACSC Information Security Manual (ISM)-ISM-1416, Australian Energy Sector Cyber Security Framework (AESCSF)-TVM-AP2, CIS Controls v7.1-18.8, CIS Controls v8-7.5, Cybersecurity Maturity Model Certification (CMMC) v.2.0 (Level 1)-SI.L1-3.14.5, FFIEC-D3.DC.Th.B.1, PCI DSS v4.0-11.3.1, PCI DSS v4.0-11.3.1.1, PCI DSS v4.0-11.3.1.2, PCI DSS v4.0-11.3.1.3

Remediation Steps:

1. Sign in to the AWS console
2. Go to the CloudFront Distributions Dashboard
3. Click on the reported web distribution
4. On 'General' tab, Click on 'Edit' button under 'Settings'
5. Note down the associated AWS WAF web ACL
6. Go to the noted WAF web ACL in AWS WAF & Shield Service
7. Under 'Rules' tab click on 'Add rules' and select 'Add managed rule groups'
8. Under 'AWS managed rule groups' enable 'Anonymous IP list' and 'Known bad inputs'
9. Click on 'Add rules'

Checkov Title: Ensure AWS Database Migration Service endpoint have SSL configured

PC Policy ID - 447fc9ef-a871-4e4b-b34c-46d4aad81f51

PC Policy Title - AWS Database Migration Service endpoint do not have SSL configured

Compliance Standard - ACSC Information Security Manual (ISM)-ISM-0469, ACSC Information Security Manual (ISM)-ISM-1552, APRA (CPS 234) Information Security-CPS234-15, APRA (CPS 234) Information Security-CPS234-16, APRA (CPS 234) Information Security-CPS234-17, APRA (CPS 234) Information Security-CPS234-21, APRA (CPS 234) Information Security-CPS234-23, APRA (CPS 234) Information Security-CPS234-27, APRA (CPS 234) Information Security-CPS234-34, Brazilian Data Protection Law (LGPD)-Article 49, CIS Controls v7.1-14.4, CIS Controls v7.1-16.5, CIS Controls v8-3.10, CSA CCM v.4.0.1-CEK-03, CSA CCM v.4.0.1-DSP-10, CSA CCM v.4.0.1-IVS-03, CSA CCM v.4.0.1-UEM-11, Copy of 1Copy of Brazilian Data Protection Law (LGPD)-Article 49, Copy of APRA (CPS 234) Information Security-CPS234-15, Copy of APRA (CPS 234) Information Security-CPS234-16, Copy of APRA (CPS 234) Information Security-CPS234-17, Copy of APRA (CPS 234) Information Security-CPS234-21, Copy of APRA (CPS 234) Information Security-CPS234-23, Copy of APRA (CPS 234) Information Security-CPS234-27, Copy of APRA (CPS 234) Information Security-CPS234-34, Copy of Brazilian Data Protection Law (LGPD)-Article 49, Cybersecurity Maturity Model Certification (CMMC) v.1.02-SC.3.185, FFIEC-D1.RM.Au.B.2, HITRUST CSF v.9.6.0-01.d, HITRUST CSF v.9.6.0-01.n, HITRUST CSF v.9.6.0-06.d, HITRUST v.9.4.2-Control Reference:09.s, ISO/IEC 27002:2013-10.1.1, ISO/IEC 27002:2013-12.2.1, ISO/IEC 27002:2013-12.3.1, ISO/IEC 27002:2013-13.1.1, ISO/IEC 27002:2013-13.1.2, ISO/IEC 27002:2013-13.1.3, ISO/IEC 27002:2013-13.2.1, ISO/IEC 27002:2013-13.2.3, ISO/IEC 27002:2013-14.1.2, ISO/IEC 27002:2013-14.1.3, ISO/IEC 27002:2013-18.1.3, ISO/IEC 27002:2013-8.3.1, ISO/IEC 27002:2013-8.3.3, ISO/IEC 27017:2015-10.1.1, ISO/IEC 27017:2015-10.1.2, ISO/IEC 27017:2015-6.1.1, ISO/IEC 27018:2019-10.1.2, ISO/IEC 27018:2019-12.3.1, MAS TRM 2021-11.1.1, MAS TRM 2021-14.1.2, NIST CSF-PR.DS-2, NIST CSF-PR.DS-5, NIST SP 800-171 Revision 2-3.13.8, NIST SP 800-172-3.1.3e, PCI DSS v3.2.1-2.3, PCI DSS v3.2.1-4.1, PCI DSS v4.0-1.3.1, Risk Management in Technology (RMiT)-10.68, TestCompliance-CPS234-15, TestCompliance-CPS234-16, TestCompliance-CPS234-17, TestCompliance-CPS234-21, TestCompliance-CPS234-23, TestCompliance-CPS234-27, TestCompliance-CPS234-34

Remediation Steps:

1. Log in to the AWS Console
2. Navigate to the AWS DMS dashboard
3. In the navigation pane, choose 'Endpoints'
4. Select the reported DMS endpoint
5. Under 'Actions', choose 'Modify'
6. In the 'Endpoint configuration' section, select the 'Secure Socket Layer (SSL) mode' from the dropdown list select suitable SSL mode according to your requirement other than 'none'.
7. Click on 'Save'

NOTE: Before modifying the SSL setting, you should be configured with the proper certificate you want to use for SSL connection under the DMS 'Certificate' service. Not all databases use SSL in the same way. An Amazon Redshift endpoint already uses an SSL connection and does not require an SSL connection set up by AWS DMS. So there are some exlcusions included in policy to report only those endpoints which can be configured using DMS SSL feature. 

Checkov Title: Ensure AWS ElastiCache Redis cluster with Multi-AZ Automatic Failover feature set to enabled

PC Policy ID - 99f6fc8c-27a7-4f30-84ef-9a2388e8e938

PC Policy Title - AWS ElastiCache Redis cluster with Multi-AZ Automatic Failover feature set to disabled

Compliance Standard - ACSC Information Security Manual (ISM)-ISM-1431, APRA (CPS 234) Information Security-CPS234-23, APRA (CPS 234) Information Security-CPS234-27, APRA (CPS 234) Information Security-CPS234-34, Brazilian Data Protection Law (LGPD)-Article 49, CIS Controls v7.1-5.1, CIS Controls v8-4.6, Copy of 1Copy of Brazilian Data Protection Law (LGPD)-Article 49, Copy of APRA (CPS 234) Information Security-CPS234-23, Copy of APRA (CPS 234) Information Security-CPS234-27, Copy of APRA (CPS 234) Information Security-CPS234-34, Copy of Brazilian Data Protection Law (LGPD)-Article 49, CyberSecurity Law of the People's Republic of China-Article 34, Cybersecurity Maturity Model Certification (CMMC) v.1.02-SC.3.183, Cybersecurity Maturity Model Certification (CMMC) v.1.02-SI.2.216, HITRUST CSF v.9.6.0-10.k, HITRUST CSF v.9.6.0-10.m, HITRUST v.9.4.2-Control Reference:10.a, MAS TRM 2021-7.2.1, MAS TRM 2021-7.2.2, MLPS 2.0-8.1.4.9, NIST 800-53 Rev 5-Predictable Failure Prevention | Failover Capability, NIST 800-53 Rev4-SI-13 (5), NIST CSF-PR.MA-1, NIST SP 800-171 Revision 2-3.7.1, NIST SP 800-172-3.4.1e, NIST SP 800-172-3.4.2e, PCI DSS v3.2.1-6.3, TestCompliance-CPS234-23, TestCompliance-CPS234-27, TestCompliance-CPS234-34

Remediation Steps:

1. Sign into the AWS console
2. In the console, select the specific region from region drop down on the top right corner, for which the alert is generated
3. Navigate to ElastiCache Dashboard
4. Click on Redis
5. Select reported Redis cluster
6. Click on 'Modify' button
7. In the 'Modify Cluster' dialog box,
a. Set 'Multi-AZ' to 'Yes'
b. Select 'Apply Immediately' checkbox, to apply the configuration changes immediately. If Apply Immediately is not selected, the changes will be processed during the next maintenance window.
c. Click on 'Modify'





