### PR TITLE
feat(kustomize): support kustomize v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,6 @@ jobs:
           python -m pip install --no-cache-dir --upgrade pipenv
       - uses: imranismail/setup-kustomize@a76db1c6419124d51470b1e388c4b29476f495f1  # v2
         if: ${{ runner.os != 'windows' }}
-        with:
-          kustomize-version: 4.x
       - name: Build & install checkov package
         run: |
           pipenv --python ${{ matrix.python }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -76,8 +76,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: imranismail/setup-kustomize@a76db1c6419124d51470b1e388c4b29476f495f1  # v2
         if: ${{ runner.os != 'windows' }}
-        with:
-          kustomize-version: 4.x
       - name: Install pipenv
         run: |
           python -m pip install --no-cache-dir --upgrade pipenv

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -300,7 +300,7 @@ class Runner(BaseRunner["KubernetesGraphManager"]):
                 logging.debug(f"An error occured testing the {self.kubectl_command} command:", exc_info=True)
 
         elif shutil.which(self.kustomize_command) is not None:
-            kustomize_version = get_kustomize_version(kustomize_command=self.kubectl_command)
+            kustomize_version = get_kustomize_version(kustomize_command=self.kustomize_command)
             if kustomize_version:
                 logging.info(
                     f"Found working version of {self.check_type} dependency {self.kustomize_command}: {kustomize_version}"

--- a/checkov/kustomize/utils.py
+++ b/checkov/kustomize/utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+import subprocess
+
+
+def get_kustomize_version(kustomize_command: str) -> str | None:
+    try:
+        proc = subprocess.run([kustomize_command, "version"], capture_output=True)  # nosec
+        version_output = proc.stdout.decode("utf-8")
+
+        if "Version:" in version_output:
+            # version <= 4 output looks like '{Version:kustomize/v4.5.7 GitCommit:...}\n'
+            kustomize_version = version_output[version_output.find("/") + 1 : version_output.find("G") - 1]
+        elif version_output.startswith("v"):
+            # version >= 5 output looks like 'v5.0.0\n'
+            kustomize_version = version_output.rstrip("\n")
+        else:
+            return None
+
+        return kustomize_version
+    except Exception:
+        logging.debug(f"An error occured testing the {kustomize_command} command:", exc_info=True)
+
+    return None

--- a/checkov/kustomize/utils.py
+++ b/checkov/kustomize/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-import subprocess
+import subprocess  # nosec
 
 
 def get_kustomize_version(kustomize_command: str) -> str | None:

--- a/tests/kustomize/test_utils.py
+++ b/tests/kustomize/test_utils.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock
+
+from pytest_mock import MockerFixture
+
+from checkov.kustomize.utils import get_kustomize_version
+
+
+def test_get_kustomize_version_v4(mocker: MockerFixture):
+    # given
+    subprocess_mock = MagicMock()
+    subprocess_mock.stdout = b"{Version:kustomize/v4.5.7 GitCommit:56d82a8378dfc8dc3b3b1085e5a6e67b82966bd7 BuildDate:2022-08-02T16:28:01Z GoOs:darwin GoArch:amd64}\n"
+
+    mocker.patch("checkov.kustomize.utils.subprocess.run", return_value=subprocess_mock)
+
+    # when
+    version = get_kustomize_version(kustomize_command="kustomize")
+
+    # then
+    assert version == "v4.5.7"
+
+
+def test_get_kustomize_version_v5(mocker: MockerFixture):
+    # given
+    subprocess_mock = MagicMock()
+    subprocess_mock.stdout = b"v5.0.0\n"
+
+    mocker.patch("checkov.kustomize.utils.subprocess.run", return_value=subprocess_mock)
+
+    # when
+    version = get_kustomize_version(kustomize_command="kustomize")
+
+    # then
+    assert version == "v5.0.0"
+
+
+def test_get_kustomize_version_none(mocker: MockerFixture):
+    # given
+    subprocess_mock = MagicMock()
+    subprocess_mock.stdout = b"command not found: kustomize\n"
+
+    mocker.patch("checkov.kustomize.utils.subprocess.run", return_value=subprocess_mock)
+
+    # when
+    version = get_kustomize_version(kustomize_command="kustomize")
+
+    # then
+    assert version is None


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- `kustomize` v5 returns a different version output compared to v4
- moved it to a separate function for better testing 🙂 
- removed the version upper bound for `setup-kustomize` in GHA

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
