### PR TITLE
feat(secrets): Implement lower entropy threshold on a line with keyword

### DIFF
--- a/tests/secrets/test_entropy_source_files/db-conn.js
+++ b/tests/secrets/test_entropy_source_files/db-conn.js
@@ -1,0 +1,6 @@
+var pg_port=1212;
+var pg_host="my-website.com:9082/BLUDB";
+var pg_user="root";
+var pg_pass="sup3rstr0ngpass1ForPG";
+
+var mongo_uri = "mongodb+srv://testuser:hub24aoeu@checkov-is-awesome-gg273.mongodb.net/test?retryWrites=true&w=majority";

--- a/tests/secrets/test_entropy_source_files/db-conn.js
+++ b/tests/secrets/test_entropy_source_files/db-conn.js
@@ -4,3 +4,7 @@ var pg_user="root";
 var pg_pass="sup3rstr0ngpass1ForPG";
 
 var mongo_uri = "mongodb+srv://testuser:hub24aoeu@checkov-is-awesome-gg273.mongodb.net/test?retryWrites=true&w=majority";
+
+// This should pass
+var password = process.env.PASSWORD
+

--- a/tests/secrets/test_runner.py
+++ b/tests/secrets/test_runner.py
@@ -313,5 +313,21 @@ class TestRunnerValid(unittest.TestCase):
                                                        enable_secret_scan_all_files=True))
         self.assertEqual(len(report.failed_checks), 0)
 
+    def test_runner_entropy_source_files(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/test_entropy_source_files"
+        runner = Runner()
+        report = runner.run(root_folder=valid_dir_path, runner_filter=RunnerFilter(framework=['secrets'],
+                                                                                   enable_secret_scan_all_files=True))
+        self.assertEqual(len(report.failed_checks), 2)
+        for failed in report.failed_checks:
+            if failed.check_id == 'CKV_SECRET_6':
+                self.assertEqual(failed.file_line_range, [4, 5])
+            elif failed.check_id == 'CKV_SECRET_4':
+                self.assertEqual(failed.file_line_range, [6, 7])
+            else:
+                self.fail(f'Got a bad result: {failed}')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

In case a keyword is found on the line, use a lower entropy limit to find the secret.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
