### PR TITLE
feat(graph): add validation for graph checks

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, List
 from checkov.common.bridgecrew.integration_features.base_integration_feature import BaseIntegrationFeature
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.bridgecrew.severities import Severities
-from checkov.common.checks_infra.checks_parser import NXGraphCheckParser
+from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.checks_infra.registry import Registry, get_graph_checks_registry
 
 if TYPE_CHECKING:
@@ -26,7 +26,7 @@ CFN_RESOURCE_TYPE_IDENTIFIER = re.compile(r"^[a-zA-Z0-9]+::[a-zA-Z0-9]+::[a-zA-Z
 class CustomPoliciesIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
         super().__init__(bc_integration=bc_integration, order=1)  # must be after policy metadata and before suppression integration
-        self.platform_policy_parser = NXGraphCheckParser()
+        self.platform_policy_parser = GraphCheckParser()
         self.policies_url = f"{self.bc_integration.api_url}/api/v1/policies/table/data"
         self.bc_cloned_checks: dict[str, list[dict[str, Any]]] = defaultdict(list)
         self.policy_level_suppression: List[str] = []

--- a/checkov/common/checks_infra/registry.py
+++ b/checkov/common/checks_infra/registry.py
@@ -8,7 +8,7 @@ from typing import Any, TYPE_CHECKING
 
 import yaml
 
-from checkov.common.checks_infra.checks_parser import NXGraphCheckParser
+from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.graph.checks_infra.base_parser import BaseGraphCheckParser
 from checkov.common.graph.checks_infra.registry import BaseRegistry
 from checkov.runner_filter import RunnerFilter
@@ -48,6 +48,11 @@ class Registry(BaseRegistry):
                         if not isinstance(check_json, dict):
                             self.logger.error(f"Loaded data from JSON is not Dict. Skipping. Data: {check_json}.")
                             continue
+
+                        if not self.parser.validate_check_config(file_path=f.name, raw_check=check_json):
+                            # proper log messages are generated inside the method
+                            continue
+
                         check = self.parser.parse_raw_check(
                             check_json, resources_types=self._get_resource_types(check_json), check_path=f'{dir}/{file}'
                         )
@@ -72,7 +77,7 @@ _registry_instances: dict[str, Registry] = {}
 def get_graph_checks_registry(check_type: str) -> Registry:
     if not _registry_instances.get(check_type):
         _registry_instances[check_type] = Registry(
-            parser=NXGraphCheckParser(),
+            parser=GraphCheckParser(),
             checks_dir=f"{Path(__file__).parent.parent.parent}/{check_type}/checks/graph_checks",
         )
     return _registry_instances[check_type]

--- a/checkov/common/graph/checks_infra/base_parser.py
+++ b/checkov/common/graph/checks_infra/base_parser.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
 from typing import Dict, Any
 
 from checkov.common.graph.checks_infra.base_check import BaseGraphCheck
 
 
 class BaseGraphCheckParser:
+    def validate_check_config(self, file_path: str, raw_check: dict[str, dict[str, Any]]) -> bool:
+        """Validates the graph check config"""
+        return True
+
     def parse_raw_check(self, raw_check: Dict[str, Dict[str, Any]], **kwargs: Any) -> BaseGraphCheck:
         raise NotImplementedError

--- a/tests/common/checks/test_graph_check_loading.py
+++ b/tests/common/checks/test_graph_check_loading.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from checkov.common.checks_infra.checks_parser import NXGraphCheckParser
+from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.checks_infra.registry import Registry
 from checkov.runner_filter import RunnerFilter
 from pathlib import Path
@@ -10,7 +10,7 @@ from checkov.terraform.runner import Runner
 
 class TestGraphChecks(unittest.TestCase):
     def test_internal_graph_checks_load(self):
-        registry = Registry(parser=NXGraphCheckParser(), checks_dir=str(
+        registry = Registry(parser=GraphCheckParser(), checks_dir=str(
             Path(__file__).parent.parent.parent.parent / "checkov" / "terraform" / "checks" / "graph_checks"))
         registry.load_checks()
         runner_filter = RunnerFilter()

--- a/tests/common/checks_infra/examples/invalid_definition.yaml
+++ b/tests/common/checks_infra/examples/invalid_definition.yaml
@@ -1,0 +1,5 @@
+metadata:
+  name: "Ensure Lambda function runs with Python 3.9"
+  id: CUSTOM_1
+  category: "GENERAL_SECURITY"
+definition:

--- a/tests/common/checks_infra/examples/missing_definition.yaml
+++ b/tests/common/checks_infra/examples/missing_definition.yaml
@@ -1,0 +1,4 @@
+metadata:
+  name: "Ensure Lambda function runs with Python 3.9"
+  id: CUSTOM_1
+  category: "GENERAL_SECURITY"

--- a/tests/common/checks_infra/examples/missing_metadata.yaml
+++ b/tests/common/checks_infra/examples/missing_metadata.yaml
@@ -1,0 +1,7 @@
+definition:
+  cond_type: attribute
+  resource_types:
+    - aws_lambda_function
+  attribute: runtime
+  operator: equals
+  value: python3.9

--- a/tests/common/checks_infra/examples/missing_metadata_category.yaml
+++ b/tests/common/checks_infra/examples/missing_metadata_category.yaml
@@ -1,0 +1,10 @@
+metadata:
+  name: "Ensure Lambda function runs with Python 3.9"
+  id: CUSTOM_1
+definition:
+  cond_type: attribute
+  resource_types:
+    - aws_lambda_function
+  attribute: runtime
+  operator: equals
+  value: python3.9

--- a/tests/common/checks_infra/examples/valid_check.yaml
+++ b/tests/common/checks_infra/examples/valid_check.yaml
@@ -1,0 +1,11 @@
+metadata:
+  name: "Ensure Lambda function runs with Python 3.9"
+  id: CUSTOM_1
+  category: "GENERAL_SECURITY"
+definition:
+  cond_type: attribute
+  resource_types:
+    - aws_lambda_function
+  attribute: runtime
+  operator: equals
+  value: python3.9

--- a/tests/common/checks_infra/test_checks_parser.py
+++ b/tests/common/checks_infra/test_checks_parser.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import yaml
+from _pytest.logging import LogCaptureFixture
+
+from checkov.common.checks_infra.checks_parser import GraphCheckParser
+
+EXAMPLES_DIR = Path(__file__).parent / "examples"
+
+
+def test_validate_check_config(caplog: LogCaptureFixture):
+    # given
+    file_path = EXAMPLES_DIR / "valid_check.yaml"
+    check_yaml = yaml.safe_load(file_path.read_text())
+
+    # when
+    valid = GraphCheckParser().validate_check_config(file_path=str(file_path), raw_check=check_yaml)
+
+    # then
+    assert valid
+    assert len(caplog.messages) == 0
+
+
+def test_validate_check_config_missing_metadata(caplog: LogCaptureFixture):
+    # given
+    file_path = EXAMPLES_DIR / "missing_metadata.yaml"
+    check_yaml = yaml.safe_load(file_path.read_text())
+
+    # when
+    valid = GraphCheckParser().validate_check_config(file_path=str(file_path), raw_check=check_yaml)
+
+    # then
+    assert not valid
+    assert caplog.messages == [
+        f"Custom policy {file_path} is missing required fields metadata.id, metadata.name, metadata.category"
+    ]
+
+
+def test_validate_check_config_missing_metadata_category(caplog: LogCaptureFixture):
+    # given
+    file_path = EXAMPLES_DIR / "missing_metadata_category.yaml"
+    check_yaml = yaml.safe_load(file_path.read_text())
+
+    # when
+    valid = GraphCheckParser().validate_check_config(file_path=str(file_path), raw_check=check_yaml)
+
+    # then
+    assert not valid
+    assert caplog.messages == [f"Custom policy {file_path} is missing required fields metadata.category"]
+
+
+def test_validate_check_config_missing_definition(caplog: LogCaptureFixture):
+    # given
+    file_path = EXAMPLES_DIR / "missing_definition.yaml"
+    check_yaml = yaml.safe_load(file_path.read_text())
+
+    # when
+    valid = GraphCheckParser().validate_check_config(file_path=str(file_path), raw_check=check_yaml)
+
+    # then
+    assert not valid
+    assert caplog.messages == [f"Custom policy {file_path} is missing required fields definition"]
+
+
+def test_validate_check_config_invalid_definition(caplog: LogCaptureFixture):
+    # given
+    file_path = EXAMPLES_DIR / "invalid_definition.yaml"
+    check_yaml = yaml.safe_load(file_path.read_text())
+
+    # when
+    valid = GraphCheckParser().validate_check_config(file_path=str(file_path), raw_check=check_yaml)
+
+    # then
+    assert not valid
+    assert caplog.messages == [
+        f"Custom policy {file_path} has an invalid 'definition' block type 'NoneType', "
+        "needs to be either a 'list' or 'dict'"
+    ]

--- a/tests/common/checks_infra/test_registry.py
+++ b/tests/common/checks_infra/test_registry.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 from checkov.common.checks_infra.registry import Registry
-from checkov.common.checks_infra.checks_parser import NXGraphCheckParser
+from checkov.common.checks_infra.checks_parser import GraphCheckParser
 
 
 class TestRegistry(unittest.TestCase):
@@ -15,5 +15,5 @@ class TestRegistry(unittest.TestCase):
     def test_valid_yaml_but_invalid_check_does_not_throw_exception(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         test_files_dir = current_dir + "/test-registry-data/valid-yaml-invalid-check"
-        r = Registry(checks_dir=test_files_dir, parser=NXGraphCheckParser())
+        r = Registry(checks_dir=test_files_dir, parser=GraphCheckParser())
         r.load_checks()

--- a/tests/common/graph/checks/test_yaml_policies_base.py
+++ b/tests/common/graph/checks/test_yaml_policies_base.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Any
 from unittest import TestCase
 
 from checkov.cloudformation.runner import Runner
-from checkov.common.checks_infra.checks_parser import NXGraphCheckParser
+from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.checks_infra.registry import Registry
 from checkov.common.graph.graph_manager import GraphManager
 from checkov.common.output.record import Record
@@ -84,7 +84,7 @@ class TestYamlPoliciesBase(TestCase):
         return self.create_report_from_graph_checks_results(checks_results, policy['metadata'])
 
     def get_checks_registry(self):
-        registry = Registry(parser=NXGraphCheckParser(), checks_dir=self.real_graph_checks_path)
+        registry = Registry(parser=GraphCheckParser(), checks_dir=self.real_graph_checks_path)
         registry.load_checks()
         if self.checks_dir:
             registry.load_external_checks(self.checks_dir)

--- a/tests/common/integration_features/test_custom_policies_integration.py
+++ b/tests/common/integration_features/test_custom_policies_integration.py
@@ -5,7 +5,7 @@ import unittest
 from checkov.common.bridgecrew.integration_features.features.custom_policies_integration import \
     CustomPoliciesIntegration
 from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
-from checkov.common.checks_infra.checks_parser import NXGraphCheckParser
+from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.checks_infra.registry import Registry, get_graph_checks_registry
 from checkov.common.models.enums import CheckResult
 from checkov.common.output.record import Record
@@ -163,9 +163,9 @@ class TestCustomPoliciesIntegration(unittest.TestCase):
         # for this test, we simulate some of the check registry manipulation; otherwise the singleton
         # instance will be modified and break other tests.
 
-        parser = NXGraphCheckParser()
+        parser = GraphCheckParser()
 
-        registry = Registry(parser=NXGraphCheckParser(), checks_dir=str(
+        registry = Registry(parser=GraphCheckParser(), checks_dir=str(
             Path(__file__).parent.parent.parent.parent / "checkov" / "terraform" / "checks" / "graph_checks"))
         checks = [parser.parse_raw_check(CustomPoliciesIntegration._convert_raw_check(p)) for p in policies]
         registry.checks = checks  # simulate that the policy downloader will do
@@ -405,9 +405,9 @@ class TestCustomPoliciesIntegration(unittest.TestCase):
         # for this test, we simulate some of the check registry manipulation; otherwise the singleton
         # instance will be modified and break other tests.
 
-        parser = NXGraphCheckParser()
+        parser = GraphCheckParser()
 
-        registry = Registry(parser=NXGraphCheckParser(), checks_dir=str(
+        registry = Registry(parser=GraphCheckParser(), checks_dir=str(
             Path(__file__).parent.parent.parent.parent / "checkov" / "terraform" / "checks" / "graph_checks"))
         checks = [parser.parse_raw_check(CustomPoliciesIntegration._convert_raw_check(p)) for p in policies]
         registry.checks = checks  # simulate that the policy downloader will do

--- a/tests/terraform/graph/checks/custom_policies/CustomPolicy1.yaml
+++ b/tests/terraform/graph/checks/custom_policies/CustomPolicy1.yaml
@@ -1,5 +1,6 @@
 metadata:
-  category: "general"
+  name: "example"
+  category: "GENERAL_SECURITY"
   scope:
   provider: "aws"
   id: "CKV2_AWS_888"

--- a/tests/terraform/graph/checks/test_custom_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_custom_yaml_policies.py
@@ -5,7 +5,7 @@ import unittest
 import warnings
 from pathlib import Path
 
-from checkov.common.checks_infra.checks_parser import NXGraphCheckParser
+from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.models.enums import CheckResult
 from checkov.common.checks_infra.registry import Registry
 from .test_yaml_policies import load_yaml_data, get_policy_results
@@ -35,7 +35,7 @@ class TestCustomYamlPolicies(unittest.TestCase):
                     assert policy is not None
                     expected = load_yaml_data("expected.yaml", dir_path)
                     assert expected is not None
-                    registry = Registry(policy_dir_path, NXGraphCheckParser())
+                    registry = Registry(policy_dir_path, GraphCheckParser())
                     report = get_policy_results(dir_path, policy, [registry])
                     expected = load_yaml_data("expected.yaml", dir_path)
 

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import yaml
 
-from checkov.common.checks_infra.checks_parser import NXGraphCheckParser
+from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.checks_infra.registry import Registry
 from checkov.common.models.enums import CheckResult
 from checkov.runner_filter import RunnerFilter
@@ -341,7 +341,7 @@ class TestYamlPolicies(unittest.TestCase):
         self.go("GCPComputeFirewallOverlyPermissiveToAllTraffic")
 
     def test_registry_load(self):
-        registry = Registry(parser=NXGraphCheckParser(), checks_dir=str(
+        registry = Registry(parser=GraphCheckParser(), checks_dir=str(
             Path(__file__).parent.parent.parent.parent.parent / "checkov" / "terraform" / "checks" / "graph_checks"))
         registry.load_checks()
         self.assertGreater(len(registry.checks), 0)

--- a/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/NetworkAclsIPs.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/NetworkAclsIPs.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NetworkACL"
 scope:
   provider: "Azure"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/PublicSG.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/PublicSG.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicSG"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/PublicSGMultipleIngress.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/PublicSGMultipleIngress.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicSGMultipleIngress"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/PublicVMs.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/PublicVMs.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicVMs"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/PublicVMsWithJsonpath.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/PublicVMsWithJsonpath.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicVMsWithJsonpath"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/SpecificBlockSG.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/SpecificBlockSG.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "SpecificBlockSG"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/TagIncludes.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/TagIncludes.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "TagIncludes"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/VariableDependentPolicy.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/contains_solver/VariableDependentPolicy.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "VariableDependentPolicy"
 scope:
   provider: "aws"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/ending_with_solver/AmiEndingWith.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/ending_with_solver/AmiEndingWith.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "AmiEndingWith"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/ending_with_solver/AmiEndingWithJsonpath.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/ending_with_solver/AmiEndingWithJsonpath.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "AmiEndingWithJsonpath"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/ending_with_solver/UnrenderedVar.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/ending_with_solver/UnrenderedVar.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "UnrenderedVar"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_ignore_case_solver/BooleanString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_ignore_case_solver/BooleanString.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "BooleanString"
 scope:
   provider: "Azure"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_ignore_case_solver/EncryptedResources.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_ignore_case_solver/EncryptedResources.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "EncryptedResources"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/BooleanString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/BooleanString.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "BooleanString"
 scope:
   provider: "Azure"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/Complex.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/Complex.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "Complex"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/EncryptedResources.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/EncryptedResources.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "EncryptedResources"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/PublicDBSG.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/PublicDBSG.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicDBSG"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/SGPorts.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/SGPorts.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "SGPorts"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/UnrenderedVar.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/equals_solver/UnrenderedVar.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "UnrenderedVar"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/exists_solver/TagEnvironmentExists.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/exists_solver/TagEnvironmentExists.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "TagEnvironmentExists"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/exists_solver/TagEnvironmentExistsAll.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/exists_solver/TagEnvironmentExistsAll.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "TagEnvironmentExistsAll"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/exists_solver/VersioningEnabledExists.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/exists_solver/VersioningEnabledExists.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "VersioningEnabledExists"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/greater_than_solver/GT.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/greater_than_solver/GT.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "GT"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/greater_than_solver/GTE.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/greater_than_solver/GTE.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "GTE"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/greater_than_solver/LT.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/greater_than_solver/LT.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "LT"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/greater_than_solver/LTE.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/greater_than_solver/LTE.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "LTE"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/ArrayIntersect.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/ArrayIntersect.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "ArrayIntersect"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/MivedValue.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/MivedValue.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "MixedValue"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/NoneAttribute.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/NoneAttribute.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NoneAttribute"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/PublicVMs.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/PublicVMs.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicVMs"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/StringAttribute.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/StringAttribute.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "StringAttribute"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/TagsIntersect.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/intersects_solver/TagsIntersect.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "TagsIntersect"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/is_empty_solver/SGPorts.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/is_empty_solver/SGPorts.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "SGPorts"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/is_empty_solver/SGPortsJsonpath.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/is_empty_solver/SGPortsJsonpath.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "SGPortsJsonpath"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/is_false_solver/FalseValue.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/is_false_solver/FalseValue.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "FalseValue"
 scope:
   provider: "Azure"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/is_false_solver/TrueValue.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/is_false_solver/TrueValue.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "TrueValue"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/is_not_empty_solver/SGPorts.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/is_not_empty_solver/SGPorts.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "SGPorts"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/is_true_solver/FalseValue.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/is_true_solver/FalseValue.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "FalseValue"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/is_true_solver/TrueValue.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/is_true_solver/TrueValue.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "TrueValue"
 scope:
   provider: "Azure"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_equals_solver/AzureSecureRule.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_equals_solver/AzureSecureRule.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "AzureSecureRule"
 scope:
   provider: "AZURE"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_equals_solver/CkSshPortOpenForAll.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_equals_solver/CkSshPortOpenForAll.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "CkSshPortOpenForAll"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_equals_solver/PublicDBSG.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_equals_solver/PublicDBSG.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicDBSG"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_exists_solver/AzureSecureRule.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_exists_solver/AzureSecureRule.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "AzureSecureRule"
 scope:
   provider: "AZURE"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_exists_solver/CkSshPortOpenForAll.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_exists_solver/CkSshPortOpenForAll.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "CkSshPortOpenForAll"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_exists_solver/PublicDBSG.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_exists_solver/PublicDBSG.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicDBSG"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_exists_solver/example.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_exists_solver/example.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "example"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_equals_solver/AzureSecureRule.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_equals_solver/AzureSecureRule.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "AzureSecureRule"
 scope:
   provider: "AZURE"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_equals_solver/CkSshPortOpenForAll.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_equals_solver/CkSshPortOpenForAll.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "CkSshPortOpenForAll"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_equals_solver/PublicDBSG.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_equals_solver/PublicDBSG.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicDBSG"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/AzureSecureRule.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/AzureSecureRule.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "AzureSecureRule"
 scope:
   provider: "AZURE"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/CkSshPortOpenForAll.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/CkSshPortOpenForAll.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "CkSshPortOpenForAll"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/PublicDBSG.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/PublicDBSG.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicDBSG"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/example.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/jsonpath_not_exists_solver/example.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "example"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/ArrayLengthEquals.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/ArrayLengthEquals.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "ArrayLengthEquals"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/StringLengthEquals.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/StringLengthEquals.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "StringLengthEquals"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_or_equal_solver/ArrayLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_or_equal_solver/ArrayLength.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "ArrayLengthGreaterThanOrEqual"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_or_equal_solver/StringLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_or_equal_solver/StringLength.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "StringLengthGreaterThanOrEqual"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_solver/ArrayLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_solver/ArrayLength.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "ArrayLengthGreaterThan"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_solver/StringLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_solver/StringLength.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "StringLengthGreaterThan"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_or_equal_solver/ArrayLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_or_equal_solver/ArrayLength.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "ArrayLengthLessThanOrEqual"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_or_equal_solver/StringLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_or_equal_solver/StringLength.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "StringLengthLessThanOrEqual"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_solver/ArrayLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_solver/ArrayLength.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "ArrayLengthLessThan"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_solver/StringLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_solver/StringLength.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "StringLengthLessThan"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/ArrayLengthNotEquals.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/ArrayLengthNotEquals.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "ArrayLengthNotEquals"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/StringLengthNotEquals.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/StringLengthNotEquals.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "StringLengthNotEquals"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_contains_solver/PublicSG.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_contains_solver/PublicSG.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicSG"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_contains_solver/PublicVMs.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_contains_solver/PublicVMs.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicVMs"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_contains_solver/SpecificBlockSG.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_contains_solver/SpecificBlockSG.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "SpecificBlockSG"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_ending_with_solver/AmiEndingWith.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_ending_with_solver/AmiEndingWith.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "AmiEndingWith"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_ignore_case_solver/BooleanString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_ignore_case_solver/BooleanString.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "BooleanString"
 scope:
   provider: "Azure"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_ignore_case_solver/EncryptedResources.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_ignore_case_solver/EncryptedResources.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "EncryptedResources"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_solver/PublicDBSG.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_solver/PublicDBSG.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicDBSG"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_solver/SGPorts.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_solver/SGPorts.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "SGPorts"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_solver/UnrenderedVar.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_equals_solver/UnrenderedVar.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "UnrenderedVar"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_exists_solver/TagEnvironmentExists.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_exists_solver/TagEnvironmentExists.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "TagEnvironmentExists"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_exists_solver/VersioningEnabledExists.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_exists_solver/VersioningEnabledExists.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "VersioningEnabledExists"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_intersects_solver/ArrayNotIntersect.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_intersects_solver/ArrayNotIntersect.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "ArrayNotIntersect"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_intersects_solver/PublicVMs.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_intersects_solver/PublicVMs.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "PublicVMs"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_intersects_solver/TagsNotIntersect.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_intersects_solver/TagsNotIntersect.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "TagsNotIntersect"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_regex_match_solver/TagPrefix.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_regex_match_solver/TagPrefix.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "TagPrefix"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_starting_with_solver/NameStartingWith.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_starting_with_solver/NameStartingWith.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NameStartingWith"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_starting_with_solver/NameStartingWithJsonpath.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_starting_with_solver/NameStartingWithJsonpath.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NameStartingWithJsonpath"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_subset_solver/Subset1.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_subset_solver/Subset1.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NotSubset1"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_subset_solver/SubsetJsonpath.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_subset_solver/SubsetJsonpath.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NotSubsetJsonpath"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/not_within_solver/NameNotWithin.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/not_within_solver/NameNotWithin.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NameNotWithin"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_equals_solver/NumberOfWordsEquals.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_equals_solver/NumberOfWordsEquals.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NumberOfWordsEquals"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_greater_than_or_equal_solver/NumberOfWordsGreaterThanOrEqual.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_greater_than_or_equal_solver/NumberOfWordsGreaterThanOrEqual.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NumberOfWordsGreaterThanOrEqual"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_greater_than_solver/NumberOfWordsGreaterThan.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_greater_than_solver/NumberOfWordsGreaterThan.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NumberOfWordsGreaterThan"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_less_than_or_equal_solver/NumberOfWordsLessThanOrEqual.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_less_than_or_equal_solver/NumberOfWordsLessThanOrEqual.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NumberOfWordsLessThanOrEqual"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_less_than_solver/NumberOfWordsLessThan.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_less_than_solver/NumberOfWordsLessThan.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NumberOfWordsLessThan"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_not_equals_solver/NumberOfWordsEquals.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/number_of_words_not_equals_solver/NumberOfWordsEquals.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NumberOfWordsNotEquals"
 definition:
   cond_type: "attribute"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/JsonPathRangeIncludesInt.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/JsonPathRangeIncludesInt.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "JsonPathRangeIncludesInt"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/JsonPathRangeIncludesString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/JsonPathRangeIncludesString.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "JsonPathRangeIncludesString"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/RangeIncludesInt.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/RangeIncludesInt.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "RangeIncludesInt"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/RangeIncludesString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/RangeIncludesString.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "RangeIncludesString"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/JsonPathRangeNotIncludesInt.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/JsonPathRangeNotIncludesInt.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "JsonPathRangeNotIncludesInt"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/JsonPathRangeNotIncludesString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/JsonPathRangeNotIncludesString.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "JsonPathRangeNotIncludesString"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/RangeNotIncludesInt.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/RangeNotIncludesInt.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "RangeNotIncludesInt"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/RangeNotIncludesString.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_not_includes_solver/RangeNotIncludesString.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "RangeNotIncludesString"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/regex_match_solver/TagPrefix.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/regex_match_solver/TagPrefix.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "TagPrefix"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/starting_with_solver/NameStartingWith.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/starting_with_solver/NameStartingWith.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NameStartingWith"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/starting_with_solver/UnrenderedVar.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/starting_with_solver/UnrenderedVar.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "UnrenderedVar"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/subset_solver/Subset1.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/subset_solver/Subset1.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "Subset1"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/NameWithin.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/NameWithin.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NameWithin"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/UnrenderedVar.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/UnrenderedVar.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "UnrenderedVar"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/WildcardWithin.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/within_solver/WildcardWithin.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "WildcardWithin"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/complex_solvers/and_solver/BucketsWithDevEnvAndPrivateACL.yaml
+++ b/tests/terraform/graph/checks_infra/complex_solvers/and_solver/BucketsWithDevEnvAndPrivateACL.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "BucketsWithDevEnvAndPrivateACL"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/complex_solvers/not_solver/BucketsWithDevEnvAndPrivateACL.yaml
+++ b/tests/terraform/graph/checks_infra/complex_solvers/not_solver/BucketsWithDevEnvAndPrivateACL.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NotTest"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/complex_solvers/not_solver/NotWithNestedDict.yaml
+++ b/tests/terraform/graph/checks_infra/complex_solvers/not_solver/NotWithNestedDict.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NotWithNestedDict"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/complex_solvers/not_solver/NotWithNestedList.yaml
+++ b/tests/terraform/graph/checks_infra/complex_solvers/not_solver/NotWithNestedList.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NotWithNestedList"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/complex_solvers/or_solver/BucketsWithEnvTag.yaml
+++ b/tests/terraform/graph/checks_infra/complex_solvers/or_solver/BucketsWithEnvTag.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "BucketsWithEnvTag"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/connection_solvers/and_connection_solver/AndComplexConnection.yaml
+++ b/tests/terraform/graph/checks_infra/connection_solvers/and_connection_solver/AndComplexConnection.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: AndComplexConnection
 scope:
   provider: AWS

--- a/tests/terraform/graph/checks_infra/connection_solvers/connection_exist_solver/NetworkInterfaceForInstance.yaml
+++ b/tests/terraform/graph/checks_infra/connection_solvers/connection_exist_solver/NetworkInterfaceForInstance.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NetworkInterfaceForInstance"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/connection_solvers/connection_exist_solver/S3BucketPolicyDataSource.yaml
+++ b/tests/terraform/graph/checks_infra/connection_solvers/connection_exist_solver/S3BucketPolicyDataSource.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "S3BucketPolicyDataSource"
 definition:
   and:

--- a/tests/terraform/graph/checks_infra/connection_solvers/connection_exist_solver/VPCForSubnet.yaml
+++ b/tests/terraform/graph/checks_infra/connection_solvers/connection_exist_solver/VPCForSubnet.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "VPCForSubnet"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/connection_solvers/connection_not_exist_solver/NoNetworkInterfaceForInstance.yaml
+++ b/tests/terraform/graph/checks_infra/connection_solvers/connection_not_exist_solver/NoNetworkInterfaceForInstance.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: "NoNetworkInterfaceForInstance"
 scope:
   provider: "AWS"

--- a/tests/terraform/graph/checks_infra/connection_solvers/or_connection_solver/SpecificInstanceComplexConnection.yaml
+++ b/tests/terraform/graph/checks_infra/connection_solvers/or_connection_solver/SpecificInstanceComplexConnection.yaml
@@ -1,4 +1,6 @@
 metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
   id: SpecificInstanceComplexConnection
 scope:
   provider: AWS

--- a/tests/terraform/graph/checks_infra/test_base.py
+++ b/tests/terraform/graph/checks_infra/test_base.py
@@ -2,7 +2,7 @@ import os
 from unittest import TestCase
 from unittest import mock
 
-from checkov.common.checks_infra.checks_parser import NXGraphCheckParser
+from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.checks_infra.registry import Registry
 from checkov.terraform.runner import Runner
 from checkov.runner_filter import RunnerFilter
@@ -17,7 +17,7 @@ class TestBaseSolver(TestCase):
             self.graph_framework = "NETWORKX"
         with mock.patch.dict(os.environ, {"CHECKOV_GRAPH_FRAMEWORK": self.graph_framework}):
             self.source = "Terraform"
-            self.registry = Registry(parser=NXGraphCheckParser(), checks_dir=self.checks_dir)
+            self.registry = Registry(parser=GraphCheckParser(), checks_dir=self.checks_dir)
             self.registry.load_checks()
             self.runner = Runner(external_registries=[self.registry])
 

--- a/tests/terraform/test_scanner_registry.py
+++ b/tests/terraform/test_scanner_registry.py
@@ -3,7 +3,7 @@ import unittest
 # do not remove this - prevents circular import dependency
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as metadata_integration  # noqa
 
-from checkov.common.checks_infra.checks_parser import NXGraphCheckParser
+from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.checks_infra.registry import Registry
 from checkov.terraform.checks.resource.registry import resource_registry as registry
 from pathlib import Path
@@ -28,7 +28,7 @@ class TestScannerRegistry(unittest.TestCase):
 
     def test_non_colliding_graph_check_ids(self):
         check_id_check_class_map = {}
-        graph_registry = Registry(parser=NXGraphCheckParser(), checks_dir=str(Path(__file__).parent.parent.parent / "checkov" / "terraform" / "checks" / "graph_checks"))
+        graph_registry = Registry(parser=GraphCheckParser(), checks_dir=str(Path(__file__).parent.parent.parent / "checkov" / "terraform" / "checks" / "graph_checks"))
         graph_registry.load_checks()
         for check in graph_registry.checks:
             check_id_check_class_map.setdefault(check.id, []).append(check)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added a simple pre validation step, before we actually "parse" a graph check, this should help users to get faster feedback for broken checks
- also renamed `NXGraphCheckParser` to just `GraphCheckParser` because it has no dependency to NetworkX, but left the original class definition for easier migration

Fixes #4288 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
