### PR TITLE
feat(kubernetes): added CKV2_K8S_EXAMPLE_1 only in tests as an example for k8s graph check for pod which is publicly accessible

### DIFF
--- a/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/Failing/Pod.yaml
+++ b/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/Failing/Pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  app: nginx-pod
+  labels:
+    app: nginx-pod
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80

--- a/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/Failing/Service.yaml
+++ b/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/Failing/Service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: nginx-pod
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
+  clusterIP: 10.0.171.239
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 192.0.2.127

--- a/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/Passing/Pod.yaml
+++ b/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/Passing/Pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  app: nginx-pod
+  labels:
+    app: no-service-attached
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80

--- a/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/Passing/Service.yaml
+++ b/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/Passing/Service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: not-attached-to-any-pod
+spec:
+  selector:
+    app: not-exist
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
+  clusterIP: 10.0.171.239
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 192.0.2.127

--- a/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/expected.yaml
+++ b/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/expected.yaml
@@ -1,2 +1,4 @@
+pass:
+  - Pod.default.app-no-service-attached
 fail:
   - Pod.default.app-nginx-pod

--- a/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/expected.yaml
+++ b/tests/kubernetes/graph/checks/resources/PodIsPubliclyAccessibleExample/expected.yaml
@@ -1,0 +1,2 @@
+fail:
+  - Pod.default.app-nginx-pod

--- a/tests/kubernetes/graph/checks/test_checks/PodIsPubliclyAccessibleExample.yaml
+++ b/tests/kubernetes/graph/checks/test_checks/PodIsPubliclyAccessibleExample.yaml
@@ -1,0 +1,21 @@
+metadata:
+  id: "CKV2_K8S_EXAMPLE_1"
+  name: "Pod is publicly accessible"
+  category: "KUBERNETES"
+definition:
+  and:
+    - cond_type: filter
+      value:
+        - Pod
+      operator: within
+      attribute: kind
+    - or:
+        - cond_type: connection
+          operator: not_exists
+          resource_types:
+            - Pod
+          connected_resource_types:
+            - Service
+        - cond_type: attribute
+          attribute: spec.ports.*.targePort
+          operator: exists

--- a/tests/kubernetes/graph/checks/test_checks/PodIsPubliclyAccessibleExample.yaml
+++ b/tests/kubernetes/graph/checks/test_checks/PodIsPubliclyAccessibleExample.yaml
@@ -16,6 +16,18 @@ definition:
             - Pod
           connected_resource_types:
             - Service
-        - cond_type: attribute
-          attribute: spec.ports.*.targePort
-          operator: exists
+        - and:
+          - cond_type: connection
+            operator: exists
+            resource_types:
+              - Pod
+            connected_resource_types:
+              - Service
+          - cond_type: attribute
+            attribute: 'spec.type'
+            operator: not_within
+            value:
+              - 'LoadBalancer'
+              - 'NodePort'
+            resource_types:
+              - Service

--- a/tests/kubernetes/graph/checks/test_yaml_policies.py
+++ b/tests/kubernetes/graph/checks/test_yaml_policies.py
@@ -62,6 +62,10 @@ class TestYamlPolicies(TestYamlPoliciesBase):
     def test_ReadAllSecrets(self) -> None:
         self.go('ReadAllSecrets')
 
+    @with_k8s_graph_flags()
+    def test_PodIsPubliclyAccessibleExample(self) -> None:
+        self.go('PodIsPubliclyAccessibleExample')
+
     def create_report_from_graph_checks_results(self, checks_results, check):
         report = Report("kubernetes")
         first_results_key = list(checks_results.keys())[0]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Added CKV2_K8S_EXAMPLE_1 as an example for k8s graph check for pod which is publicly accessible.
Note this is just used in tests to provide an example, and is not a real check.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
