### PR TITLE
fix(dockerfile): adjust the file abs path for Dockerfile graph results

### DIFF
--- a/checkov/dockerfile/runner.py
+++ b/checkov/dockerfile/runner.py
@@ -27,6 +27,7 @@ from checkov.dockerfile.utils import (
     DOCKERFILE_ENDLINE,
     get_files_definitions,
     get_scannable_file_paths,
+    get_abs_path,
 )
 from checkov.runner_filter import RunnerFilter
 
@@ -111,7 +112,7 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, list[_Instruction]]]"], B
 
         # run graph checks
         if CHECKOV_CREATE_GRAPH and self.graph_registry:
-            self.add_graph_check_results(report=report, runner_filter=runner_filter)
+            self.add_graph_check_results(report=report, runner_filter=runner_filter, root_folder=root_folder)
 
         if runner_filter.run_image_referencer:
             if files:
@@ -135,16 +136,8 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, list[_Instruction]]]"], B
 
         for docker_file_path, instructions in self.definitions.items():
             self.pbar.set_additional_data({"Current File Scanned": os.path.relpath(docker_file_path, root_folder)})
-            # There are a few cases here. If -f was used, there could be a leading / because it's an absolute path,
-            # or there will be no leading slash; root_folder will always be none.
-            # If -d is used, root_folder will be the value given, and -f will start with a / (hardcoded above).
-            # The goal here is simply to get a valid path to the file (which docker_file_path does not always give).
-            if docker_file_path[0] == "/":
-                path_to_convert = (root_folder + docker_file_path) if root_folder else docker_file_path
-            else:
-                path_to_convert = (os.path.join(root_folder, docker_file_path)) if root_folder else docker_file_path
 
-            file_abs_path = os.path.abspath(path_to_convert)
+            file_abs_path = get_abs_path(root_folder=root_folder, file_path=docker_file_path)
             report.add_resource(file_abs_path)
             skipped_checks = collect_skipped_checks(instructions)
 
@@ -212,7 +205,7 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, list[_Instruction]]]"], B
             self.pbar.update()
         self.pbar.close()
 
-    def add_graph_check_results(self, report: Report, runner_filter: RunnerFilter) -> None:
+    def add_graph_check_results(self, report: Report, runner_filter: RunnerFilter, root_folder: str | None) -> None:
         """Adds graph check results to given report"""
 
         graph_checks_results = self.run_graph_checks_results(runner_filter, self.check_type)
@@ -221,6 +214,7 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, list[_Instruction]]]"], B
             for check_result in check_results:
                 entity = check_result["entity"]
                 entity_file_path: str = entity[CustomAttributes.FILE_PATH]
+                file_abs_path = get_abs_path(root_folder=root_folder, file_path=entity_file_path)
                 resource_type: str = entity[CustomAttributes.RESOURCE_TYPE]
                 start_line = entity[START_LINE]
                 end_line = entity[END_LINE]
@@ -229,7 +223,7 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, list[_Instruction]]]"], B
                     report=report,
                     definitions_raw=self.definitions_raw,
                     docker_file_path=entity_file_path,
-                    file_abs_path=os.path.abspath(entity_file_path),
+                    file_abs_path=file_abs_path,
                     check=check,
                     check_result=check_result,
                     startline=start_line,

--- a/checkov/dockerfile/utils.py
+++ b/checkov/dockerfile/utils.py
@@ -58,3 +58,21 @@ def get_files_definitions(
             logging.info(f"Dockerfile skipping {file} as it can't be read as text file")
 
     return definitions, definitions_raw
+
+
+def get_abs_path(root_folder: str | None, file_path: str) -> str:
+    """Creates the abs path
+
+    There are a few cases here. If -f was used, there could be a leading / because it's an absolute path,
+    or there will be no leading slash; root_folder will always be none.
+    If -d is used, root_folder will be the value given, and -f will start with a / (hardcoded above).
+    The goal here is simply to get a valid path to the file (which docker_file_path does not always give).
+    """
+
+    if root_folder and file_path.startswith("/"):
+        # remove the leading slash, if it exists
+        file_path = file_path[1:]
+
+    path_to_convert = os.path.join(root_folder, file_path) if root_folder else file_path
+
+    return os.path.abspath(path_to_convert)

--- a/tests/dockerfile/test_runner.py
+++ b/tests/dockerfile/test_runner.py
@@ -91,11 +91,17 @@ class TestRunnerValid(unittest.TestCase):
         valid_dir_path = current_dir + "/resources/expose_port/pass"
         runner = Runner()
         report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
-                            runner_filter=RunnerFilter(framework='all',checks=['CKV_DOCKER_1']))
-        self.assertEqual(len(report.passed_checks), 1)
+                            runner_filter=RunnerFilter(framework=["all"],checks=["CKV_DOCKER_1", "CKV2_DOCKER_1"]))
+        self.assertEqual(len(report.passed_checks), 2)
         self.assertEqual(report.parsing_errors, [])
         self.assertEqual(report.failed_checks, [])
         self.assertEqual(report.skipped_checks, [])
+
+        #  also check the abs file paths
+        record_python = next(check for check in report.passed_checks if check.check_id == "CKV_DOCKER_1")
+        assert record_python.file_abs_path.endswith("checkov/tests/dockerfile/resources/expose_port/pass/Dockerfile")
+        record_graph = next(check for check in report.passed_checks if check.check_id == "CKV2_DOCKER_1")
+        assert record_graph.file_abs_path.endswith("checkov/tests/dockerfile/resources/expose_port/pass/Dockerfile")
 
     def test_runner_skip_check(self):
         #  given


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- aligns the file abs path of Dockerfile graph checks to the one of the Python checks

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
