### PR TITLE
feat(general): Use --no-fail-on-crash to gracefully exit commit_repository and setup_bridgecrew_credentials

### DIFF
--- a/checkov/main.py
+++ b/checkov/main.py
@@ -109,7 +109,7 @@ DEFAULT_RUNNERS = (
 )
 
 
-def exit_run(no_fail_on_crash: bool):
+def exit_run(no_fail_on_crash: bool) -> None:
     exit(0) if no_fail_on_crash else exit(2)
 
 
@@ -335,12 +335,13 @@ def run(banner: str = checkov_banner, argv: List[str] = sys.argv[1:]) -> Optiona
     git_configuration_folders = [os.getenv("CKV_GITHUB_CONF_DIR_PATH", default_github_dir_path),
                                  os.getcwd() + '/' + os.getenv('CKV_GITLAB_CONF_DIR_NAME', 'gitlab_conf')]
 
-    def commit_repository() -> str:
+    def commit_repository() -> Optional[str]:
         try:
             return bc_integration.commit_repository(config.branch)
         except Exception as e:
             logging.debug(f"commit_repository failed, exiting: {e}")
             exit_run(config.no_fail_on_crash)
+            return ""
 
     if config.directory:
         exit_codes = []


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
In cases where `commit_repository` or `setup_bridgecrew_credentials` fail, catch the failures and exit the run with either 0 or 2 exit codes, depending on whether the user has set `--no-fail-on-crash` or not.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
