### PR TITLE
feat(secrets): Keep original secrets data in runtime for further validation

### DIFF
--- a/checkov/secrets/coordinator.py
+++ b/checkov/secrets/coordinator.py
@@ -1,0 +1,43 @@
+from typing import Optional, Iterable
+
+from detect_secrets.core.potential_secret import PotentialSecret
+
+from checkov.common.bridgecrew.severities import Severity
+from checkov.common.typing import _CheckResult
+
+
+class EnrichedSecret:
+    def __init__(self, potential_secret: PotentialSecret, check_id: str, bc_check_id: str, secret_key: str,
+                 severity: Optional[Severity], result: _CheckResult, code_block: list[tuple[int, str]],
+                 resource: str):
+        self.potential_secret = potential_secret
+        self.check_id = check_id
+        self.bc_check_id = bc_check_id
+        self.secret_key = secret_key
+        self.severity = severity
+        self.result = result
+        self.code_block = code_block
+        self.resource = resource
+
+
+class SecretsCoordinator:
+    def __init__(self):
+        self._secrets = {}
+
+    def add_secret(self, enriched_secret: EnrichedSecret) -> None:
+        # can be changed to any other suitable way.
+        # should not have duplicates? - if duplicates allowed, implementation should be changed
+        # may be saved by file type first, then by key - or any other preprocessing that may help differ the secrets.
+        self._secrets[enriched_secret.secret_key] = enriched_secret
+
+    def get_secrets(self) -> dict[str, EnrichedSecret]:
+        return self._secrets
+
+    def get_resources(self) -> Iterable[str]:
+        return {secret.resource for secret in self._secrets.values()}
+
+
+secrets_coordinator = SecretsCoordinator()
+
+
+

--- a/checkov/secrets/coordinator.py
+++ b/checkov/secrets/coordinator.py
@@ -1,7 +1,6 @@
-from typing import Optional, Iterable, TYPE_CHECKING
+from typing import Optional, Iterable, List, Tuple, Dict
 
-if TYPE_CHECKING:
-    from detect_secrets.core.potential_secret import PotentialSecret
+from detect_secrets.core.potential_secret import PotentialSecret
 
 from checkov.common.bridgecrew.severities import Severity
 from checkov.common.typing import _CheckResult
@@ -12,7 +11,7 @@ class EnrichedSecret:
                  "resource")
 
     def __init__(self, potential_secret: PotentialSecret, check_id: str, bc_check_id: str, secret_key: str,
-                 severity: Optional[Severity], result: _CheckResult, code_block: list[tuple[int, str]],
+                 severity: Optional[Severity], result: _CheckResult, code_block: List[Tuple[int, str]],
                  resource: str):
         self.potential_secret = potential_secret
         self.check_id = check_id
@@ -26,7 +25,7 @@ class EnrichedSecret:
 
 class SecretsCoordinator:
     def __init__(self) -> None:
-        self._secrets: dict[str, EnrichedSecret] = {}
+        self._secrets: Dict[str, EnrichedSecret] = {}
 
     def add_secret(self, enriched_secret: EnrichedSecret) -> None:
         # can be changed to any other suitable way.

--- a/checkov/secrets/coordinator.py
+++ b/checkov/secrets/coordinator.py
@@ -26,7 +26,7 @@ class SecretsCoordinator:
             self._secrets[enriched_secret.resource] = enriched_secret
 
     def get_resources(self) -> Iterable[str]:
-        return {secret.resource for secret in self._secrets.values()}
+        return self._secrets.keys()
 
 
 secrets_coordinator: SecretsCoordinator = SecretsCoordinator()

--- a/checkov/secrets/coordinator.py
+++ b/checkov/secrets/coordinator.py
@@ -17,13 +17,11 @@ class SecretsCoordinator:
     def __init__(self) -> None:
         self._secrets: Dict[str, EnrichedSecret] = {}
 
-    def add_secret(self, enriched_secret: EnrichedSecret, check_result: _CheckResult) -> None:
+    def add_secret(self, enriched_secret: EnrichedSecret) -> None:
         # can be changed to any other suitable way.
         # should not have duplicates? - if duplicates allowed, implementation should be changed
         # may be saved by file type first, then by key - or any other preprocessing that may help differ the secrets.
-
-        if check_result.get('result') == CheckResult.FAILED and enriched_secret.original_secret is not None:
-            self._secrets[enriched_secret.resource] = enriched_secret
+        self._secrets[enriched_secret.resource] = enriched_secret
 
     def get_resources(self) -> Iterable[str]:
         return self._secrets.keys()

--- a/checkov/secrets/coordinator.py
+++ b/checkov/secrets/coordinator.py
@@ -1,8 +1,5 @@
 from typing import Iterable, Dict, Optional
 
