### PR TITLE
platform(terraform): remove redundant exc_info for module without source

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -232,7 +232,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
                                 )
                             except Exception:
                                 logging.warning(
-                                    f"Module {self.vertices[dest_node_index]} does not have source attribute, skipping", exc_info=True
+                                    f"Module {self.vertices[dest_node_index]} does not have source attribute, skipping"
                                 )
                         else:
                             self._create_edge(origin_node_index, dest_node_index, attribute_key, cross_variable_edges)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
remove redundant `exc_info` for module without source when creating edges

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
