### PR TITLE
chore: use mock.patch for setting env vars

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1189,6 +1189,7 @@
         },
         "wcwidth": {
             "hashes": [
+                "sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e",
                 "sha256:a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0"
             ],
             "version": "==0.2.6"

--- a/tests/bicep/graph/checks/test_yaml_policies.py
+++ b/tests/bicep/graph/checks/test_yaml_policies.py
@@ -28,7 +28,6 @@ class TestYamlPolicies(TestYamlPoliciesBase):
         )
 
     def setUp(self) -> None:
-        os.environ["UNIQUE_TAG"] = ""
         warnings.filterwarnings("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 

--- a/tests/cloudformation/graph/checks/test_yaml_policies.py
+++ b/tests/cloudformation/graph/checks/test_yaml_policies.py
@@ -23,7 +23,6 @@ class TestYamlPolicies(TestYamlPoliciesBase):
                          os.path.join(file_dir, "test_checks"), "cloudformation", __file__, args)
 
     def setUp(self) -> None:
-        os.environ['UNIQUE_TAG'] = ''
         warnings.filterwarnings("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 

--- a/tests/cloudformation/graph/graph_builder/test_render.py
+++ b/tests/cloudformation/graph/graph_builder/test_render.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 from unittest.case import TestCase
 
 from checkov.cloudformation.graph_builder.graph_components.block_types import BlockType
@@ -8,12 +9,8 @@ from checkov.common.graph.db_connectors.networkx.networkx_db_connector import Ne
 TEST_DIRNAME = os.path.dirname(os.path.realpath(__file__))
 
 
+@mock.patch.dict(os.environ, {"RENDER_ASYNC_MAX_WORKERS": "50", "RENDER_VARIABLES_ASYNC": "False"})
 class TestRenderer(TestCase):
-    def setUp(self) -> None:
-        os.environ['UNIQUE_TAG'] = ''
-        os.environ['RENDER_ASYNC_MAX_WORKERS'] = '50'
-        os.environ['RENDER_VARIABLES_ASYNC'] = 'False'
-
     def test_render_ref(self):
         relative_path = './resources/variable_rendering/render_ref/'
         yaml_test_dir = os.path.realpath(os.path.join(TEST_DIRNAME, relative_path, 'yaml'))

--- a/tests/common/bridgecrew/vulnerability_scanning/integrations/test_docker_image_scanning.py
+++ b/tests/common/bridgecrew/vulnerability_scanning/integrations/test_docker_image_scanning.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from aioresponses import aioresponses
@@ -162,10 +163,10 @@ def test_should_download_new_twistcli(tmp_path: Path):
     assert scanner.should_download()
 
 
+@mock.patch.dict(os.environ, {"CHECKOV_EXPIRATION_TIME_IN_SEC": str(CHECKOV_SEC_IN_WEEK)})
 def test_not_should_download_twistcli(tmp_path: Path):
     # given
     scanner = ImageScanner()
-    os.environ["CHECKOV_EXPIRATION_TIME_IN_SEC"] = str(CHECKOV_SEC_IN_WEEK)
     twistcli_path = tmp_path / "twistcli"
     twistcli_path.touch()
     scanner.twistcli_path = twistcli_path
@@ -174,10 +175,10 @@ def test_not_should_download_twistcli(tmp_path: Path):
     assert not scanner.should_download()
 
 
+@mock.patch.dict(os.environ, {"CHECKOV_EXPIRATION_TIME_IN_SEC": "0"})
 def test_should_download_twistcli_again(tmp_path: Path):
     # given
     scanner = ImageScanner()
-    os.environ["CHECKOV_EXPIRATION_TIME_IN_SEC"] = "0"
     twistcli_path = tmp_path / "twistcli"
     twistcli_path.touch()
     scanner.twistcli_path = twistcli_path

--- a/tests/common/output/test_get_exit_code.py
+++ b/tests/common/output/test_get_exit_code.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import unittest
+from unittest import mock
 
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.bridgecrew.code_categories import CodeCategoryType, CodeCategoryConfiguration
@@ -138,10 +139,20 @@ class TestGetExitCode(unittest.TestCase):
         self.assertEqual(combined_test_soft_fail_id_hard_fail_sev, 1)
         self.assertEqual(combined_test_soft_fail_id_hard_fail_sev_fail, 0)
 
-        os.environ[PARSE_ERROR_FAIL_FLAG] = 'true'
-        r.add_parsing_error('some_file.tf')
-        self.assertEqual(r.get_exit_code({'soft_fail': False, 'soft_fail_checks': [], 'soft_fail_threshold': None, 'hard_fail_checks': [], 'hard_fail_threshold': None}), 1)
-        del os.environ[PARSE_ERROR_FAIL_FLAG]
+        with mock.patch.dict(os.environ, {PARSE_ERROR_FAIL_FLAG: "true"}):
+            r.add_parsing_error("some_file.tf")
+            self.assertEqual(
+                r.get_exit_code(
+                    {
+                        "soft_fail": False,
+                        "soft_fail_checks": [],
+                        "soft_fail_threshold": None,
+                        "hard_fail_checks": [],
+                        "hard_fail_threshold": None,
+                    }
+                ),
+                1,
+            )
 
     def test_get_fail_thresholds_enforcement_rules(self):
 

--- a/tests/dockerfile/graph_builder/checks/test_yaml_policies.py
+++ b/tests/dockerfile/graph_builder/checks/test_yaml_policies.py
@@ -28,7 +28,6 @@ class TestYamlPolicies(TestYamlPoliciesBase):
         )
 
     def setUp(self) -> None:
