### PR TITLE
chore(general): Don't fail if specific check throws exception

### DIFF
--- a/checkov/common/checks/base_check_registry.py
+++ b/checkov/common/checks/base_check_registry.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from itertools import chain
 from typing import Generator, Tuple, Dict, List, Optional, Any, TYPE_CHECKING
 
+from checkov.common.models.enums import CheckResult
 from checkov.common.typing import _SkippedCheck, _CheckResult
 from checkov.runner_filter import RunnerFilter
 
@@ -138,14 +139,23 @@ class BaseCheckRegistry:
         skip_info: _SkippedCheck,
     ) -> _CheckResult:
         self.logger.debug("Running check: {} on file {}".format(check.name, scanned_file))
-        result = check.run(
-            scanned_file=scanned_file,
-            entity_configuration=entity_configuration,
-            entity_name=entity_name,
-            entity_type=entity_type,
-            skip_info=skip_info,
-        )
-        return result
+        try:
+            result = check.run(
+                scanned_file=scanned_file,
+                entity_configuration=entity_configuration,
+                entity_name=entity_name,
+                entity_type=entity_type,
+                skip_info=skip_info,
+            )
+            return result
+        except Exception as e:
+            logging.error(f'Failed to run check {check.id} on {scanned_file}:{entity_type}.{entity_name} due to {e}',
+                          exc_info=True)
+            logging.info(f'Entity configuration: {entity_configuration}')
+            return _CheckResult(
+                result=CheckResult.UNKNOWN, suppress_comment="", evaluated_keys=[],
+                results_configuration=entity_configuration, check=check, entity=entity_configuration
+            )
 
     @staticmethod
     def _directory_has_init_py(directory: str) -> bool:

--- a/checkov/common/checks/base_check_registry.py
+++ b/checkov/common/checks/base_check_registry.py
@@ -148,8 +148,8 @@ class BaseCheckRegistry:
                 skip_info=skip_info,
             )
             return result
-        except Exception as e:
-            logging.error(f'Failed to run check {check.id} on {scanned_file}:{entity_type}.{entity_name} due to {e}',
+        except Exception:
+            logging.error(f'Failed to run check {check.id} on {scanned_file}:{entity_type}.{entity_name}',
                           exc_info=True)
             logging.info(f'Entity configuration: {entity_configuration}')
             return _CheckResult(


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

In the past we've had crashes caused by bad check implementations. This catches it and logs an error so the run will continue gracefully. Example log (in case of a failed check):
```
2022-12-01 13:30:12,037 [ThreadPoolEx] [ERROR]  Failed to run check CKV_GHA_2 on /Users/nkor/terragoat/.github/workflows/semgrep.yml:jobs.semgrep due to ValueError: 
NoneType: None
2022-12-01 13:30:12,037 [ThreadPoolEx] [ERROR]  Please submit an issue to https://github.com/bridgecrewio/checkov with the above details and example code to get this fixed. Contributions are welcome!
```

`NoneType: None` is because the error I created has no stack trace... Will be more informative in real life.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
