### PR TITLE
feat(azure): change detect image source

### DIFF
--- a/checkov/azure_pipelines/checks/job/DetectImagesUsage.py
+++ b/checkov/azure_pipelines/checks/job/DetectImagesUsage.py
@@ -15,7 +15,7 @@ class DetectImageUsage(BaseAzurePipelinesCheck):
             name=name,
             id=id,
             categories=(CheckCategories.SUPPLY_CHAIN,),
-            supported_entities=("*.image[]", "*.vmImage[]", "*.container[]"),
+            supported_entities=("jobs[]", "*.container[]"),
             block_type=BlockType.ARRAY,
         )
 

--- a/tests/azure_pipelines/image_referencer/test_runner.py
+++ b/tests/azure_pipelines/image_referencer/test_runner.py
@@ -39,7 +39,7 @@ def test_azure_pipelines_workflow(mocker: MockerFixture):
     sca_image_report = next(report for report in reports if report.check_type == CheckType.SCA_IMAGE)
 
     assert len(azure_pipelines_report.resources) == 0
-    assert len(azure_pipelines_report.passed_checks) == 0
+    assert len(azure_pipelines_report.passed_checks) == 1
     assert len(azure_pipelines_report.failed_checks) == 2
     assert len(azure_pipelines_report.skipped_checks) == 0
     assert len(azure_pipelines_report.parsing_errors) == 0


### PR DESCRIPTION
This PR changes DetectImageUsage to iterate over the job of the azure pipelines workflow file.
Since extracted images have the job as their resource(without container/pool/.. suffix) we must make sure the DetectImageUsage runs over the jobs.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
