### PR TITLE
fix(terraform): fix default behaviour of CKV_GCP_19

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GKEBasicAuth.py
+++ b/checkov/terraform/checks/resource/gcp/GKEBasicAuth.py
@@ -1,37 +1,36 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
-from typing import List
 
 
 class GKEBasicAuth(BaseResourceCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure GKE basic auth is disabled"
         id = "CKV_GCP_19"
-        supported_resources = ['google_container_cluster']
-        categories = [CheckCategories.KUBERNETES]
+        supported_resources = ('google_container_cluster',)
+        categories = (CheckCategories.KUBERNETES,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
-        """
-            Looks for password configuration at azure_instance:
-            https://www.terraform.io/docs/providers/google/r/compute_ssl_policy.html
-        :param conf: google_compute_ssl_policy configuration
-        :return: <CheckResult>
-        """
-        if 'master_auth' in conf.keys():
-            username = conf['master_auth'][0].get('username')
-            password = conf['master_auth'][0].get('password')
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        # since GKE 1.19 the usage of basic auth is deprecated and in the provider version 4+ removed
+        master_auth = conf.get("master_auth")
+        if master_auth and isinstance(master_auth, list):
+            username = master_auth[0].get('username')
+            password = master_auth[0].get('password')
             if username or password:
                 # only if both are set to the empty string it is fine
-                # https://www.terraform.io/docs/providers/google/r/container_cluster.html
+                # https://registry.terraform.io/providers/hashicorp/google/3.90.1/docs/resources/container_cluster.html
                 if username and password:
                     if username[0] == '' and password[0] == '':
                         return CheckResult.PASSED
                 return CheckResult.FAILED
-            return CheckResult.PASSED
-        return CheckResult.FAILED
 
-    def get_evaluated_keys(self) -> List[str]:
+        return CheckResult.PASSED
+
+    def get_evaluated_keys(self) -> list[str]:
         return ['master_auth/[0]/username', 'master_auth/[0]/password']
 
 

--- a/tests/terraform/checks/resource/gcp/example_GKEBasicAuth/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GKEBasicAuth/main.tf
@@ -1,5 +1,5 @@
 
-resource "google_container_cluster" "fail4" {
+resource "google_container_cluster" "fail2" {
   name               = "marcellus-wallace"
   location           = "us-central1-a"
   initial_node_count = 3
@@ -11,18 +11,6 @@ resource "google_container_cluster" "fail4" {
       issue_client_certificate = false
     }
   }
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-}
-
-
-resource "google_container_cluster" "fail3" {
-  name               = "marcellus-wallace"
-  location           = "us-central1-a"
-  initial_node_count = 3
 
   timeouts {
     create = "30m"
@@ -47,13 +35,6 @@ resource "google_container_cluster" "fail" {
   }
 
 }
-
-resource "google_container_cluster" "fail2" {
-  name               = "google_cluster"
-  monitoring_service = "monitoring.googleapis.com"
-  master_authorized_networks_config {}
-}
-
 
 resource "google_container_cluster" "pass" {
   name               = "google_cluster"
@@ -80,3 +61,13 @@ resource "google_container_cluster" "pass2" {
 
 }
 
+resource "google_container_cluster" "pass3" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/tests/terraform/checks/resource/gcp/test_GKEBasicAuth.py
+++ b/tests/terraform/checks/resource/gcp/test_GKEBasicAuth.py
@@ -1,5 +1,5 @@
 import unittest
-import os
+from pathlib import Path
 
 from checkov.terraform.checks.resource.gcp.GKEBasicAuth import check
 from checkov.runner_filter import RunnerFilter
@@ -7,31 +7,26 @@ from checkov.terraform.runner import Runner
 
 
 class TestGKEBinaryAuthorization(unittest.TestCase):
-
     def test(self):
-        runner = Runner()
-        current_dir = os.path.dirname(os.path.realpath(__file__))
-
-        test_files_dir = current_dir + "/example_GKEBasicAuth"
-        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        test_files_dir = Path(__file__).parent / "example_GKEBasicAuth"
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
         passing_resources = {
             'google_container_cluster.pass',
             'google_container_cluster.pass2',
+            'google_container_cluster.pass3',
         }
         failing_resources = {
             'google_container_cluster.fail',
             'google_container_cluster.fail2',
-            'google_container_cluster.fail3',
-            'google_container_cluster.fail4',
         }
 
-        passed_check_resources = set([c.resource for c in report.passed_checks])
-        failed_check_resources = set([c.resource for c in report.failed_checks])
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary['passed'], 2)
-        self.assertEqual(summary['failed'], 4)
+        self.assertEqual(summary['passed'], 3)
+        self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- usage of basic auth is deprecated since GKE 1.19 and removed in the provider version 4+

Fixes #4264 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
