### PR TITLE
fix(github): Fix GHA IR resource names in case of 2 identical images

### DIFF
--- a/checkov/github_actions/image_referencer/provider.py
+++ b/checkov/github_actions/image_referencer/provider.py
@@ -48,8 +48,8 @@ class GithubActionProvider:
 
                 elif isinstance(container, str):
                     image = container
-                    start_line = [line_number for line_number, line in self.workflow_line_numbers if image in line
-                                  and line_number >= job_object[START_LINE]][0]
+                    start_line = [line_number for line_number, line in
+                                  self.workflow_line_numbers[job_object[START_LINE]:] if image in line][0]
                     end_line = start_line + 1
 
                 if image:

--- a/checkov/github_actions/image_referencer/provider.py
+++ b/checkov/github_actions/image_referencer/provider.py
@@ -48,7 +48,8 @@ class GithubActionProvider:
 
                 elif isinstance(container, str):
                     image = container
-                    start_line = [line_number for line_number, line in self.workflow_line_numbers if image in line][0]
+                    start_line = [line_number for line_number, line in self.workflow_line_numbers if image in line
+                                  and line_number >= job_object[START_LINE]][0]
                     end_line = start_line + 1
 
                 if image:

--- a/tests/github_actions/image_referencer/conftest.py
+++ b/tests/github_actions/image_referencer/conftest.py
@@ -158,7 +158,7 @@ def workflow_line_numbers_with_two_identical_images() -> list[tuple[int, str]]:
             (21, '        run: |\n'),
             (22, '          terragrunt init\n'),
             (23, '          terragrunt destroy -auto-approve -var-file devl.tfvars\n'),
-            (24, '  first_job:\n'),
+            (24, '  second_job:\n'),
             (25, '    runs-on: ubuntu-latest\n'),
             (26, '    name: Name\n'),
             (27, '    container: node:14.16\n'),

--- a/tests/github_actions/image_referencer/conftest.py
+++ b/tests/github_actions/image_referencer/conftest.py
@@ -133,6 +133,134 @@ def workflow_without_images() -> dict[str, Any]:
         "__endline__": 21
     }
 
