### PR TITLE
fix(secrets): Disable verify secrets if skip_download is specified

### DIFF
--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -194,7 +194,7 @@ class Record:
 
         status_message = colored("\t{} for resource: {}\n".format(status, self.resource), status_color)
 
-        secret_validation_status_string = "" # nosec
+        secret_validation_status_string = ""  # nosec
         if self.check_result["result"] == CheckResult.FAILED and \
                 hasattr(self, 'validation_status') and \
                 os.getenv("CKV_VALIDATE_SECRETS"):

--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -194,7 +194,7 @@ class Record:
 
         status_message = colored("\t{} for resource: {}\n".format(status, self.resource), status_color)
 
-        secret_validation_status_string = ""
+        secret_validation_status_string = "" # nosec
         if self.check_result["result"] == CheckResult.FAILED and \
                 hasattr(self, 'validation_status') and \
                 os.getenv("CKV_VALIDATE_SECRETS"):

--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -193,8 +193,12 @@ class Record:
                         )
 
         status_message = colored("\t{} for resource: {}\n".format(status, self.resource), status_color)
-        secret_validation_status_string = f'\tStatus: {self.validation_status}\n' if \
-            self.check_result["result"] == CheckResult.FAILED and hasattr(self, 'validation_status') else ""
+
+        secret_validation_status_string = ""
+        if self.check_result["result"] == CheckResult.FAILED and \
+                hasattr(self, 'validation_status') and \
+                os.getenv("CKV_VALIDATE_SECRETS"):
+            secret_validation_status_string = f'\tStatus: {self.validation_status}\n'
 
         if self.check_result["result"] == CheckResult.FAILED and code_lines and not compact:
             return f"{check_message}{status_message}{severity_message}{detail}{file_details}{secret_validation_status_string}{caller_file_details}{guideline_message}{code_lines}{evaluation_message}"

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -298,6 +298,10 @@ class Runner(BaseRunner[None]):
                 'Secrets verification is off, enabled it via env var CKV_VALIDATE_SECRETS and provide an api key')
             return VerifySecretsResult.INSUFFICIENT_PARAMS
 
+        if bc_integration.skip_download:
+            logging.debug('Skipping secrets verification as flag skip-download was specified')
+            return VerifySecretsResult.INSUFFICIENT_PARAMS
+
         request_body = {
             "reportS3Path": enriched_secrets_s3_path
         }

--- a/tests/secrets/conftest.py
+++ b/tests/secrets/conftest.py
@@ -2,31 +2,15 @@ import pytest
 
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.models.enums import CheckResult
-
-from checkov.common.bridgecrew.bc_source import SourceType
-
-from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration, bc_integration
 from checkov.common.output.report import Report
 from checkov.common.output.secrets_record import SecretsRecord
 
 
-@pytest.fixture(scope='package')
-def mock_bc_integration() -> BcPlatformIntegration:
+@pytest.fixture
+def mock_bc_integration():
+    from checkov.common.bridgecrew.platform_integration import bc_integration
     bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
-    bc_integration.setup_bridgecrew_credentials(
-        repo_id="bridgecrewio/checkov",
-        skip_fixes=True,
-        skip_download=True,
-        source=SourceType("Github", False),
-        source_version="1.0",
-        repo_branch="master",
-    )
-    return bc_integration
-
-
-@pytest.fixture(scope='function')
-def mock_bc_integration_no_api_key() -> BcPlatformIntegration:
-    bc_integration.bc_api_key = None
+    bc_integration.skip_download = False
     return bc_integration
 
 


### PR DESCRIPTION
…if not CKV_VALIDATE_SECRETS

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description


*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description

*Include a description of what makes it a violation and any relevant external links.*
* Disable verify secrets if skip_download is specified
* Don't show secret validation status on a violation if CKV_VALIDATE_SECRETS not specified
* Fix BcIntegration mocks for validate secrets 

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
