### PR TITLE
feat(kubernetes): Added CKV2_K8S_5 check that no service account or node can read all secrets

### DIFF
--- a/checkov/kubernetes/checks/graph_checks/ReadAllSecrets.yaml
+++ b/checkov/kubernetes/checks/graph_checks/ReadAllSecrets.yaml
@@ -1,5 +1,5 @@
 metadata:
-  id: "CKV2_K8S_5"
+  id: CKV2_K8S_5
   name: "No ServiceAccount/Node should be able to read all secrets"
   category: "KUBERNETES"
 definition:

--- a/checkov/kubernetes/checks/graph_checks/ReadAllSecrets.yaml
+++ b/checkov/kubernetes/checks/graph_checks/ReadAllSecrets.yaml
@@ -1,0 +1,61 @@
+metadata:
+  id: "CKV2_K8S_5"
+  name: "No ServiceAccount/Node should be able to read all secrets"
+  category: "KUBERNETES"
+definition:
+  and:
+    - cond_type: filter
+      value:
+        - ClusterRoleBinding
+        - RoleBinding
+      operator: within
+      attribute: kind
+    - or:
+        - cond_type: connection
+          operator: not_exists
+          resource_types:
+            - ClusterRoleBinding
+            - RoleBinding
+          connected_resource_types:
+            - ClusterRole
+            - Role
+        - not:
+            cond_type: attribute
+            attribute: 'subjects.*.kind'
+            operator: within
+            value:
+              - 'Node'
+              - 'ServiceAccount'
+            resource_types:
+              - ClusterRoleBinding
+              - RoleBinding
+        - and:
+            - cond_type: connection
+              operator: exists
+              resource_types:
+                - ClusterRoleBinding
+                - RoleBinding
+              connected_resource_types:
+                - ClusterRole
+                - Role
+            - or:
+              - cond_type: attribute
+                attribute: rules.resources
+                operator: not_intersects
+                value:
+                  - 'secrets'
+                  - '*'
+                resource_types:
+                  - ClusterRole
+                  - Role
+              - cond_type: attribute
+                attribute: rules.verbs
+                operator: not_intersects
+                value:
+                  - 'get'
+                  - 'watch'
+                  - 'list'
+                  - '*'
+                resource_types:
+                  - ClusterRole
+                  - Role

--- a/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Failing/ClusterRole.yaml
+++ b/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Failing/ClusterRole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-reader
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - "secrets"
+  verbs:
+    - "get"
+    - "watch"
+    - "list"

--- a/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Failing/ClusterRoleBinding.yaml
+++ b/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Failing/ClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+# This cluster role binding allows the pod "pod1" to read secrets in any namespace.
+kind: ClusterRoleBinding
+metadata:
+  name: read-secrets-global
+subjects:
+- kind: ServiceAccount
+  name: sa1
+roleRef:
+  kind: ClusterRole
+  name: secret-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Passing/ClusterRole.yaml
+++ b/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Passing/ClusterRole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pods-reader
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+  verbs:
+    - "get"
+    - "watch"
+    - "list"

--- a/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Passing/ClusterRoleBinding.yaml
+++ b/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Passing/ClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+# This cluster role binding allows the pod "pod1" to read secrets in any namespace.
+kind: ClusterRoleBinding
+metadata:
+  name: read-pods-global
+subjects:
+- kind: ServiceAccount
+  name: sa1
+roleRef:
+  kind: ClusterRole
+  name: pods-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/kubernetes/graph/checks/resources/ReadAllSecrets/expected.yaml
+++ b/tests/kubernetes/graph/checks/resources/ReadAllSecrets/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "ClusterRoleBinding.default.read-pods-global"
+fail:
+  - "ClusterRoleBinding.default.read-secrets-global"

--- a/tests/kubernetes/graph/checks/test_yaml_policies.py
+++ b/tests/kubernetes/graph/checks/test_yaml_policies.py
@@ -58,6 +58,10 @@ class TestYamlPolicies(TestYamlPoliciesBase):
     def test_ModifyServicesStatus(self) -> None:
         self.go('ModifyServicesStatus')
 
+    @with_k8s_graph_flags()
+    def test_ReadAllSecrets(self) -> None:
+        self.go('ReadAllSecrets')
+
     def create_report_from_graph_checks_results(self, checks_results, check):
         report = Report("kubernetes")
         first_results_key = list(checks_results.keys())[0]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Added CKV2_K8S_5 check that no service account or node can read all secrets

## New/Edited policies 

- Added CKV2_K8S_5 check that no service account or node can read all secrets

### Fix
Remove `secrets` from the available `resources` in `Role/ClusterRole`, or remove any read related verb from `verbs`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