+@pytest.fixture
+def workflow_line_numbers_with_two_identical_images() -> list[tuple[int, str]]:
+    return [(1, 'name: Name\n'),
+            (2, 'on:\n'),
+            (3, '  workflow_dispatch:\n'),
+            (4, '    inputs:\n'),
+            (5, '      logLevel:\n'),
+            (6, "        description: 'Log level'\n"),
+            (7, '\n'),
+            (8, 'jobs:\n'),
+            (9, '  first_job:\n'),
+            (10, '    runs-on: ubuntu-latest\n'),
+            (11, '    name: Name\n'),
+            (12, '    container: node:14.16\n'),
+            (13, '    steps:\n'),
+            (14, '      - name: Checkout codebase\n'),
+            (15, '        uses: actions/checkout@v3\n'),
+            (16, '      - name: infrastructure\n'),
+            (17, '        working-directory: terraform\n'),
+            (18, '        shell: bash\n'),
+            (19, '        env:\n'),
+            (20, '          TF_INPUT: 0\n'),
+            (21, '        run: |\n'),
+            (22, '          terragrunt init\n'),
+            (23, '          terragrunt destroy -auto-approve -var-file devl.tfvars\n'),
+            (24, '  first_job:\n'),
+            (25, '    runs-on: ubuntu-latest\n'),
+            (26, '    name: Name\n'),
+            (27, '    container: node:14.16\n'),
+            (28, '    steps:\n'),
+            (29, '      - name: Checkout codebase\n'),
+            (30, '        uses: actions/checkout@v3\n'),
+            (31, '      - name: infrastructure\n'),
+            (32, '        working-directory: terraform\n'),
+            (33, '        shell: bash\n'),
+            (34, '        env:\n'),
+            (35, '          TF_INPUT: 0\n'),
+            (36, '        run: |\n'),
+            (37, '          terragrunt init\n'),
+            (38, '          terragrunt destroy -auto-approve -var-file devl.tfvars\n')
+            ]
+
+
+@pytest.fixture
+def workflow_with_two_identical_images() -> dict[str, Any]:
+    return {
+        "name": "Name",
+        "on": {
+            "workflow_dispatch": {
+                "inputs": {
+                    "logLevel": {
+                        "description": "Log level",
+                        "__startline__": 6,
+                        "__endline__": 8
+                    },
+                    "__startline__": 5,
+                    "__endline__": 8
+                },
+                "__startline__": 4,
+                "__endline__": 8
+            },
+            "__startline__": 3,
+            "__endline__": 8
+        },
+        "jobs": {
+            "first_job": {
+                "runs-on": "ubuntu-latest",
+                "name": "Name",
+                "container": "node:14.16",
+                "steps": [
+                    {
+                        "name": "Checkout codebase",
+                        "uses": "actions/checkout@v3",
+                        "__startline__": 14,
+                        "__endline__": 16
+                    },
+                    {
+                        "name": "infrastructure",
+                        "working-directory": "terraform",
+                        "shell": "bash",
+                        "env": {
+                            "TF_INPUT": 0,
+                            "__startline__": 20,
+                            "__endline__": 21
+                        },
+                        "run": "terragrunt init\nterragrunt destroy -auto-approve -var-file devl.tfvars\n",
+                        "__startline__": 16,
+                        "__endline__": 24
+                    }
+                ],
+                "__startline__": 10,
+                "__endline__": 24
+            },
+            "second_job": {
+                "runs-on": "ubuntu-latest",
+                "name": "Name",
+                "container": "node:14.16",
+                "steps": [
+                    {
+                        "name": "Checkout codebase",
+                        "uses": "actions/checkout@v3",
+                        "__startline__": 29,
+                        "__endline__": 31
+                    },
+                    {
+                        "name": "infrastructure",
+                        "working-directory": "terraform",
+                        "shell": "bash",
+                        "env": {
+                            "TF_INPUT": 0,
+                            "__startline__": 35,
+                            "__endline__": 36
+                        },
+                        "run": "terragrunt init\nterragrunt destroy -auto-approve -var-file devl.tfvars\n",
+                        "__startline__": 31,
+                        "__endline__": 39
+                    }
+                ],
+                "__startline__": 25,
+                "__endline__": 39
+            },
+            "__startline__": 24,
+            "__endline__": 39
+        },
+        "__startline__": 1,
+        "__endline__": 39
+    }
+
 
 @pytest.fixture
 def workflow_line_numbers_without_image() -> list[tuple[int, str]]:

--- a/tests/github_actions/image_referencer/test_github_action_provider.py
+++ b/tests/github_actions/image_referencer/test_github_action_provider.py
@@ -43,6 +43,7 @@ def test_extract_images_from_workflow_correct_line_numbers(workflow_with_two_ide
     assert len(images) == 2
     assert images[0].start_line != images[1].start_line
     assert images[0].end_line != images[1].end_line
+    assert images[0].related_resource_id != images[1].related_resource_id
 
 
 @pytest.mark.parametrize(

--- a/tests/github_actions/image_referencer/test_github_action_provider.py
+++ b/tests/github_actions/image_referencer/test_github_action_provider.py
@@ -32,6 +32,19 @@ def test_extract_images_from_workflow_no_images(workflow_without_images, workflo
     assert not images
 
 
+def test_extract_images_from_workflow_correct_line_numbers(workflow_with_two_identical_images,
+                                                           workflow_line_numbers_with_two_identical_images):
+    file_path = '/.github/workflows/unsecure_command.yaml'
+
+    gha_provider = GithubActionProvider(file_path=file_path, workflow_config=workflow_with_two_identical_images,
+                                        workflow_line_numbers=workflow_line_numbers_with_two_identical_images)
+    images = gha_provider.extract_images_from_workflow()
+
+    assert len(images) == 2
+    assert images[0].start_line != images[1].start_line
+    assert images[0].end_line != images[1].end_line
+
+
 @pytest.mark.parametrize(
     "start_line,end_line,expected_key",
     [


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

In case the image name appears twice in the same file, we calculated its start & end lines by it's first reference in the file, which caused empty related_resource_ids for images.

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
