### PR TITLE
chore: add missing type hints under cloudformation

### DIFF
--- a/checkov/bicep/graph_builder/variable_rendering/renderer.py
+++ b/checkov/bicep/graph_builder/variable_rendering/renderer.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from checkov.bicep.graph_builder.local_graph import BicepLocalGraph
 
 
-class BicepVariableRenderer(VariableRenderer):
+class BicepVariableRenderer(VariableRenderer["BicepLocalGraph"]):
     def __init__(self, local_graph: BicepLocalGraph) -> None:
         super().__init__(local_graph)
 

--- a/checkov/cloudformation/checks/utils/iam_cloudformation_document_to_policy_converter.py
+++ b/checkov/cloudformation/checks/utils/iam_cloudformation_document_to_policy_converter.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import copy
+from typing import Any
 
-from checkov.common.parsers.node import DictNode
 
-
-def convert_cloudformation_conf_to_iam_policy(conf: DictNode) -> DictNode:
+def convert_cloudformation_conf_to_iam_policy(conf: dict[str, Any]) -> dict[str, Any]:
     """
         converts terraform parsed configuration to iam policy document
     """

--- a/checkov/cloudformation/graph_builder/graph_components/blocks.py
+++ b/checkov/cloudformation/graph_builder/graph_components/blocks.py
@@ -36,9 +36,9 @@ class CloudformationBlock(Block):
     def update_attribute(
         self, attribute_key: str,
         attribute_value: Any,
-        change_origin_id: int,
+        change_origin_id: int | None,
         previous_breadcrumbs: List[BreadcrumbMetadata],
-        attribute_at_dest: str,
+        attribute_at_dest: str | None,
         transform_step: bool = False,
     ) -> None:
         super().update_attribute(
@@ -82,7 +82,7 @@ class CloudformationBlock(Block):
     @staticmethod
     def _should_add_previous_breadcrumbs(change_origin_id: Optional[int],
                                          previous_breadcrumbs: List[BreadcrumbMetadata],
-                                         attribute_at_dest: Optional[str]):
+                                         attribute_at_dest: Optional[str]) -> bool:
         return (
             change_origin_id is not None
             and attribute_at_dest is not None
@@ -90,5 +90,5 @@ class CloudformationBlock(Block):
         )
 
     @staticmethod
-    def _should_set_changed_attributes(change_origin_id: Optional[int], attribute_at_dest: Optional[str]):
+    def _should_set_changed_attributes(change_origin_id: Optional[int], attribute_at_dest: Optional[str]) -> bool:
         return change_origin_id is not None and attribute_at_dest is not None

--- a/checkov/cloudformation/graph_builder/graph_components/generic_resource_encryption.py
+++ b/checkov/cloudformation/graph_builder/graph_components/generic_resource_encryption.py
@@ -1,13 +1,15 @@
-from typing import Dict, List, Union, Any
+from __future__ import annotations
+
 from checkov.common.graph.graph_builder import EncryptionTypes
 from checkov.common.graph.graph_builder.graph_components.generic_resource_encryption_base import GenericResourceEncryptionBase
