### PR TITLE
feat(terraform_plan): support multiple references in one resource

### DIFF
--- a/checkov/common/graph/graph_builder/graph_components/attribute_names.py
+++ b/checkov/common/graph/graph_builder/graph_components/attribute_names.py
@@ -23,6 +23,7 @@ class CustomAttributes:
     ENCRYPTION = "encryption_"
     ENCRYPTION_DETAILS = "encryption_details_"
     TF_RESOURCE_ADDRESS = "__address__"
+    REFERENCES = "references_"
 
 
 def props(cls: Any) -> List[str]:

--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -5,6 +5,7 @@ import json
 import logging
 from typing import Optional, Tuple, Dict, List, Any
 
+from checkov.common.graph.graph_builder import CustomAttributes
 from checkov.common.parsers.node import DictNode, ListNode
 from checkov.terraform.context_parsers.tf_plan import parse
 
@@ -106,9 +107,11 @@ def _hclify(
                 ret_dict[conf_key] = [ref]
                 found_ref = True
         if not found_ref:
-            for value in conf.values():
-                if isinstance(value, dict) and "references" in value.keys():
-                    ret_dict["references_"] = value["references"]
+            ret_dict[CustomAttributes.REFERENCES] = [
+                value["references"]
+                for value in conf.values()
+                if isinstance(value, dict) and "references" in value
+            ]
 
     return ret_dict
 

--- a/tests/terraform/runner/extra_tf_plan_checks/nsg_rule_connection.yaml
+++ b/tests/terraform/runner/extra_tf_plan_checks/nsg_rule_connection.yaml
@@ -1,0 +1,17 @@
+metadata:
+  name: "Ensure that connection exists between NSG and rule"
+  id: "CUSTOM_CONNECTION_1"
+  category: "NETWORKING"
+definition:
+  and:
+    - cond_type: connection
+      resource_types:
+      - azurerm_network_security_group
+      connected_resource_types:
+      - azurerm_network_security_rule
+      operator: exists
+    - cond_type: filter
+      attribute: resource_type
+      value:
+      - azurerm_network_security_group
+      operator: within

--- a/tests/terraform/runner/resources/plan_with_resource_reference/tfplan_extra_ref.json
+++ b/tests/terraform/runner/resources/plan_with_resource_reference/tfplan_extra_ref.json
@@ -1,0 +1,373 @@
+{
+  "format_version": "1.1",
+  "terraform_version": "1.3.6",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "azurerm_network_security_group.fail",
+          "mode": "managed",
+          "type": "azurerm_network_security_group",
+          "name": "fail",
+          "provider_name": "registry.terraform.io/hashicorp/azurerm",
+          "schema_version": 0,
+          "values": {
+            "location": "canadacentral",
+            "name": "fail",
+            "resource_group_name": "test",
+            "tags": null,
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "security_rule": []
+          }
+        },
+        {
+          "address": "azurerm_network_security_group.pass",
+          "mode": "managed",
+          "type": "azurerm_network_security_group",
+          "name": "pass",
+          "provider_name": "registry.terraform.io/hashicorp/azurerm",
+          "schema_version": 0,
+          "values": {
+            "location": "canadacentral",
+            "name": "pass",
+            "resource_group_name": "test",
+            "tags": null,
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "security_rule": []
+          }
+        },
+        {
+          "address": "azurerm_network_security_rule.pass",
+          "mode": "managed",
+          "type": "azurerm_network_security_rule",
+          "name": "pass",
+          "provider_name": "registry.terraform.io/hashicorp/azurerm",
+          "schema_version": 0,
+          "values": {
+            "access": "Deny",
+            "description": null,
+            "destination_address_prefix": "*",
+            "destination_address_prefixes": null,
+            "destination_application_security_group_ids": null,
+            "destination_port_range": "3389",
+            "destination_port_ranges": null,
+            "direction": "Inbound",
+            "name": "pass",
+            "network_security_group_name": "pass",
+            "priority": 100,
+            "protocol": "Tcp",
+            "resource_group_name": "test",
+            "source_address_prefix": "*",
+            "source_address_prefixes": null,
+            "source_application_security_group_ids": null,
+            "source_port_range": "*",
+            "source_port_ranges": null,
+            "timeouts": null
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "azurerm_resource_group.test",
+          "mode": "managed",
+          "type": "azurerm_resource_group",
+          "name": "test",
+          "provider_name": "registry.terraform.io/hashicorp/azurerm",
+          "schema_version": 0,
+          "values": {
+            "location": "canadacentral",
+            "name": "test",
+            "tags": null,
+            "timeouts": null
+          },
+          "sensitive_values": {}
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "azurerm_network_security_group.fail",
+      "mode": "managed",
+      "type": "azurerm_network_security_group",
+      "name": "fail",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "location": "canadacentral",
+          "name": "fail",
+          "resource_group_name": "test",
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "id": true,
+          "security_rule": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "security_rule": []
+        }
+      }
+    },
+    {
+      "address": "azurerm_network_security_group.pass",
+      "mode": "managed",
+      "type": "azurerm_network_security_group",
+      "name": "pass",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "location": "canadacentral",
+          "name": "pass",
+          "resource_group_name": "test",
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "id": true,
+          "security_rule": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "security_rule": []
+        }
+      }
+    },
+    {
+      "address": "azurerm_network_security_rule.pass",
+      "mode": "managed",
+      "type": "azurerm_network_security_rule",
+      "name": "pass",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "access": "Deny",
+          "description": null,
+          "destination_address_prefix": "*",
+          "destination_address_prefixes": null,
+          "destination_application_security_group_ids": null,
+          "destination_port_range": "3389",
+          "destination_port_ranges": null,
+          "direction": "Inbound",
+          "name": "pass",
+          "network_security_group_name": "pass",
+          "priority": 100,
+          "protocol": "Tcp",
+          "resource_group_name": "test",
+          "source_address_prefix": "*",
+          "source_address_prefixes": null,
+          "source_application_security_group_ids": null,
+          "source_port_range": "*",
+          "source_port_ranges": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "azurerm_resource_group.test",
+      "mode": "managed",
+      "type": "azurerm_resource_group",
+      "name": "test",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "location": "canadacentral",
+          "name": "test",
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "azurerm": {
+        "name": "azurerm",
+        "full_name": "registry.terraform.io/hashicorp/azurerm",
+        "version_constraint": ">= 3.36.0",
+        "expressions": {
+          "features": [
+            {
+              "key_vault": [
+                {
+                  "purge_soft_delete_on_destroy": {
+                    "constant_value": true
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "azurerm_network_security_group.fail",
+          "mode": "managed",
+          "type": "azurerm_network_security_group",
+          "name": "fail",
+          "provider_config_key": "azurerm",
+          "expressions": {
+            "location": {
+              "references": [
+                "azurerm_resource_group.test.location",
+                "azurerm_resource_group.test"
+              ]
+            },
+            "name": {
+              "constant_value": "fail"
+            },
+            "resource_group_name": {
+              "references": [
+                "azurerm_resource_group.test.name",
+                "azurerm_resource_group.test"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "azurerm_network_security_group.pass",
+          "mode": "managed",
+          "type": "azurerm_network_security_group",
+          "name": "pass",
+          "provider_config_key": "azurerm",
+          "expressions": {
+            "location": {
+              "references": [
+                "azurerm_resource_group.test.location",
+                "azurerm_resource_group.test"
+              ]
+            },
+            "name": {
+              "constant_value": "pass"
+            },
+            "resource_group_name": {
+              "references": [
+                "azurerm_resource_group.test.name",
+                "azurerm_resource_group.test"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "azurerm_network_security_rule.pass",
+          "mode": "managed",
+          "type": "azurerm_network_security_rule",
+          "name": "pass",
+          "provider_config_key": "azurerm",
+          "expressions": {
+            "access": {
+              "constant_value": "Deny"
+            },
+            "destination_address_prefix": {
+              "constant_value": "*"
+            },
+            "destination_port_range": {
+              "constant_value": "3389"
+            },
+            "direction": {
+              "constant_value": "Inbound"
+            },
+            "name": {
+              "constant_value": "pass"
+            },
+            "network_security_group_name": {
+              "references": [
+                "azurerm_network_security_group.pass.name",
+                "azurerm_network_security_group.pass"
+              ]
+            },
+            "priority": {
+              "constant_value": 100
+            },
+            "protocol": {
+              "constant_value": "Tcp"
+            },
+            "resource_group_name": {
+              "references": [
+                "azurerm_resource_group.test.name",
+                "azurerm_resource_group.test"
+              ]
+            },
+            "source_address_prefix": {
+              "constant_value": "*"
+            },
+            "source_port_range": {
+              "constant_value": "*"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "azurerm_resource_group.test",
+          "mode": "managed",
+          "type": "azurerm_resource_group",
+          "name": "test",
+          "provider_config_key": "azurerm",
+          "expressions": {
+            "location": {
+              "constant_value": "Canada Central"
+            },
+            "name": {
+              "constant_value": "test"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "relevant_attributes": [
+    {
+      "resource": "azurerm_resource_group.test",
+      "attribute": [
+        "location"
+      ]
+    },
+    {
+      "resource": "azurerm_resource_group.test",
+      "attribute": [
+        "name"
+      ]
+    },
+    {
+      "resource": "azurerm_network_security_group.pass",
+      "attribute": [
+        "name"
+      ]
+    }
+  ]
+}

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -501,6 +501,29 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(summary["failed"], 0)
         self.assertEqual(summary["passed"], 1)
 
+    def test_runner_with_resource_reference_extra_ref(self):
+        # given
+        valid_plan_path = Path(__file__).parent / "resources/plan_with_resource_reference/tfplan_extra_ref.json"
+        extra_checks_dir_path = [str(Path(__file__).parent / "extra_tf_plan_checks")]
+        allowed_checks = ["CUSTOM_CONNECTION_1"]
+
+        # when
+        report = Runner().run(
+            root_folder=None,
+            files=[str(valid_plan_path)],
+            external_checks_dir=extra_checks_dir_path,
+            runner_filter=RunnerFilter(framework=["terraform_plan"], checks=allowed_checks),
+        )
+
+        # then
+        summary = report.get_summary()
+
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+        self.assertEqual(summary["resource_count"], 4)
+
     def test_runner_skip_graph_when_no_plan_exists(self):
         # given
         tf_file_path = Path(__file__).parent / "resource/example/example.tf"

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -101,7 +101,6 @@ class TestRunnerValid(unittest.TestCase):
 
         passing_tf_dir_path = current_dir + "/resources/valid_tf_only_passed_checks"
 
-        print("testing dir" + passing_tf_dir_path)
         runner = Runner()
         report = runner.run(root_folder=passing_tf_dir_path, external_checks_dir=None)
         report_json = report.get_json()
@@ -120,7 +119,6 @@ class TestRunnerValid(unittest.TestCase):
 
         tf_dir_path = current_dir + "/resources/mutli_line_ternary"
 
-        print("testing dir" + tf_dir_path)
         runner = Runner()
         report = runner.run(root_folder=tf_dir_path, external_checks_dir=None)
         self.assertListEqual(report.parsing_errors, [])
@@ -133,7 +131,6 @@ class TestRunnerValid(unittest.TestCase):
         tf_dir_path = current_dir + "/resources/extra_check_test"
         extra_checks_dir_path = [current_dir + "/extra_checks"]
 
-        print("testing dir" + tf_dir_path)
         runner = Runner()
         report = runner.run(root_folder=tf_dir_path, external_checks_dir=extra_checks_dir_path)
         report_json = report.get_json()
@@ -1089,7 +1086,6 @@ class TestRunnerValid(unittest.TestCase):
         for record in report.failed_checks:
             if "inside" in record.resource:
                 found_inside = True
-                print(record)
                 self.assertEqual(record.resource, "module.test_module.aws_s3_bucket.inside")
                 assert record.file_path == "/module/module.tf"
                 self.assertEqual(record.file_line_range, [7, 9])


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added support for more than one reference per resource

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
