### PR TITLE
fix(kubernetes): removed obsolete error logging

### DIFF
--- a/checkov/kubernetes/checks/resource/base_container_check.py
+++ b/checkov/kubernetes/checks/resource/base_container_check.py
@@ -74,7 +74,6 @@ class BaseK8sContainerCheck(BaseK8Check):
                 spec = conf["spec"]["template"]["spec"]
                 metadata = conf["spec"]["template"].get("metadata", {})
             except (KeyError, TypeError):
-                logging.info(f"failed to extract {evaluated_key_prefix} for {self.entity_path}")
                 return CheckResult.UNKNOWN
         elif self.entity_type == "CronJob":
             evaluated_key_prefix = "spec/jobTemplate/spec/template/spec"
@@ -82,7 +81,6 @@ class BaseK8sContainerCheck(BaseK8Check):
                 spec = conf["spec"]["jobTemplate"]["spec"]["template"]["spec"]
                 metadata = conf["spec"]["jobTemplate"]["spec"]["template"].get("metadata", {})
             except (KeyError, TypeError):
-                logging.info(f"failed to extract {evaluated_key_prefix} for {self.entity_path}")
                 return CheckResult.UNKNOWN
         else:
             logging.info(f"entity type {self.entity_type} not supported")


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

remove obsolete error logging while parsing templates since the parsing strategy has changed

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
