### PR TITLE
fix(helm): address incorrect file path reported in helm check result

### DIFF
--- a/tests/helm/test_runner_image_referencer.py
+++ b/tests/helm/test_runner_image_referencer.py
@@ -78,7 +78,7 @@ def test_deployment_resources(mocker: MockerFixture, image_cached_result, licens
     from checkov.common.bridgecrew.platform_integration import bc_integration
 
     # given
-    file_name = "hello-world/templates/deployment.yaml"
+    file_name = "templates/deployment.yaml"
     image_name = "nginx:1.16.0"
     code_lines = "3-42"
     test_folder = RESOURCES_PATH / "image_referencer"
@@ -122,7 +122,7 @@ def test_deployment_resources(mocker: MockerFixture, image_cached_result, licens
     assert sca_image_report.image_cached_results[0]["dockerImageName"] == image_name
     assert (
         sca_image_report.image_cached_results[0]["relatedResourceId"]
-        == "/hello-world/templates/deployment.yaml:Deployment.default.release-name-hello-world"
+        == "/templates/deployment.yaml:Deployment.default.release-name-hello-world"
     )
     assert sca_image_report.image_cached_results[0]["packages"] == [
         {"type": "os", "name": "zlib", "version": "1.2.12-r1", "licenses": ["Zlib"]}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

When the chart name is different from the name of directory where the chart resides, checkov reports incorrect `file_path` and `repo_file_path` in the report. This is due to the fact that we are removing the chart name suffix from the chart directory instead of removing the prefix from the source comment for each resource once the template is ran.

Fixes #2708

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
