### PR TITLE
fix(kubernetes): extract pods only for supported resources

### DIFF
--- a/checkov/kubernetes/graph_builder/local_graph.py
+++ b/checkov/kubernetes/graph_builder/local_graph.py
@@ -144,6 +144,9 @@ class KubernetesLocalGraph(LocalGraph[KubernetesBlock]):
         if not template or not isinstance(template, dict):
             all_resources.append(conf)
             return
+        if is_invalid_k8_pod_definition(template):
+            all_resources.append(conf)
+            return
         if conf.get('kind') in SUPPORTED_POD_CONTAINERS_TYPES:
             # means this is a Pod resource nested in a supported template container resource
             template[PARENT_RESOURCE_ID_KEY_NAME] = get_resource_id(conf)
@@ -154,9 +157,6 @@ class KubernetesLocalGraph(LocalGraph[KubernetesBlock]):
                 return
             template[PARENT_RESOURCE_KEY_NAME] = metadata.get('name', "")
             spec.pop('template', None)
-        if is_invalid_k8_pod_definition(template):
-            all_resources.append(conf)
-            return
         all_resources.append(conf)
         KubernetesLocalGraph._extract_nested_resources_recursive(template, all_resources)
 

--- a/checkov/kubernetes/graph_builder/local_graph.py
+++ b/checkov/kubernetes/graph_builder/local_graph.py
@@ -153,10 +153,10 @@ class KubernetesLocalGraph(LocalGraph[KubernetesBlock]):
                 all_resources.append(conf)
                 return
             template[PARENT_RESOURCE_KEY_NAME] = metadata.get('name', "")
+            spec.pop('template', None)
         if is_invalid_k8_pod_definition(template):
             all_resources.append(conf)
             return
-        spec.pop('template', None)
         all_resources.append(conf)
         KubernetesLocalGraph._extract_nested_resources_recursive(template, all_resources)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

K8s Pods are extracted even if the parent type is not supported. This fix extracts Pods only for supported parents types

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
