### PR TITLE
feat(secrets): extract new detector_utils file from entropy keyword combinator

### DIFF
--- a/checkov/secrets/plugins/detector_utils.py
+++ b/checkov/secrets/plugins/detector_utils.py
@@ -5,7 +5,6 @@ import re
 from re import Pattern
 from typing import Any, TYPE_CHECKING
 
-from detect_secrets.plugins.high_entropy_strings import HighEntropyStringsPlugin
 from detect_secrets.util.filetype import FileType
 from detect_secrets.plugins.keyword import DENYLIST
 from detect_secrets.plugins.keyword import AFFIX_REGEX
@@ -23,6 +22,7 @@ if TYPE_CHECKING:
     from checkov.secrets.parsers.multiline_parser import BaseMultiLineParser
     from detect_secrets.core.potential_secret import PotentialSecret
     from detect_secrets.util.code_snippet import CodeSnippet
+    from detect_secrets.plugins.high_entropy_strings import HighEntropyStringsPlugin
 
 MAX_KEYWORD_LIMIT = 500
 

--- a/checkov/secrets/plugins/detector_utils.py
+++ b/checkov/secrets/plugins/detector_utils.py
@@ -196,14 +196,14 @@ def detect_secret(
         line_number: int = 0,
         **kwargs: Any,
 ) -> set[PotentialSecret]:
-    for entropy_scanner in scanners:
-        matches = entropy_scanner.analyze_line(filename, line, line_number, **kwargs)
+    for scanner in scanners:
+        matches = scanner.analyze_line(filename, line, line_number, **kwargs)
         if matches:
             return matches
     return set()
 
 
