### PR TITLE
fix(secrets): add function to add the custom policies to the metadata_integration not in the multiprocess

### DIFF
--- a/checkov/main.py
+++ b/checkov/main.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import signal
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -936,5 +937,10 @@ class Checkov:
 
 
 if __name__ == '__main__':
+    start_time = datetime.now()
     ckv = Checkov()
-    sys.exit(ckv.run())
+    end_time = datetime.now()
+    ckv.run()
+    logging.debug(f'total time = {end_time - start_time}')
+    sys.exit()
+

--- a/checkov/secrets/plugins/custom_regex_detector.py
+++ b/checkov/secrets/plugins/custom_regex_detector.py
@@ -3,104 +3,20 @@ from __future__ import annotations
 import logging
 from typing import Set, Any, Generator, Pattern, Optional, Dict, Tuple, List, TYPE_CHECKING, cast
 
-from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import \
-    integration as metadata_integration
-import yaml
+
 from detect_secrets.constants import VerifiedResult
 from detect_secrets.core.potential_secret import PotentialSecret
 from detect_secrets.plugins.base import RegexBasedDetector
 from detect_secrets.util.inject import call_function_with_arguments
 import re
 
-from checkov.common.bridgecrew.platform_integration import bc_integration
+from checkov.secrets.plugins.load_detectors import load_detectors
 
 MIN_CHARACTERS = 5
 MAX_CHARACTERS = 100
 
 if TYPE_CHECKING:
     from detect_secrets.util.code_snippet import CodeSnippet
