### PR TITLE
chore: add pipenv cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ on:
       - kubernetes/requirements.txt
       - coverage.svg
       - '.swm/**'
+      - '.pre-commit-config.yaml'
 
 concurrency:
   group: 'build'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3
     - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4
+      id: setup-python
       with:
         python-version: 3.7
         cache: "pipenv"
@@ -46,6 +47,10 @@ jobs:
         pipenv --python 3.7
         pipenv install --dev
         pipenv run pip install typed-ast  # for some reason this has an old version
+    - uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12  # v3
+      with:
+        path: ~/.mypy_cache
+        key: mypy-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('Pipfile.lock') }}
     - name: Run Mypy
       run: |
         pipenv run mypy

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -6,14 +6,9 @@ permissions: read-all
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3
-      - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4
-        with:
-          python-version: 3.9
-      - name: pre-commit
-        uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507  # v3
+    uses: bridgecrewio/gha-reusable-workflows/.github/workflows/pre-commit.yaml@main
+    with:
+      python-version: "3.9"
 
   cfn-lint:
     runs-on: [self-hosted, public, linux, x64]
@@ -30,31 +25,7 @@ jobs:
           cfn-lint tests/cloudformation/checks/resource/aws/**/* -i W
 
   mypy:
-    runs-on: ubuntu-latest
-    env:
-      MYPY_CACHE_DIR: ~/.cache/mypy
-    steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3
-    - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4
-      id: setup-python
-      with:
-        python-version: 3.7
-        cache: "pipenv"
-        cache-dependency-path: "Pipfile.lock"
-    - name: Install pipenv
-      run: |
-        python -m pip install --no-cache-dir --upgrade pipenv
-    - name: Install dependencies
-      run: |
-        pipenv --python 3.7
-        pipenv install --dev
-    - uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12  # v3
-      with:
-        path: ${{ env.MYPY_CACHE_DIR }}
-        key: mypy-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('Pipfile.lock') }}
-    - name: Run Mypy
-      run: |
-        pipenv run mypy
+    uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main
 
   unit-tests:
     strategy:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -36,6 +36,8 @@ jobs:
     - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4
       with:
         python-version: 3.7
+        cache: "pipenv"
+        cache-dependency-path: "Pipfile.lock"
     - name: Install pipenv
       run: |
         python -m pip install --no-cache-dir --upgrade pipenv
@@ -61,6 +63,8 @@ jobs:
         uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4
         with:
           python-version: ${{ matrix.python }}
+          cache: "pipenv"
+          cache-dependency-path: "Pipfile.lock"
       - name: Install pipenv
         run: |
           python -m pip install --no-cache-dir --upgrade pipenv
@@ -87,6 +91,8 @@ jobs:
       - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4
         with:
           python-version: ${{ matrix.python }}
+          cache: "pipenv"
+          cache-dependency-path: "Pipfile.lock"
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # v3
       - uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78  # v3
         with:
@@ -135,6 +141,8 @@ jobs:
       - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4
         with:
           python-version: ${{ matrix.python }}
+          cache: "pipenv"
+          cache-dependency-path: "Pipfile.lock"
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # v3
       - uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78  # v3
         with:
@@ -175,6 +183,8 @@ jobs:
       - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pipenv"
+          cache-dependency-path: "Pipfile.lock"
       - uses: azure/setup-helm@f382f75448129b3be48f8121b9857be18d815a82  # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -31,6 +31,8 @@ jobs:
 
   mypy:
     runs-on: ubuntu-latest
+    env:
+      MYPY_CACHE_DIR: ~/.cache/mypy
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3
     - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4
@@ -46,10 +48,9 @@ jobs:
       run: |
         pipenv --python 3.7
         pipenv install --dev
-        pipenv run pip install typed-ast  # for some reason this has an old version
     - uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12  # v3
       with:
-        path: ~/.mypy_cache
+        path: ${{ env.MYPY_CACHE_DIR }}
         key: mypy-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('Pipfile.lock') }}
     - name: Run Mypy
       run: |


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- add pipenv cache to all PR jobs
- add mypy cache

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
