### PR TITLE
fix(kubernetes): handle k8s resource with missing required data

### DIFF
--- a/checkov/kubernetes/graph_builder/local_graph.py
+++ b/checkov/kubernetes/graph_builder/local_graph.py
@@ -147,7 +147,12 @@ class KubernetesLocalGraph(LocalGraph[KubernetesBlock]):
         if conf.get('kind') in SUPPORTED_POD_CONTAINERS_TYPES:
             # means this is a Pod resource nested in a supported template container resource
             template[PARENT_RESOURCE_ID_KEY_NAME] = get_resource_id(conf)
-            template[PARENT_RESOURCE_KEY_NAME] = conf.get('metadata', {}).get('name', "")
+            metadata = conf.get('metadata', {})
+            if not metadata:
+                # resource does not contain all required fields and can not be associated with the pod
+                all_resources.append(conf)
+                return
+            template[PARENT_RESOURCE_KEY_NAME] = metadata.get('name', "")
         if is_invalid_k8_pod_definition(template):
             all_resources.append(conf)
             return

--- a/checkov/kubernetes/kubernetes_utils.py
+++ b/checkov/kubernetes/kubernetes_utils.py
@@ -71,7 +71,7 @@ def get_skipped_checks(entity_conf: dict[str, Any]) -> list[_SkippedCheck]:
         return skipped
     if "metadata" in entity_conf.keys():
         metadata = entity_conf["metadata"]
-    if "annotations" in metadata.keys() and metadata["annotations"] is not None:
+    if metadata and "annotations" in metadata.keys() and metadata["annotations"] is not None:
         if isinstance(metadata["annotations"], dict):
             metadata["annotations"] = force_list(metadata["annotations"])
         for annotation in metadata["annotations"]:

--- a/tests/kubernetes/graph/resources/faulty_resources/deployment_missing_metadata.yaml
+++ b/tests/kubernetes/graph/resources/faulty_resources/deployment_missing_metadata.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+spec:
+  selector:
+    matchLabels:
+      app: myapp
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+      - name: podName
+        image: ngnix
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 80

--- a/tests/kubernetes/graph/test_local_graph.py
+++ b/tests/kubernetes/graph/test_local_graph.py
@@ -181,3 +181,16 @@ class TestKubernetesLocalGraph(TestGraph):
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(6, len(local_graph.vertices))
         self.assertEqual(1, len(local_graph.edges))
+
+    def test_deployment_with_missing_metadata(self) -> None:
+        relative_file_path = "resources/faulty_resources/deployment_missing_metadata.yaml"
+        definitions = {}
+        file = os.path.realpath(os.path.join(TEST_DIRNAME, relative_file_path))
+        (definitions[relative_file_path], definitions_raw) = parse(file)
+        graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
+
+        local_graph = KubernetesLocalGraph(definitions)
+        local_graph.edge_builders = (NetworkPolicyEdgeBuilder, LabelSelectorEdgeBuilder)
+        local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
+        self.assertEqual(0, len(local_graph.vertices))
+        self.assertEqual(0, len(local_graph.edges))


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

When `Deployment` resource is missing metadata object it can't be associated to the nested pod (anyway this is required so the resource is not valid when it's missing). Skipping the extraction of the nested in this case

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
