### PR TITLE
feat(dockerfile): Add checks for unsafe wget and pip usages

### DIFF
--- a/checkov/dockerfile/checks/graph_checks/RunPipTrustedHost.yaml
+++ b/checkov/dockerfile/checks/graph_checks/RunPipTrustedHost.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "CKV2_DOCKER_4"
+  name: "Ensure that certificate validation isn't disabled with the pip '--trusted-host' option"
+  category: "APPLICATION_SECURITY"
+definition:
+    cond_type: attribute
+    resource_types:
+      - RUN
+    attribute: value
+    operator: not_regex_match
+    value: ".*(pip3?[^\\|&;]*\\s+--trusted-host).*"

--- a/checkov/dockerfile/checks/graph_checks/RunUnsafeWget.yaml
+++ b/checkov/dockerfile/checks/graph_checks/RunUnsafeWget.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "CKV2_DOCKER_3"
+  name: "Ensure that certificate validation isn't disabled with wget"
+  category: "APPLICATION_SECURITY"
+definition:
+    cond_type: attribute
+    resource_types:
+      - RUN
+    attribute: value
+    operator: not_regex_match
+    value: ".*(wget[^\\|&;]*\\s+--no-check-certificate).*"

--- a/tests/dockerfile/graph_builder/checks/resources/RunPipTrustedHost/expected.yaml
+++ b/tests/dockerfile/graph_builder/checks/resources/RunPipTrustedHost/expected.yaml
@@ -1,0 +1,17 @@
+pass:
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+fail:
+  - 'fail/Dockerfile.basic.RUN'
+  - 'fail/Dockerfile.basic.RUN'
+  - 'fail/Dockerfile.basic.RUN'
+  - 'fail/Dockerfile.basic.RUN'
+  - 'fail/Dockerfile.multiline.RUN'
+  - 'fail/Dockerfile.multiline.RUN'
+  - 'fail/Dockerfile.shell.RUN'
+evaluated_keys:
+  - 'value'

--- a/tests/dockerfile/graph_builder/checks/resources/RunPipTrustedHost/fail/Dockerfile.basic
+++ b/tests/dockerfile/graph_builder/checks/resources/RunPipTrustedHost/fail/Dockerfile.basic
@@ -1,0 +1,5 @@
+FROM alpine:3.5
+RUN pip install checkov --trusted-host pypi.org --trusted-host files.pythonhosted.org
+RUN pip install checkov --trusted-host=pypi.python.org --trusted-host=pypi.org
+RUN pip3 install checkov --trusted-host pypi.org --trusted-host files.pythonhosted.org
+RUN pip3 install checkov --trusted-host=pypi.python.org --trusted-host=pypi.org

--- a/tests/dockerfile/graph_builder/checks/resources/RunPipTrustedHost/fail/Dockerfile.multiline
+++ b/tests/dockerfile/graph_builder/checks/resources/RunPipTrustedHost/fail/Dockerfile.multiline
@@ -1,0 +1,7 @@
+FROM alpine:3.5
+RUN pip \
+    --trusted-host pypi.org \
+    install checkov
+RUN pip \
+    install checkov \
+    --trusted-host=pypi.org

--- a/tests/dockerfile/graph_builder/checks/resources/RunPipTrustedHost/fail/Dockerfile.shell
+++ b/tests/dockerfile/graph_builder/checks/resources/RunPipTrustedHost/fail/Dockerfile.shell
@@ -1,0 +1,2 @@
+FROM alpine:3.5
+RUN echo "panw" && pip --trusted-host=pypi.python.org --trusted-host=pypi.org install checkov

--- a/tests/dockerfile/graph_builder/checks/resources/RunPipTrustedHost/pass/Dockerfile
+++ b/tests/dockerfile/graph_builder/checks/resources/RunPipTrustedHost/pass/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.5
+RUN pip install checkov
+RUN pip3 install checkov
+RUN pip install checkov | grep "--trusted-host"
+RUN pip3 install checkov; grep "--trusted-host"
+RUN pip install checkov &&\
+    echo "--trusted-host"
+RUN pip3 install checkov ||\
+    grep "--trusted-host" /etc/passwd

--- a/tests/dockerfile/graph_builder/checks/resources/RunUnsafeWget/expected.yaml
+++ b/tests/dockerfile/graph_builder/checks/resources/RunUnsafeWget/expected.yaml
@@ -1,0 +1,14 @@
+pass:
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+fail:
+  - 'fail/Dockerfile.basic.RUN'
+  - 'fail/Dockerfile.multiline.RUN'
+  - 'fail/Dockerfile.shell.RUN'
+evaluated_keys:
+  - 'value'

--- a/tests/dockerfile/graph_builder/checks/resources/RunUnsafeWget/fail/Dockerfile.basic
+++ b/tests/dockerfile/graph_builder/checks/resources/RunUnsafeWget/fail/Dockerfile.basic
@@ -1,0 +1,2 @@
+FROM alpine:3.5
+RUN wget --no-progress --no-check-certificate -o file https://example.com

--- a/tests/dockerfile/graph_builder/checks/resources/RunUnsafeWget/fail/Dockerfile.multiline
+++ b/tests/dockerfile/graph_builder/checks/resources/RunUnsafeWget/fail/Dockerfile.multiline
@@ -1,0 +1,4 @@
+FROM alpine:3.5
+RUN wget \
+    --no-check-certificate \
+    https://example.com

--- a/tests/dockerfile/graph_builder/checks/resources/RunUnsafeWget/fail/Dockerfile.shell
+++ b/tests/dockerfile/graph_builder/checks/resources/RunUnsafeWget/fail/Dockerfile.shell
@@ -1,0 +1,2 @@
+FROM alpine:3.5
+RUN echo "panw" && wget --no-check-certificate https://example.com

