### PR TITLE
fix(terraform): adjust CKV_AZURE_168 to check for unresolvable variable references

### DIFF
--- a/checkov/terraform/checks/resource/azure/AKSMaxPodsMinimum.py
+++ b/checkov/terraform/checks/resource/azure/AKSMaxPodsMinimum.py
@@ -18,16 +18,26 @@ class AKSMaxPodsMinimum(BaseResourceCheck):
         max_pods = 30  # default is 30
 
         self.evaluated_keys = ["max_pods"]
-        if "max_pods" in conf.keys() and isinstance(conf["max_pods"][0], int):
-            max_pods = conf["max_pods"][0]
+        pods = conf.get("max_pods")
+        if pods and isinstance(pods, list):
+            pods = pods[0]
+            if self._is_variable_dependant(pods):
+                return CheckResult.UNKNOWN
+            elif isinstance(pods, int):
+                max_pods = pods
 
-        if "default_node_pool" in conf.keys():
+        pool = conf.get("default_node_pool")
+        if pool and isinstance(pool, list):
             self.evaluated_keys = ["default_node_pool/max_pods"]
-            pool = conf["default_node_pool"][0]
-            if "max_pods" in pool.keys():
-                max_pods_list = pool["max_pods"]
-                if max_pods_list and isinstance(max_pods_list, list) and isinstance(max_pods_list[0], int):
-                    max_pods = max_pods_list[0]
+
+            pool = pool[0]
+            pods = pool.get("max_pods")
+            if pods and isinstance(pods, list):
+                pods = pods[0]
+                if self._is_variable_dependant(pods):
+                    return CheckResult.UNKNOWN
+                elif isinstance(pods, int):
+                    max_pods = pods
 
         if max_pods < 50:
             return CheckResult.FAILED

--- a/tests/terraform/checks/resource/azure/example_AKSMaxPodsMinimum/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AKSMaxPodsMinimum/main.tf
@@ -120,3 +120,34 @@ resource "azurerm_kubernetes_cluster_node_pool" "fail2" {
     Environment = "Production"
   }
 }
+
+# unknown
+
+resource "azurerm_kubernetes_cluster_node_pool" "unknown" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.example.id
+  vm_size               = "Standard_DS2_v2"
+  node_count            = 1
+  max_pods              = var.max_pods
+}
+
+resource "azurerm_kubernetes_cluster" "unknown_2" {
+  name                = "example-aks1"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  dns_prefix          = "exampleaks1"
+
+  default_node_pool {
+    name       = var.default_node_pool.name
+    node_count = var.default_node_pool.node_count
+    vm_size    = var.default_node_pool.vm_size
+    max_pods   = var.max_pods
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  local_account_disabled  = var.local_account_disabled
+  private_cluster_enabled = var.private_cluster
+}

--- a/tests/terraform/checks/resource/azure/test_AKSMaxPodsMinimum.py
+++ b/tests/terraform/checks/resource/azure/test_AKSMaxPodsMinimum.py
@@ -7,7 +7,6 @@ from checkov.terraform.checks.resource.azure.AKSMaxPodsMinimum import check
 
 
 class TestAKSMaxPodsMinimum(unittest.TestCase):
-
     def test(self):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -30,13 +29,14 @@ class TestAKSMaxPodsMinimum(unittest.TestCase):
         }
         skipped_resources = {}
 
-        passed_check_resources = set([c.resource for c in report.passed_checks])
-        failed_check_resources = set([c.resource for c in report.failed_checks])
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
 
         self.assertEqual(summary['passed'], len(passing_resources))
         self.assertEqual(summary['failed'], len(failing_resources))
         self.assertEqual(summary['skipped'], len(skipped_resources))
         self.assertEqual(summary['parsing_errors'], 0)
+        self.assertEqual(summary['resource_count'], len(passing_resources) + len(failing_resources) + 2)  # 2 unknown
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added an extra check for making sure the value is not an unresolved variable reference

Fixes #4290 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
