### PR TITLE
feat(terraform): AWS:check global DocDB cluster is encrypted

### DIFF
--- a/checkov/terraform/checks/resource/aws/DocDBGlobalClusterEncryption.py
+++ b/checkov/terraform/checks/resource/aws/DocDBGlobalClusterEncryption.py
@@ -1,0 +1,17 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class DocDBGlobalClusterEncryption(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure DocDB Global Cluster is encrypted at rest (default is unencrypted)"
+        id = "CKV_AWS_292"
+        supported_resources = ['aws_docdb_global_cluster']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "storage_encrypted"
+
+
+check = DocDBGlobalClusterEncryption()

--- a/checkov/terraform/checks/resource/aws/DocDBGlobalClusterEncryption.py
+++ b/checkov/terraform/checks/resource/aws/DocDBGlobalClusterEncryption.py
@@ -3,14 +3,14 @@ from checkov.terraform.checks.resource.base_resource_value_check import BaseReso
 
 
 class DocDBGlobalClusterEncryption(BaseResourceValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure DocDB Global Cluster is encrypted at rest (default is unencrypted)"
         id = "CKV_AWS_292"
-        supported_resources = ['aws_docdb_global_cluster']
-        categories = [CheckCategories.ENCRYPTION]
+        supported_resources = ('aws_docdb_global_cluster',)
+        categories = (CheckCategories.ENCRYPTION,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
+    def get_inspected_key(self) -> str:
         return "storage_encrypted"
 
 

--- a/tests/terraform/checks/resource/aws/example_DocDBGlobalClusterEncryption/main.tf
+++ b/tests/terraform/checks/resource/aws/example_DocDBGlobalClusterEncryption/main.tf
@@ -1,0 +1,19 @@
+resource "aws_docdb_global_cluster" "fail" {
+  global_cluster_identifier = "global-test"
+  engine                    = "docdb"
+  engine_version            = "4.0.0"
+}
+
+resource "aws_docdb_global_cluster" "fail2" {
+  global_cluster_identifier = "global-test"
+  engine                    = "docdb"
+  engine_version            = "4.0.0"
+  storage_encrypted = false
+}
+
+resource "aws_docdb_global_cluster" "pass" {
+  global_cluster_identifier = "global-test"
+  engine                    = "docdb"
+  engine_version            = "4.0.0"
+  storage_encrypted = true
+}

--- a/tests/terraform/checks/resource/aws/test_DocDBGlobalClusterEncryption.py
+++ b/tests/terraform/checks/resource/aws/test_DocDBGlobalClusterEncryption.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.DocDBGlobalClusterEncryption import check
+from checkov.terraform.runner import Runner
+
+class TestDocDBGlobalClusterEncryption(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_DocDBGlobalClusterEncryption"
+        report = runner.run(
+            root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
+        )
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_docdb_global_cluster.pass",
+        }
+        failing_resources = {
+            "aws_docdb_global_cluster.fail",
+            "aws_docdb_global_cluster.fail2",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
