### PR TITLE
fix(kubernetes): allow filtering of custom with built-in Kubernetes check IDs

### DIFF
--- a/tests/kubernetes/test_base_registry.py
+++ b/tests/kubernetes/test_base_registry.py
@@ -141,6 +141,20 @@ class TestRunnerFilter(unittest.TestCase):
         check = TestCheck('CKV_EXT_999')
         self.assertFalse(instance._should_run_scan(check, {}, run_filter, CheckType.KUBERNETES))
 
+    def test_run_by_id_external_custom(self):
+        instance = Registry(report_type=CheckType.KUBERNETES)
+        run_filter = RunnerFilter(checks=["K8S_EXT_999"], skip_checks=[])
+        run_filter.notify_external_check("K8S_EXT_999")
+        check = TestCheck('K8S_EXT_999')
+        self.assertTrue(instance._should_run_scan(check, {}, run_filter, CheckType.KUBERNETES))
+
+    def test_run_by_id_external_custom_disabled(self):
+        instance = Registry(report_type=CheckType.KUBERNETES)
+        run_filter = RunnerFilter(checks=[], skip_checks=["K8S_EXT_999"])
+        run_filter.notify_external_check("K8S_EXT_999")
+        check = TestCheck('K8S_EXT_999')
+        self.assertFalse(instance._should_run_scan(check, {}, run_filter, CheckType.KUBERNETES))
+
     # Namespace filtering
 
     def test_namespace_allow_default(self):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- we have a special Kubernetes feature, which allows users to filter checks by passing in the namespace, luckily `_` are not allowed in the name, therefore I adjusted the should run logic to leverage this limitations

Fixes #4196 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
