### PR TITLE
feat(general): fix circleci crash when cannot find image

### DIFF
--- a/checkov/circleci_pipelines/image_referencer/provider.py
+++ b/checkov/circleci_pipelines/image_referencer/provider.py
@@ -17,7 +17,7 @@ class CircleCIProvider:
     def generate_resource_key(self, start_line: int, end_line: int, tag: str) -> str:
         sub_name = Runner.resolve_sub_name(self.workflow_config, start_line, end_line, tag)
         if not sub_name:    # Failed to locate the resource in the config file
-            return None
+            return ''
         image_name = Runner.resolve_image_name(self.workflow_config[tag][sub_name], start_line, end_line)
         new_key = f'{tag}({sub_name}).docker.image{image_name}' if sub_name else tag
         return new_key

--- a/checkov/circleci_pipelines/image_referencer/provider.py
+++ b/checkov/circleci_pipelines/image_referencer/provider.py
@@ -16,6 +16,8 @@ class CircleCIProvider:
 
     def generate_resource_key(self, start_line: int, end_line: int, tag: str) -> str:
         sub_name = Runner.resolve_sub_name(self.workflow_config, start_line, end_line, tag)
+        if not sub_name:    # Failed to locate the resource in the config file
+            return None
         image_name = Runner.resolve_image_name(self.workflow_config[tag][sub_name], start_line, end_line)
         new_key = f'{tag}({sub_name}).docker.image{image_name}' if sub_name else tag
         return new_key
@@ -35,13 +37,14 @@ class CircleCIProvider:
                 image_name = result.get("image")
                 if image_name:
                     resource_id = self.generate_resource_key(result[START_LINE], result[END_LINE], tag)
-                    images.append(
-                        Image(
-                            file_path=self.file_path,
-                            name=image_name,
-                            start_line=result[START_LINE],
-                            end_line=result[END_LINE],
-                            related_resource_id=resource_id,
+                    if resource_id:
+                        images.append(
+                            Image(
+                                file_path=self.file_path,
+                                name=image_name,
+                                start_line=result[START_LINE],
+                                end_line=result[END_LINE],
+                                related_resource_id=resource_id,
+                            )
                         )
-                    )
         return images

--- a/tests/circleci_pipelines/image_referencer/test_manager.py
+++ b/tests/circleci_pipelines/image_referencer/test_manager.py
@@ -18,3 +18,22 @@ def test_extract_images_from_workflow_no_images(circle_ci_filepath_workflow_no_i
     images = manager.extract_images_from_workflow()
 
     assert not images
+
+def test_extract_images_from_workflow_nested(circle_ci_filepath_workflow_no_images_config):
+    file_path = '/tmp/test_path'
+    config = {
+        'workspace_root': '/go/src/github.com/gruntwork-io/terragrunt',
+        'defaults': {'working_directory': '/go/src/github.com/gruntwork-io/terragrunt', 'docker': [
+            {'image': '087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.11',
+             '__startline__': 6, '__endline__': 8}], '__startline__': 3, '__endline__': 8},
+        'jobs': {
+            'install_dependencies': {'working_directory': '/go/src/github.com/gruntwork-io/terragrunt', 'docker': [
+                {'image': '087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.11',
+                 '__startline__': 6, '__endline__': 8}], 'steps': ['checkout'], '__startline__': 11, '__endline__': 32}
+        }, '__startline__': 1, '__endline__': 143
+    }
+
+    manager = CircleCIImageReferencerManager(file_path=file_path, workflow_config=config)
+    images = manager.extract_images_from_workflow()
+
+    assert not images

--- a/tests/circleci_pipelines/image_referencer/test_manager.py
+++ b/tests/circleci_pipelines/image_referencer/test_manager.py
@@ -23,13 +23,17 @@ def test_extract_images_from_workflow_nested(circle_ci_filepath_workflow_no_imag
     file_path = '/tmp/test_path'
     config = {
         'workspace_root': '/go/src/github.com/gruntwork-io/terragrunt',
-        'defaults': {'working_directory': '/go/src/github.com/gruntwork-io/terragrunt', 'docker': [
-            {'image': '087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.11',
-             '__startline__': 6, '__endline__': 8}], '__startline__': 3, '__endline__': 8},
-        'jobs': {
-            'install_dependencies': {'working_directory': '/go/src/github.com/gruntwork-io/terragrunt', 'docker': [
+        'defaults': {
+            'working_directory': '/go/src/github.com/gruntwork-io/terragrunt', 'docker': [
                 {'image': '087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.11',
-                 '__startline__': 6, '__endline__': 8}], 'steps': ['checkout'], '__startline__': 11, '__endline__': 32}
+                    '__startline__': 6, '__endline__': 8}], '__startline__': 3, '__endline__': 8
+        },
+        'jobs': {
+            'install_dependencies': {
+                'working_directory': '/go/src/github.com/gruntwork-io/terragrunt', 'docker': [
+                {'image': '087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.11',
+                 '__startline__': 6, '__endline__': 8}], 'steps': ['checkout'], '__startline__': 11, '__endline__': 32
+            }
         }, '__startline__': 1, '__endline__': 143
     }
 


### PR DESCRIPTION
This PR fixes a case in circleCI IR which crashes when unable to find image resource.
We need to find a long term solution in which we find nested images which are not aligned according to start/end lines.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
