### PR TITLE
fix(cloudformation): fix CloudFormation checks related to number values

### DIFF
--- a/checkov/cloudformation/checks/resource/base_resource_value_check.py
+++ b/checkov/cloudformation/checks/resource/base_resource_value_check.py
@@ -60,7 +60,8 @@ class BaseResourceValueCheck(BaseResourceCheck):
                 # CFN files are parsed differently from terraform, which causes the path search above to behave differently.
                 # The tesult is path parts with integer indexes, instead of strings like '[0]'. This logic replaces
                 # those, allowing inspected_keys in checks to use the same syntax.
-                for i in range(0, len(match)):
+                # The last value shouldn't be changed, because it could be indeed a valid number
+                for i in range(0, len(match) - 1):
                     if type(match[i]) == int:
                         match[i] = f"[{match[i]}]"
 

--- a/tests/cloudformation/checks/resource/aws/example_RDSEnhancedMonitorEnabled/PASS.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSEnhancedMonitorEnabled/PASS.yaml
@@ -10,3 +10,13 @@ Resources:
       MasterUserPassword: 'password'
       MonitoringInterval: '60'
       MonitoringRoleArn: 'arn:aws:iam::123456789012:role/rds-monitoring-role'
+  EnabledNumber:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: 'mydb'
+      DBInstanceClass: 'db.t3.micro'
+      Engine: 'mysql'
+      MasterUsername: 'master'
+      MasterUserPassword: 'password'
+      MonitoringInterval: 30
+      MonitoringRoleArn: 'arn:aws:iam::123456789012:role/rds-monitoring-role'

--- a/tests/cloudformation/checks/resource/aws/test_RDSEnhancedMonitorEnabled.py
+++ b/tests/cloudformation/checks/resource/aws/test_RDSEnhancedMonitorEnabled.py
@@ -19,6 +19,7 @@ class TestRDSEnhancedMonitorEnabled(unittest.TestCase):
 
         passing_resources = {
             "AWS::RDS::DBInstance.Enabled",
+            "AWS::RDS::DBInstance.EnabledNumber",
         }
         failing_resources = {
             "AWS::RDS::DBInstance.Default",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- adjusted our base value check to not blindly change every integer to a string, it will leave the last value of the found key-value pair to be as it is

Fixes #4242 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
