### PR TITLE
feat(kubernetes): inject k8s FF flags to instance instead of constructor

### DIFF
--- a/checkov/kubernetes/graph_manager.py
+++ b/checkov/kubernetes/graph_manager.py
@@ -27,14 +27,13 @@ class KubernetesGraphManager(GraphManager[KubernetesLocalGraph, "dict[str, list[
         excluded_paths: list[str] | None = None
     ) -> tuple[KubernetesLocalGraph, dict[str, list[dict[str, Any]]]]:
         definitions, definitions_raw = get_folder_definitions(source_dir, excluded_paths)
-        local_graph = self.build_graph_from_definitions(definitions=definitions, render_variables=False, graph_flags=self.graph_flags)
+        local_graph = self.build_graph_from_definitions(definitions=definitions, render_variables=False)
         return local_graph, definitions
 
     def build_graph_from_definitions(
-        self, definitions: dict[str, list[dict[str, Any]]], render_variables: bool = True, graph_flags: K8sGraphFlags | None = None
-    ) -> KubernetesLocalGraph:
+        self, definitions: dict[str, list[dict[str, Any]]], render_variables: bool = True) -> KubernetesLocalGraph:
         local_graph = KubernetesLocalGraph(definitions)
-        if graph_flags is None:
-            graph_flags = K8sGraphFlags()
-        local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
+        if self.graph_flags is None:
+            self.graph_flags = K8sGraphFlags()
+        local_graph.build_graph(render_variables=False, graph_flags=self.graph_flags)
         return local_graph

--- a/checkov/kubernetes/graph_manager.py
+++ b/checkov/kubernetes/graph_manager.py
@@ -31,7 +31,7 @@ class KubernetesGraphManager(GraphManager[KubernetesLocalGraph, "dict[str, list[
         return local_graph, definitions
 
     def build_graph_from_definitions(
-        self, definitions: dict[str, list[dict[str, Any]]], render_variables: bool = True) -> KubernetesLocalGraph:
+            self, definitions: dict[str, list[dict[str, Any]]], render_variables: bool = True) -> KubernetesLocalGraph:
         local_graph = KubernetesLocalGraph(definitions)
         if self.graph_flags is None:
             self.graph_flags = K8sGraphFlags()

--- a/checkov/kubernetes/graph_manager.py
+++ b/checkov/kubernetes/graph_manager.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 class KubernetesGraphManager(GraphManager[KubernetesLocalGraph, "dict[str, list[dict[str, Any]]]"]):
     def __init__(self, db_connector: DBConnector[DiGraph], source: str = "Kubernetes") -> None:
         super().__init__(db_connector=db_connector, parser=None, source=source)
+        self.graph_flags: K8sGraphFlags | None = None
 
     def build_graph_from_source_directory(
         self,
@@ -23,11 +24,10 @@ class KubernetesGraphManager(GraphManager[KubernetesLocalGraph, "dict[str, list[
         render_variables: bool = True,
         parsing_errors: dict[str, Exception] | None = None,
         download_external_modules: bool = False,
-        excluded_paths: list[str] | None = None,
-        graph_flags: K8sGraphFlags | None = None
+        excluded_paths: list[str] | None = None
     ) -> tuple[KubernetesLocalGraph, dict[str, list[dict[str, Any]]]]:
         definitions, definitions_raw = get_folder_definitions(source_dir, excluded_paths)
-        local_graph = self.build_graph_from_definitions(definitions=definitions, render_variables=False, graph_flags=graph_flags)
+        local_graph = self.build_graph_from_definitions(definitions=definitions, render_variables=False, graph_flags=self.graph_flags)
         return local_graph, definitions
 
     def build_graph_from_definitions(

--- a/tests/kubernetes/graph/test_graph_manager.py
+++ b/tests/kubernetes/graph/test_graph_manager.py
@@ -43,6 +43,7 @@ class TestKubernetesGraphManager(TestGraph):
         resource = definitions[relative_file_path][0]
 
         graph_manager = KubernetesGraphManager(db_connector=NetworkxConnector())
-        local_graph = graph_manager.build_graph_from_definitions(definitions, graph_flags=graph_flags)
+        graph_manager.graph_flags = graph_flags
+        local_graph = graph_manager.build_graph_from_definitions(definitions)
         self.assertEqual(1, len(local_graph.vertices))
         self.assert_vertex(local_graph.vertices[0], resource)

--- a/tests/kubernetes/graph/test_graph_manager.py
+++ b/tests/kubernetes/graph/test_graph_manager.py
@@ -15,7 +15,8 @@ class TestKubernetesGraphManager(TestGraph):
         root_dir = os.path.realpath(os.path.join(TEST_DIRNAME, "../runner/resources"))
         graph_manager = KubernetesGraphManager(db_connector=NetworkxConnector())
         graph_flags = K8sGraphFlags(create_complex_vertices=False, create_edges=False)
-        local_graph, definitions = graph_manager.build_graph_from_source_directory(root_dir, render_variables=False, graph_flags=graph_flags)
+        graph_manager.graph_flags = graph_flags
+        local_graph, definitions = graph_manager.build_graph_from_source_directory(root_dir, render_variables=False)
 
         expected_resources_by_file = {
             os.path.join(root_dir, "example.yaml"): [


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Allow setting K8S FFs as instance vars instead of a constructor arguments. This will allow a unified call to `graph_manager.build_graph_from_source_directory()` for all frameworks

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
