### PR TITLE
feat(terraform): Add CKV2_AWS_51 to Ensure AWS Managed AdministratorAccess IAM policy is not used

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/IAMDoNotUseAdministratorAccessPolicy.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/IAMDoNotUseAdministratorAccessPolicy.yaml
@@ -1,0 +1,35 @@
+---
+metadata:
+  id: "CKV2_AWS_51"
+  name: "Ensure AWS Managed AdministratorAccess IAM policy is not used."
+  category: "IAM"
+  severity: "high"
+definition:
+  not:
+    or:
+      - cond_type: attribute
+        resource_types:
+        - "data.aws_iam_policy"
+        attribute: "name"
+        operator: equals
+        value: "AdministratorAccess" 
+      - cond_type: attribute
+        resource_types:
+        - "aws_iam_user_policy_attachment"
+        - "aws_iam_role_policy_attachment"
+        - "aws_iam_group_policy_attachment"
+        attribute: "policy_arn"
+        operator: contains
+        value: "AdministratorAccess"
+      - cond_type: attribute
+        resource_types:
+        - "data.aws_iam_policy"
+        attribute: "arn"
+        operator: contains
+        value: "AdministratorAccess" 
+      - cond_type: attribute
+        resource_types:
+        - "aws_ssoadmin_managed_policy_attachment"
+        attribute: "managed_policy_arn"
+        operator: contains
+        value: "AdministratorAccess"

--- a/tests/terraform/graph/checks/resources/IAMDoNotUseAdministratorAccessPolicy/expected.yaml
+++ b/tests/terraform/graph/checks/resources/IAMDoNotUseAdministratorAccessPolicy/expected.yaml
@@ -1,0 +1,12 @@
+pass:
+  - "aws_iam_policy.other_access_name_pass"
+  - "aws_iam_policy.other_access_arn_pass"
+  - "aws_iam_user_policy_attachment.test_attach_pass"
+  - "aws_ssoadmin_managed_policy_attachment.amazon_ec2_read_only_access_pass"
+fail:
+  - "aws_iam_policy.administrator_access_name_fail"
+  - "aws_iam_policy.administrator_access_arn_fail"
+  - "aws_iam_user_policy_attachment.test_attach_fail"
+  - "aws_iam_role_policy_attachment.test_attach_fail"
+  - "aws_iam_group_policy_attachment.test_attach_fail"
+  - "aws_ssoadmin_managed_policy_attachment.administrator_access_fail"

--- a/tests/terraform/graph/checks/resources/IAMDoNotUseAdministratorAccessPolicy/main.tf
+++ b/tests/terraform/graph/checks/resources/IAMDoNotUseAdministratorAccessPolicy/main.tf
@@ -1,0 +1,52 @@
+# Test data type with AdministratorAccess via name - Fail
+data "aws_iam_policy" "administrator_access_name_fail" {
+  name = "AdministratorAccess"
+}
+# Test data type with AdministratorAccess via ARN - Fail
+data "aws_iam_policy" "administrator_access_arn_fail" {
+  arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+# Test data type with other policy via name - Pass
+data "aws_iam_policy" "other_access_name_pass" {
+  name = "AmazonEC2ReadOnlyAccess"
+}
+# Test data type with other policy via ARN - Pass
+data "aws_iam_policy" "other_access_arn_pass" {
+  arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+}
+
+# Test user policy attachment with AdministratorAccess - Fail
+resource "aws_iam_user_policy_attachment" "test_attach_fail" {
+  user       = aws_iam_user.user.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+# Test user policy attachment with other policy - Fail
+resource "aws_iam_user_policy_attachment" "test_attach_pass" {
+  user       = aws_iam_user.user2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+}
+
+# Test role policy attachment with AdministratorAccess - Fail
+resource "aws_iam_role_policy_attachment" "test_attach_fail" {
+  role       = aws_iam_role.role.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+# Test group policy attachment with AdministratorAccess - Fail
+resource "aws_iam_group_policy_attachment" "test_attach_fail" {
+  group      = aws_iam_group.group.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+# Test SSO policy attachment with AdministratorAccess - Fail
+resource "aws_ssoadmin_managed_policy_attachment" "administrator_access_fail" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.my_instance.arns)[0]
+  managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.admins.arn
+}
+# Test SSO policy attachment with other policy - Pass
+resource "aws_ssoadmin_managed_policy_attachment" "amazon_ec2_read_only_access_pass" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.my_instance.arns)[0]
+  managed_policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.viewers.arn
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -167,6 +167,9 @@ class TestYamlPolicies(unittest.TestCase):
     def test_AutoScalingEnabledLB(self):
         self.go("AutoScalingEnabledLB")
 
+    def test_IAMDoNotUseAdministratorAccessPolicy(self):
+        self.go("IAMDoNotUseAdministratorAccessPolicy")
+    
     def test_IAMGroupHasAtLeastOneUser(self):
         self.go("IAMGroupHasAtLeastOneUser")
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Add new Check to Ensure AWS Managed AdministratorAccess IAM policy is not used.

Fixes # (issue)

## New/Edited policies (Delete if not relevant)
Add CKV2_AWS_51

### Description
*Include a description of what makes it a violation and any relevant external links.*
In general, AdministratorAccess policy should not be used due to high risk privileges.

### Fix
*How does someone fix the issue in code and/or in runtime?*
Use least privilege and create custom policy or attach a much lower privilege policy that fits their needs.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