-        os.environ["UNIQUE_TAG"] = ""
         warnings.filterwarnings("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 

--- a/tests/github_actions/checks/graph_checks/test_yaml_policies.py
+++ b/tests/github_actions/checks/graph_checks/test_yaml_policies.py
@@ -29,7 +29,6 @@ class TestYamlPolicies(TestYamlPoliciesBase):
         )
 
     def setUp(self) -> None:
-        os.environ["UNIQUE_TAG"] = ""
         warnings.filterwarnings("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 

--- a/tests/sca_package/conftest.py
+++ b/tests/sca_package/conftest.py
@@ -8,8 +8,6 @@ from pytest_mock import MockerFixture
 
 import pytest
 
-os.environ['CHECKOV_RUN_SCA_PACKAGE_SCAN_V2'] = 'false'
-
 from checkov.common.bridgecrew.bc_source import SourceType
 from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration, bc_integration
 from checkov.common.output.report import Report
@@ -17,6 +15,11 @@ from checkov.sca_package.runner import Runner
 from checkov.runner_filter import RunnerFilter
 
 EXAMPLES_DIR = Path(__file__).parent / "examples"
+
+@pytest.fixture(autouse=True)
+def mock_env_vars():
+    with mock.patch.dict(os.environ, {"CHECKOV_RUN_SCA_PACKAGE_SCAN_V2": "false"}):
+        yield
 
 
 @pytest.fixture()

--- a/tests/sca_package_2/conftest.py
+++ b/tests/sca_package_2/conftest.py
@@ -8,8 +8,6 @@ from pytest_mock import MockerFixture
 
 import pytest
 
-os.environ['CHECKOV_RUN_SCA_PACKAGE_SCAN_V2'] = 'true'
-
 from checkov.common.bridgecrew.bc_source import SourceType
 from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration, bc_integration
 from checkov.common.output.report import Report
@@ -17,6 +15,11 @@ from checkov.sca_package_2.runner import Runner
 from checkov.runner_filter import RunnerFilter
 
 EXAMPLES_DIR = Path(__file__).parent / "examples"
+
+@pytest.fixture(autouse=True)
+def mock_env_vars():
+    with mock.patch.dict(os.environ, {"CHECKOV_RUN_SCA_PACKAGE_SCAN_V2": "true"}):
+        yield
 
 
 @pytest.fixture()

--- a/tests/serverless/checks/aws/test_AdminPolicyDocument.py
+++ b/tests/serverless/checks/aws/test_AdminPolicyDocument.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest import mock
 
 from checkov.serverless.checks.function.aws.AdminPolicyDocument import check
 from checkov.serverless.runner import Runner
@@ -7,12 +8,10 @@ from checkov.runner_filter import RunnerFilter
 
 class TestAdminPolicyDocument(unittest.TestCase):
 
+    @mock.patch.dict(os.environ, {"sneaky_var": "*"})
     def test_summary(self):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
-
-        # Used in
-        os.environ["sneaky_var"] = "*"
 
         test_files_dir = current_dir + "/example_AdminPolicyDocument"
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))

--- a/tests/terraform/graph/checks/test_yaml_connected_nodes.py
+++ b/tests/terraform/graph/checks/test_yaml_connected_nodes.py
@@ -7,7 +7,6 @@ from .test_yaml_policies import load_yaml_data, get_policy_results
 
 class TestYamlConnectedNodes(unittest.TestCase):
     def setUp(self) -> None:
-        os.environ['UNIQUE_TAG'] = ''
         warnings.filterwarnings("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -19,7 +19,6 @@ from checkov.terraform.runner import Runner
 
 class TestYamlPolicies(unittest.TestCase):
     def setUp(self) -> None:
-        os.environ['UNIQUE_TAG'] = ''
         warnings.filterwarnings("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 

--- a/tests/terraform/graph/variable_rendering/test_render_scenario.py
+++ b/tests/terraform/graph/variable_rendering/test_render_scenario.py
@@ -218,9 +218,8 @@ class TestRendererScenarios(TestCase):
     def test_default_var_types(self):
         self.go("default_var_types")
 
+    @mock.patch.dict(os.environ, {"RENDER_VARIABLES_ASYNC": "False", "LOG_LEVEL": "INFO"})
     def go(self, dir_name, different_expected=None, replace_expected=False, vars_files=None, remove_abs_dir=False):
-        os.environ['RENDER_VARIABLES_ASYNC'] = 'False'
-        os.environ['LOG_LEVEL'] = 'INFO'
         different_expected = {} if not different_expected else different_expected
         resources_dir = os.path.realpath(
             os.path.join(TEST_DIRNAME, '../../parser/resources/parser_scenarios', dir_name))

--- a/tests/terraform/graph/variable_rendering/test_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_renderer.py
@@ -19,12 +19,8 @@ from tests.terraform.graph.variable_rendering.expected_data import (
 TEST_DIRNAME = os.path.dirname(os.path.realpath(__file__))
 
 
+@mock.patch.dict(os.environ, {"RENDER_ASYNC_MAX_WORKERS": "50", "RENDER_VARIABLES_ASYNC": "False"})
 class TestRenderer(TestCase):
-    def setUp(self) -> None:
-        os.environ['UNIQUE_TAG'] = ''
-        os.environ['RENDER_ASYNC_MAX_WORKERS'] = '50'
-        os.environ['RENDER_VARIABLES_ASYNC'] = 'False'
-
     def test_render_local(self):
         resources_dir = os.path.join(TEST_DIRNAME, '../resources/variable_rendering/render_local')
         graph_manager = TerraformGraphManager('acme', ['acme'])


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- replaced `os.environ` usage for setting the env var in tests to use `mock.patch` to remove side effects

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
