### PR TITLE
docs(general): fix links in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,9 @@ or straight forward features but will help us in evaluating the PR.
 
 #### Tests for new checks
 
-When you add a new check, please write a test for it. While there are many different ways that tests have been written in the past, we have standardized on [this](https://github.com/bridgecrewio/checkov/blob/master/tests/terraform/checks/resource/aws/test_IAMAdminPolicyDocument.py) format. The key points are:
+When you add a new check, please write a test for it. While there are many different ways that tests have been written in the past, we have standardized on [this](https://github.com/bridgecrewio/checkov/blob/main/tests/terraform/checks/resource/aws/test_IAMAdminPolicyDocument.py) format. The key points are:
 
-* The test defines templates as strings (in this case, in separate files, but hardcoding a string is also acceptable) and parses them using the runner. The configuration should NOT be hard-coded as an object, as in [this](https://github.com/bridgecrewio/checkov/blob/master/tests/terraform/checks/resource/aws/test_ALBListenerHTTPS.py) example. The reason is that parsers sometimes produce unexpected object structures, so it is quite common that hardcoding the object allows the test to pass but causes the check to be incorrect in practice.
+* The test defines templates as strings (in this case, in separate files, but hardcoding a string is also acceptable) and parses them using the runner. The configuration should NOT be hard-coded as an object, as in [this](https://github.com/bridgecrewio/checkov/blob/main/tests/terraform/checks/resource/aws/test_ALBListenerHTTPS.py) example. The reason is that parsers sometimes produce unexpected object structures, so it is quite common that hardcoding the object allows the test to pass but causes the check to be incorrect in practice.
 * The test explicitly lists which resources should pass and which should fail. Merely checking the count of passes and failures is not enough. While rare, in the past this has resulted in tests that pass but checks that are incorrect in practice.
 
 #### Running tests
@@ -111,7 +111,7 @@ Use re.compile for all regex in order to scan them in flake8.
 ### Documentation is awesome
 
 Contributing to the documentation is not mandatory but it will ensure people are aware of your important contribution. 
-The best way to add documentation is by including suggestions to the [docs](https://github.com/bridgecrewio/checkov/tree/master/docs) 
+The best way to add documentation is by including suggestions to the [docs](https://github.com/bridgecrewio/checkov/tree/main/docs) 
 library as part of your PR. If you'd rather send us a short blurb on slack that's also fine.
 
 ## Creating a pull-request

--- a/docs/2.Basics/Scanning Credentials and Secrets.md
+++ b/docs/2.Basics/Scanning Credentials and Secrets.md
@@ -8,7 +8,7 @@ nav_order: 5
 # Scanning Credentials and Secrets
 
 Checkov can scan for a number of different common credentials such as AWS access keys, Azure service credentials, or private keys that are hard-coded in a Terraform code block.
-See list of regular expressions [here](https://github.com/bridgecrewio/checkov/blob/master/checkov/common/util/secrets.py).
+See list of regular expressions [here](https://github.com/bridgecrewio/checkov/blob/main/checkov/common/util/secrets.py).
 
 Let’s assume we have the following Terraform provider block:
 

--- a/docs/3.Custom Policies/Python Custom Policies.md
+++ b/docs/3.Custom Policies/Python Custom Policies.md
@@ -26,7 +26,7 @@ Specify a `name`, `ID`, `relevant resources` and `categories`.
 
 **Note for Supported Resources Parameter:** If you extend `checkov.terraform.checks.resource.base_resource_check.BaseResourceCheck`, the check is registered for all Terraform resources.
 
-The following example produces a policy that ensures that new RDS services spun-up are encrypted at rest, given a scanned Terraform configuration ([CKV_AWS_16](https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/aws/RDSEncryption.py)).
+The following example produces a policy that ensures that new RDS services spun-up are encrypted at rest, given a scanned Terraform configuration ([CKV_AWS_16](https://github.com/bridgecrewio/checkov/blob/main/checkov/terraform/checks/resource/aws/RDSEncryption.py)).
 1. Create a new file in the AWS check directory ``checkov/terraform/checks/resource/aws/RDSEncryption.py``.
 2. Import the following:
 
@@ -111,7 +111,7 @@ def scan_resource_conf(self, conf):
 ```
 
 Produces the following CLI report:
-![details-cli-screenshot](https://raw.githubusercontent.com/bridgecrewio/checkov/master/docs/checkov-scan-cli-details.png)
+![details-cli-screenshot](https://raw.githubusercontent.com/bridgecrewio/checkov/main/docs/checkov-scan-cli-details.png)
 
 7. Conclude the policy name and operationalize it with the statement:
 

--- a/docs/6.Contribution/Contribute YAML-based Policies.md
+++ b/docs/6.Contribution/Contribute YAML-based Policies.md
@@ -9,7 +9,7 @@ nav_order: 3
 
 1. Define a policy as described [here](https://www.checkov.io/3.Custom%20Policies/YAML%20Custom%20Policies.html).
 2. Create a branch under the `checkov2` fork (will be changed + the URLs after merge) - `https://github.com/bridgecrewio/checkov`
-3. Add `<policy_name>.yaml` file to `https://github.com/bridgecrewio/checkov/tree/master/checkov/terraform/checks/graph_checks` inside the relevant provider folder that matches your current policy.
+3. Add `<policy_name>.yaml` file to `https://github.com/bridgecrewio/checkov/tree/main/checkov/terraform/checks/graph_checks` inside the relevant provider folder that matches your current policy.
 
 ## Example
 `checkov/terraform/checks/graph_checks/aws/EBSAddedBackup.yaml`
@@ -35,7 +35,7 @@ definition:
 ```
 
 ## YAML Format Testing
-1 - Add the test resources directory to: `https://github.com/bridgecrewio/checkov/tree/master/tests/terraform/graph/checks/resources` and create a folder with the same name as your Custom Policy. In this folder, add the Terraform file(s) which are resources for testing the policy, and `expected.yaml` - all the resources that should pass and the resources that should fail.
+1 - Add the test resources directory to: `https://github.com/bridgecrewio/checkov/tree/main/tests/terraform/graph/checks/resources` and create a folder with the same name as your Custom Policy. In this folder, add the Terraform file(s) which are resources for testing the policy, and `expected.yaml` - all the resources that should pass and the resources that should fail.
 
 ### Terraform Files Example 
 `tests//terraform/graph/checks/resources/EBSAddedBackup/main.tf`

--- a/docs/6.Contribution/Contribution New IaC Runner.md
+++ b/docs/6.Contribution/Contribution New IaC Runner.md
@@ -208,7 +208,7 @@ Example: [https://github.com/bridgecrewio/checkov/pull/2551/files#diff-5c3fa5974
 #### Create an example check
 
 Reference: 
-[Contribute Python-Based Policies](https://github.com/bridgecrewio/checkov/blob/master/docs/6.Contribution/Contribute%20Python-Based%20Policies.md)
+[Contribute Python-Based Policies](https://github.com/bridgecrewio/checkov/blob/main/docs/6.Contribution/Contribute%20Python-Based%20Policies.md)
 
 
 #### Create test cases


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Updating a few links in the docs that were pointing to `master` to now point at the `main` branch.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
