### PR TITLE
feat(sca): ignore package.json file when yarn.lock exists

### DIFF
--- a/checkov/sca_package/runner.py
+++ b/checkov/sca_package/runner.py
@@ -145,17 +145,18 @@ class Runner(BaseRunner[None]):
                 if file_path.name in SUPPORTED_PACKAGE_FILES and not any(p in file_path.parts for p in excluded_paths)
             }
 
-            package_lock_parent_paths = set()
+            package_json_lock_parent_paths = set()
             if exclude_package_json:
-                # filter out package.json, if package-lock.json exists
-                package_lock_parent_paths = {
-                    file_path.parent for file_path in input_paths if file_path.name == "package-lock.json"
+                # filter out package.json, if package-lock.json or yarn.lock exists
+                package_json_lock_parent_paths = {
+                    file_path.parent for file_path in input_paths if
+                    file_path.name in {"package-lock.json", "yarn.lock"}
                 }
 
             input_paths = {
                 file_path
                 for file_path in input_paths
-                if (file_path.name != "package.json" or file_path.parent not in package_lock_parent_paths) and file_path.name not in excluded_file_names
+                if (file_path.name != "package.json" or file_path.parent not in package_json_lock_parent_paths) and file_path.name not in excluded_file_names
             }
 
         for file in files or []:


### PR DESCRIPTION

## Description

currently if we have yarn.lock file and package.json, we build a DT for yarn.lock and scan package.json.


Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
