### PR TITLE
fix(terraform): handle unexpected container definition type

### DIFF
--- a/checkov/terraform/image_referencer/provider/aws.py
+++ b/checkov/terraform/image_referencer/provider/aws.py
@@ -64,9 +64,10 @@ def extract_images_from_aws_ecs_task_definition(resource: dict[str, Any]) -> lis
     definitions = extract_json(resource.get("container_definitions"))
     if isinstance(definitions, list):
         for definition in definitions:
-            name = definition.get("image")
-            if name and isinstance(name, str):
-                image_names.append(name)
+            if isinstance(definition, dict):
+                name = definition.get("image")
+                if name and isinstance(name, str):
+                    image_names.append(name)
 
     return image_names
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

skip extracting images from containers definitions with unexpected type

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
