### PR TITLE
fix(dockerfile): fix Dockerfile inline skip handling

### DIFF
--- a/checkov/dockerfile/base_registry.py
+++ b/checkov/dockerfile/base_registry.py
@@ -33,13 +33,16 @@ class Registry(BaseCheckRegistry):
         results: "dict[BaseCheck, _CheckResult]" = {}
         if not entity:
             return results
-        for instruction, checks in self.checks.items():
-            skip_info: _SkippedCheck = {}
-            if instruction in entity:
 
+        skipped_check_ids = {skipped_check["id"]: skipped_check for skipped_check in skipped_checks}
+
+        for instruction, checks in self.checks.items():
+            if instruction in entity:
                 for check in checks:
-                    if check.id in [x['id'] for x in skipped_checks]:
-                        skip_info = [x for x in skipped_checks if x['id'] == check.id][0]
+                    skip_info = {}
+                    if skipped_check_ids:
+                        if check.id in skipped_check_ids:
+                            skip_info = skipped_check_ids[check.id]
 
                     if runner_filter.should_run_check(check, report_type=CheckType.DOCKERFILE):
                         self.update_result(
@@ -54,9 +57,9 @@ class Registry(BaseCheckRegistry):
 
         for check in self.wildcard_checks["*"]:
             skip_info = {}
-            if skipped_checks:
-                if check.id in [x['id'] for x in skipped_checks]:
-                    skip_info = [x for x in skipped_checks if x['id'] == check.id][0]
+            if skipped_check_ids:
+                if check.id in skipped_check_ids:
+                    skip_info = skipped_check_ids[check.id]
 
             if runner_filter.should_run_check(check, report_type=CheckType.DOCKERFILE):
                 self.update_result(

--- a/checkov/dockerfile/base_registry.py
+++ b/checkov/dockerfile/base_registry.py
@@ -39,7 +39,7 @@ class Registry(BaseCheckRegistry):
         for instruction, checks in self.checks.items():
             if instruction in entity:
                 for check in checks:
-                    skip_info = {}
+                    skip_info: "_SkippedCheck" = {}
                     if skipped_check_ids:
                         if check.id in skipped_check_ids:
                             skip_info = skipped_check_ids[check.id]

--- a/tests/dockerfile/resources/expose_port/skip/Dockerfile
+++ b/tests/dockerfile/resources/expose_port/skip/Dockerfile
@@ -1,3 +1,4 @@
+#checkov:skip=CKV_DOCKER_5: no need to skip
 FROM gliderlabs/alpine:3.3
 RUN apk --no-cache add nginx
 EXPOSE 3000 80 443 22


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- fixed logic for handling for inline skips in Dockerfile, which didn't reset the `skip_info` after each check ran
- optimized the code a bit by creating a skipped check ID `dict` for faster and easy lookup

Fixes #3952 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
