### PR TITLE
fix(kubernetes): move Kubernetes context error message

### DIFF
--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -182,12 +182,13 @@ class Runner(ImageReferencerMixin[None], BaseRunner[KubernetesGraphManager]):
         # Moves report generation logic out of run() method in Runner class.
         # Allows function overriding of a much smaller function than run() for other "child" frameworks such as Kustomize, Helm
         # Where Kubernetes CHECKS are needed, but the specific file references are to another framework for the user output (or a mix of both).
-        if not self.context:
-            # this shouldn't happen
-            logging.error("Context for Kubernetes runner was not set")
-            return report
 
         if results:
+            if not self.context:
+                # this shouldn't happen
+                logging.error("Context for Kubernetes runner was not set")
+                return report
+
             for check, check_result in results.items():
                 resource_id = get_resource_id(entity_conf)
                 if not resource_id:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- when helm or kustomize is run without finding any files, then a error message is printed to stdout

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