--- a/tests/dockerfile/graph_builder/checks/resources/RunUnsafeWget/pass/Dockerfile
+++ b/tests/dockerfile/graph_builder/checks/resources/RunUnsafeWget/pass/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.5
+RUN wget https://example.com
+RUN wget --no-progress -o file https://example.com
+RUN wget -lol https://example.com
+RUN wget https://example.com | grep "--no-check-certificate" /etc/passwd
+RUN wget https://example.com; grep "--no-check-certificate" /etc/passwd
+RUN wget https://example.com &&\
+    echo "--no-check-certificate"
+RUN wget https://example.com ||\
+    grep "--no-check-certificate" /etc/passwd

--- a/tests/dockerfile/graph_builder/checks/test_yaml_policies.py
+++ b/tests/dockerfile/graph_builder/checks/test_yaml_policies.py
@@ -41,6 +41,9 @@ class TestYamlPolicies(TestYamlPoliciesBase):
     def test_RunUnsafeWget(self):
         self.go("RunUnsafeWget")
 
+    def test_RunPipTrustedHost(self):
+        self.go("RunPipTrustedHost")
+
     def test_registry_load(self):
         registry = self.get_checks_registry()
         self.assertGreater(len(registry.checks), 0)

--- a/tests/dockerfile/graph_builder/checks/test_yaml_policies.py
+++ b/tests/dockerfile/graph_builder/checks/test_yaml_policies.py
@@ -38,6 +38,9 @@ class TestYamlPolicies(TestYamlPoliciesBase):
     def test_RunUnsafeCurl(self):
         self.go("RunUnsafeCurl")
 
+    def test_RunUnsafeWget(self):
+        self.go("RunUnsafeWget")
+
     def test_registry_load(self):
         registry = self.get_checks_registry()
         self.assertGreater(len(registry.checks), 0)

--- a/tests/dockerfile/image_referencer/test_runner_dockerfile_resources.py
+++ b/tests/dockerfile/image_referencer/test_runner_dockerfile_resources.py
@@ -40,7 +40,7 @@ def test_simple_dockerfile(mocker: MockerFixture, image_cached_result, license_s
     sca_image_report = next(report for report in reports if report.check_type == CheckType.SCA_IMAGE)
 
     assert len(tf_report.resources) == 1
-    assert len(tf_report.passed_checks) == 6
+    assert len(tf_report.passed_checks) == 7
     assert len(tf_report.failed_checks) == 2
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0
@@ -92,7 +92,7 @@ def test_multi_stage_dockerfile(mocker: MockerFixture, image_cached_result):
     sca_image_report = next(report for report in reports if report.check_type == CheckType.SCA_IMAGE)
 
     assert len(tf_report.resources) == 1
-    assert len(tf_report.passed_checks) == 8
+    assert len(tf_report.passed_checks) == 10
     assert len(tf_report.failed_checks) == 2
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0
@@ -135,7 +135,7 @@ def test_multi_platform_dockerfile(mocker: MockerFixture, image_cached_result):
     sca_image_report = next(report for report in reports if report.check_type == CheckType.SCA_IMAGE)
 
     assert len(tf_report.resources) == 1
-    assert len(tf_report.passed_checks) == 5
+    assert len(tf_report.passed_checks) == 6
     assert len(tf_report.failed_checks) == 3
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0

--- a/tests/dockerfile/image_referencer/test_runner_dockerfile_resources.py
+++ b/tests/dockerfile/image_referencer/test_runner_dockerfile_resources.py
@@ -40,7 +40,7 @@ def test_simple_dockerfile(mocker: MockerFixture, image_cached_result, license_s
     sca_image_report = next(report for report in reports if report.check_type == CheckType.SCA_IMAGE)
 
     assert len(tf_report.resources) == 1
-    assert len(tf_report.passed_checks) == 7
+    assert len(tf_report.passed_checks) == 8
     assert len(tf_report.failed_checks) == 2
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0
@@ -92,7 +92,7 @@ def test_multi_stage_dockerfile(mocker: MockerFixture, image_cached_result):
     sca_image_report = next(report for report in reports if report.check_type == CheckType.SCA_IMAGE)
 
     assert len(tf_report.resources) == 1
-    assert len(tf_report.passed_checks) == 10
+    assert len(tf_report.passed_checks) == 12
     assert len(tf_report.failed_checks) == 2
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0
@@ -135,7 +135,7 @@ def test_multi_platform_dockerfile(mocker: MockerFixture, image_cached_result):
     sca_image_report = next(report for report in reports if report.check_type == CheckType.SCA_IMAGE)
 
     assert len(tf_report.resources) == 1
-    assert len(tf_report.passed_checks) == 6
+    assert len(tf_report.passed_checks) == 7
     assert len(tf_report.failed_checks) == 3
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Add 2 new checks to detect unsafe usages of `curl` and `pip` in dockerfiles where certificate validation is disabled.

## New/Edited policies
CKV2_DOCKER_3
CKV2_DOCKER_4

### Description

CKV2_DOCKER_3
Using the command line option `--no-check-certificate` with `wget` disables SSL certificate validation.
https://manpages.ubuntu.com/manpages/jammy/en/man1/wget.1.html

CKV2_DOCKER_4
Using the command line option `--trusted-host` with `pip` disables SSL certificate validation.
https://pip.pypa.io/en/stable/cli/pip/#cmdoption-trusted-host
https://pip.pypa.io/en/stable/topics/https-certificates/

### Fix

CKV2_DOCKER_3
Remove the option, possibly use `--ca-certificate` or `--ca-directory` to specify additional certificates if needed.

CKV2_DOCKER_4
Remove the option, possibly use `--cert` to specify additional certificates if needed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
