### PR TITLE
feat(terraform_plan): add check details to TF plan scan results

### DIFF
--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -195,18 +195,30 @@ class Runner(TerraformRunner):
                     if check.id in TF_LIFECYCLE_CHECK_IDS:
                         # can't be evaluated in TF plan
                         continue
-                    censored_code_lines = omit_secret_value_from_checks(check=check,
-                                                                        check_result=check_result,
-                                                                        entity_code_lines=entity_code_lines,
-                                                                        entity_config=entity_config,
-                                                                        resource_attributes_to_omit=RESOURCE_ATTRIBUTES_TO_OMIT)
-                    record = Record(check_id=check.id, bc_check_id=check.bc_id, check_name=check.name,
-                                    check_result=check_result,
-                                    code_block=censored_code_lines, file_path=scanned_file,
-                                    file_line_range=entity_lines_range,
-                                    resource=entity_id, resource_address=entity_address, evaluations=None,
-                                    check_class=check.__class__.__module__, file_abs_path=full_file_path,
-                                    severity=check.severity)
+
+                    censored_code_lines = omit_secret_value_from_checks(
+                        check=check,
+                        check_result=check_result,
+                        entity_code_lines=entity_code_lines,
+                        entity_config=entity_config,
+                        resource_attributes_to_omit=RESOURCE_ATTRIBUTES_TO_OMIT
+                    )
+                    record = Record(
+                        check_id=check.id,
+                        bc_check_id=check.bc_id,
+                        check_name=check.name,
+                        check_result=check_result,
+                        code_block=censored_code_lines,
+                        file_path=scanned_file,
+                        file_line_range=entity_lines_range,
+                        resource=entity_id,
+                        resource_address=entity_address,
+                        evaluations=None,
+                        check_class=check.__class__.__module__,
+                        file_abs_path=full_file_path,
+                        severity=check.severity,
+                        details=check.details,
+                    )
                     record.set_guideline(check.guideline)
                     report.add_record(record=record)
 

--- a/tests/terraform/runner/extra_tf_plan_checks/secret_not_deleted.py
+++ b/tests/terraform/runner/extra_tf_plan_checks/secret_not_deleted.py
@@ -18,6 +18,7 @@ class KmsKeyNotDeleted(BaseResourceCheck):
     def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:
         actions = conf.get(TF_PLAN_RESOURCE_CHANGE_ACTIONS)
         if isinstance(actions, list) and "delete" in actions:
+            self.details.append("some great details")
             return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -593,6 +593,10 @@ class TestRunnerValid(unittest.TestCase):
         resource_ids = [check.resource for check in report.failed_checks]
         self.assertCountEqual(resource_ids,["aws_secretsmanager_secret.default", "aws_secretsmanager_secret.default"])
 
+        # check also the details
+        failed_check = next(check for check in report.failed_checks if check.check_id == "CUSTOM_DELETE_1")
+        self.assertEqual(failed_check.details, ["some great details"])
+
     def test_runner_nested_child_modules_with_connections(self):
         # given
         tf_file_path = Path(__file__).parent / "resources/plan_nested_child_modules_with_connections/tfplan.json"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- adds the check details to Terraform plan scan results

Fixes #4088 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