-def analyze_multiline(
+def analyze_multiline_keyword_combinator(
         filename: str,
         scanners: tuple[HighEntropyStringsPlugin, ...],
         multiline_parser: BaseMultiLineParser,

--- a/checkov/secrets/plugins/detector_utils.py
+++ b/checkov/secrets/plugins/detector_utils.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from checkov.secrets.parsers.multiline_parser import BaseMultiLineParser
     from detect_secrets.core.potential_secret import PotentialSecret
     from detect_secrets.util.code_snippet import CodeSnippet
-    from detect_secrets.plugins.high_entropy_strings import HighEntropyStringsPlugin
+    from detect_secrets.plugins.base import BasePlugin
 
 MAX_KEYWORD_LIMIT = 500
 
@@ -190,7 +190,7 @@ def extract_from_string(pattern: dict[Pattern[str], int] | None, string: str) ->
 
 
 def detect_secret(
-        scanners: tuple[HighEntropyStringsPlugin, ...],
+        scanners: tuple[BasePlugin, ...],
         filename: str,
         line: str,
         line_number: int = 0,
@@ -205,7 +205,7 @@ def detect_secret(
 
 def analyze_multiline_keyword_combinator(
         filename: str,
-        scanners: tuple[HighEntropyStringsPlugin, ...],
+        scanners: tuple[BasePlugin, ...],
         multiline_parser: BaseMultiLineParser,
         line_number: int,
         context: CodeSnippet | None = None,

--- a/checkov/secrets/plugins/detector_utils.py
+++ b/checkov/secrets/plugins/detector_utils.py
@@ -193,7 +193,7 @@ def detect_secret(
         scanners: tuple[HighEntropyStringsPlugin, ...],
         filename: str,
         line: str,
-        line_number: int,
+        line_number: int = 0,
         **kwargs: Any,
 ) -> set[PotentialSecret]:
     for entropy_scanner in scanners:
@@ -207,7 +207,7 @@ def analyze_multiline(
         filename: str,
         scanners: tuple[HighEntropyStringsPlugin, ...],
         multiline_parser: BaseMultiLineParser,
-        line_number: int = 0,
+        line_number: int,
         context: CodeSnippet | None = None,
         raw_context: CodeSnippet | None = None,
         value_pattern: dict[Pattern[str], int] | None = None,

--- a/checkov/secrets/plugins/detector_utils.py
+++ b/checkov/secrets/plugins/detector_utils.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+import re
+from re import Pattern
+from typing import Any, TYPE_CHECKING
+
+from detect_secrets.plugins.high_entropy_strings import HighEntropyStringsPlugin
+from detect_secrets.util.filetype import FileType
+from detect_secrets.plugins.keyword import DENYLIST
+from detect_secrets.plugins.keyword import AFFIX_REGEX
+from detect_secrets.plugins.keyword import CLOSING
+from detect_secrets.plugins.keyword import OPTIONAL_WHITESPACE
+from detect_secrets.plugins.keyword import QUOTE
+from detect_secrets.plugins.keyword import SECRET
+
+from checkov.secrets.parsers.terraform.multiline_parser import terraform_multiline_parser
+from checkov.secrets.parsers.terraform.single_line_parser import terraform_single_line_parser
+from checkov.secrets.parsers.yaml.multiline_parser import yml_multiline_parser
+from checkov.secrets.parsers.json.multiline_parser import json_multiline_parser
+
+if TYPE_CHECKING:
+    from checkov.secrets.parsers.multiline_parser import BaseMultiLineParser
+    from detect_secrets.core.potential_secret import PotentialSecret
+    from detect_secrets.util.code_snippet import CodeSnippet
+
+MAX_KEYWORD_LIMIT = 500
+
+DENY_LIST_REGEX = r'|'.join(DENYLIST)
+# Support for suffix after keyword i.e. password_secure = "value"
+DENY_LIST_REGEX2 = r'({denylist}){suffix}'.format(
+    denylist=DENY_LIST_REGEX,
+    suffix=AFFIX_REGEX,
+)
+
+KEY = r'{words}({closing})?'.format(
+    words=AFFIX_REGEX,
+    closing=CLOSING,
+)
+
+FOLLOWED_BY_COLON_VALUE_KEYWORD_REGEX = re.compile(
+    # e.g. var: MY_PASSWORD_123
+    r'{whitespace}({key})?:{whitespace}({quote}?){words}{denylist}({closing})?(\3)'.format(
+        key=KEY,
+        whitespace=OPTIONAL_WHITESPACE,
+        quote=QUOTE,
+        words=AFFIX_REGEX,
+        denylist=DENY_LIST_REGEX2,
+        closing=CLOSING,
+    ),
+    flags=re.IGNORECASE,
+)
+
+QUOTES_REQUIRED_FOLLOWED_BY_COLON_VALUE_KEYWORD_REGEX = re.compile(
+    # e.g. var: MY_PASSWORD_123
+    r'{whitespace}"({key})?":{whitespace}("?){words}{denylist}({closing})?(\3)'.format(
+        key=KEY,
+        whitespace=OPTIONAL_WHITESPACE,
+        words=AFFIX_REGEX,
+        denylist=DENY_LIST_REGEX2,
+        closing=CLOSING,
+    ),
+    flags=re.IGNORECASE,
+)
+
+FOLLOWED_BY_COLON_VALUE_SECRET_REGEX = re.compile(
+    # e.g. var: Zmlyc3Rfc2VjcmV0X2hlcmVfd2hvYV9tdWx0aWxsaW5lX3Nob3VsZF93b3JrXzE==
+    r'{whitespace}({key})?:{whitespace}({quote}?)({secret})(\3)'.format(
+        key=KEY,
+        whitespace=OPTIONAL_WHITESPACE,
+        quote=QUOTE,
+        secret=SECRET,
+    ),
+    flags=re.IGNORECASE,
+)
+
+QUOTES_REQUIRED_FOLLOWED_BY_COLON_VALUE_SECRET_REGEX = re.compile(
+    # e.g. var: Zmlyc3Rfc2VjcmV0X2hlcmVfd2hvYV9tdWx0aWxsaW5lX3Nob3VsZF93b3JrXzE==
+    r'{whitespace}"({key})?":{whitespace}("?)({secret})(\3)'.format(
+        key=KEY,
+        whitespace=OPTIONAL_WHITESPACE,
+        secret=SECRET,
+    ),
+    flags=re.IGNORECASE,
+)
+
+FOLLOWED_BY_EQUAL_VALUE_KEYWORD_REGEX = re.compile(
+    # e.g. var = MY_PASSWORD_123
+    r'{whitespace}({key})?={whitespace}({quote}?){words}{denylist}({closing})?(\3)'.format(
+        key=KEY,
+        whitespace=OPTIONAL_WHITESPACE,
+        quote=QUOTE,
+        words=AFFIX_REGEX,
+        denylist=DENY_LIST_REGEX2,
+        closing=CLOSING,
+    ),
+    flags=re.IGNORECASE,
+)
+
+FOLLOWED_BY_EQUAL_VALUE_SECRET_REGEX = re.compile(
+    # e.g. var = Zmlyc3Rfc2VjcmV0X2hlcmVfd2hvYV9tdWx0aWxsaW5lX3Nob3VsZF93b3JrXzE==
+    r'{whitespace}({key})?={whitespace}({quote}?)({secret})(\3)'.format(
+        key=KEY,
+        whitespace=OPTIONAL_WHITESPACE,
+        quote=QUOTE,
+        secret=SECRET,
+    ),
+    flags=re.IGNORECASE,
+)
+
+#  if the current regex is not enough, can add more regexes to check
+
+YML_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP = {
+    FOLLOWED_BY_COLON_VALUE_KEYWORD_REGEX: 4,
+}
+
+YML_PAIR_VALUE_SECRET_REGEX_TO_GROUP = {
+    FOLLOWED_BY_COLON_VALUE_SECRET_REGEX: 4,
+}
+
+JSON_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP = {
+    QUOTES_REQUIRED_FOLLOWED_BY_COLON_VALUE_KEYWORD_REGEX: 4,
+}
+
+JSON_PAIR_VALUE_SECRET_REGEX_TO_GROUP = {
+    QUOTES_REQUIRED_FOLLOWED_BY_COLON_VALUE_SECRET_REGEX: 4,
+}
+
+TERRAFORM_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP = {
+    FOLLOWED_BY_EQUAL_VALUE_KEYWORD_REGEX: 4,
+}
+
+TERRAFORM_PAIR_VALUE_SECRET_REGEX_TO_GROUP = {
+    FOLLOWED_BY_EQUAL_VALUE_SECRET_REGEX: 4,
+}
+
+REGEX_VALUE_KEYWORD_BY_FILETYPE = {
+    FileType.YAML: YML_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP,
+    FileType.JSON: JSON_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP,
+    FileType.TERRAFORM: TERRAFORM_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP,
+}
+
+REGEX_VALUE_SECRET_BY_FILETYPE = {
+    FileType.YAML: YML_PAIR_VALUE_SECRET_REGEX_TO_GROUP,
+    FileType.JSON: JSON_PAIR_VALUE_SECRET_REGEX_TO_GROUP,
+    FileType.TERRAFORM: TERRAFORM_PAIR_VALUE_SECRET_REGEX_TO_GROUP,
+}
+
+SINGLE_LINE_PARSER = {
+    FileType.TERRAFORM: terraform_single_line_parser,
+}
+
+MULTILINE_PARSERS = {
+    FileType.YAML: (
+        (FileType.YAML, yml_multiline_parser),
+    ),
+    FileType.JSON: (
+        (FileType.JSON, json_multiline_parser),
+    ),
+    FileType.TERRAFORM: (
+        (FileType.TERRAFORM, terraform_multiline_parser),
+        (FileType.JSON, json_multiline_parser),
+        (FileType.YAML, yml_multiline_parser),
+    ),
+}
+
+
+def remove_fp_secrets_in_keys(detected_secrets: set[PotentialSecret], line: str) -> None:
+    for detected_secret in detected_secrets:
+        if detected_secret.secret_value and line.replace('"', '').replace("'", '').startswith(
+                detected_secret.secret_value):
+            # Found keyword prefix as potential secret
+            detected_secrets.remove(detected_secret)
+            break
+
+
+def format_reducing_noise_secret(string: str) -> str:
+    return json.dumps(string)
+
+
+def extract_from_string(pattern: dict[Pattern[str], int] | None, string: str) -> set[str]:
+    matches: set[str] = set()
+    if not pattern:
+        return matches
+    for value_regex, group_number in pattern.items():
+        match = value_regex.search(string)
+        if match:
+            matches |= {match.group(group_number)}
+    return matches
+
+
+def detect_secret(
+        scanners: tuple[HighEntropyStringsPlugin, ...],
+        filename: str,
+        line: str,
+        line_number: int = 0,
+        **kwargs: Any,
+) -> set[PotentialSecret]:
+    for entropy_scanner in scanners:
+        matches = entropy_scanner.analyze_line(filename, line, line_number, **kwargs)
+        if matches:
+            return matches
+    return set()
+
+
+def analyze_multiline(
+        filename: str,
+        scanners: tuple[HighEntropyStringsPlugin, ...],
+        multiline_parser: BaseMultiLineParser,
+        line_number: int = 0,
+        context: CodeSnippet | None = None,
+        raw_context: CodeSnippet | None = None,
+        value_pattern: dict[Pattern[str], int] | None = None,
+        secret_pattern: dict[Pattern[str], int] | None = None,
+        **kwargs: Any,
+) -> set[PotentialSecret]:
+    secrets: set[PotentialSecret] = set()
+    if context is None or raw_context is None:
+        return secrets
+    value_secrets = extract_from_string(pattern=secret_pattern, string=context.target_line)
+    for possible_secret in value_secrets:
+        secret_adjust = format_reducing_noise_secret(possible_secret)
+
+        entropy_on_value = detect_secret(
+            scanners=scanners,
+            filename=filename,
+            line=secret_adjust,
+            line_number=line_number,
+            kwargs=kwargs
+        )
+
+        if entropy_on_value:
+            possible_keywords: set[str] = set()
+            backwards_range = range(context.target_index - 1, -1, -1)
+            forward_range = range(context.target_index + 1, len(context.lines))
+
+            possible_keywords |= multiline_parser.get_lines_from_same_object(
+                search_range=forward_range,
+                context=context,
+                raw_context=raw_context,
+                line_length_limit=MAX_KEYWORD_LIMIT)
+            possible_keywords |= multiline_parser.get_lines_from_same_object(
+                search_range=backwards_range,
+                context=context,
+                raw_context=raw_context,
+                line_length_limit=MAX_KEYWORD_LIMIT)
+
+            for other_value in possible_keywords:
+                if extract_from_string(pattern=value_pattern, string=other_value):
+                    secrets |= entropy_on_value
+                    break
+    return secrets

--- a/checkov/secrets/plugins/detector_utils.py
+++ b/checkov/secrets/plugins/detector_utils.py
@@ -193,7 +193,7 @@ def detect_secret(
         scanners: tuple[HighEntropyStringsPlugin, ...],
         filename: str,
         line: str,
-        line_number: int = 0,
+        line_number: int,
         **kwargs: Any,
 ) -> set[PotentialSecret]:
     for entropy_scanner in scanners:
@@ -221,7 +221,7 @@ def analyze_multiline(
     for possible_secret in value_secrets:
         secret_adjust = format_reducing_noise_secret(possible_secret)
 
-        entropy_on_value = detect_secret(
+        potential_secrets = detect_secret(
             scanners=scanners,
             filename=filename,
             line=secret_adjust,
@@ -229,7 +229,7 @@ def analyze_multiline(
             kwargs=kwargs
         )
 
-        if entropy_on_value:
+        if potential_secrets:
             possible_keywords: set[str] = set()
             backwards_range = range(context.target_index - 1, -1, -1)
             forward_range = range(context.target_index + 1, len(context.lines))
@@ -247,6 +247,6 @@ def analyze_multiline(
 
             for other_value in possible_keywords:
                 if extract_from_string(pattern=value_pattern, string=other_value):
-                    secrets |= entropy_on_value
+                    secrets |= potential_secrets
                     break
     return secrets

--- a/checkov/secrets/plugins/entropy_keyword_combinator.py
+++ b/checkov/secrets/plugins/entropy_keyword_combinator.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import json
 import re
 from typing import Generator
 from typing import Any
 from typing import TYPE_CHECKING
-from typing import Pattern
 
 from detect_secrets.plugins.high_entropy_strings import Base64HighEntropyString
 from detect_secrets.plugins.high_entropy_strings import HexHighEntropyString
@@ -17,17 +15,14 @@ from detect_secrets.plugins.keyword import OPTIONAL_WHITESPACE
 from detect_secrets.plugins.keyword import QUOTE
 from detect_secrets.plugins.keyword import SECRET
 from detect_secrets.plugins.base import BasePlugin
-from detect_secrets.util.filetype import FileType
-from detect_secrets.util.filetype import determine_file_type
 
-from checkov.secrets.parsers.terraform.multiline_parser import terraform_multiline_parser
-from checkov.secrets.parsers.terraform.single_line_parser import terraform_single_line_parser
+from detect_secrets.util.filetype import determine_file_type
+from checkov.secrets.plugins.detector_utils import SINGLE_LINE_PARSER, MULTILINE_PARSERS, \
+    REGEX_VALUE_KEYWORD_BY_FILETYPE, REGEX_VALUE_SECRET_BY_FILETYPE, remove_fp_secrets_in_keys, detect_secret, analyze_multiline
+
 from checkov.secrets.runner import SOURCE_CODE_EXTENSION
-from checkov.secrets.parsers.yaml.multiline_parser import yml_multiline_parser
-from checkov.secrets.parsers.json.multiline_parser import json_multiline_parser
 
 if TYPE_CHECKING:
-    from checkov.secrets.parsers.multiline_parser import BaseMultiLineParser
     from detect_secrets.core.potential_secret import PotentialSecret
     from detect_secrets.util.code_snippet import CodeSnippet
 
@@ -119,71 +114,16 @@ FOLLOWED_BY_EQUAL_VALUE_SECRET_REGEX = re.compile(
     flags=re.IGNORECASE,
 )
 
-#  if the current regex is not enough, can add more regexes to check
-
-YML_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP = {
-    FOLLOWED_BY_COLON_VALUE_KEYWORD_REGEX: 4,
-}
-
-YML_PAIR_VALUE_SECRET_REGEX_TO_GROUP = {
-    FOLLOWED_BY_COLON_VALUE_SECRET_REGEX: 4,
-}
-
-JSON_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP = {
-    QUOTES_REQUIRED_FOLLOWED_BY_COLON_VALUE_KEYWORD_REGEX: 4,
-}
-
-JSON_PAIR_VALUE_SECRET_REGEX_TO_GROUP = {
-    QUOTES_REQUIRED_FOLLOWED_BY_COLON_VALUE_SECRET_REGEX: 4,
-}
-
-TERRAFORM_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP = {
-    FOLLOWED_BY_EQUAL_VALUE_KEYWORD_REGEX: 4,
-}
-
-TERRAFORM_PAIR_VALUE_SECRET_REGEX_TO_GROUP = {
-    FOLLOWED_BY_EQUAL_VALUE_SECRET_REGEX: 4,
-}
-
-REGEX_VALUE_KEYWORD_BY_FILETYPE = {
-    FileType.YAML: YML_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP,
-    FileType.JSON: JSON_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP,
-    FileType.TERRAFORM: TERRAFORM_PAIR_VALUE_KEYWORD_REGEX_TO_GROUP,
-}
-
-REGEX_VALUE_SECRET_BY_FILETYPE = {
-    FileType.YAML: YML_PAIR_VALUE_SECRET_REGEX_TO_GROUP,
-    FileType.JSON: JSON_PAIR_VALUE_SECRET_REGEX_TO_GROUP,
-    FileType.TERRAFORM: TERRAFORM_PAIR_VALUE_SECRET_REGEX_TO_GROUP,
-}
-
-SINGLE_LINE_PARSER = {
-    FileType.TERRAFORM: terraform_single_line_parser,
-}
-
-MULTILINE_PARSERS = {
-    FileType.YAML: (
-        (FileType.YAML, yml_multiline_parser),
-    ),
-    FileType.JSON: (
-        (FileType.JSON, json_multiline_parser),
-    ),
-    FileType.TERRAFORM: (
-        (FileType.TERRAFORM, terraform_multiline_parser),
-        (FileType.JSON, json_multiline_parser),
-        (FileType.YAML, yml_multiline_parser),
-    ),
-}
-
 
 class EntropyKeywordCombinator(BasePlugin):
     secret_type = ""  # nosec  # noqa: CCE003  # a static attribute
 
-    def __init__(self, limit: float = ENTROPY_KEYWORD_LIMIT) -> None:
+    def __init__(self, limit: float = ENTROPY_KEYWORD_LIMIT, max_line_length: int = MAX_LINE_LENGTH) -> None:
         iac_limit = ENTROPY_KEYWORD_COMBINATOR_LIMIT
         self.high_entropy_scanners_iac = (Base64HighEntropyString(limit=iac_limit), HexHighEntropyString(limit=iac_limit))
         self.high_entropy_scanners = (Base64HighEntropyString(limit=limit), HexHighEntropyString(limit=limit))
         self.keyword_scanner = KeywordDetector()
+        self.max_line_length = max_line_length
 
     def analyze_string(self, string: str) -> Generator[str, None, None]:
         yield ""
@@ -197,7 +137,7 @@ class EntropyKeywordCombinator(BasePlugin):
             raw_context: CodeSnippet | None = None,
             **kwargs: Any,
     ) -> set[PotentialSecret]:
-        if len(line) > MAX_LINE_LENGTH:
+        if len(line) > self.max_line_length:
             # to keep good performance we skip long lines
             return set()
 
@@ -227,16 +167,15 @@ class EntropyKeywordCombinator(BasePlugin):
                             quoted_secret = f"\"{pt.secret_value}\""
                             if line.find(quoted_secret) < 0:    # replace potential secret with quoted version
                                 line = line.replace(pt.secret_value, f"\"{pt.secret_value}\"", 1)
-                    detected_secrets = self.detect_secret(
+                    detected_secrets = detect_secret(
                         scanners=self.high_entropy_scanners_iac,
                         filename=filename,
                         line=line,
                         line_number=line_number,
                         kwargs=kwargs
                     )
-                    # postprocess detected secrets - filter out potential secrets on keyword and re-run secret detection
-                    # on their value only
-                    self.remove_fp_secrets_in_keys(detected_secrets, line)
+                    # postprocess detected secrets - filter out potential secrets on keyword
+                    remove_fp_secrets_in_keys(detected_secrets, line)
                     return detected_secrets
 
             # not so classic key-value pair, from multiline, that is only in an array format.
@@ -248,9 +187,9 @@ class EntropyKeywordCombinator(BasePlugin):
                     value_keyword_regex_to_group = REGEX_VALUE_KEYWORD_BY_FILETYPE.get(parser_file_type)
                     secret_keyword_regex_to_group = REGEX_VALUE_SECRET_BY_FILETYPE.get(parser_file_type)
 
-                    potential_secrets = self.analyze_multiline(
+                    potential_secrets = analyze_multiline(
                         filename=filename,
-                        line=line,
+                        scanners=self.high_entropy_scanners,
                         multiline_parser=multiline_parser,
                         line_number=line_number,
                         context=context,
@@ -264,7 +203,7 @@ class EntropyKeywordCombinator(BasePlugin):
                         # return a possible secret, otherwise check with next parser
                         return potential_secrets
         else:
-            return self.detect_secret(
+            return detect_secret(
                 # If we found a keyword (i.e. db_pass = ), lower the threshold to the iac threshold
                 scanners=self.high_entropy_scanners if not keyword_on_key else self.high_entropy_scanners_iac,
                 filename=filename,
@@ -273,90 +212,4 @@ class EntropyKeywordCombinator(BasePlugin):
                 kwargs=kwargs
             )
 
-        return set()
-
-    def remove_fp_secrets_in_keys(self, detected_secrets: set[PotentialSecret], line: str) -> None:
-        for detected_secret in detected_secrets:
-            if detected_secret.secret_value and line.replace('"', '').replace("'", '').startswith(
-                    detected_secret.secret_value):
-                # Found keyword prefix as potential secret
-                detected_secrets.remove(detected_secret)
-                break
-
-    def analyze_multiline(
-            self,
-            filename: str,
-            line: str,
-            multiline_parser: BaseMultiLineParser,
-            line_number: int = 0,
-            context: CodeSnippet | None = None,
-            raw_context: CodeSnippet | None = None,
-            value_pattern: dict[Pattern[str], int] | None = None,
-            secret_pattern: dict[Pattern[str], int] | None = None,
-            **kwargs: Any,
-    ) -> set[PotentialSecret]:
-        secrets: set[PotentialSecret] = set()
-        if context is None or raw_context is None:
-            return secrets
-        value_secrets = self.extract_from_string(pattern=secret_pattern, string=context.target_line)
-        for possible_secret in value_secrets:
-            secret_adjust = self.format_reducing_noise_secret(possible_secret)
-
-            entropy_on_value = self.detect_secret(
-                scanners=self.high_entropy_scanners,
-                filename=filename,
-                line=secret_adjust,
-                line_number=line_number,
-                kwargs=kwargs
-            )
-
-            if entropy_on_value:
-                possible_keywords: set[str] = set()
-                backwards_range = range(context.target_index - 1, -1, -1)
-                forward_range = range(context.target_index + 1, len(context.lines))
-
-                possible_keywords |= multiline_parser.get_lines_from_same_object(
-                    search_range=forward_range,
-                    context=context,
-                    raw_context=raw_context,
-                    line_length_limit=MAX_KEYWORD_LIMIT)
-                possible_keywords |= multiline_parser.get_lines_from_same_object(
-                    search_range=backwards_range,
-                    context=context,
-                    raw_context=raw_context,
-                    line_length_limit=MAX_KEYWORD_LIMIT)
-
-                for other_value in possible_keywords:
-                    if self.extract_from_string(pattern=value_pattern, string=other_value):
-                        secrets |= entropy_on_value
-                        break
-        return secrets
-
-    @staticmethod
-    def format_reducing_noise_secret(string: str) -> str:
-        return json.dumps(string)
-
-    @staticmethod
-    def extract_from_string(pattern: dict[Pattern[str], int] | None, string: str) -> set[str]:
-        matches: set[str] = set()
-        if not pattern:
-            return matches
-        for value_regex, group_number in pattern.items():
-            match = value_regex.search(string)
-            if match:
-                matches |= {match.group(group_number)}
-        return matches
-
-    @staticmethod
-    def detect_secret(
-            scanners: tuple[Base64HighEntropyString, HexHighEntropyString],
-            filename: str,
-            line: str,
-            line_number: int = 0,
-            **kwargs: Any,
-    ) -> set[PotentialSecret]:
-        for entropy_scanner in scanners:
-            matches = entropy_scanner.analyze_line(filename, line, line_number, **kwargs)
-            if matches:
-                return matches
         return set()

--- a/checkov/secrets/plugins/entropy_keyword_combinator.py
+++ b/checkov/secrets/plugins/entropy_keyword_combinator.py
@@ -18,7 +18,7 @@ from detect_secrets.plugins.base import BasePlugin
 
 from detect_secrets.util.filetype import determine_file_type
 from checkov.secrets.plugins.detector_utils import SINGLE_LINE_PARSER, MULTILINE_PARSERS, \
-    REGEX_VALUE_KEYWORD_BY_FILETYPE, REGEX_VALUE_SECRET_BY_FILETYPE, remove_fp_secrets_in_keys, detect_secret, analyze_multiline
+    REGEX_VALUE_KEYWORD_BY_FILETYPE, REGEX_VALUE_SECRET_BY_FILETYPE, remove_fp_secrets_in_keys, detect_secret, analyze_multiline_keyword_combinator
 
 from checkov.secrets.runner import SOURCE_CODE_EXTENSION
 
@@ -187,7 +187,7 @@ class EntropyKeywordCombinator(BasePlugin):
                     value_keyword_regex_to_group = REGEX_VALUE_KEYWORD_BY_FILETYPE.get(parser_file_type)
                     secret_keyword_regex_to_group = REGEX_VALUE_SECRET_BY_FILETYPE.get(parser_file_type)
 
-                    potential_secrets = analyze_multiline(
+                    potential_secrets = analyze_multiline_keyword_combinator(
                         filename=filename,
                         scanners=self.high_entropy_scanners,
                         multiline_parser=multiline_parser,


### PR DESCRIPTION
This PR extracts utils from entropy keyword combinator so we can use them for other probability-based detectors and plugins. We are deleting a few methods from entropy keyword combinator and adding them to detector_utils.
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
