### PR TITLE
fix(secrets): change default secret validation status to unavailable

### DIFF
--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -357,7 +357,7 @@ class Runner(BaseRunner[None]):
 
                 if secrets_record.validation_status is None:
                     logging.debug(f'Failed to find verification status of {key}, setting by default to Unknown')
-                    secrets_record.validation_status = ValidationStatus.UNKNOWN.value
+                    secrets_record.validation_status = ValidationStatus.UNAVAILABLE.value
 
         return VerifySecretsResult.SUCCESS
 

--- a/tests/secrets/test_secrets_verification.py
+++ b/tests/secrets/test_secrets_verification.py
@@ -151,3 +151,5 @@ def test_runner_verify_secrets(mock_bc_integration, mock_metadata_integration):
     for check in report.failed_checks:
         if check.file_path == rel_resource_path and check.resource == resource_id:
             assert check.validation_status == 'Valid'
+        else:
+            assert check.validation_status == 'Unavailable'


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
