### PR TITLE
fix(sca): catch exceptional error during SCA results polling

### DIFF
--- a/checkov/sca_package_2/scanner.py
+++ b/checkov/sca_package_2/scanner.py
@@ -5,6 +5,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from requests import JSONDecodeError
+
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.util.http_utils import request_wrapper
 
@@ -73,7 +75,13 @@ class Scanner:
                 headers=bc_integration.get_default_headers("GET"),
                 params={"repoId": bc_integration.repo_id}
             )
-            response_json = response.json()
+
+            try:
+                response_json = response.json()
+            except JSONDecodeError:
+                logging.error(f"Unexpected response from {self.bc_cli_scan_api_url}: {response.text}")
+                return {}
+
             current_state = response_json.get("status", "")
             if not current_state:
                 logging.error("Failed to poll scan results.")


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- when I tested the SCA scanning locally I got once a very strange JSON decode error, if this happens again, then we hopefully get the actual response and handle it more gracefully 🙂 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
