### PR TITLE
fix(terraform): default value for CKV_AZURE_5

### DIFF
--- a/checkov/terraform/checks/resource/azure/AKSRbacEnabled.py
+++ b/checkov/terraform/checks/resource/azure/AKSRbacEnabled.py
@@ -23,10 +23,10 @@ class AKSRbacEnabled(BaseResourceCheck):
         ]
 
         for key in self.evaluated_keys:
-            if dpath.search(conf, key) and dpath.get(conf, key)[0]:
-                return CheckResult.PASSED
+            if dpath.search(conf, key):
+                return CheckResult.PASSED if dpath.get(conf, key)[0] else CheckResult.FAILED
 
-        return CheckResult.FAILED
+        return CheckResult.PASSED
 
 
 check = AKSRbacEnabled()

--- a/tests/terraform/checks/resource/azure/test_AKSRbacEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_AKSRbacEnabled.py
@@ -45,7 +45,7 @@ class TestAKSRbacEnabled(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
-    def test_failure_default(self):
+    def test_success_default(self):
         resource_conf = {
             "name": ["example-aks1"],
             "location": ["${azurerm_resource_group.example.location}"],
@@ -64,7 +64,7 @@ class TestAKSRbacEnabled(unittest.TestCase):
         }
 
         scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.FAILED, scan_result)
+        self.assertEqual(CheckResult.PASSED, scan_result)
 
     # azurerm < 2.99.0
     def test_success(self):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

The check CKV_AZURE_5 should succeed if the `role_based_access_control_enabled` property is not set in resource `azurerm_kubernetes_cluster` as its default value is `true`.

Fixes #4227 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
