### PR TITLE
fix(secrets): fix error when secret is None

### DIFF
--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -119,7 +119,10 @@ def omit_multiple_secret_values_from_line(secrets: set[str], line_text: str) -> 
     return censored_line
 
 
-def omit_secret_value_from_line(secret: str, line_text: str) -> str:
+def omit_secret_value_from_line(secret: str | None, line_text: str) -> str:
+    if not secret:
+        return line_text
+
     secret_length = len(secret)
     secret_len_to_expose = secret_length // 4 if secret_length < 100 else secret_length // 10
 

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -45,6 +45,10 @@ class TestSecrets(unittest.TestCase):
 
         self.assertEqual(censored_line, 'access_key: "AKIAI***************"')
 
+    def test_omit_none_secret_from_line(self):
+        line = 'text'
+        self.assertEqual(line, omit_secret_value_from_line(secret=None, line_text=line))
+
     def test_get_secrets_from_secrets(self):
         s = 'access_key: "AKIAIOSFODNN7EXAMPLE"'
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Fix TypeError when secret is None

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
