### PR TITLE
feat(general): add logic to vcs scanning to prevent empty repo collabs failing check

### DIFF
--- a/checkov/github/checks/repository_collaborators.py
+++ b/checkov/github/checks/repository_collaborators.py
@@ -24,7 +24,7 @@ class GithubRepositoryCollaborators(BaseGithubCheck):
     def scan_entity_conf(self, conf: dict[str, Any], entity_type: str) -> CheckResult:  # type:ignore[override]
         ckv_metadata, conf = self.resolve_ckv_metadata_conf(conf=conf)
         if 'repository_collaborators' in ckv_metadata.get('file_name', ''):
-            if repository_collaborators_schema.validate(conf):
+            if conf and repository_collaborators_schema.validate(conf):
                 admin_collaborators = 0
                 for item in conf:
                     if isinstance(item, dict):

--- a/tests/github/test_runner.py
+++ b/tests/github/test_runner.py
@@ -121,6 +121,23 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.skipped_checks, [])
 
     @mock.patch.dict(os.environ, {"CKV_GITHUB_CONFIG_FETCH_DATA": "False", "PYCHARM_HOSTED": "1"}, clear=True)
+    def test_runner_empty_repo_collaborators(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = os.path.join(current_dir, "resources", "github_conf", "empty_collabs")
+        runner = Runner()
+        runner.github.github_conf_dir_path = valid_dir_path
+
+        checks = ["CKV_GITHUB_9"]
+        report = runner.run(
+            root_folder=valid_dir_path,
+            runner_filter=RunnerFilter(checks=checks)
+        )
+        self.assertEqual(len(report.failed_checks), 0)
+        self.assertEqual(report.parsing_errors, [])
+        self.assertEqual(len(report.passed_checks), 0)
+        self.assertEqual(report.skipped_checks, [])
+
+    @mock.patch.dict(os.environ, {"CKV_GITHUB_CONFIG_FETCH_DATA": "False", "PYCHARM_HOSTED": "1"}, clear=True)
     def test_runner_repo_security_no_rules(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         valid_dir_path = os.path.join(current_dir, "resources", "github_conf", "repo_no_rules")


### PR DESCRIPTION
This PR prevents failure of vcs repo collabs check when the payload is empty.
This is a possible scenario in some cases.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
