### PR TITLE
feat(sca): create bom report when extra_resources is not empty

### DIFF
--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -312,10 +312,11 @@ class RunnerRegistry:
                     sarif_reports.append(report)
                 if "cli" in config.output:
                     cli_reports.append(report)
-                if any(cyclonedx in config.output for cyclonedx in CYCLONEDX_OUTPUTS):
-                    cyclonedx_reports.append(report)
                 if "gitlab_sast" in config.output:
                     gitlab_reports.append(report)
+            if not report.is_empty() or len(report.extra_resources):
+                if any(cyclonedx in config.output for cyclonedx in CYCLONEDX_OUTPUTS):
+                    cyclonedx_reports.append(report)
                 if "csv" in config.output:
                     git_org = ""
                     git_repository = ""


### PR DESCRIPTION


## Description

when we have package file without any vulnerabilities -> the bom report will be empty


Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