-from checkov.common.models.enums import CheckResult
-from checkov.common.typing import _CheckResult
-
 
 class EnrichedSecret:
     __slots__ = ("original_secret", "bc_check_id", "resource")

--- a/checkov/secrets/coordinator.py
+++ b/checkov/secrets/coordinator.py
@@ -1,12 +1,16 @@
-from typing import Optional, Iterable
+from typing import Optional, Iterable, TYPE_CHECKING
 
-from detect_secrets.core.potential_secret import PotentialSecret
+if TYPE_CHECKING:
+    from detect_secrets.core.potential_secret import PotentialSecret
 
 from checkov.common.bridgecrew.severities import Severity
 from checkov.common.typing import _CheckResult
 
 
 class EnrichedSecret:
+    __slots__ = ("potential_secret", "check_id", "bc_check_id", "secret_key", "severity", "result", "code_block",
+                 "resource")
+
     def __init__(self, potential_secret: PotentialSecret, check_id: str, bc_check_id: str, secret_key: str,
                  severity: Optional[Severity], result: _CheckResult, code_block: list[tuple[int, str]],
                  resource: str):
@@ -21,8 +25,8 @@ class EnrichedSecret:
 
 
 class SecretsCoordinator:
-    def __init__(self):
-        self._secrets = {}
+    def __init__(self) -> None:
+        self._secrets: dict[str, EnrichedSecret] = {}
 
     def add_secret(self, enriched_secret: EnrichedSecret) -> None:
         # can be changed to any other suitable way.
@@ -30,14 +34,8 @@ class SecretsCoordinator:
         # may be saved by file type first, then by key - or any other preprocessing that may help differ the secrets.
         self._secrets[enriched_secret.secret_key] = enriched_secret
 
-    def get_secrets(self) -> dict[str, EnrichedSecret]:
-        return self._secrets
-
     def get_resources(self) -> Iterable[str]:
         return {secret.resource for secret in self._secrets.values()}
 
 
-secrets_coordinator = SecretsCoordinator()
-
-
-
+secrets_coordinator: SecretsCoordinator = SecretsCoordinator()

--- a/checkov/secrets/coordinator.py
+++ b/checkov/secrets/coordinator.py
@@ -1,6 +1,6 @@
 from typing import Optional, Iterable, List, Tuple, Dict
 
-from detect_secrets.core.potential_secret import PotentialSecret
+from detect_secrets.core.potential_secret import PotentialSecret # noqa TC002
 
 from checkov.common.bridgecrew.severities import Severity
 from checkov.common.typing import _CheckResult

--- a/checkov/secrets/coordinator.py
+++ b/checkov/secrets/coordinator.py
@@ -4,13 +4,15 @@ from typing import Iterable, Dict, Optional
 class EnrichedSecret:
     __slots__ = ("original_secret", "bc_check_id", "resource")
 
-    def __init__(self, original_secret: Optional[str], bc_check_id: str, resource: str):
+    def __init__(self, original_secret: Optional[str], bc_check_id: str, resource: str) -> None:
         self.original_secret = original_secret
         self.bc_check_id = bc_check_id
         self.resource = resource
 
 
 class SecretsCoordinator:
+    __slots__ = ("_secrets", )
+
     def __init__(self) -> None:
         self._secrets: Dict[str, EnrichedSecret] = {}
 

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, Optional
 
 from detect_secrets import SecretsCollection
 from detect_secrets.core import scan
@@ -258,7 +258,8 @@ class Runner(BaseRunner[None]):
         return None
 
     @staticmethod
-    def save_secret_to_coordinator(secret_value: str, bc_check_id: str, resource: str, result: _CheckResult):
+    def save_secret_to_coordinator(secret_value: Optional[str], bc_check_id: str, resource: str, result: _CheckResult)\
+            -> None:
         enriched_secret = EnrichedSecret(original_secret=secret_value, bc_check_id=bc_check_id, resource=resource)
         if result.get('result') == CheckResult.FAILED and enriched_secret.original_secret is not None:
             secrets_coordinator.add_secret(enriched_secret=enriched_secret)

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -29,8 +29,8 @@ from checkov.common.typing import _CheckResult
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 from checkov.common.util.dockerfile import is_docker_file
 from checkov.common.util.secrets import omit_secret_value_from_line
-from checkov.secrets.coordinator import EnrichedSecret
 from checkov.runner_filter import RunnerFilter
+from checkov.secrets.coordinator import EnrichedSecret
 from checkov.secrets.coordinator import secrets_coordinator
 
 if TYPE_CHECKING:

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -174,16 +174,11 @@ class Runner(BaseRunner[None]):
                 # 'secret.secret_value' can actually be 'None', but only when 'PotentialSecret' was created
                 # via 'load_secret_from_dict'
                 enriched_secret = EnrichedSecret(
-                    potential_secret=secret,
-                    check_id=check_id,
+                    original_secret=secret.secret_value,
                     bc_check_id=bc_check_id,
-                    secret_key=secret_key,
-                    severity=severity,
-                    result=result,
-                    code_block=[(secret.line_number, line_text)],
                     resource=resource
                 )
