### PR TITLE
fix(sca): invoke packaging.Version instead of parse

### DIFF
--- a/checkov/common/packaging/version.py
+++ b/checkov/common/packaging/version.py
@@ -25,7 +25,7 @@ def parse(version: str) -> packaging_version.Version | LegacyVersion:
     a valid PEP 440 version or a legacy version.
     """
     try:
-        return packaging_version.parse(version)
+        return packaging_version.Version(version)
     except packaging_version.InvalidVersion:
         return LegacyVersion(version)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- if the user has the old `packaging` version installed, then it will result in an error during the complaint version calculation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
