### PR TITLE
fix(terraform): add a method for get the entity definition path from the entity itself

### DIFF
--- a/checkov/terraform/context_parsers/base_parser.py
+++ b/checkov/terraform/context_parsers/base_parser.py
@@ -45,6 +45,14 @@ class BaseContextParser(ABC):
         """
         raise NotImplementedError
 
+    def get_entity_definition_path(self, entity_block: Dict[str, Dict[str, Any]]) -> List[str]:
+        """
+        returns the entity's path in the entity definition block
+        :param entity_block: entity definition block
+        :return: list of nested entity's keys in the entity definition block
+        """
+        return self.get_entity_context_path(entity_block)
+
     def _is_block_signature(self, line_num: int, line_tokens: List[str], entity_context_path: List[str]) -> bool:
         """
         Determine if the given tokenized line token is the entity signature line

--- a/checkov/terraform/context_parsers/parsers/provider_context_parser.py
+++ b/checkov/terraform/context_parsers/parsers/provider_context_parser.py
@@ -16,6 +16,10 @@ class ProviderContextParser(BaseContextParser):
         entity_type, entity_value = next(iter(entity_block.items()))
         return [entity_type, entity_value.get("alias", ["default"])[0]]
 
+    def get_entity_definition_path(self, entity_block: Dict[str, Dict[str, Any]]) -> List[str]:
+        entity_type, _ = next(iter(entity_block.items()))
+        return [entity_type]
+
     def enrich_definition_block(self, definition_blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
         for entity_block in definition_blocks:
             entity_type, entity_config = next(iter(entity_block.items()))

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 from typing import List, Optional, Union, Any, Dict, Set, Tuple
+from hcl2 import START_LINE, END_LINE
 
 from typing_extensions import TypedDict
 
@@ -542,7 +543,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
 
             context_parser = parser_registry.context_parsers[vertex.block_type]
             vertex_context = vertex.config
-            definition_path = context_parser.get_entity_context_path(vertex.config)
+            definition_path = context_parser.get_entity_definition_path(vertex.config)
             for path in definition_path:
                 vertex_context = vertex_context.get(path, vertex_context)
             vertex_context[CustomAttributes.TF_RESOURCE_ADDRESS] = address

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 from typing import List, Optional, Union, Any, Dict, Set, Tuple
-from hcl2 import START_LINE, END_LINE
 
 from typing_extensions import TypedDict
 

--- a/tests/terraform/graph/graph_builder/test_graph_builder.py
+++ b/tests/terraform/graph/graph_builder/test_graph_builder.py
@@ -320,3 +320,5 @@ class TestGraphBuilder(TestCase):
         assert resource_1.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS) == 'module.s3_module.module.inner_s3_module.aws_s3_bucket_public_access_block.var_bucket'
         resource_2 = self.get_vertex_by_name_and_type(local_graph, BlockType.RESOURCE, 'aws_s3_bucket.example')
         assert resource_2.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS) == 'aws_s3_bucket.example'
+        provider = self.get_vertex_by_name_and_type(local_graph, BlockType.PROVIDER, 'aws.test_provider')
+        assert provider.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS) == 'aws.test_provider'

--- a/tests/terraform/graph/resources/nested_modules_address/main.tf
+++ b/tests/terraform/graph/resources/nested_modules_address/main.tf
@@ -1,5 +1,7 @@
 provider "aws" {
   region  = "us-west-2"
+  alias = "test_provider"
+  test_provider = True
 }
 
 module "s3_module" {


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
add a new `get_entity_definition_path` method in the context parsers for getting the entity definition path from the entity itself
will solve updating the address for provider blocks

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
