### PR TITLE
fix(cloudformation): Add check for Aurora RDS instances for MultiAZ

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/RDSMultiAZEnabled.py
+++ b/checkov/cloudformation/checks/resource/aws/RDSMultiAZEnabled.py
@@ -1,8 +1,7 @@
-from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.cloudformation.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.common.models.enums import CheckCategories
 
-
-class RDSMultiAZEnabled(BaseResourceValueCheck):
+class RDSMultiAZEnabled(BaseResourceCheck):
     def __init__(self):
         name = "Ensure that RDS instances have Multi-AZ enabled"
         id = "CKV_AWS_157"
@@ -10,8 +9,18 @@ class RDSMultiAZEnabled(BaseResourceValueCheck):
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return 'Properties/MultiAZ'
-
+    def scan_resource_conf(self, conf):
+        properties = conf.get("Properties")
+        aurora = "aurora"
+        if properties:
+            engine = properties.get("Engine")
+            if engine and engine in aurora:
+                return CheckResult.PASSED
+            value = properties.get("MultiAZ")
+            if isinstance(value, bool):
+                value = str(value).lower()
+            if value == "true":
+                return CheckResult.PASSED
+        return CheckResult.FAILED
 
 check = RDSMultiAZEnabled()

--- a/tests/cloudformation/checks/resource/aws/example_RDSMultiAZEnabled/RDSMultiAZEnabled-PASSED-2.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_RDSMultiAZEnabled/RDSMultiAZEnabled-PASSED-2.yaml
@@ -1,0 +1,9 @@
+Resources:
+  MyDBAurora:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: 'mydb_enabled'
+      DBInstanceClass: 'db.t3.micro'
+      Engine: 'aurora-mysql'
+      MasterUsername: 'master'
+      MasterUserPassword: 'password'

--- a/tests/cloudformation/checks/resource/aws/test_RDSMultiAZEnabled.py
+++ b/tests/cloudformation/checks/resource/aws/test_RDSMultiAZEnabled.py
@@ -18,6 +18,7 @@ class TestRDSMultiAZEnabled(unittest.TestCase):
 
         passing_resources = {
             "AWS::RDS::DBInstance.MyDBEnabled",
+            "AWS::RDS::DBInstance.MyDBAurora"
         }
         failing_resources = {
             "AWS::RDS::DBInstance.MyDBDefault",
@@ -27,7 +28,7 @@ class TestRDSMultiAZEnabled(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Add necessary checks to pass Aurora instances for CKV_AWS_157 for CloudFormation. For Aurora RDS instances, `MultiAZ` is not applicable since Multi AZ is a feature of Aurora by default. 

Fixes # ([4287](https://github.com/bridgecrewio/checkov/issues/4287))

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
