### PR TITLE
feat(terraform/gcp): Ensure Basic role are not used at Org/Folder/Project level (CKV_GCP_115, CKV_GCP_116, CKV_GCP_117)

### DIFF
--- a/checkov/terraform/checks/resource/gcp/AbsGoogleBasicRoles.py
+++ b/checkov/terraform/checks/resource/gcp/AbsGoogleBasicRoles.py
@@ -1,0 +1,16 @@
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+BASIC_ROLES = [
+    "roles/owner",
+    "roles/editor",
+    "roles/viewer",
+]
+
+
+class AbsGoogleBasicRoles(BaseResourceCheck):
+    def scan_resource_conf(self, conf):
+        self.evaluated_keys = ['role']
+        if 'role' in conf and conf['role'][0] in BASIC_ROLES:
+            return CheckResult.FAILED
+        return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/gcp/GoogleFolderBasicRole.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleFolderBasicRole.py
@@ -1,0 +1,14 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.gcp.AbsGoogleBasicRoles import AbsGoogleBasicRoles
+
+
+class GoogleFolderBasicRoles(AbsGoogleBasicRoles):
+    def __init__(self) -> None:
+        name = "Ensure basic roles are not used at folder level."
+        id = "CKV_GCP_116"
+        supported_resources = ('google_folder_iam_member', 'google_folder_iam_binding')
+        categories = (CheckCategories.IAM,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+
+check = GoogleFolderBasicRoles()

--- a/checkov/terraform/checks/resource/gcp/GoogleOrgBasicRole.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleOrgBasicRole.py
@@ -1,0 +1,14 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.gcp.AbsGoogleBasicRoles import AbsGoogleBasicRoles
+
+
+class GoogleOrgBasicRoles(AbsGoogleBasicRoles):
+    def __init__(self) -> None:
+        name = "Ensure basic roles are not used at organization level."
+        id = "CKV_GCP_115"
+        supported_resources = ('google_organization_iam_member', 'google_organization_iam_binding')
+        categories = (CheckCategories.IAM,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+
+check = GoogleOrgBasicRoles()

--- a/checkov/terraform/checks/resource/gcp/GoogleProjectBasicRole.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleProjectBasicRole.py
@@ -1,0 +1,14 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.gcp.AbsGoogleBasicRoles import AbsGoogleBasicRoles
+
+
+class GoogleProjectBasicRoles(AbsGoogleBasicRoles):
+    def __init__(self) -> None:
+        name = "Ensure basic roles are not used at project level."
+        id = "CKV_GCP_117"
+        supported_resources = ('google_project_iam_member', 'google_project_iam_binding')
+        categories = (CheckCategories.IAM,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+
+check = GoogleProjectBasicRoles()

--- a/tests/terraform/checks/resource/gcp/example_GoogleFolderBasicRole/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleFolderBasicRole/main.tf
@@ -1,0 +1,59 @@
+resource "google_folder_iam_member" "owner" {
+  folder  = "folders/1234567"
+  role    = "roles/owner"
+  member  = "user:jane@example.com"
+}
+
+resource "google_folder_iam_member" "editor" {
+  folder  = "folders/1234567"
+  role    = "roles/editor"
+  member  = "user:jane@example.com"
+}
+
+resource "google_folder_iam_member" "viewer" {
+  folder  = "folders/1234567"
+  role    = "roles/viewer"
+  member  = "user:jane@example.com"
+}
+
+resource "google_folder_iam_member" "other" {
+  folder  = "folders/1234567"
+  role    = "roles/other"
+  member  = "user:jane@example.com"
+}
+
+resource "google_folder_iam_binding" "owner" {
+  folder  = "folders/1234567"
+  role    = "roles/owner"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+resource "google_folder_iam_binding" "editor" {
+  folder  = "folders/1234567"
+  role    = "roles/editor"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+resource "google_folder_iam_binding" "viewer" {
+  folder  = "folders/1234567"
+  role    = "roles/viewer"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+resource "google_folder_iam_binding" "other" {
+  folder  = "folders/1234567"
+  role    = "roles/other"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}

--- a/tests/terraform/checks/resource/gcp/example_GoogleOrgBasicRole/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleOrgBasicRole/main.tf
@@ -1,0 +1,59 @@
+resource "google_organization_iam_member" "owner" {
+  org_id  = "your-organization-id"
+  role    = "roles/owner"
+  member  = "user:jane@example.com"
+}
+
+resource "google_organization_iam_member" "editor" {
+  org_id  = "your-organization-id"
+  role    = "roles/editor"
+  member  = "user:jane@example.com"
+}
+
+resource "google_organization_iam_member" "viewer" {
+  org_id  = "your-organization-id"
+  role    = "roles/viewer"
+  member  = "user:jane@example.com"
+}
+
+resource "google_organization_iam_member" "other" {
+  org_id  = "your-organization-id"
+  role    = "roles/other"
+  member  = "user:jane@example.com"
+}
+
+resource "google_organization_iam_binding" "owner" {
+  org_id  = "your-organization-id"
+  role    = "roles/owner"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+resource "google_organization_iam_binding" "editor" {
+  org_id  = "your-organization-id"
+  role    = "roles/editor"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+resource "google_organization_iam_binding" "viewer" {
+  org_id  = "your-organization-id"
+  role    = "roles/viewer"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+resource "google_organization_iam_binding" "other" {
+  org_id  = "your-organization-id"
+  role    = "roles/other"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}

--- a/tests/terraform/checks/resource/gcp/example_GoogleProjectBasicRole/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleProjectBasicRole/main.tf
@@ -1,0 +1,59 @@
+resource "google_project_iam_member" "owner" {
+  project  = "your-project-id"
+  role    = "roles/owner"
+  member  = "user:jane@example.com"
+}
+
+resource "google_project_iam_member" "editor" {
+  project  = "your-project-id"
+  role    = "roles/editor"
+  member  = "user:jane@example.com"
+}
+
+resource "google_project_iam_member" "viewer" {
+  project  = "your-project-id"
+  role    = "roles/viewer"
+  member  = "user:jane@example.com"
+}
+
+resource "google_project_iam_member" "other" {
+  project  = "your-project-id"
+  role    = "roles/other"
+  member  = "user:jane@example.com"
+}
+
+resource "google_project_iam_binding" "owner" {
+  project  = "your-project-id"
+  role    = "roles/owner"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+resource "google_project_iam_binding" "editor" {
+  project  = "your-project-id"
+  role    = "roles/editor"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+resource "google_project_iam_binding" "viewer" {
+  project  = "your-project-id"
+  role    = "roles/viewer"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}
+
+resource "google_project_iam_binding" "other" {
+  project  = "your-project-id"
+  role    = "roles/other"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}

--- a/tests/terraform/checks/resource/gcp/test_GoogleFolderBasicRole.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleFolderBasicRole.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+from checkov.terraform.checks.resource.gcp.GoogleFolderBasicRole import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestGoogleFolderBasicRole(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_GoogleFolderBasicRole"
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_folder_iam_member.other',
+            'google_folder_iam_binding.other',
+        }
+        failing_resources = {
+            'google_folder_iam_member.owner',
+            'google_folder_iam_member.editor',
+            'google_folder_iam_member.viewer',
+            'google_folder_iam_binding.owner',
+            'google_folder_iam_binding.editor',
+            'google_folder_iam_binding.viewer',
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GoogleOrgBasicRole.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleOrgBasicRole.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+from checkov.terraform.checks.resource.gcp.GoogleOrgBasicRole import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestGoogleOrgBasicRole(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_GoogleOrgBasicRole"
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_organization_iam_member.other',
+            'google_organization_iam_binding.other',
+        }
+        failing_resources = {
+            'google_organization_iam_member.owner',
+            'google_organization_iam_member.editor',
+            'google_organization_iam_member.viewer',
+            'google_organization_iam_binding.owner',
+            'google_organization_iam_binding.editor',
+            'google_organization_iam_binding.viewer',
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GoogleProjectBasicRole.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleProjectBasicRole.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+from checkov.terraform.checks.resource.gcp.GoogleProjectBasicRole import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestGoogleProjectBasicRole(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_GoogleProjectBasicRole"
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_project_iam_member.other',
+            'google_project_iam_binding.other',
+        }
+        failing_resources = {
+            'google_project_iam_member.owner',
+            'google_project_iam_member.editor',
+            'google_project_iam_member.viewer',
+            'google_project_iam_binding.owner',
+            'google_project_iam_binding.editor',
+            'google_project_iam_binding.viewer',
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Add three new checks:
- Add `CKV_GCP_115` to ensure Basic role are not used at `Organization` level
- Add `CKV_GCP_116` to ensure Basic role are not used at `Folder` level
- Add `CKV_GCP_117` to ensure Basic role are not used at `Project` level

The Basic roles are legacy roles that include thousands of permissions across all Google Cloud services. In production environments, Google recommends to not granting basic roles unless there is no alternative.  

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
