### PR TITLE
feat(terraform): Add cloudsplaining checks to tf aws_iam_policy CKV_AWS_287-290

### DIFF
--- a/checkov/terraform/checks/resource/aws/IAMCredentialsExposure.py
+++ b/checkov/terraform/checks/resource/aws/IAMCredentialsExposure.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import List, Union, Dict, Any, TYPE_CHECKING
+
+from checkov.terraform.checks.resource.base_cloudsplaining_resource_iam_check import BaseTerraformCloudsplainingResourceIAMCheck
+
+if TYPE_CHECKING:
+    from cloudsplaining.scan.policy_document import PolicyDocument
+
+
+class CloudSplainingCredentialsExposure(BaseTerraformCloudsplainingResourceIAMCheck):
+    excluded_actions = {"ecr:GetAuthorizationToken"}  # noqa: CCE003  # a static attribute
+
+    def __init__(self) -> None:
+        name = "Ensure IAM policies does not allow credentials exposure"
+        id = "CKV_AWS_287"
+        super().__init__(name=name, id=id)
+
+    def cloudsplaining_analysis(self, policy: PolicyDocument) -> Union[List[str], List[Dict[str, Any]]]:
+        return [x for x in policy.credentials_exposure if x not in CloudSplainingCredentialsExposure.excluded_actions]
+
+
+check = CloudSplainingCredentialsExposure()

--- a/checkov/terraform/checks/resource/aws/IAMDataExfiltration.py
+++ b/checkov/terraform/checks/resource/aws/IAMDataExfiltration.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import List, TYPE_CHECKING
+
+from checkov.terraform.checks.resource.base_cloudsplaining_resource_iam_check import BaseTerraformCloudsplainingResourceIAMCheck
+
+if TYPE_CHECKING:
+    from cloudsplaining.scan.policy_document import PolicyDocument
+
+
+class IAMDataExfiltration(BaseTerraformCloudsplainingResourceIAMCheck):
+    def __init__(self) -> None:
+        name = "Ensure IAM policies does not allow data exfiltration"
+        id = "CKV_AWS_288"
+        super().__init__(name=name, id=id)
+
+    def cloudsplaining_analysis(self, policy: PolicyDocument) -> List[str]:
+        return policy.allows_data_exfiltration_actions
+
+
+check = IAMDataExfiltration()

--- a/checkov/terraform/checks/resource/aws/IAMPermissionsManagement.py
+++ b/checkov/terraform/checks/resource/aws/IAMPermissionsManagement.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import List, Dict, Any, Union, TYPE_CHECKING
+
+from checkov.terraform.checks.resource.base_cloudsplaining_resource_iam_check import BaseTerraformCloudsplainingResourceIAMCheck
+
+if TYPE_CHECKING:
+    from cloudsplaining.scan.policy_document import PolicyDocument
+
+
+class IAMPermissionsManagement(BaseTerraformCloudsplainingResourceIAMCheck):
+    def __init__(self) -> None:
+        name = "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
+        id = "CKV_AWS_289"
+        super().__init__(name=name, id=id)
+
+    def cloudsplaining_analysis(self, policy: PolicyDocument) -> Union[List[str], List[Dict[str, Any]]]:
+        return policy.permissions_management_without_constraints
+
+
+check = IAMPermissionsManagement()

--- a/checkov/terraform/checks/resource/aws/IAMWriteAccess.py
+++ b/checkov/terraform/checks/resource/aws/IAMWriteAccess.py
@@ -1,0 +1,15 @@
+from checkov.terraform.checks.resource.base_cloudsplaining_resource_iam_check import BaseTerraformCloudsplainingResourceIAMCheck
+
+
+class cloudsplainingWriteAccess(BaseTerraformCloudsplainingResourceIAMCheck):
+
+    def __init__(self):
+        name = "Ensure IAM policies does not allow write access without constraints"
+        id = "CKV_AWS_290"
+        super().__init__(name=name, id=id)
+
+    def cloudsplaining_analysis(self, policy):
+        return policy.write_actions_without_constraints
+
+
+check = cloudsplainingWriteAccess()