+from checkov.common.util.data_structures_utils import get_empty_list_str
 
 
 class GenericResourceEncryption(GenericResourceEncryptionBase):
     def __init__(
         self,
         resource_type: str,
-        attribute_values_map: Dict[str, Union[List[bool], List[str]]],
+        attribute_values_map: dict[str, list[bool] | list[str]],
         enabled_by_default: bool = False,
     ) -> None:
         super().__init__(resource_type,
@@ -20,38 +22,38 @@ class GenericResourceEncryption(GenericResourceEncryptionBase):
 
 # This map allows dynamically creating the check for each resource type based on GenericResourceEncryption.
 # Please check out the constructor to understand all the edge cases.
-ENCRYPTION_BY_RESOURCE_TYPE: Dict[str, Any] = {
+ENCRYPTION_BY_RESOURCE_TYPE: dict[str, GenericResourceEncryption] = {
     "AWS::ECR::Repository": GenericResourceEncryption(
         "AWS::ECR::Repository",
         {
             "EncryptionConfiguration.EncryptionType": [EncryptionTypes.AES256.value, EncryptionTypes.KMS_VALUE.value],
-            "EncryptionConfiguration.KmsKey": [],
+            "EncryptionConfiguration.KmsKey": get_empty_list_str(),
         },
     ),
     "AWS::Neptune::DBCluster": GenericResourceEncryption(
-        "AWS::Neptune::DBCluster", {"StorageEncrypted": [True], "KmsKeyId": []}
+        "AWS::Neptune::DBCluster", {"StorageEncrypted": [True], "KmsKeyId": get_empty_list_str()}
     ),
-    "AWS::EFS::FileSystem": GenericResourceEncryption("AWS::EFS::FileSystem", {"Encrypted": [True], "KmsKeyId": []}),
-    "AWS::EC2::Volume": GenericResourceEncryption("AWS::EC2::Volume", {"Encrypted": [True], "KmsKeyId": []}),
+    "AWS::EFS::FileSystem": GenericResourceEncryption("AWS::EFS::FileSystem", {"Encrypted": [True], "KmsKeyId": get_empty_list_str()}),
+    "AWS::EC2::Volume": GenericResourceEncryption("AWS::EC2::Volume", {"Encrypted": [True], "KmsKeyId": get_empty_list_str()}),
     "AWS::ElastiCache::ReplicationGroup": GenericResourceEncryption(
         "AWS::ElastiCache::ReplicationGroup", {"AtRestEncryptionEnabled": [True], "KmsKeyId": ["arn"]}
     ),
     "AWS::Elasticsearch::Domain": GenericResourceEncryption(
         "AWS::Elasticsearch::Domain",
-        {"EncryptionAtRestOptions.Enabled": [True], "EncryptionAtRestOptions.KmsKeyId": [], "NodeToNodeEncryptionOptions.Enabled": [True]},
+        {"EncryptionAtRestOptions.Enabled": [True], "EncryptionAtRestOptions.KmsKeyId": get_empty_list_str(), "NodeToNodeEncryptionOptions.Enabled": [True]},
     ),
     "AWS::MSK::Cluster": GenericResourceEncryption(
-        "AWS::MSK::Cluster", {"EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId": []}
+        "AWS::MSK::Cluster", {"EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId": get_empty_list_str()}
     ),
     "AWS::DocDB::DBCluster": GenericResourceEncryption(
-        "AWS::DocDB::DBCluster", {"StorageEncrypted": [True], "KmsKeyId": []}
+        "AWS::DocDB::DBCluster", {"StorageEncrypted": [True], "KmsKeyId": get_empty_list_str()}
     ),
-    "AWS::CodeBuild::Project": GenericResourceEncryption("AWS::CodeBuild::Project", {"EncryptionKey": []}),
+    "AWS::CodeBuild::Project": GenericResourceEncryption("AWS::CodeBuild::Project", {"EncryptionKey": get_empty_list_str()}),
     "AWS::CodeBuild::ReportGroup": GenericResourceEncryption(
         "AWS::CodeBuild::ReportGroup",
         {
             "ExportConfig.S3Destination.EncryptionDisabled": [False],
-            "ExportConfig.S3Destination.EncryptionKey": [],
+            "ExportConfig.S3Destination.EncryptionKey": get_empty_list_str(),
         },
     ),
     "AWS::Athena::WorkGroup": GenericResourceEncryption(
@@ -62,19 +64,19 @@ ENCRYPTION_BY_RESOURCE_TYPE: Dict[str, Any] = {
                 "SSE_KMS",
                 "CSE_KMS",
             ],
-            "WorkGroupConfiguration.ResultConfiguration.EncryptionConfiguration.KmsKey": [],
+            "WorkGroupConfiguration.ResultConfiguration.EncryptionConfiguration.KmsKey": get_empty_list_str(),
         },
     ),
     "AWS::Kinesis::Stream": GenericResourceEncryption(
-        "AWS::Kinesis::Stream", {"StreamEncryption.EncryptionType": [EncryptionTypes.KMS_VALUE.value], "StreamEncryption.KeyId": []}
+        "AWS::Kinesis::Stream", {"StreamEncryption.EncryptionType": [EncryptionTypes.KMS_VALUE.value], "StreamEncryption.KeyId": get_empty_list_str()}
     ),
-    "AWS::EKS::Cluster": GenericResourceEncryption("AWS::EKS::Cluster", {"EncryptionConfig.Provider.KeyArn": []}),
+    "AWS::EKS::Cluster": GenericResourceEncryption("AWS::EKS::Cluster", {"EncryptionConfig.Provider.KeyArn": get_empty_list_str()}),
     "AWS::DynamoDB::Table": GenericResourceEncryption(
         "AWS::DynamoDB::Table",
-        {"SSESpecification.SSEEnabled": [True], "SSESpecification.KMSMasterKeyId": [], "SSESpecification.SSEType": []},
+        {"SSESpecification.SSEEnabled": [True], "SSESpecification.KMSMasterKeyId": get_empty_list_str(), "SSESpecification.SSEType": get_empty_list_str()},
         enabled_by_default=True,
     ),
-    "AWS::RDS::DBCluster": GenericResourceEncryption("AWS::RDS::DBCluster", {"StorageEncrypted": [True], "KmsKeyId": []}),
+    "AWS::RDS::DBCluster": GenericResourceEncryption("AWS::RDS::DBCluster", {"StorageEncrypted": [True], "KmsKeyId": get_empty_list_str()}),
     "AWS::RDS::GlobalCluster": GenericResourceEncryption("AWS::RDS::GlobalCluster", {"StorageEncrypted": [True]}),
     "AWS::S3::Bucket": GenericResourceEncryption(
         "AWS::S3::Bucket",
@@ -83,16 +85,16 @@ ENCRYPTION_BY_RESOURCE_TYPE: Dict[str, Any] = {
                 EncryptionTypes.AWS_KMS_VALUE.value,
                 EncryptionTypes.AES256.value,
             ],
-            "server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.KMSMasterKeyID": [],
+            "server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.KMSMasterKeyID": get_empty_list_str(),
         },
     ),
     "AWS::Logs::LogGroup": GenericResourceEncryption(
-        "AWS::Logs::LogGroup", {"KmsKeyId": []}, enabled_by_default=True
+        "AWS::Logs::LogGroup", {"KmsKeyId": get_empty_list_str()}, enabled_by_default=True
     ),
-    "AWS::CloudTrail::Trail": GenericResourceEncryption("AWS::CloudTrail::Trail", {"KMSKeyId": []}),
+    "AWS::CloudTrail::Trail": GenericResourceEncryption("AWS::CloudTrail::Trail", {"KMSKeyId": get_empty_list_str()}),
     "AWS::DAX::Cluster": GenericResourceEncryption("AWS::DAX::Cluster", {"SSESpecification.SSEEnabled": [True]}),
-    "AWS::Redshift::Cluster": GenericResourceEncryption("AWS::Redshift::Cluster", {"Encrypted": [True], "KmsKeyId": []}),
-    "AWS::SNS::Topic": GenericResourceEncryption("AWS::SNS::Topic", {"KmsMasterKeyId": []}),
-    "AWS::SQS::Queue": GenericResourceEncryption("AWS::SQS::Queue", {"KmsMasterKeyId": []}),
+    "AWS::Redshift::Cluster": GenericResourceEncryption("AWS::Redshift::Cluster", {"Encrypted": [True], "KmsKeyId": get_empty_list_str()}),
+    "AWS::SNS::Topic": GenericResourceEncryption("AWS::SNS::Topic", {"KmsMasterKeyId": get_empty_list_str()}),
+    "AWS::SQS::Queue": GenericResourceEncryption("AWS::SQS::Queue", {"KmsMasterKeyId": get_empty_list_str()}),
     "AWS::RDS::DBInstance": GenericResourceEncryption("AWS::RDS::DBInstance", {"StorageEncrypted": [True]})
 }

