### PR TITLE
fix(terraform): fix getting graph entity config in terraform runner

### DIFF
--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -241,7 +241,7 @@ class Runner(ImageReferencerMixin[None], BaseRunner[TerraformGraphManager]):
                             if referrer_id:
                                 resource = f'{referrer_id}.{resource_id}'
                         definition_context_file_path = get_tf_definition_key_from_module_dependency(full_file_path, module_dependency, module_dependency_num)
-                    entity_config = self.get_graph_resource_entity_config(entity, entity_context)
+                    entity_config = self.get_graph_resource_entity_config(entity)
                     censored_code_lines = omit_secret_value_from_graph_checks(check=check, check_result=check_result,
                                                                               entity_code_lines=entity_context.get(
                                                                                   'code_lines'),
@@ -627,9 +627,11 @@ class Runner(ImageReferencerMixin[None], BaseRunner[TerraformGraphManager]):
 
         return images
 
-    def get_graph_resource_entity_config(self, entity, entity_context):
-        definition_path = entity_context.get('definition_path', [])
-        entity_config = entity['config_']
+    @staticmethod
+    def get_graph_resource_entity_config(entity):
+        context_parser = parser_registry.context_parsers[entity[CustomAttributes.BLOCK_TYPE]]
+        entity_config = entity[CustomAttributes.CONFIG]
+        definition_path = context_parser.get_entity_definition_path(entity_config)
         for path in definition_path:
             entity_config = entity_config[path]
         return entity_config

--- a/tests/terraform/runner/resources/get_graph_resource_entity_config/main.tf
+++ b/tests/terraform/runner/resources/get_graph_resource_entity_config/main.tf
@@ -1,0 +1,37 @@
+provider "aws" {
+  alias      = "plain_text_access_keys_provider"
+  region     = "us-west-1"
+  access_key = "AKIAIOSFODNN7EXAMPLE"
+  secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+}
+
+locals {
+  resource_prefix = {
+    value = "${data.aws_caller_identity.current.account_id}-${var.company_name}-${var.environment}"
+  }
+}
+
+resource "aws_s3_bucket" "data" {
+  # bucket is public
+  # bucket is not encrypted
+  # bucket does not have access logs
+  # bucket does not have versioning
+  bucket        = "${local.resource_prefix.value}-data"
+  acl           = "public-read"
+  force_destroy = true
+  tags = {
+    Name                 = "${local.resource_prefix.value}-data"
+    Environment          = local.resource_prefix.value
+    git_commit           = "d68d2897add9bc2203a5ed0632a5cdd8ff8cefb0"
+    git_file             = "terraform/aws/s3.tf"
+    git_last_modified_at = "2020-06-16 14:46:24"
+    git_last_modified_by = "nimrodkor@gmail.com"
+    git_modifiers        = "nimrodkor"
+    git_org              = "try-bridgecrew"
+    git_repo             = "terragoat"
+    yor_trace            = "fc8c2d7a-1997-4fc2-95c1-277cba5c2a38"
+  }
+  versioning {
+    enabled = "${var.versioning_enabled}"
+  }
+}

--- a/tests/terraform/runner/resources/get_graph_resource_entity_config/variables.tf
+++ b/tests/terraform/runner/resources/get_graph_resource_entity_config/variables.tf
@@ -1,0 +1,15 @@
+variable "versioning_enabled" {
+  type        = bool
+  default     = false
+  description = "A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket"
+}
+
+variable "company_name" {
+  default = "acme"
+}
+
+variable "environment" {
+  default = "dev"
+}
+
+data "aws_caller_identity" "current" {}

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -14,12 +14,15 @@ from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.bridgecrew.severities import Severities, BcSeverities
 
 from checkov.common.checks_infra.registry import get_graph_checks_registry
+from checkov.common.graph.db_connectors.networkx.networkx_db_connector import NetworkxConnector
+from checkov.common.graph.graph_builder import CustomAttributes
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.common.output.report import Report
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.terraform.context_parsers.registry import parser_registry
+from checkov.terraform.graph_manager import TerraformGraphManager
 from checkov.terraform.parser import Parser
 from checkov.terraform.runner import Runner
 from checkov.terraform.checks.resource.registry import resource_registry
@@ -1627,6 +1630,17 @@ class TestRunnerValid(unittest.TestCase):
     def tearDown(self):
         parser_registry.context = {}
         resource_registry.checks = self.orig_checks
+
+    def test_get_graph_resource_entity_config(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        path_to_scan = os.path.join(current_dir, 'resources', 'get_graph_resource_entity_config')
+        graph_manager = TerraformGraphManager(db_connector=NetworkxConnector())
+        graph, _ = graph_manager.build_graph_from_source_directory(path_to_scan)
+        graph_manager.save_graph(graph)
+        graph_connector = graph_manager.get_reader_endpoint()
+        for _, data in graph_connector.nodes(data=True):
+            config = Runner.get_graph_resource_entity_config(data)
+            self.assertIn(CustomAttributes.TF_RESOURCE_ADDRESS, config)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
fix getting graph entity config in terraform runner, in some block types (`provider` for example) the entity config is not under the `definition_path` of the entity.

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
