### PR TITLE
fix(terraform): fix nested module resources ids in the report

### DIFF
--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -24,8 +24,7 @@ from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.runners.base_runner import BaseRunner, CHECKOV_CREATE_GRAPH
 from checkov.common.util import data_structures_utils
 from checkov.common.util.consts import RESOLVED_MODULE_ENTRY_NAME
-from checkov.common.util.parser_utils import get_module_from_full_path, get_abs_path, get_current_module_index, \
-    get_tf_definition_key
+from checkov.common.util.parser_utils import get_module_from_full_path, get_abs_path, get_tf_definition_key
 from checkov.common.util.secrets import omit_secret_value_from_checks
 from checkov.common.variables.context import EvaluationContext
 from checkov.runner_filter import RunnerFilter
@@ -231,16 +230,13 @@ class Runner(ImageReferencerMixin[None], BaseRunner[TerraformGraphManager]):
                     module_dependency_num = entity.get(CustomAttributes.MODULE_DEPENDENCY_NUM)
                     if module_dependency and module_dependency_num:
                         if self.enable_nested_modules:
-                            module_index = get_current_module_index(module_dependency)
-                            tf_path = get_tf_definition_key(full_file_path, module_dependency[:module_index],
-                                                            module_dependency_num,
-                                                            module_dependency[module_index:])
+                            resource = entity.get(CustomAttributes.TF_RESOURCE_ADDRESS, resource_id)
                         else:
                             module_dependency_path = module_dependency.split(PATH_SEPARATOR)[-1]
                             tf_path = get_tf_definition_key(full_file_path, module_dependency_path, module_dependency_num)
-                        referrer_id = self._find_id_for_referrer(tf_path)
-                        if referrer_id:
-                            resource = f'{referrer_id}.{resource_id}'
+                            referrer_id = self._find_id_for_referrer(tf_path)
+                            if referrer_id:
+                                resource = f'{referrer_id}.{resource_id}'
                     record = Record(
                         check_id=check.id,
                         bc_check_id=check.bc_id,
@@ -353,11 +349,12 @@ class Runner(ImageReferencerMixin[None], BaseRunner[TerraformGraphManager]):
             caller_file_line_range = None
 
             if self.enable_nested_modules:
+                entity_id = entity_config.get(CustomAttributes.TF_RESOURCE_ADDRESS)
                 module, _ = get_module_from_full_path(full_file_path)
                 if module:
-                    referrer_id = self._find_id_for_referrer(full_file_path)
-                    entity_id = f"{referrer_id}.{entity_id}"
-                    module_name = referrer_id.split('.')[-1]
+                    full_definition_path = entity_id.split('.')
+                    module_name_index = len(full_definition_path) - full_definition_path[::-1].index(BlockType.MODULE) # the next item after the last 'module' prefix is the module name
+                    module_name = full_definition_path[module_name_index]
                     caller_context = definition_context[module].get(BlockType.MODULE, {}).get(module_name)
                     caller_file_line_range = [caller_context.get('start_line'), caller_context.get('end_line')]
                     abs_caller_file = get_abs_path(module)
@@ -586,10 +583,7 @@ class Runner(ImageReferencerMixin[None], BaseRunner[TerraformGraphManager]):
                         continue
 
                     if full_file_path in module_content[RESOLVED_MODULE_ENTRY_NAME]:
-                        if self.enable_nested_modules:
-                            id_referrer = module_content.get(CustomAttributes.TF_RESOURCE_ADDRESS)
-                        else:
-                            id_referrer = f"module.{module_name}"
+                        id_referrer = f"module.{module_name}"
                         self.referrer_cache[full_file_path] = id_referrer
                         return id_referrer
 

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -353,7 +353,7 @@ class Runner(ImageReferencerMixin[None], BaseRunner[TerraformGraphManager]):
                 module, _ = get_module_from_full_path(full_file_path)
                 if module:
                     full_definition_path = entity_id.split('.')
-                    module_name_index = len(full_definition_path) - full_definition_path[::-1].index(BlockType.MODULE) # the next item after the last 'module' prefix is the module name
+                    module_name_index = len(full_definition_path) - full_definition_path[::-1].index(BlockType.MODULE)  # the next item after the last 'module' prefix is the module name
                     module_name = full_definition_path[module_name_index]
                     caller_context = definition_context[module].get(BlockType.MODULE, {}).get(module_name)
                     caller_file_line_range = [caller_context.get('start_line'), caller_context.get('end_line')]

--- a/tests/terraform/runner/resources/resource_ids_nested_modules/main.tf
+++ b/tests/terraform/runner/resources/resource_ids_nested_modules/main.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region  = "us-west-2"
+}
+
+module "s3_module" {
+  source = "./module"
+  acl    = "public-read"
+}
+
+
+resource "aws_s3_bucket" "example" {
+  bucket = "example"
+  acl    = "public-read"
+}
+

--- a/tests/terraform/runner/resources/resource_ids_nested_modules/module/main.tf
+++ b/tests/terraform/runner/resources/resource_ids_nested_modules/module/main.tf
@@ -1,0 +1,9 @@
+module "inner_s3_module" {
+  source = "./module2"
+  acl    = var.acl
+}
+
+resource "aws_s3_bucket" "example2" {
+  bucket = "example"
+  acl    = var.acl
+}

--- a/tests/terraform/runner/resources/resource_ids_nested_modules/module/module2/main.tf
+++ b/tests/terraform/runner/resources/resource_ids_nested_modules/module/module2/main.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "example3" {
+  bucket = "example"
+  acl    = var.acl
+}

--- a/tests/terraform/runner/resources/resource_ids_nested_modules/module/module2/variable.tf
+++ b/tests/terraform/runner/resources/resource_ids_nested_modules/module/module2/variable.tf
@@ -1,0 +1,3 @@
+variable "acl" {
+  type = string
+}

--- a/tests/terraform/runner/resources/resource_ids_nested_modules/module/variable.tf
+++ b/tests/terraform/runner/resources/resource_ids_nested_modules/module/variable.tf
@@ -1,0 +1,3 @@
+variable "acl" {
+  type = string
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
fix terraform resources ids in the report

Fixes # (issue)
after fixing the `__address__` attribute for modules, the nested module resources ids in the report didn't contain the 'module' prefix.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