--- a/checkov/cloudformation/graph_builder/graph_to_definitions.py
+++ b/checkov/cloudformation/graph_builder/graph_to_definitions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from typing import List, Dict, Any, Tuple
 
@@ -7,7 +9,7 @@ from checkov.cloudformation.graph_builder.graph_components.blocks import Cloudfo
 
 
 def convert_graph_vertices_to_definitions(
-    vertices: List[CloudformationBlock], root_folder: str
+    vertices: List[CloudformationBlock], root_folder: str | None
 ) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Dict[str, Any]]]:
     definitions: Dict[str, Dict[str, Any]] = {}
     breadcrumbs: Dict[str, Dict[str, Any]] = {}

--- a/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
@@ -4,7 +4,7 @@ import logging
 from copy import deepcopy
 from typing import TYPE_CHECKING, Tuple, List, Any, Dict, Optional, Callable
 
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 from checkov.cloudformation.graph_builder.graph_components.block_types import BlockType
 from checkov.cloudformation.graph_builder.utils import get_referenced_vertices_in_value, find_all_interpolations

--- a/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
@@ -17,7 +17,10 @@ from checkov.common.graph.graph_builder.variable_rendering.renderer import Varia
 if TYPE_CHECKING:
     from checkov.cloudformation.graph_builder.graph_components.blocks import CloudformationBlock
     from checkov.cloudformation.graph_builder.local_graph import CloudformationLocalGraph
+    from typing_extensions import TypeAlias
 
+_EdgeEvaluationMethodsEntry: TypeAlias = "dict[str, Callable[[Any, dict[str, Any]], tuple[str | None, str | None]]]"
+_VertexEvaluationMethodsEntry: TypeAlias = "dict[str, Callable[[Any], str | None]]"
 
 class _EvaluatedEdge(TypedDict):
     vertex_index: int