-                secrets_coordinator.add_secret(enriched_secret)
+                secrets_coordinator.add_secret(enriched_secret=enriched_secret, check_result=result)
                 line_text_censored = omit_secret_value_from_line(cast(str, secret.secret_value), line_text)
                 report.add_record(Record(
                     check_id=check_id,

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -259,7 +259,6 @@ class Runner(BaseRunner[None]):
     @staticmethod
     def save_secret_to_coordinator(secret_value: Optional[str], bc_check_id: str, resource: str, result: _CheckResult)\
             -> None:
-        if result.get('result') == CheckResult.FAILED:
+        if result.get('result') == CheckResult.FAILED and secret_value is not None:
             enriched_secret = EnrichedSecret(original_secret=secret_value, bc_check_id=bc_check_id, resource=resource)
-            if enriched_secret.original_secret is not None:
-                secrets_coordinator.add_secret(enriched_secret=enriched_secret)
+            secrets_coordinator.add_secret(enriched_secret=enriched_secret)

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -259,6 +259,7 @@ class Runner(BaseRunner[None]):
     @staticmethod
     def save_secret_to_coordinator(secret_value: Optional[str], bc_check_id: str, resource: str, result: _CheckResult)\
             -> None:
-        enriched_secret = EnrichedSecret(original_secret=secret_value, bc_check_id=bc_check_id, resource=resource)
-        if result.get('result') == CheckResult.FAILED and enriched_secret.original_secret is not None:
-            secrets_coordinator.add_secret(enriched_secret=enriched_secret)
+        if result.get('result') == CheckResult.FAILED:
+            enriched_secret = EnrichedSecret(original_secret=secret_value, bc_check_id=bc_check_id, resource=resource)
+            if enriched_secret.original_secret is not None:
+                secrets_coordinator.add_secret(enriched_secret=enriched_secret)

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -173,7 +173,6 @@ class Runner(BaseRunner[None]):
                 report.add_resource(resource)
                 # 'secret.secret_value' can actually be 'None', but only when 'PotentialSecret' was created
                 # via 'load_secret_from_dict'
-                logging.info(f"{bc_check_id=}")
                 self.save_secret_to_coordinator(secret.secret_value, bc_check_id, resource, result)
                 line_text_censored = omit_secret_value_from_line(cast(str, secret.secret_value), line_text)
                 report.add_record(Record(

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -29,8 +29,8 @@ from checkov.common.typing import _CheckResult
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 from checkov.common.util.dockerfile import is_docker_file
 from checkov.common.util.secrets import omit_secret_value_from_line
-from checkov.runner_filter import RunnerFilter
 from checkov.secrets.coordinator import EnrichedSecret
+from checkov.runner_filter import RunnerFilter
 from checkov.secrets.coordinator import secrets_coordinator
 
 if TYPE_CHECKING:

--- a/tests/secrets/test_coordinator.py
+++ b/tests/secrets/test_coordinator.py
@@ -6,7 +6,7 @@ from checkov.secrets.runner import Runner
 from checkov.secrets.coordinator import secrets_coordinator
 
 
-class TestCCoordinator(unittest.TestCase):
+class TestCoordinator(unittest.TestCase):
 
     def test_same_resources_in_report_and_coordinator(self):
         test_root_folder = f'{Path(__file__).parent}'

--- a/tests/secrets/test_coordinator.py
+++ b/tests/secrets/test_coordinator.py
@@ -1,0 +1,17 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.secrets.runner import Runner
+from checkov.secrets.coordinator import secrets_coordinator
+
+
+class TestCCoordinator(unittest.TestCase):
+
+    def test_same_resources_in_report_and_coordinator(self):
+        test_root_folder = f'{Path(__file__).parent}'
+
+        report = Runner().run(
+            root_folder=test_root_folder, runner_filter=RunnerFilter(framework=['secrets'])
+        )
+        self.assertEqual(secrets_coordinator.get_resources(), report.resources)

--- a/tests/secrets/test_coordinator.py
+++ b/tests/secrets/test_coordinator.py
@@ -14,4 +14,6 @@ class TestCCoordinator(unittest.TestCase):
         report = Runner().run(
             root_folder=test_root_folder, runner_filter=RunnerFilter(framework=['secrets'])
         )
-        self.assertEqual(secrets_coordinator.get_resources(), report.resources)
+        secrets_resources_in_coordinator = secrets_coordinator.get_resources()
+        failed_resources_from_report = set(f"{record.file_abs_path}:{record.resource}" for record in report.failed_checks)
+        self.assertEqual(secrets_resources_in_coordinator, failed_resources_from_report)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

added a class to save secrets data for further validation.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
