### PR TITLE
feat(secrets): Omit secrets from reports based on secrets reports

### DIFF
--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -16,6 +16,7 @@ from typing import List, Dict, Any, Optional, cast, TYPE_CHECKING, TypeVar
 from typing_extensions import Literal
 
 from checkov.common.bridgecrew.code_categories import CodeCategoryMapping
+from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import \
     integration as metadata_integration
 from checkov.common.bridgecrew.integration_features.features.repo_config_integration import \
@@ -103,7 +104,8 @@ class RunnerRegistry:
         merged_reports = self._merge_reports(reports)
         logging.debug(f"got {len(merged_reports)} reports")
         start = time.time()
-        SecretsOmitter(merged_reports).omit()
+        if bc_integration.bc_api_key:
+            SecretsOmitter(merged_reports).omit()
         logging.debug(f"Omitting secrets took {time.time() - start}")
         for scan_report in merged_reports:
             self._handle_report(scan_report, repo_root_for_plan_enrichment)

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import re
-import time
 
 from collections import defaultdict
 from collections.abc import Iterable

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -102,11 +102,9 @@ class RunnerRegistry:
             reports = parallel_runner.run_function(func=_parallel_run, items=self.runners, group_size=1)
 
         merged_reports = self._merge_reports(reports)
-        logging.debug(f"got {len(merged_reports)} reports")
-        start = time.time()
         if bc_integration.bc_api_key:
             SecretsOmitter(merged_reports).omit()
-        logging.debug(f"Omitting secrets took {time.time() - start}")
+
         for scan_report in merged_reports:
             self._handle_report(scan_report, repo_root_for_plan_enrichment)
         return self.scan_reports

--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 from enum import Enum
 from typing import Iterator

--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -83,7 +83,7 @@ class SecretsOmitter:
                     continue
 
                 for secret_line_index, omitted_line in \
-                        zip(list(range(secret_check_line_range[0], secret_check_line_range[1] + 1)),
+                        zip(list(range(secret_check_line_range[0], secret_check_line_range[1] + 1)),  # noqa: B905
                             secrets_check_lines):
                     for entry_index, (line_index, _) in enumerate(check.code_block):
                         if secret_line_index == line_index:

--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -83,8 +83,8 @@ class SecretsOmitter:
                     continue
 
                 for secret_line_index, omitted_line in \
-                        zip(range(secret_check_line_range[0], secret_check_line_range[1] + 1), secrets_check_lines,
-                            strict=True):
+                        zip(list(range(secret_check_line_range[0], secret_check_line_range[1] + 1)),
+                            secrets_check_lines, strict=True):
                     for entry_index, (line_index, _) in enumerate(check.code_block):
                         if secret_line_index == line_index:
                             check.code_block[entry_index] = (line_index, omitted_line)

--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 import logging
 from enum import Enum
-from typing import Iterator
+from typing import Iterator, TYPE_CHECKING
 
 from checkov.common.bridgecrew.check_type import CheckType
-from checkov.common.output.record import Record
-from checkov.common.output.report import Report
+
+if TYPE_CHECKING:
+    from checkov.common.output.record import Record
+    from checkov.common.output.report import Report
 
 
 class SecretsOmitterStatus(Enum):
-    Success = 0
-    InsufficientReports = 1
-    Failed = 2
+    SUCCESS = 0
+    INSUFFICIENT_REPORTS = 1
 
 
 class SecretsOmitter:
@@ -57,7 +58,7 @@ class SecretsOmitter:
     def omit(self) -> SecretsOmitterStatus:
         if not self.reports or not self.secrets_report:
             logging.debug("Insufficient reports to omit secrets")
-            return SecretsOmitterStatus.InsufficientReports
+            return SecretsOmitterStatus.INSUFFICIENT_REPORTS
 
         files_with_secrets: set[str] = {secret_check.file_path for secret_check in self._secret_check()}
         for check in self._non_secret_check():
@@ -83,4 +84,4 @@ class SecretsOmitter:
                         if secret_line_index == line_index:
                             check.code_block[entry_index] = (line_index, omitted_line)
 
-        return SecretsOmitterStatus.Success
+        return SecretsOmitterStatus.SUCCESS

--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -84,7 +84,7 @@ class SecretsOmitter:
 
                 for secret_line_index, omitted_line in \
                         zip(list(range(secret_check_line_range[0], secret_check_line_range[1] + 1)),
-                            secrets_check_lines, strict=True):
+                            secrets_check_lines):
                     for entry_index, (line_index, _) in enumerate(check.code_block):
                         if secret_line_index == line_index:
                             check.code_block[entry_index] = (line_index, omitted_line)

--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -78,8 +78,13 @@ class SecretsOmitter:
                         not SecretsOmitter._line_range_overlaps(secret_check_line_range, check_line_range):
                     continue
 