@@ -37,7 +40,7 @@ class CloudformationVariableRenderer(VariableRenderer["CloudformationLocalGraph"
 
     def __init__(self, local_graph: "CloudformationLocalGraph") -> None:
         super().__init__(local_graph)
-        self.edge_evaluation_methods: "dict[str, Callable[[Any, dict[str, Any]], tuple[str | None, str | None]]]" = {
+        self.edge_evaluation_methods: _EdgeEvaluationMethodsEntry = {
             IntrinsicFunctions.REF: self._evaluate_ref_connection,
             IntrinsicFunctions.FIND_IN_MAP: self._evaluate_findinmap_connection,
             IntrinsicFunctions.GET_ATT: self._evaluate_getatt_connection,
@@ -117,7 +120,7 @@ class CloudformationVariableRenderer(VariableRenderer["CloudformationLocalGraph"
 
         if isinstance(selection_list, str):
             selection_list = selection_list.split(', ')
-        # convert idx_to_select to int if possible cause it might be a str_node
+        # convert idx_to_select to int if possible because it might be a str_node
         if isinstance(idx_to_select, str) and str.isdecimal(idx_to_select):
             idx_to_select = int(idx_to_select)
         if isinstance(idx_to_select, int) and isinstance(selection_list, list) \

--- a/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 _EdgeEvaluationMethodsEntry: TypeAlias = "dict[str, Callable[[Any, dict[str, Any]], tuple[str | None, str | None]]]"
 _VertexEvaluationMethodsEntry: TypeAlias = "dict[str, Callable[[Any], str | None]]"
 
+
 class _EvaluatedEdge(TypedDict):
     vertex_index: int
     attribute_key: str

--- a/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from typing import TYPE_CHECKING, Tuple, List, Any, Dict, Optional
+from typing import TYPE_CHECKING, Tuple, List, Any, Dict, Optional, Callable
+
+from mypy_extensions import TypedDict
 
 from checkov.cloudformation.graph_builder.graph_components.block_types import BlockType
 from checkov.cloudformation.graph_builder.utils import get_referenced_vertices_in_value, find_all_interpolations
@@ -13,10 +15,19 @@ from checkov.common.graph.graph_builder.graph_components.blocks import Block
 from checkov.common.graph.graph_builder.variable_rendering.renderer import VariableRenderer
 
 if TYPE_CHECKING:
+    from checkov.cloudformation.graph_builder.graph_components.blocks import CloudformationBlock
     from checkov.cloudformation.graph_builder.local_graph import CloudformationLocalGraph
 
 
-class CloudformationVariableRenderer(VariableRenderer):
+class _EvaluatedEdge(TypedDict):
+    vertex_index: int
+    attribute_key: str
+    attribute_value: Any
+    change_origin_id: int | None
+    attribute_at_dest: str | None
+
+
+class CloudformationVariableRenderer(VariableRenderer["CloudformationLocalGraph"]):
     EDGE_EVALUATION_CFN_FUNCTIONS = (
         IntrinsicFunctions.REF, IntrinsicFunctions.FIND_IN_MAP, IntrinsicFunctions.GET_ATT,
         IntrinsicFunctions.SUB, ConditionFunctions.IF)
@@ -26,13 +37,13 @@ class CloudformationVariableRenderer(VariableRenderer):
 
     def __init__(self, local_graph: "CloudformationLocalGraph") -> None:
         super().__init__(local_graph)
-        self.edge_evaluation_methods = {
+        self.edge_evaluation_methods: "dict[str, Callable[[Any, dict[str, Any]], tuple[str | None, str | None]]]" = {
             IntrinsicFunctions.REF: self._evaluate_ref_connection,
             IntrinsicFunctions.FIND_IN_MAP: self._evaluate_findinmap_connection,
             IntrinsicFunctions.GET_ATT: self._evaluate_getatt_connection,
             IntrinsicFunctions.SUB: self._evaluate_sub_connection
         }
-        self.vertex_evaluation_methods = {
+        self.vertex_evaluation_methods: "dict[str, Callable[[Any], str | None]]" = {
             IntrinsicFunctions.SELECT: self._evaluate_select_function,
             IntrinsicFunctions.JOIN: self._evaluate_join_function
         }
@@ -91,14 +102,19 @@ class CloudformationVariableRenderer(VariableRenderer):
     """
 
     @staticmethod
-    def _evaluate_select_function(value: str) -> Optional[str]:
+    def _evaluate_select_function(value: list[int | str | list[str]]) -> Optional[str]:
         evaluated_value = None
         if len(value) != 2:
             return None
+
         idx_to_select = value[0]
+        if not isinstance(idx_to_select, (int, str)):
+            return None
+
         selection_list = value[1]
         if not isinstance(selection_list, (str, list)):
             return None
+
         if isinstance(selection_list, str):
             selection_list = selection_list.split(', ')
         # convert idx_to_select to int if possible cause it might be a str_node
@@ -119,7 +135,7 @@ class CloudformationVariableRenderer(VariableRenderer):
         """
 
     @staticmethod
-    def _evaluate_join_function(value: str) -> Optional[str]:
+    def _evaluate_join_function(value: list[str | list[str]]) -> Optional[str]:
         evaluated_value = None
         if len(value) != 2:
             return None
@@ -129,8 +145,8 @@ class CloudformationVariableRenderer(VariableRenderer):
             return None
         if isinstance(values_list, str):
             values_list = values_list.split(', ')
-        for value in values_list:
-            if not isinstance(value, str):
+        for inner_value in values_list:
+            if not isinstance(inner_value, str):
                 return None
         if isinstance(delimiter, str) and isinstance(values_list, list):
             for curr_value in values_list:
@@ -141,7 +157,7 @@ class CloudformationVariableRenderer(VariableRenderer):
         return evaluated_value
 
     @staticmethod
-    def _evaluate_ref_connection(value: str, dest_vertex_attributes: Dict[str, Any]) -> (Optional[str], Optional[str]):
+    def _evaluate_ref_connection(value: Any, dest_vertex_attributes: Dict[str, Any]) -> tuple[str | None, str | None]:
         # in case of Ref we take only Parameter's default value
         attribute_at_dest = 'Default'
         evaluated_value = dest_vertex_attributes.get(attribute_at_dest)
@@ -153,9 +169,9 @@ class CloudformationVariableRenderer(VariableRenderer):
             return str(evaluated_value), attribute_at_dest
         return None, None
 
-    def _fetch_vertex_attributes(self, block_name, block_type):
+    def _fetch_vertex_attributes(self, block_name: str, block_type: str) -> dict[str, Any] | None:
         vertex_attributes = None
-        vertex_index_list = self.local_graph.vertices_block_name_map.get(block_type, None).get(block_name, None)
+        vertex_index_list = self.local_graph.vertices_block_name_map.get(block_type, {}).get(block_name, None)
         if isinstance(vertex_index_list, list):
             vertex_index = vertex_index_list[0]
             vertex_attributes = self.local_graph.get_vertex_attributes_by_index(vertex_index)
@@ -189,7 +205,7 @@ class CloudformationVariableRenderer(VariableRenderer):
 
         return self._evaluate_condition(condition_to_evaluate, value_to_evaluate)
 
-    def _evaluate_condition(self, condition_fn: str, value: Any) -> Optional[bool]:
+    def _evaluate_condition(self, condition_fn: str | None, value: Any) -> Optional[bool]:
         """
         Evaluate CFN condition function's value
         Examples
@@ -245,8 +261,9 @@ class CloudformationVariableRenderer(VariableRenderer):
         return None
 
     @staticmethod
-    def _evaluate_findinmap_connection(value: List[str], dest_vertex_attributes: Dict[str, Any]) -> (
-            Optional[str], Optional[str]):
+    def _evaluate_findinmap_connection(
+        value: Any, dest_vertex_attributes: Dict[str, Any]
+    ) -> tuple[str | None, str | None]:
         # value = [ "MapName", "TopLevelKey", "SecondLevelKey"]
         if isinstance(value, list) and len(value) == 3:
             map_name = value[0]
@@ -264,14 +281,15 @@ class CloudformationVariableRenderer(VariableRenderer):
         return None, None
 
     @staticmethod
-    def _evaluate_getatt_connection(value: List[str], dest_vertex_attributes: Dict[str, Any]) -> (
-            Optional[str], Optional[str]):
+    def _evaluate_getatt_connection(
+        value: Any, dest_vertex_attributes: Dict[str, Any]
+    ) -> tuple[str | None, str | None]:
         # value = [ "logicalNameOfResource", "attributeName" ]
         try:
             if isinstance(value, list) and len(value) == 2:
                 resource_name = value[0]
                 attribute_at_dest = value[1]
-                dest_name = dest_vertex_attributes.get(CustomAttributes.BLOCK_NAME).split('.')[-1]
+                dest_name = dest_vertex_attributes[CustomAttributes.BLOCK_NAME].split('.')[-1]
                 evaluated_value = dest_vertex_attributes.get(
                     attribute_at_dest)  # we extract only build time atts, not runtime
 
@@ -285,8 +303,9 @@ class CloudformationVariableRenderer(VariableRenderer):
 
         return None, None
 
-    def _evaluate_sub_connection(self, value: str, dest_vertex_attributes: Dict[str, Any]) -> (
-            Optional[str], Optional[str]):
+    def _evaluate_sub_connection(
+        self, value: Any, dest_vertex_attributes: Dict[str, Any]
+    ) -> tuple[str | None, str | None]:
         if isinstance(value, (list, dict)):
             # TODO: Render values of list/dict types
             return None, None
@@ -320,8 +339,9 @@ class CloudformationVariableRenderer(VariableRenderer):
 
         return evaluated_value, attribute_at_dest
 
-    def _evaluate_if_connection(self, value: List[str], condition_vertex_attributes: Dict[str, Any]) -> (
-            Optional[str], Optional[str]):
+    def _evaluate_if_connection(
+        self, value: List[str], condition_vertex_attributes: Dict[str, Any]
+    ) -> tuple[str | None, str | None]:
         """
         Evaluate a Condition Function IF.
         This method receives 2 parameters:
@@ -359,7 +379,7 @@ class CloudformationVariableRenderer(VariableRenderer):
             if isinstance(operand_to_eval, str):
                 # The operand is a simple string
                 evaluated_value = operand_to_eval
-                evaluated_value_hierarchy = operand_index
+                evaluated_value_hierarchy = str(operand_index)
             elif isinstance(operand_to_eval, dict) and ConditionFunctions.IF in operand_to_eval:
                 # The operand is {'Fn::If': new value to evaluate}
                 condition_to_eval = operand_to_eval[ConditionFunctions.IF]
@@ -403,7 +423,7 @@ class CloudformationVariableRenderer(VariableRenderer):
         vertices_block_name_map[BlockType.RESOURCE] = updated_resources_blocks_name_map
         return vertices_block_name_map
 
-    def _handle_dependson_condition_connections(self, edge: Edge, origin_vertex: Block) -> None:
+    def _handle_dependson_condition_connections(self, edge: Edge, origin_vertex: CloudformationBlock) -> None:
         if edge.label == IntrinsicFunctions.CONDITION:
             dest_vertex_attributes = self.local_graph.get_vertex_attributes_by_index(edge.dest)
             evaluated_condition = self._evaluate_condition_by_vertex_attributes(dest_vertex_attributes)
@@ -423,7 +443,7 @@ class CloudformationVariableRenderer(VariableRenderer):
         if cfn_evaluation_function:
             original_value = val_to_eval.get(cfn_evaluation_function, None)
 
-            evaluated_edges = list()
+            evaluated_edges: "list[_EvaluatedEdge]" = []
             for edge in edge_list:
                 dest_vertex_attributes = self.local_graph.get_vertex_attributes_by_index(edge.dest)
                 try:
@@ -431,6 +451,7 @@ class CloudformationVariableRenderer(VariableRenderer):
                         edge, origin_vertex, cfn_evaluation_function, val_to_eval, dest_vertex_attributes)
                 except KeyError:
                     logging.info(f'Failed to evalue cfn function. val_to_eval: {val_to_eval}')
+                    continue
 
                 if evaluated_value and evaluated_value != original_value:
                     # succeeded to evaluate an edge
@@ -448,13 +469,13 @@ class CloudformationVariableRenderer(VariableRenderer):
 
             if len(evaluated_edges) == len(edge_list):
                 # succeeded in evaluation all of the edges
-                for evaluated_value in evaluated_edges:
+                for evaluated_edge in evaluated_edges:
                     self.local_graph.update_vertex_attribute(
-                        vertex_index=evaluated_value['vertex_index'],
-                        attribute_key=evaluated_value['attribute_key'],
-                        attribute_value=evaluated_value['attribute_value'],
-                        change_origin_id=evaluated_value['change_origin_id'],
-                        attribute_at_dest=evaluated_value['attribute_at_dest']
+                        vertex_index=evaluated_edge['vertex_index'],
+                        attribute_key=evaluated_edge['attribute_key'],
+                        attribute_value=evaluated_edge['attribute_value'],
+                        change_origin_id=evaluated_edge['change_origin_id'],
+                        attribute_at_dest=evaluated_edge['attribute_at_dest']
                     )
 
     def _evaluate_cfn_function(

--- a/checkov/cloudformation/graph_builder/variable_rendering/vertex_reference.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/vertex_reference.py
@@ -1,13 +1,13 @@
-from typing import Union, List
+from __future__ import annotations
 
 from checkov.common.graph.graph_builder.variable_rendering.vertex_reference import VertexReference
 from checkov.cloudformation.graph_builder.graph_components.block_types import BlockType
 
 
-class CloudformationVertexReference(VertexReference[BlockType]):
-    def __init__(self, block_type: Union[str, BlockType], sub_parts: List[str], origin_value: str) -> None:
+class CloudformationVertexReference(VertexReference):
+    def __init__(self, block_type: str, sub_parts: list[str], origin_value: str) -> None:
         super().__init__(block_type, sub_parts, origin_value)
 
     @staticmethod
-    def block_type_str_to_enum(block_type_str: str) -> BlockType:
+    def block_type_str_to_enum(block_type_str: str) -> str:
         return BlockType().get(block_type_str)

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -98,8 +98,10 @@ class Runner(ImageReferencerMixin[None], BaseRunner[CloudformationGraphManager])
                     if vertex.block_type == BlockType.RESOURCE:
                         report.add_resource(f'{vertex.path}:{vertex.id}')
                 self.graph_manager.save_graph(local_graph)
-                self.definitions, self.breadcrumbs = convert_graph_vertices_to_definitions(local_graph.vertices,
-                                                                                           root_folder)
+                self.definitions, self.breadcrumbs = convert_graph_vertices_to_definitions(
+                    vertices=local_graph.vertices,
+                    root_folder=root_folder,
+                )
 
         # TODO: replace with real graph rendering
         for cf_file in self.definitions.keys():

--- a/checkov/common/graph/graph_builder/graph_components/blocks.py
+++ b/checkov/common/graph/graph_builder/graph_components/blocks.py
@@ -150,7 +150,6 @@ class Block:
         if (
             self._should_add_previous_breadcrumbs(change_origin_id, previous_breadcrumbs, attribute_at_dest)
             and change_origin_id is not None
-            and attribute_at_dest is not None
         ):
             previous_breadcrumbs.append(BreadcrumbMetadata(change_origin_id, attribute_at_dest))
 

--- a/checkov/common/graph/graph_builder/graph_components/blocks.py
+++ b/checkov/common/graph/graph_builder/graph_components/blocks.py
@@ -136,9 +136,9 @@ class Block:
         self,
         attribute_key: str,
         attribute_value: Any,
-        change_origin_id: int,
+        change_origin_id: int | None,
         previous_breadcrumbs: list[BreadcrumbMetadata],
-        attribute_at_dest: str,
+        attribute_at_dest: str | None,
         transform_step: bool = False,
     ) -> None:
         self.update_inner_attribute(
@@ -147,7 +147,11 @@ class Block:
             value_to_update=attribute_value
         )
 
-        if self._should_add_previous_breadcrumbs(change_origin_id, previous_breadcrumbs, attribute_at_dest):
+        if (
+            self._should_add_previous_breadcrumbs(change_origin_id, previous_breadcrumbs, attribute_at_dest)
+            and change_origin_id is not None
+            and attribute_at_dest is not None
+        ):
             previous_breadcrumbs.append(BreadcrumbMetadata(change_origin_id, attribute_at_dest))
 
         # update the numbered attributes, if the new value is a list

--- a/checkov/common/graph/graph_builder/local_graph.py
+++ b/checkov/common/graph/graph_builder/local_graph.py
@@ -85,12 +85,12 @@ class LocalGraph(Generic[_Block]):
         vertex_index: int,
         attribute_key: str,
         attribute_value: Any,
-        change_origin_id: int,
-        attribute_at_dest: str,
+        change_origin_id: int | None,
+        attribute_at_dest: str | None,
         transform_step: bool = False
     ) -> None:
         previous_breadcrumbs = []
-        if attribute_at_dest:
+        if attribute_at_dest and change_origin_id is not None:
             previous_breadcrumbs = self.vertices[change_origin_id].changed_attributes.get(attribute_at_dest, [])
         self.vertices[vertex_index].update_attribute(
             attribute_key, attribute_value, change_origin_id, previous_breadcrumbs, attribute_at_dest, transform_step

--- a/checkov/common/graph/graph_builder/variable_rendering/breadcrumb_metadata.py
+++ b/checkov/common/graph/graph_builder/variable_rendering/breadcrumb_metadata.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 class BreadcrumbMetadata:
     __slots__ = ("attribute_key", "vertex_id")
 
-    def __init__(self, vertex_id: int, attribute_key: str):
+    def __init__(self, vertex_id: int, attribute_key: str | None):
         self.vertex_id = vertex_id
         self.attribute_key = attribute_key

--- a/checkov/common/graph/graph_builder/variable_rendering/breadcrumb_metadata.py
+++ b/checkov/common/graph/graph_builder/variable_rendering/breadcrumb_metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+
 class BreadcrumbMetadata:
     __slots__ = ("attribute_key", "vertex_id")
 

--- a/checkov/common/graph/graph_builder/variable_rendering/renderer.py
+++ b/checkov/common/graph/graph_builder/variable_rendering/renderer.py
@@ -3,22 +3,22 @@ from __future__ import annotations
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Dict, Any, Iterable, TypeVar
+from typing import TYPE_CHECKING, List, Dict, Any, Iterable, TypeVar, Generic
 
 from checkov.common.graph.graph_builder import Edge
 from checkov.common.graph.graph_builder.utils import run_function_multithreaded
 
 if TYPE_CHECKING:
     from checkov.common.graph.graph_builder.graph_components.blocks import Block  # noqa
-    from checkov.common.graph.graph_builder.local_graph import LocalGraph
+    from checkov.common.graph.graph_builder.local_graph import LocalGraph  # noqa
 
-_Block = TypeVar("_Block", bound="Block")
+_LocalGraph = TypeVar("_LocalGraph", bound="LocalGraph[Any]")
 
 
-class VariableRenderer(ABC):
+class VariableRenderer(ABC, Generic[_LocalGraph]):
     MAX_NUMBER_OF_LOOPS = 50
 
-    def __init__(self, local_graph: LocalGraph[_Block]) -> None:
+    def __init__(self, local_graph: _LocalGraph) -> None:
         self.local_graph = local_graph
         self.run_async = True if os.getenv("RENDER_VARIABLES_ASYNC") == "True" else False
         self.max_workers = int(os.getenv("RENDER_ASYNC_MAX_WORKERS", 50))

--- a/checkov/common/graph/graph_builder/variable_rendering/vertex_reference.py
+++ b/checkov/common/graph/graph_builder/variable_rendering/vertex_reference.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, TypeVar, Generic, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from checkov.common.graph.graph_builder.graph_components.block_types import BlockType  # noqa
-
-_BlockT = TypeVar("_BlockT", bound="BlockType")
+from typing import Any
 
 
-class VertexReference(ABC, Generic[_BlockT]):
+class VertexReference(ABC):
     __slots__ = ("block_type", "sub_parts", "origin_value")
 
-    def __init__(self, block_type: str | _BlockT, sub_parts: list[str], origin_value: str) -> None:
-        self.block_type: _BlockT = self.block_type_str_to_enum(block_type) if isinstance(block_type, str) else block_type
+    def __init__(self, block_type: str, sub_parts: list[str], origin_value: str) -> None:
+        self.block_type = self.block_type_str_to_enum(block_type) if isinstance(block_type, str) else block_type
         self.sub_parts = sub_parts
         self.origin_value = origin_value
 
@@ -31,5 +26,5 @@ class VertexReference(ABC, Generic[_BlockT]):
 
     @staticmethod
     @abstractmethod
-    def block_type_str_to_enum(block_type_str: str) -> _BlockT:
+    def block_type_str_to_enum(block_type_str: str) -> str:
         pass

--- a/checkov/common/util/data_structures_utils.py
+++ b/checkov/common/util/data_structures_utils.py
@@ -29,7 +29,9 @@ def merge_dicts(*dicts: dict[_T, Any]) -> dict[_T, Any]:
     return res
 
 
-def search_deep_keys(search_text: str, obj: dict[str, Any] | list[dict[str, Any]], path: list[int | str]) -> list[list[int | str]]:
+def search_deep_keys(
+    search_text: str, obj: dict[str, Any] | list[dict[str, Any]] | None, path: list[int | str]
+) -> list[list[int | str]]:
     """Search deep for keys and get their values"""
     keys: list[list[int | str]] = []
     if isinstance(obj, dict):
@@ -84,3 +86,16 @@ def find_in_dict(input_dict: dict[str, Any], key_path: str) -> Any:
         return None
 
     return value
+
+
+def get_empty_list_str() -> list[str]:
+    """Returns an empty list with type 'list[str]'
+
+    This is needed for using empty lists with a list union type hint
+    ex.
+        foo: list[str] | list[int] = []
+
+    more info can be found here https://github.com/python/mypy/issues/6463
+    """
+
+    return []

--- a/checkov/terraform/graph_builder/variable_rendering/vertex_reference.py
+++ b/checkov/terraform/graph_builder/variable_rendering/vertex_reference.py
@@ -1,15 +1,15 @@
-from typing import Union, List
+from __future__ import annotations
 
 from checkov.common.graph.graph_builder.variable_rendering.vertex_reference import VertexReference
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 
 
-class TerraformVertexReference(VertexReference[BlockType]):
-    def __init__(self, block_type: Union[str, BlockType], sub_parts: List[str], origin_value: str) -> None:
+class TerraformVertexReference(VertexReference):
+    def __init__(self, block_type: str, sub_parts: list[str], origin_value: str) -> None:
         super().__init__(block_type, sub_parts, origin_value)
 
     @staticmethod
-    def block_type_str_to_enum(block_type_str: str) -> BlockType:
+    def block_type_str_to_enum(block_type_str: str) -> str:
         if block_type_str == "var":
             return BlockType.VARIABLE
         if block_type_str == "local":

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 mypy_path = extra_stubs
 
 files = checkov
-exclude = checkov/(arm|cloudformation/(checks|graph_builder)|kubernetes/checks|serverless|terraform)
+exclude = checkov/(arm|cloudformation/checks|kubernetes/checks|serverless|terraform)
 strict = True
 disallow_subclassing_any = False
 implicit_reexport = True


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- finished up type hinting `cloudformation`
- `cloudformation/checks` is skipped intentionally, because I still have to find a solution for our decorator usage

Fixes #3661 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
