### PR TITLE
fix(general): ignore repo_id setting when list flag is set

### DIFF
--- a/checkov/common/util/docs_generator.py
+++ b/checkov/common/util/docs_generator.py
@@ -38,6 +38,9 @@ from checkov.runner_filter import RunnerFilter
 
 ID_PARTS_PATTERN = re.compile(r'([^_]*)_([^_]*)_(\d+)')
 CODE_LINK_BASE = 'https://github.com/bridgecrewio/checkov/blob/main/checkov'
+SKIP_CHECK_IDS = {
+    "CKV_SECRET_10",  # this is an intermediate step, which is needed for another check
+}
 
 
 def get_compare_key(c: list[str] | tuple[str, ...]) -> list[tuple[str, str, int, int, str]]:
@@ -168,6 +171,9 @@ def get_checks(frameworks: Optional[List[str]] = None, use_bc_ids: bool = False,
         add_from_repository(ansible_registry, "resource", "Ansible")
     if any(x in framework_list for x in ("all", "secrets")):
         for check_id, check_type in CHECK_ID_TO_SECRET_TYPE.items():
+            if check_id in SKIP_CHECK_IDS:
+                continue
+
             if not filtered_policy_ids or check_id in filtered_policy_ids:
                 if use_bc_ids:
                     check_id = metadata_integration.get_bc_id(check_id)

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -690,17 +690,18 @@ class Checkov:
                                 'created it, not the token ID visible later on. If you are using environment variables, '
                                 'make sure they are properly set and exported.')
 
-            if self.config.repo_id is None and not self.config.list:
+            if not self.config.list:
                 # if you are only listing policies, then the API key will be used to fetch policies, but that's it,
-                # so the repo is not required
-                self.parser.error("--repo-id argument is required when using --bc-api-key")
-            elif self.config.repo_id:
-                repo_id_sections = self.config.repo_id.split('/')
-                if len(repo_id_sections) < 2 or any(len(section) == 0 for section in repo_id_sections):
-                    self.parser.error(
-                        "--repo-id argument format should be 'organization/repository_name' E.g "
-                        "bridgecrewio/checkov"
-                    )
+                # so the repo is not required and ignored
+                if self.config.repo_id is None:
+                    self.parser.error("--repo-id argument is required when using --bc-api-key")
+                else:
+                    repo_id_sections = self.config.repo_id.split('/')
+                    if len(repo_id_sections) < 2 or any(len(section) == 0 for section in repo_id_sections):
+                        self.parser.error(
+                            "--repo-id argument format should be 'organization/repository_name' E.g "
+                            "bridgecrewio/checkov"
+                        )
 
             try:
                 bc_integration.bc_api_key = self.config.bc_api_key

--- a/integration_tests/test_checkov_platform_only_policies.py
+++ b/integration_tests/test_checkov_platform_only_policies.py
@@ -1,18 +1,18 @@
-import os
 import platform
 import sys
 import unittest
 import re
+from pathlib import Path
 
 from checkov.common.models.consts import ckv_check_id_pattern
 
-current_dir = os.path.dirname(os.path.realpath(__file__))
+current_dir = Path(__file__).parent
 
 
 class TestCheckovPlatformOnlyPolicies(unittest.TestCase):
 
     def test_no_ckv_ids_api_key(self):
-        checks_list_path = os.path.join(current_dir, '..', 'checkov_checks_list.txt')
+        checks_list_path = current_dir.parent / 'checkov_checks_list.txt'
         if sys.version_info[1] == 7 and platform.system() == 'Linux':
             with open(checks_list_path, encoding='utf-8') as f:
                 for i, line in enumerate(f):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- fixed an issue when the `repo-id` and `list` flag are used at the same time
  - this fix the broken list test under integration tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
