### PR TITLE
fix(general): Remove empty links from GitLab SAST output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,6 +275,9 @@ jobs:
         uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96  # v4
         with:
           images: ${{ env.DH_IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.authors=Bridgecrew
+            org.opencontainers.image.version=${{ needs.bump-version.outputs.version }}
       - name: Build and export image to Docker
         # buildx changes the driver to 'docker-container' which doesn't expose the image to the host,
         # so it is built and loaded to Docker and in the next step pushed to the registry
@@ -292,6 +295,7 @@ jobs:
           context: .
           platforms: 'linux/amd64,linux/arm64'
           push: true
+          labels: ${{ steps.docker_meta.outputs.labels }}
           tags: |
             ${{ env.DH_IMAGE_NAME }}:latest
             ${{ env.DH_IMAGE_NAME }}:${{ env.SHORT_IMAGE_TAG }}

--- a/checkov/common/output/gitlab_sast.py
+++ b/checkov/common/output/gitlab_sast.py
@@ -79,7 +79,7 @@ class GitLabSast:
     def _create_iac_vulnerability(self, record: Record) -> dict[str, Any]:
         severity = record.severity.name.lower() if record.severity else ""
 
-        vulnerability = {
+        vulnerability: "dict[str, Any]" = {
             "id": str(uuid4()),
             "identifiers": [
                 {
@@ -118,7 +118,7 @@ class GitLabSast:
 
         severity = record.severity.name.lower() if record.severity else ""
 
-        vulnerability = {
+        vulnerability: "dict[str, Any]" = {
             "id": str(uuid4()),
             "identifiers": [
                 {

--- a/tests/common/output/test_gitlab_sast_report.py
+++ b/tests/common/output/test_gitlab_sast_report.py
@@ -52,12 +52,13 @@ def test_iac_output():
     # remove dynamic data
     for vul in output["vulnerabilities"]:
         del vul["id"]
-        del vul["links"]
         del vul["solution"]
         del vul["description"]
         del vul["location"]["file"]
-        for ident in vul["identifiers"]:
-            del ident["url"]
+        if "links" in vul:
+            del vul["links"]
+            for ident in vul["identifiers"]:
+                del ident["url"]
     assert sorted(output["vulnerabilities"], key=itemgetter("name")) == sorted(
         [
             {
@@ -171,7 +172,7 @@ def test_sca_package_output():
             "description": "Django before 1.11.27, 2.x before 2.2.9, and 3.x before 3.0.1 allows account takeover. ...",
             "severity": "Medium",
             "solution": "fixed in 3.0.1, 2.2.9, 1.11.27",
-        }
+        },
     ]
 
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- removed empty links from the GitLab SAST output
- sneaked in a small change regarding Docker labels, which are still missing in the final images

Fixes #4384 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