+                if len(secrets_check_lines) != secret_check_line_range[1] - secret_check_line_range[0] + 1:
+                    logging.error("Secrets lines does not match the length of the line range, sanity check failed")
+                    continue
+
                 for secret_line_index, omitted_line in \
-                        zip(range(secret_check_line_range[0], secret_check_line_range[1] + 1), secrets_check_lines):
+                        zip(range(secret_check_line_range[0], secret_check_line_range[1] + 1), secrets_check_lines,
+                            strict=True):
                     for entry_index, (line_index, _) in enumerate(check.code_block):
                         if secret_line_index == line_index:
                             check.code_block[entry_index] = (line_index, omitted_line)

--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import itertools
 import logging
 from enum import Enum
 from typing import Iterator, TYPE_CHECKING

--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -31,8 +31,7 @@ class SecretsOmitter:
 
     def _non_secret_check(self) -> Iterator[Record]:
         for report in self.reports:
-            checks = report.failed_checks + report.passed_checks
-            for check in checks:
+            for check in itertools.chain(report.failed_checks, report.passed_checks):
                 yield check
 
     @staticmethod

--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -1,0 +1,67 @@
+from typing import Iterator
+
+from checkov.common.bridgecrew.check_type import CheckType
+from checkov.common.output.record import Record
+from checkov.common.output.report import Report
+
+
+class SecretsOmitter:
+    def __init__(self, reports: list[Report]):
+        self.reports = [report for report in reports if report.check_type != CheckType.SECRETS]
+        secrets_report = [report for report in reports if report.check_type == CheckType.SECRETS]
+        self.secrets_report = secrets_report[0] if len(secrets_report) == 1 else []
+
+    def _secret_check(self) -> Iterator[Record]:
+        for check in self.secrets_report.failed_checks:
+            yield check
+
+    def _non_secret_check(self) -> Iterator[Record]:
+        for report in self.reports:
+            checks = report.failed_checks + report.passed_checks
+            for check in checks:
+                yield check
+
+    @staticmethod
+    def get_secret_lines(check: Record) -> tuple[list[int], list[str]]:
+        secret_lines_range = [-1, -1]
+        secrets_lines = []
+        for idx, line in check.code_block:
+            if '*' in line:
+                secrets_lines.append(line)
+                if secret_lines_range[0] == -1:
+                    secret_lines_range[0] = idx
+                else:
+                    secret_lines_range[1] = idx
+        if secret_lines_range[1] == -1:
+            secret_lines_range[1] = secret_lines_range[0]
+
+        return secret_lines_range, secrets_lines
+
+    @staticmethod
+    def _line_range_overlaps(r1: list[int], r2: list[int]) -> bool:
+        return r1[0] <= r2[1] and r1[1] >= r2[0]
+
+    def omit(self) -> None:
+        if not self.reports or not self.secrets_report:
+            return
+
+        for secret_check in self._secret_check():
+            secret_check_file_path = secret_check.file_path
+            secret_check_line_range, secrets_check_lines = SecretsOmitter.get_secret_lines(secret_check)
+            if secret_check_line_range == [-1, -1]:
+                continue
+
+            for check in self._non_secret_check():
+                check_file_path = check.file_path
+                check_line_range = check.file_line_range
+
+                if secret_check_file_path != check_file_path or \
+                        not SecretsOmitter._line_range_overlaps(secret_check_line_range, check_line_range):
+                    continue
+
+                for secret_line_index, omitted_line in \
+                        zip(range(secret_check_line_range[0], secret_check_line_range[1] + 1), secrets_check_lines):
+                    for entry_index, (line_index, _) in enumerate(check.code_block):
+                        if secret_line_index == line_index:
+                            check.code_block[entry_index] = (line_index, omitted_line)
+

--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -59,15 +59,19 @@ class SecretsOmitter:
             logging.debug("Insufficient reports to omit secrets")
             return SecretsOmitterStatus.InsufficientReports
 
-        for secret_check in self._secret_check():
-            secret_check_file_path = secret_check.file_path
-            secret_check_line_range, secrets_check_lines = SecretsOmitter.get_secret_lines(secret_check.code_block)
-            if secret_check_line_range == [-1, -1]:
+        files_with_secrets: set[str] = {secret_check.file_path for secret_check in self._secret_check()}
+        for check in self._non_secret_check():
+            check_file_path = check.file_path
+            check_line_range = check.file_line_range
+
+            if check_file_path not in files_with_secrets:
                 continue
 
