### PR TITLE
feat(terraform): added aws_ssoadmin_managed_policy_attachment resource to CKV_AWS_274

### DIFF
--- a/checkov/terraform/checks/resource/aws/IAMManagedAdminPolicy.py
+++ b/checkov/terraform/checks/resource/aws/IAMManagedAdminPolicy.py
@@ -16,7 +16,7 @@ class IAMManagedAdminPolicy(BaseResourceCheck):
         description = "Disallow IAM roles, users, and groups from using the AWS AdministratorAccess policy"
 
         # This is the Unique ID for your check
-        id = "CKV_AWS_274"
+        id = "POL1"
 
         # These are the terraform objects supported by this check (ex: aws_iam_policy_document)
         supported_resources = (
@@ -25,6 +25,7 @@ class IAMManagedAdminPolicy(BaseResourceCheck):
             "aws_iam_role_policy_attachment",
             "aws_iam_user_policy_attachment",
             "aws_iam_group_policy_attachment",
+            "aws_ssoadmin_managed_policy_attachment",
         )
 
         # Valid CheckCategories are defined in checkov/common/models/enums.py
@@ -45,6 +46,13 @@ class IAMManagedAdminPolicy(BaseResourceCheck):
         ):
             policy_arn = conf.get("policy_arn")
             if policy_arn and policy_arn[0] == ADMIN_POLICY_ARN:
+                return CheckResult.FAILED
+
+        elif self.entity_type in (
+            "aws_ssoadmin_managed_policy_attachment"
+        ):
+            managed_policy_arn = conf.get("managed_policy_arn")
+            if managed_policy_arn and managed_policy_arn[0] == ADMIN_POLICY_ARN:
                 return CheckResult.FAILED
 
         return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/aws/IAMManagedAdminPolicy.py
+++ b/checkov/terraform/checks/resource/aws/IAMManagedAdminPolicy.py
@@ -16,7 +16,7 @@ class IAMManagedAdminPolicy(BaseResourceCheck):
         description = "Disallow IAM roles, users, and groups from using the AWS AdministratorAccess policy"
 
         # This is the Unique ID for your check
-        id = "POL1"
+        id = "CKV_AWS_274"
 
         # These are the terraform objects supported by this check (ex: aws_iam_policy_document)
         supported_resources = (

--- a/checkov/terraform/checks/resource/aws/IAMManagedAdminPolicy.py
+++ b/checkov/terraform/checks/resource/aws/IAMManagedAdminPolicy.py
@@ -45,14 +45,14 @@ class IAMManagedAdminPolicy(BaseResourceCheck):
             "aws_iam_group_policy_attachment",
         ):
             policy_arn = conf.get("policy_arn")
-            if policy_arn and policy_arn[0] == ADMIN_POLICY_ARN:
+            if policy_arn and isinstance(policy_arn, list) and policy_arn[0] == ADMIN_POLICY_ARN:
                 return CheckResult.FAILED
 
         elif self.entity_type in (
             "aws_ssoadmin_managed_policy_attachment"
         ):
             managed_policy_arn = conf.get("managed_policy_arn")
-            if managed_policy_arn and managed_policy_arn[0] == ADMIN_POLICY_ARN:
+            if managed_policy_arn and isinstance(managed_policy_arn, list) and managed_policy_arn[0] == ADMIN_POLICY_ARN:
                 return CheckResult.FAILED
 
         return CheckResult.PASSED

--- a/tests/terraform/checks/resource/aws/example_IAMManagedAdminPolicy/IAMManagedAdminPolicy.tf
+++ b/tests/terraform/checks/resource/aws/example_IAMManagedAdminPolicy/IAMManagedAdminPolicy.tf
@@ -26,6 +26,12 @@ resource "aws_iam_group_policy_attachment" "fail5" {
   group      = "group"
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
+# Test SSO policy attachment with AdministratorAccess - Fail
+resource "aws_ssoadmin_managed_policy_attachment" "fail6" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.my_instance.arns)[0]
+  managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.admins.arn
+}
 
 # Pass
 
@@ -59,6 +65,12 @@ resource "aws_iam_group_policy_attachment" "pass5" {
 resource "aws_iam_role_policy_attachment" "pass6" {
   role       = aws_iam_role.fail1.name
 #  policy_arn = ""  # not valid, just to simulate a TF plan behaviour
+}
+# Test SSO policy attachment with other policy - Pass
+resource "aws_ssoadmin_managed_policy_attachment" "pass7" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.my_instance.arns)[0]
+  managed_policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.viewers.arn
 }
 
 # Data

--- a/tests/terraform/checks/resource/aws/test_IAMManagedAdminPolicy.py
+++ b/tests/terraform/checks/resource/aws/test_IAMManagedAdminPolicy.py
@@ -24,6 +24,7 @@ class TestIAMManagedAdminPolicy(unittest.TestCase):
             "aws_iam_user_policy_attachment.pass4",
             "aws_iam_group_policy_attachment.pass5",
             "aws_iam_role_policy_attachment.pass6",
+            "aws_ssoadmin_managed_policy_attachment.pass7",
         }
 
         failing_resources = {
@@ -32,6 +33,7 @@ class TestIAMManagedAdminPolicy(unittest.TestCase):
             "aws_iam_role_policy_attachment.fail3",
             "aws_iam_user_policy_attachment.fail4",
             "aws_iam_group_policy_attachment.fail5",
+            "aws_ssoadmin_managed_policy_attachment.fail6",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*
Added aws_ssoadmin_managed_policy_attachment resource to CKV_AWS_274

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

CKV_AWS_274 - edited

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
