### PR TITLE
feat(terraform): add CKV_GCP_114 to ensure that Public Access Prevention is enforced on GoogleCloudStorage bucket.

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleStoragePublicAccessPrevention.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleStoragePublicAccessPrevention.py
@@ -6,8 +6,8 @@ from checkov.terraform.checks.resource.base_resource_value_check import BaseReso
 
 class GoogleStoragePublicAccessPrevention(BaseResourceValueCheck):
     def __init__(self) -> None:
-        name = "Public access prevention should be enforced"
-        id = "CKV_GCP_112"
+        name = "Ensure public access prevention is enforced on Cloud Storage bucket"
+        id = "CKV_GCP_114"
         supported_resources = ["google_storage_bucket"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/checkov/terraform/checks/resource/gcp/GoogleStoragePublicAccessPrevention.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleStoragePublicAccessPrevention.py
@@ -3,6 +3,7 @@ from typing import Any
 from checkov.common.models.enums import CheckCategories
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
+
 class GoogleStoragePublicAccessPrevention(BaseResourceValueCheck):
     def __init__(self) -> None:
         name = "Public access prevention should be enforced"

--- a/checkov/terraform/checks/resource/gcp/GoogleStoragePublicAccessPrevention.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleStoragePublicAccessPrevention.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+class GoogleStoragePublicAccessPrevention(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Public access prevention should be enforced"
+        id = "CKV_GCP_112"
+        supported_resources = ["google_storage_bucket"]
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "public_access_prevention"
+
+    def get_expected_value(self) -> Any:
+        return "enforced"
+
+
+check = GoogleStoragePublicAccessPrevention()

--- a/tests/terraform/checks/resource/gcp/example_GoogleStoragePublicAccessPrevention/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleStoragePublicAccessPrevention/main.tf
@@ -1,0 +1,16 @@
+resource "google_storage_bucket" "inherited" {
+  name                     = "foo"
+  location                 = "EU"
+  public_access_prevention = "inherited"
+}
+
+resource "google_storage_bucket" "default" {
+  name                     = "foo"
+  location                 = "EU"
+}
+
+resource "google_storage_bucket" "enforced" {
+  name                     = "foo"
+  location                 = "EU"
+  public_access_prevention = "enforced"
+}

--- a/tests/terraform/checks/resource/gcp/test_GoogleStoragePublicAccessPrevention.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleStoragePublicAccessPrevention.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.gcp.GoogleStoragePublicAccessPrevention import check
+from checkov.terraform.runner import Runner
+
+
+class TestGoogleStoragePublicAccessPrevention(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_GoogleStoragePublicAccessPrevention"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "google_storage_bucket.enforced",
+        }
+
+        failing_resources = {
+            "google_storage_bucket.inherited",
+            "google_storage_bucket.default",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Creation of a new check  `CKV_GCP_112` for the terraform ressource `google_storage_bucket` to ensure the parameter `public_access_prevention` is set to enforced.

Public access prevention protects Cloud Storage buckets and objects from being accidentally exposed to the public. When you enforce public access prevention, no one can make data in applicable buckets public through IAM policies or ACLs. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