-
-
-def load_detectors() -> list[dict[str, Any]]:
-    detectors: List[dict[str, Any]] = []
-    try:
-        customer_run_config_response = bc_integration.customer_run_config_response
-        policies_list: List[dict[str, Any]] = []
-        if customer_run_config_response:
-            policies_list = customer_run_config_response.get('secretsPolicies', [])
-    except Exception as e:
-        logging.error(f"Failed to get detectors from customer_run_config_response, error: {e}")
-        return []
-
-    if policies_list:
-        detectors = modify_secrets_policy_to_detectors(policies_list)
-    if detectors:
-        logging.info(f"Successfully loaded {len(detectors)} detectors from bc_integration")
-    return detectors
-
-
-def modify_secrets_policy_to_detectors(policies_list: List[dict[str, Any]]) -> List[dict[str, Any]]:
-    secrets_list = transforms_policies_to_detectors_list(policies_list)
-    logging.debug(f"(modify_secrets_policy_to_detectors) secrets_list = {secrets_list}")
-    return secrets_list
-
-
-def add_to_custom_detectors(custom_detectors: List[Dict[str, Any]], name: str, check_id: str, regex: str, is_custom: str) -> None:
-    custom_detectors.append({'Name': name,
-                             'Check_ID': check_id,
-                             'Regex': regex,
-                             'isCustom': is_custom})
-    if is_custom:
-        logging.debug(f"(add_to_custom_detectors) is custom check_id = {check_id}")
-        metadata_integration.check_metadata[check_id] = {'id': check_id}
-
-
-def add_detectors_from_condition_query(custom_detectors: List[Dict[str, Any]], condition_query: Dict[str, Any], secret_policy: Dict[str, Any], check_id: str) -> bool:
-    parsed = False
-    cond_type = condition_query['cond_type']
-    if cond_type == 'secrets':
-        value = condition_query['value']
-        if type(value) is str:
-            value = [value]
-        for regex in value:
-            parsed = True
-            add_to_custom_detectors(custom_detectors, secret_policy['title'], check_id, regex, secret_policy['isCustom'])
-            logging.info(f"Regex : {secret_policy['title']} added to custom_detectors, custom_detectors len {len(custom_detectors)} ")
-    return parsed
-
-
-def add_detectors_from_code(custom_detectors: List[Dict[str, Any]], code: str, secret_policy: Dict[str, Any], check_id: str) -> bool:
-    parsed = False
-    code_dict = yaml.safe_load(code)
-    if 'definition' in code_dict:
-        if 'value' in code_dict['definition']:
-            parsed = True
-            if type(code_dict['definition']['value']) is str:
-                code_dict['definition']['value'] = [code_dict['definition']['value']]
-            for regex in code_dict['definition']['value']:
-                add_to_custom_detectors(custom_detectors, secret_policy['title'], check_id, regex,
-                                        secret_policy['isCustom'])
-                logging.info(f"Regex : {secret_policy['title']} added to custom_detectors")
-    return parsed
-
-
-def transforms_policies_to_detectors_list(custom_secrets: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    custom_detectors: List[Dict[str, Any]] = []
-    condition_query = None
-    for secret_policy in custom_secrets:
-        parsed = False
-        check_id = secret_policy['checkovCheckId'] if secret_policy['checkovCheckId'] else \
-            secret_policy['incidentId']
-        code = secret_policy['code']
-        if 'conditionQuery' in secret_policy:
-            condition_query = secret_policy['conditionQuery']
-        if condition_query:
-            parsed = add_detectors_from_condition_query(custom_detectors, condition_query, secret_policy, check_id)
-        elif code:
-            parsed = add_detectors_from_code(custom_detectors, code, secret_policy, check_id)
-        if not parsed:
-            logging.info(f"policy : {secret_policy} could not be parsed")
-    return custom_detectors
 
 
 class CustomRegexDetector(RegexBasedDetector):

--- a/checkov/secrets/plugins/load_detectors.py
+++ b/checkov/secrets/plugins/load_detectors.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import \
+    integration as metadata_integration
+import yaml
+
+from checkov.common.bridgecrew.platform_integration import bc_integration
+
+
+def load_detectors() -> list[dict[str, Any]]:
+    detectors: List[dict[str, Any]] = []
+    try:
+        customer_run_config_response = bc_integration.customer_run_config_response
+        policies_list: List[dict[str, Any]] = []
+        if customer_run_config_response:
+            policies_list = customer_run_config_response.get('secretsPolicies', [])
+    except Exception as e:
+        logging.error(f"Failed to get detectors from customer_run_config_response, error: {e}")
+        return []
+
+    if policies_list:
+        detectors = modify_secrets_policy_to_detectors(policies_list)
+    if detectors:
+        logging.info(f"Successfully loaded {len(detectors)} detectors from bc_integration")
+    return detectors
+
+
+def modify_secrets_policy_to_detectors(policies_list: List[dict[str, Any]]) -> List[dict[str, Any]]:
+    secrets_list = transforms_policies_to_detectors_list(policies_list)
+    logging.debug(f"(modify_secrets_policy_to_detectors) secrets_list = {secrets_list}")
+    return secrets_list
+
+
+def add_to_custom_detectors(custom_detectors: List[Dict[str, Any]], name: str, check_id: str, regex: str,
+                            is_custom: str) -> None:
+    custom_detectors.append({'Name': name,
+                             'Check_ID': check_id,
+                             'Regex': regex,
+                             'isCustom': is_custom})
+    if is_custom:
+        logging.debug(f"(add_to_custom_detectors) is custom check_id = {check_id}")
+        metadata_integration.check_metadata[check_id] = {'id': check_id}
+
+
+def add_detectors_from_condition_query(custom_detectors: List[Dict[str, Any]], condition_query: Dict[str, Any],
+                                       secret_policy: Dict[str, Any], check_id: str) -> bool:
+    parsed = False
+    cond_type = condition_query['cond_type']
+    if cond_type == 'secrets':
+        value = condition_query['value']
+        if type(value) is str:
+            value = [value]
+        for regex in value:
+            parsed = True
+            add_to_custom_detectors(custom_detectors, secret_policy['title'], check_id, regex,
+                                    secret_policy['isCustom'])
+            logging.info(
+                f"Regex : {secret_policy['title']} added to custom_detectors, custom_detectors len {len(custom_detectors)} ")
+    return parsed
+
+
+def add_detectors_from_code(custom_detectors: List[Dict[str, Any]], code: str, secret_policy: Dict[str, Any],
+                            check_id: str) -> bool:
+    parsed = False
+    code_dict = yaml.safe_load(code)
+    if 'definition' in code_dict:
+        if 'value' in code_dict['definition']:
+            parsed = True
+            if type(code_dict['definition']['value']) is str:
+                code_dict['definition']['value'] = [code_dict['definition']['value']]
+            for regex in code_dict['definition']['value']:
+                add_to_custom_detectors(custom_detectors, secret_policy['title'], check_id, regex,
+                                        secret_policy['isCustom'])
+                logging.info(f"Regex : {secret_policy['title']} added to custom_detectors")
+    return parsed
+
+
+def transforms_policies_to_detectors_list(custom_secrets: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    custom_detectors: List[Dict[str, Any]] = []
+    condition_query = None
+    for secret_policy in custom_secrets:
+        parsed = False
+        check_id = secret_policy['checkovCheckId'] if secret_policy['checkovCheckId'] else \
+            secret_policy['incidentId']
+        code = secret_policy['code']
+        if 'conditionQuery' in secret_policy:
+            condition_query = secret_policy['conditionQuery']
+        if condition_query:
+            parsed = add_detectors_from_condition_query(custom_detectors, condition_query, secret_policy, check_id)
+        elif code:
+            parsed = add_detectors_from_code(custom_detectors, code, secret_policy, check_id)
+        if not parsed:
+            logging.info(f"policy : {secret_policy} could not be parsed")
+    return custom_detectors
+
+


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

### Description
separate the lode detectors function from the CustomRegexDetector class and add a function to the runner to add custom detectors to metadata integration

### Fix
added function to add the custom policies to the metadata_integration, not in multiprocess

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
