### PR TITLE
feat(azure): add CKV_AZUREPIPELINES_4 preventing malicious setting of system variables via user defined input

### DIFF
--- a/checkov/azure_pipelines/checks/job/DefineSettableVariables.py
+++ b/checkov/azure_pipelines/checks/job/DefineSettableVariables.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.azure_pipelines.checks.base_azure_pipelines_check import BaseAzurePipelinesCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.yaml_doc.enums import BlockType
+
+
+class DefineSettableVariables(BaseAzurePipelinesCheck):
+    def __init__(self) -> None:
+        name = "Ensure a task enforces settableVariables to prevent malicious user input overriding system vars."
+        id = "CKV_AZUREPIPELINES_4"
+        super().__init__(
+            name=name,
+            id=id,
+            categories=(CheckCategories.SUPPLY_CHAIN,),
+            supported_entities=("jobs[].steps[]", "stages[].jobs[].steps[]"),
+            block_type=BlockType.ARRAY,
+        )
+
+    def scan_conf(self, conf: dict[str, Any]) -> tuple[CheckResult, dict[str, Any]]:
+        run_cmd = conf.get("bash") or conf.get("powershell")
+        if run_cmd and isinstance(run_cmd, str):
+            target_subsection = conf.get("target")
+            if target_subsection:
+                settableVariables_subsection = target_subsection.get("settableVariables")
+                if settableVariables_subsection:
+                    return CheckResult.PASSED, conf
+
+            return CheckResult.FAILED, conf
+
+        else:
+            return CheckResult.UNKNOWN, conf
+
+
+check = DefineSettableVariables()

--- a/tests/azure_pipelines/checks/jobs/example_DefineSettableVariables/azure-pipelines.yml
+++ b/tests/azure_pipelines/checks/jobs/example_DefineSettableVariables/azure-pipelines.yml
@@ -1,0 +1,53 @@
+resources:
+- repo: self
+
+trigger:
+- master
+
+stages:
+- stage: Example
+  jobs:
+  - job: PassDefineSettableVariables
+    pool:
+      vmImage: 'ubuntu-18.04'
+
+    container: ubuntu
+
+    steps:
+      - bash: |
+          echo "##vso[task.setvariable variable=power;issecret=false]something"
+        target:
+          settableVariables:
+          - power
+      - powershell: |
+          Write-Host "##vso[task.setvariable variable=sauce;issecret=false]something"
+        target:
+          settableVariables:
+            - sauce
+  - job: UnknownNoBashOrPowershell
+    pool:
+      vmImage: 'ubuntu-18.04'
+
+    container: ubuntu@sha256:a0a45bd8c6c4acd6967396366f01f2a68f73406327285edc5b7b07cb1cf073db
+
+jobs:
+- job: FailDoNotDefineSettableVariables
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - bash: |
+      echo "##vso[task.setvariable variable=normal_variable;]something"
+      echo "##vso[task.setvariable variable=secret_variable;issecret=true]super-secret"
+    name: setSecretVariableStep
+  - powershell: |
+      Write-Host "##vso[task.setvariable variable=normal_variable;]something"
+      Write-Host "##vso[task.setvariable variable=secret_variable;issecret=true]super-secret"
+
+- job: FailDoNotDefineSettableVariables2
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - bash: |
+      echo "##vso[task.setvariable variable=normal_variable;]something"
+  - powershell: |
+      Write-Host "##vso[task.setvariable variable=normal_variable;]something"

--- a/tests/azure_pipelines/checks/jobs/test_DefineSettableVariables.py
+++ b/tests/azure_pipelines/checks/jobs/test_DefineSettableVariables.py
@@ -16,8 +16,8 @@ def test_examples():
     summary = report.get_summary()
 
     passing_resources = {
-        f"jobs[1](PassSetNormalVariable).steps[0]",
-        f"jobs[1](PassSetNormalVariable).steps[1]",
+        f"stages[0](Example).jobs[0](PassDefineSettableVariables).steps[0]",
+        f"stages[0](Example).jobs[0](PassDefineSettableVariables).steps[1]",
     }
 
     failing_resources = {

--- a/tests/azure_pipelines/checks/jobs/test_DefineSettableVariables.py
+++ b/tests/azure_pipelines/checks/jobs/test_DefineSettableVariables.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from checkov.azure_pipelines.runner import Runner
+from checkov.azure_pipelines.checks.job.SetSecretVariable import check
+from checkov.runner_filter import RunnerFilter
+
+
+def test_examples():
+    # given
+    test_files_dir = Path(__file__).parent / "example_DefineSettableVariables"
+
+    # when
+    report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+    # then
+    summary = report.get_summary()
+
+    passing_resources = {
+        f"jobs[1](PassSetNormalVariable).steps[0]",
+        f"jobs[1](PassSetNormalVariable).steps[1]",
+    }
+
+    failing_resources = {
+        f"jobs[0](FailDoNotDefineSettableVariables).steps[0]",
+        f"jobs[0](FailDoNotDefineSettableVariables2).steps[0]",
+    }
+
+    passed_check_resources = {c.resource for c in report.passed_checks}
+    failed_check_resources = {c.resource for c in report.failed_checks}
+
+    assert summary["passed"] == len(passing_resources)
+    assert summary["failed"] == len(failing_resources)
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0
+
+    assert passed_check_resources == passing_resources
+    assert failed_check_resources == failing_resources


### PR DESCRIPTION
"Ensure a task enforces settableVariables to prevent malicious user input overriding system vars."

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

### Description

From: https://learn.microsoft.com/en-us/azure/devops/pipelines/security/misc?view=azure-devops (Search `settableVariables`)

"" Because pipeline variables are exported as environment variables to subsequent tasks, tasks that output user-provided data (for example, the contents of open issues retrieved from a REST API) can be vulnerable to injection attacks. Such user content can set environment variables that can in turn be used to exploit the agent host. To disallow this, pipeline authors can explicitly declare which variables are settable via the settableVariable command. Specifying an empty list disallows setting all variables. ""

Example (Azure Docs)
```
# this task will fail because the task is only allowed to set the 'expectedVar' variable, or a variable prefixed with "ok"
- task: PowerShell@2
  target:
    commands: restricted
    settableVariables:
    - expectedVar
    - ok*
  inputs:
    targetType: 'inline'
    script: |
      Write-Host "##vso[task.setvariable variable=BadVar]myValue"
```

This check ensures that any job/stage with a Bash or Powershell component has also defined a `settableVariables` list.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
