### PR TITLE
fix(circleci): add resource to ir

### DIFF
--- a/checkov/circleci_pipelines/checks/DetectImagesUsage.py
+++ b/checkov/circleci_pipelines/checks/DetectImagesUsage.py
@@ -16,7 +16,7 @@ class DetectImageUsage(BaseCircleCIPipelinesCheck):
             block_type=BlockType.ARRAY,
             supported_entities=(
                 "executors.*.docker[].{image: image, __startline__: __startline__, __endline__:__endline__}",
-                'jobs.*.docker[].{image: image, __startline__: __startline__, __endline__:__endline__}',
+                "jobs.*.docker[].{image: image, __startline__: __startline__, __endline__:__endline__}",
             )
         )
 

--- a/checkov/circleci_pipelines/checks/DetectImagesUsage.py
+++ b/checkov/circleci_pipelines/checks/DetectImagesUsage.py
@@ -16,6 +16,7 @@ class DetectImageUsage(BaseCircleCIPipelinesCheck):
             block_type=BlockType.ARRAY,
             supported_entities=(
                 "executors.*.docker[].{image: image, __startline__: __startline__, __endline__:__endline__}",
+                'jobs.*.docker[].{image: image, __startline__: __startline__, __endline__:__endline__}',
             )
         )
 

--- a/tests/circleci_pipelines/image_referencer/test_runner.py
+++ b/tests/circleci_pipelines/image_referencer/test_runner.py
@@ -35,7 +35,7 @@ def test_circleCI_workflow(mocker: MockerFixture, image_cached_result, file_path
     sca_image_report = next(report for report in reports if report.check_type == CheckType.SCA_IMAGE)
 
     assert len(circleci_report.resources) == 0
-    assert len(circleci_report.passed_checks) == 21
+    assert len(circleci_report.passed_checks) == 32
     assert len(circleci_report.failed_checks) == 13
     assert len(circleci_report.skipped_checks) == 0
     assert len(circleci_report.parsing_errors) == 0
@@ -62,5 +62,5 @@ def test_runner_image_check(file_path):
 
     assert len(report.failed_checks) == 0
     assert report.parsing_errors == []
-    assert len(report.passed_checks) == 1
+    assert len(report.passed_checks) == 12
     assert report.skipped_checks ==[]

--- a/tests/circleci_pipelines/test_runner.py
+++ b/tests/circleci_pipelines/test_runner.py
@@ -25,7 +25,7 @@ class TestRunnerValid(unittest.TestCase):
         )
         self.assertEqual(len(report.failed_checks), 13)
         self.assertEqual(report.parsing_errors, [])
-        self.assertEqual(len(report.passed_checks), 21)
+        self.assertEqual(len(report.passed_checks), 32)
         self.assertEqual(report.skipped_checks, [])
         report.print_console()
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

Images can be found in `executors` or `jobs` in circleci.
originally, `jobs...` entity was not included `supported_entities` in the in the entities.
This check should have all the resources that have IR findings, even if they exist in some other check.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