--- a/tests/terraform/checks/resource/aws/example_IAMCredentialsExposure/main.tf
+++ b/tests/terraform/checks/resource/aws/example_IAMCredentialsExposure/main.tf
@@ -1,0 +1,80 @@
+# pass
+
+resource "aws_iam_policy" "allowed_action" {
+  policy = <<POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ecr:GetAuthorizationToken"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+POLICY
+}
+
+resource "aws_iam_policy" "deny" {
+    policy = <<POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Deny",
+        "Action": ["*"],
+        "Resource": "*",
+        "Sid": "DenyOutsideCallers",
+        "Condition" : {
+          "NotIpAddress": {"aws:SourceIp": "1.2.3.4/16"},
+          "Bool": {"aws:ViaAWSService": "false"}
+        }
+      }
+    ]
+  }
+POLICY
+}
+
+resource "aws_iam_policy" "pass" {
+  policy = <<POLICY
+    {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Effect": "Allow",
+        "Action": [
+          "lambda:CreateFunction",
+          "lambda:CreateEventSourceMapping",
+          "dynamodb:CreateTable",
+        ],
+        "Resource": "*"
+      }
+      ]
+    }
+POLICY
+}
+
+# fail
+
+resource "aws_iam_policy" "fail" {
+    policy = <<POLICY
+    {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Effect": "Allow",
+        "Action": [
+          "s3:GetObject",
+          "iam:CreateAccessKey"
+        ],
+        "Resource": "*"
+      }
+      ]
+    }
+POLICY
+}
+
+# unknown
+

--- a/tests/terraform/checks/resource/aws/example_IAMDataExfiltration/main.tf
+++ b/tests/terraform/checks/resource/aws/example_IAMDataExfiltration/main.tf
@@ -1,0 +1,50 @@
+# pass
+
+resource "aws_iam_policy" "pass" {
+  policy = <<POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "lambda:CreateFunction",
+          "lambda:CreateEventSourceMapping",
+          "dynamodb:CreateTable",
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+POLICY
+}
+
+# fail
+
+resource "aws_iam_policy" "fail" {
+  policy = <<POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "iam:PassRole",
+          "ssm:GetParameter",
+          "s3:GetObject",
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParametersByPath",
+          "secretsmanager:GetSecretValue",
+          "s3:PutObject",
+          "ec2:CreateTags"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+POLICY
+}
+
+# unknown
+

--- a/tests/terraform/checks/resource/aws/example_IAMPermissionsManagement/main.tf
+++ b/tests/terraform/checks/resource/aws/example_IAMPermissionsManagement/main.tf
@@ -1,0 +1,36 @@
+# pass
+
+resource "aws_iam_policy" "pass" {
+  policy = <<POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["s3:*"],
+        "Resource": "arn:aws:s3:::example"
+      }
+    ]
+  }
+POLICY
+}
+
+# fail
+
+resource "aws_iam_policy" "fail" {
+  policy = <<POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["iam:*"],
+        "Resource": "*"
+      }
+    ]
+  }
+POLICY
+}
+
+# unknown
+

--- a/tests/terraform/checks/resource/aws/example_IAMWriteAccess/main.tf
+++ b/tests/terraform/checks/resource/aws/example_IAMWriteAccess/main.tf
@@ -1,0 +1,58 @@
+# pass
+
+resource "aws_iam_policy" "restrictable" {
+  policy = <<POLICY
+    {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Effect": "Allow",
+        "Action": [
+          "s3:*",
+        ],
+        "Resource": "arn:aws:s3:::bucket"
+      }
+      ]
+    }
+POLICY
+}
+
+resource "aws_iam_policy" "unrestrictable" {
+  policy = <<POLICY
+    {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Effect": "Allow",
+        "Action": [
+          "xray:PutTelemetryRecords",
+          "xray:PutTraceSegments",
+        ],
+        "Resource": "*"
+      }
+      ]
+    }
+POLICY
+}
+
+# fail
+
+resource "aws_iam_policy" "fail" {
+  policy = <<POLICY
+    {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Effect": "Allow",
+        "Action": [
+          "s3:*",
+        ],
+        "Resource": "*"
+      }
+      ]
+    }
+POLICY
+}
+
+# unknown
+

