### PR TITLE
docs(general): fix reference link in Contributing docs page

### DIFF
--- a/docs/6.Contribution/Contribute YAML-based Policies.md
+++ b/docs/6.Contribution/Contribute YAML-based Policies.md
@@ -9,7 +9,7 @@ nav_order: 3
 
 1. Define a policy as described [here](https://www.checkov.io/3.Custom%20Policies/YAML%20Custom%20Policies.html).
 2. Create a branch under the `checkov2` fork (will be changed + the URLs after merge) - `https://github.com/bridgecrewio/checkov`
-3. Add `<policy_name>.yaml` file to `https://github.com/bridgecrewio/checkov/tree/master/checkov/terraform/graph/checks` inside the relevant provider folder that matches your current policy.
+3. Add `<policy_name>.yaml` file to `https://github.com/bridgecrewio/checkov/tree/master/checkov/terraform/checks/graph_checks` inside the relevant provider folder that matches your current policy.
 
 ## Example
 `checkov/terraform/checks/graph_checks/aws/EBSAddedBackup.yaml`


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Updated an incorrect reference link in the docs.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
