### PR TITLE
fix(sca): support BC_VUL_X IDs in GitLab SAST output

### DIFF
--- a/checkov/common/output/gitlab_sast.py
+++ b/checkov/common/output/gitlab_sast.py
@@ -65,7 +65,7 @@ class GitLabSast:
                     vulnerability = None
                     if check.check_id.startswith("BC_LIC"):
                         vulnerability = self._create_license_vulnerability(record=check)
-                    elif check.check_id.startswith("CKV_CVE"):
+                    elif check.check_id.startswith(("BC_VUL", "CKV_CVE")):
                         vulnerability = self._create_cve_vulnerability(record=check)
 
                     if vulnerability:

--- a/tests/common/output/test_gitlab_sast_report.py
+++ b/tests/common/output/test_gitlab_sast_report.py
@@ -106,10 +106,20 @@ def test_sca_package_output():
         vulnerability_details=vulnerability_details,
         licenses="OSI_BDS",
     )
+    # also add a BC_VUL_2 record
+    bc_record = create_report_cve_record(
+        rootless_file_path=rootless_file_path,
+        file_abs_path=file_abs_path,
+        check_class=check_class,
+        vulnerability_details=vulnerability_details,
+        licenses="OSI_BDS",
+    )
+    bc_record.check_id = "BC_VUL_2"
 
     report = Report(CheckType.SCA_PACKAGE)
     report.add_resource(record.resource)
     report.add_record(record)
+    report.add_record(bc_record)
 
     report.extra_resources.add(
         ExtraResource(
@@ -130,6 +140,22 @@ def test_sca_package_output():
     for vul in output["vulnerabilities"]:
         del vul["id"]
     assert output["vulnerabilities"] == [
+        {
+            "identifiers": [
+                {
+                    "name": "CVE-2019-19844 - django: 1.2",
+                    "type": "cve",
+                    "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-19844",
+                    "value": "CVE-2019-19844",
+                }
+            ],
+            "links": [{"url": "https://nvd.nist.gov/vuln/detail/CVE-2019-19844"}],
+            "location": {"file": "path/to/requirements.txt"},
+            "name": "CVE-2019-19844 - django: 1.2",
+            "description": "Django before 1.11.27, 2.x before 2.2.9, and 3.x before 3.0.1 allows account takeover. ...",
+            "severity": "Medium",
+            "solution": "fixed in 3.0.1, 2.2.9, 1.11.27",
+        },
         {
             "identifiers": [
                 {


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- depending on which package scan is used old/new a record can have different `check_id` values

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
