### PR TITLE
fix(terraform_plan): fix in deep analysis

### DIFF
--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -249,7 +249,8 @@ class Runner(TerraformRunner):
     def get_entity_context_and_evaluations(self, entity):
         raw_context = self.get_entity_context(entity[CustomAttributes.BLOCK_NAME].split("."),
                                               entity[CustomAttributes.FILE_PATH])
-        raw_context['definition_path'] = entity[CustomAttributes.BLOCK_NAME].split('.')
+        if raw_context:
+            raw_context['definition_path'] = entity[CustomAttributes.BLOCK_NAME].split('.')
         return raw_context, None
 
     def get_entity_context(self, definition_path, full_file_path):

--- a/tests/terraform/runner/resources/plan_and_tf_combine_graph/source/module2/main.tf
+++ b/tests/terraform/runner/resources/plan_and_tf_combine_graph/source/module2/main.tf
@@ -9,3 +9,7 @@ resource "aws_s3_bucket_public_access_block" "var_bucket" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+resource "aws_s3_bucket" "example3" {
+  bucket = "example"
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
An exception was raised when we got graph check results on the terraform files because they aren't saved in the definitions_context. 
Thus results are filtered out anyway so we can return None for the context.
Add terraform resource that has graph check result for the plan_and_tf_combine_graph test

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
