### PR TITLE
platform(dockerfile): Execute twistcli against the user's Compute console when using PCCS

### DIFF
--- a/checkov/common/bridgecrew/severities.py
+++ b/checkov/common/bridgecrew/severities.py
@@ -16,10 +16,11 @@ class BcSeverities:
     INFO = 'INFO'
     LOW = 'LOW'
     MEDIUM = 'MEDIUM'
+    MODERATE = 'MODERATE'
     HIGH = 'HIGH'
     CRITICAL = 'CRITICAL'
-    MODERATE = 'MODERATE'
     IMPORTANT = 'IMPORTANT'
+    UNIMPORTANT = 'UNIMPORTANT'
     OFF = 'OFF'
 
 
@@ -32,6 +33,7 @@ Severities = {
     BcSeverities.HIGH: Severity(BcSeverities.HIGH, 4),
     BcSeverities.IMPORTANT: Severity(BcSeverities.HIGH, 4),
     BcSeverities.CRITICAL: Severity(BcSeverities.CRITICAL, 5),
+    BcSeverities.UNIMPORTANT: Severity(BcSeverities.HIGH, 999),
     BcSeverities.OFF: Severity(BcSeverities.OFF, 999),
 }
 

--- a/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
@@ -84,7 +84,15 @@ class ImageScanner:
             logging.info('twistcli file removed')
 
     def run_image_scan(self, docker_image_id: str) -> Dict[str, Any]:
-        command = f"./{self.twistcli_path} images scan --address {docker_image_scanning_integration.get_proxy_address()} --token {docker_image_scanning_integration.get_bc_api_key()} --details --output-file \"{DOCKER_IMAGE_SCAN_RESULT_FILE_NAME}\" {docker_image_id}"
+        if bc_integration.prisma_cloud_compute_url:
+            address = bc_integration.prisma_cloud_compute_url
+            username, password = bc_integration.bc_api_key.split('::')
+            authentication = f"--user {username} --password {password}"
+        else:
+            address = docker_image_scanning_integration.get_proxy_address()
+            token = docker_image_scanning_integration.get_bc_api_key()
+            authentication = f"--token {token}"
+        command = f"./{self.twistcli_path} images scan --address {address} {authentication} --details --output-file \"{DOCKER_IMAGE_SCAN_RESULT_FILE_NAME}\" {docker_image_id}"
         logging.debug(f"TwistCLI: {command}")
         try:
             subprocess.run([command], check=True, shell=True)  # nosec

--- a/checkov/common/bridgecrew/vulnerability_scanning/integrations/twistcli.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/integrations/twistcli.py
@@ -26,7 +26,10 @@ class TwistcliIntegration(ABC):
         return f"{bc_integration.api_url}{self.vulnerabilities_base_path}/docker-images/twistcli/proxy"
 
     def download_twistcli(self, cli_file_name: Path) -> bool:
-        # backwards compatibility, should be removed in a later stage
+        # Backwards compatibility, should be removed in a later stage
+        # Could also use bc_integration.prisma_cloud_compute_url if set,
+        # but all tenants are upgraded within the same fixed window,
+        # so any version differences are ephemeral and supported.
         try:
             cli_file_name_path = cli_file_name if isinstance(cli_file_name, Path) else Path(cli_file_name)
             os_type = platform.system().lower()

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -82,7 +82,16 @@ class Runner(PackageRunner):
             image_id: str,
             output_path: Path,
     ) -> Dict[str, Any]:
-        command = f"{Path(bridgecrew_dir) / TWISTCLI_FILE_NAME} images scan --address {docker_image_scanning_integration.get_proxy_address()} --token {docker_image_scanning_integration.get_bc_api_key()} --details --output-file \"{output_path}\" {image_id}"
+        if bc_integration.prisma_cloud_compute_url:
+            address = bc_integration.prisma_cloud_compute_url
+            username, password = bc_integration.bc_api_key.split('::')
+            authentication = f"--user {username} --password {password}"
+        else:
+            address = docker_image_scanning_integration.get_proxy_address()
+            token = docker_image_scanning_integration.get_bc_api_key()
+            authentication = f"--token {token}"
+        command = f"{Path(bridgecrew_dir) / TWISTCLI_FILE_NAME} images scan --address {address} {authentication} --details --output-file \"{output_path}\" {image_id}"
+        logging.debug(f"TwistCLI: {command}")
         process = await asyncio.create_subprocess_shell(
             command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
         )

--- a/checkov/sca_package/scanner.py
+++ b/checkov/sca_package/scanner.py
@@ -170,8 +170,16 @@ class Scanner:
             input_path: Path,
     ) -> Dict[str, Any]:
         output_path = Path(f'results-{input_path.name}.json')
-
-        command = f"{Path(bridgecrew_dir) / TWISTCLI_FILE_NAME} coderepo scan --address {docker_image_scanning_integration.get_proxy_address()} --token {docker_image_scanning_integration.get_bc_api_key()} --details --output-file \"{output_path}\" {input_path}"
+        if bc_integration.prisma_cloud_compute_url:
+            address = bc_integration.prisma_cloud_compute_url
+            username, password = bc_integration.bc_api_key.split('::')
+            authentication = f"--user {username} --password {password}"
+        else:
+            address = docker_image_scanning_integration.get_proxy_address()
+            token = docker_image_scanning_integration.get_bc_api_key()
+            authentication = f"--token {token}"
+        command = f"{Path(bridgecrew_dir) / TWISTCLI_FILE_NAME} coderepo scan --address {address} {authentication} --details --output-file \"{output_path}\" {input_path}"
+        logging.debug(f"TwistCLI: {command}")
         process = await asyncio.create_subprocess_shell(
             command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
         )


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Use the Prisma Cloud API to identify the the user's Prisma Cloud Compute Tenant
Allowing checkov to execute twistcli image scans against the user's Prisma Cloud Compute Tenant
Allowing image scans to honor the user's Defend > Images > Vulnerabilities > Rules
Allowing users to view image scan results in Monitor > Vulnerabilities > Images > CI

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