-            for check in self._non_secret_check():
-                check_file_path = check.file_path
-                check_line_range = check.file_line_range
+            for secret_check in self._secret_check():
+                secret_check_file_path = secret_check.file_path
+                secret_check_line_range, secrets_check_lines = SecretsOmitter.get_secret_lines(secret_check.code_block)
+                if secret_check_line_range == [-1, -1]:
+                    continue
 
                 if secret_check_file_path != check_file_path or \
                         not SecretsOmitter._line_range_overlaps(secret_check_line_range, check_line_range):

--- a/tests/common/secrets_omitter/test_secrets_omitter.py
+++ b/tests/common/secrets_omitter/test_secrets_omitter.py
@@ -43,7 +43,7 @@ def test_get_secret_lines(code_block, expected_range, expected_lines):
     ],
 )
 def test_omit_insufficient_reports(reports):
-    assert SecretsOmitter(reports).omit() == SecretsOmitterStatus.InsufficientReports
+    assert SecretsOmitter(reports).omit() == SecretsOmitterStatus.INSUFFICIENT_REPORTS
 
 
 def test_omit():
@@ -66,5 +66,5 @@ def test_omit():
 
     res = SecretsOmitter([secrets_report, report]).omit()
 
-    assert res == SecretsOmitterStatus.Success
+    assert res == SecretsOmitterStatus.SUCCESS
     assert report.passed_checks[0].code_block == [(2, 'bc*'), (3, 'efg******'), (4, 'abcd'), (5, 'abc')]

--- a/tests/common/secrets_omitter/test_secrets_omitter.py
+++ b/tests/common/secrets_omitter/test_secrets_omitter.py
@@ -1,0 +1,70 @@
+import pytest
+
+from checkov.common.bridgecrew.check_type import CheckType
+from checkov.common.models.enums import CheckResult
+from checkov.common.output.record import Record
+from checkov.common.output.report import Report
+from checkov.common.util.secrets_omitter import SecretsOmitter, SecretsOmitterStatus
+
+
+@pytest.mark.parametrize(
+    "r1,r2,expected_result",
+    [
+        ([10, 20], [15, 17], True),
+        ([10, 20], [18, 21], True),
+        ([10, 20], [9, 12], True),
+        ([10, 20], [20, 25], True),
+        ([10, 20], [30, 40], False)
+    ],
+)
+def test_line_ranges_overlap(r1, r2, expected_result):
+    assert expected_result == SecretsOmitter._line_range_overlaps(r1, r2)
+
+
+@pytest.mark.parametrize(
+    "code_block,expected_range,expected_lines",
+    [
+        ([(1, 'ab***'), (2, 'abcd')], [1, 1], ['ab***']),
+        ([(1, 'abcd'), (2, 'abc')], [-1, -1], []),
+        ([(1, 'ab***'), (2, 'bc*'), (3, 'efg******')], [1, 3], ['ab***', 'bc*', 'efg******'])
+    ],
+)
+def test_get_secret_lines(code_block, expected_range, expected_lines):
+    line_range, lines = SecretsOmitter.get_secret_lines(code_block)
+    assert line_range == expected_range
+    assert lines == expected_lines
+
+
+@pytest.mark.parametrize(
+    "reports",
+    [
+        ([Report(CheckType.SECRETS)]),
+        ([Report(CheckType.GITHUB_ACTIONS)])
+    ],
+)
+def test_omit_insufficient_reports(reports):
+    assert SecretsOmitter(reports).omit() == SecretsOmitterStatus.InsufficientReports
+
+
+def test_omit():
+    file_path = 'filepath'
+    failed_secrets_record = Record(check_id='a', check_name='a', check_result={"result": CheckResult.FAILED},
+                                   code_block=[(1, 'ab***'), (2, 'bc*'), (3, 'efg******'), (4, 'abcd'), (5, 'abc')],
+                                   file_path=file_path, file_line_range=[], resource='', evaluations={}, check_class='',
+                                   file_abs_path=''
+                                   )
+    secrets_report = Report(CheckType.SECRETS)
+    secrets_report.add_record(failed_secrets_record)
+
+    record = Record(check_id='b', check_name='b', check_result={"result": CheckResult.PASSED},
+                    code_block=[(2, 'SECRET'), (3, 'SECRET'), (4, 'abcd'), (5, 'abc')],
+                    file_path=file_path, file_line_range=[2, 5], resource='', evaluations={}, check_class='',
+                    file_abs_path=''
+                    )
+    report = Report(CheckType.GITHUB_ACTIONS)
+    report.add_record(record)
+
+    res = SecretsOmitter([secrets_report, report]).omit()
+
+    assert res == SecretsOmitterStatus.Success
+    assert report.passed_checks[0].code_block == [(2, 'bc*'), (3, 'efg******'), (4, 'abcd'), (5, 'abc')]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

SecretsOmitter will work for users using an API key & enabled secrets runner.

This module will process all reports and clear secrets from the code block of non-secrets records.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
