### PR TITLE
feat(gha): add gha permissions lines

### DIFF
--- a/checkov/common/runners/object_runner.py
+++ b/checkov/common/runners/object_runner.py
@@ -243,6 +243,13 @@ class Runner(BaseRunner[ObjectGraphManager]):  # if a graph is added, Any needs 
                 end_line = entity[END_LINE]
 
                 if self.check_type == CheckType.GITHUB_ACTIONS:
+                    if entity.get(CustomAttributes.BLOCK_NAME) == 'permissions' and start_line == 0 and end_line == 0:
+                        # reconstruct permissions start-end lines since we do not have that information during graph build
+                        for line in self.definitions_raw[entity_file_path]:
+                            if line and 'permissions' in line[1]:
+                                start_line = line[0]
+                                end_line = line[0]
+                                break
                     record: "Record" = GithubActionsRecord(
                         check_id=check.id,
                         bc_check_id=check.bc_id,

--- a/tests/github_actions/test_runner.py
+++ b/tests/github_actions/test_runner.py
@@ -279,6 +279,7 @@ class TestRunnerValid(unittest.TestCase):
 
         # then
         assert len(report.failed_checks) == 1
+        assert report.failed_checks[0].file_line_range == [7, 8]
         assert len(report.passed_checks) == 0
         assert len(report.skipped_checks) == 0
         assert len(report.parsing_errors) == 0


### PR DESCRIPTION
This PR reconstructs GHA permissions block lines on the report.
We are referencing the definitions_raw struct to extract the lines.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
