### PR TITLE
fix(terraform): fix error for push_skipped_checks_down with definition that not in the definition context

### DIFF
--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -555,7 +555,7 @@ class Runner(ImageReferencerMixin[None], BaseRunner[TerraformGraphManager]):
             return
 
         for definition in resolved_paths:
-            for block_type, block_configs in definition_context[definition].items():
+            for block_type, block_configs in definition_context.get(definition, {}).items():
                 # skip if type is not a Terraform resource
                 if block_type not in CHECK_BLOCK_TYPES:
                     continue


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
## Description
files without `definition_blocks_types` don't save in the definition context.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