--- a/tests/terraform/checks/resource/aws/test_IAMCredentialsExposure.py
+++ b/tests/terraform/checks/resource/aws/test_IAMCredentialsExposure.py
@@ -1,0 +1,43 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.IAMCredentialsExposure import check
+from checkov.terraform.runner import Runner
+
+
+class TestIAMCredentialsExposure(unittest.TestCase):
+    def setUp(self):
+        from checkov.terraform.checks.utils.base_cloudsplaining_iam_scanner import BaseTerraformCloudsplainingIAMScanner
+        # needs to be reset, because the cache belongs to the class not instance
+        BaseTerraformCloudsplainingIAMScanner.policy_document_cache = {}
+
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_IAMCredentialsExposure"
+
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_iam_policy.allowed_action",
+            "aws_iam_policy.deny",
+            "aws_iam_policy.pass",
+        }
+        failing_resources = {
+            "aws_iam_policy.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_IAMDataExfiltration.py
+++ b/tests/terraform/checks/resource/aws/test_IAMDataExfiltration.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.IAMDataExfiltration import check
+from checkov.terraform.runner import Runner
+
+
+class TestIAMDataExfiltration(unittest.TestCase):
+    def setUp(self):
+        from checkov.terraform.checks.utils.base_cloudsplaining_iam_scanner import BaseTerraformCloudsplainingIAMScanner
+        # needs to be reset, because the cache belongs to the class not instance
+        BaseTerraformCloudsplainingIAMScanner.policy_document_cache = {}
+
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_IAMDataExfiltration"
+
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_iam_policy.pass",
+        }
+        failing_resources = {
+            "aws_iam_policy.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_IAMPermissionsManagement.py
+++ b/tests/terraform/checks/resource/aws/test_IAMPermissionsManagement.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.IAMPermissionsManagement import check
+from checkov.terraform.runner import Runner
+
+
+class TestIAMPermissionsManagement(unittest.TestCase):
+    def setUp(self):
+        from checkov.terraform.checks.utils.base_cloudsplaining_iam_scanner import BaseTerraformCloudsplainingIAMScanner
+        # needs to be reset, because the cache belongs to the class not instance
+        BaseTerraformCloudsplainingIAMScanner.policy_document_cache = {}
+
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_IAMPermissionsManagement"
+
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_iam_policy.pass",
+        }
+        failing_resources = {
+            "aws_iam_policy.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_IAMWriteAccess.py
+++ b/tests/terraform/checks/resource/aws/test_IAMWriteAccess.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.IAMWriteAccess import check
+from checkov.terraform.runner import Runner
+
+
+class TestIAMWriteAccess(unittest.TestCase):
+    def setUp(self):
+        from checkov.terraform.checks.utils.base_cloudsplaining_iam_scanner import BaseTerraformCloudsplainingIAMScanner
+        # needs to be reset, because the cache belongs to the class not instance
+        BaseTerraformCloudsplainingIAMScanner.policy_document_cache = {}
+
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_IAMWriteAccess"
+
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_iam_policy.restrictable",
+            "aws_iam_policy.unrestrictable",
+        }
+        failing_resources = {
+            "aws_iam_policy.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Added equivalences for CKV_AWS_107/108/109/111 for terraform's `aws_iam_policy` resource (matching the relevant data object `aws_iam_policy_document`.
Regards to this [issue](https://github.com/bridgecrewio/checkov/issues/3572)

## New/Edited policies (Delete if not relevant)
* CKV_AWS_287 - for IAM credentials exposure
* CKV_AWS_288 - for IAM data exfiltration
* CKV_AWS_289 - for IAM permission management
* CKV_AWS_290 - for IAM write access

### Fix
* CKV_AWS_287 - remove permissions to allow `iam:CreateAccessKey`
* CKV_AWS_288 - remove any permission to get ssm objects, secrets, etc
* CKV_AWS_289 - remove permissions to change iam
* CKV_AWS_290 - remove write permissions

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
