### PR TITLE
feat(kubernetes): support inline skips for Kubernetes graph checks

### DIFF
--- a/checkov/kubernetes/kubernetes_utils.py
+++ b/checkov/kubernetes/kubernetes_utils.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import logging
 import os
 from copy import deepcopy
-from typing import Dict, Any
+from typing import Dict, Any, TYPE_CHECKING
 
 import dpath
 
-from checkov.common.typing import _SkippedCheck
+from checkov.common.models.enums import CheckResult
 from checkov.runner_filter import RunnerFilter
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as metadata_integration
 from checkov.common.models.consts import YAML_COMMENT_MARK
@@ -15,6 +15,9 @@ from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.runners.base_runner import filter_ignored_paths
 from checkov.common.util.type_forcers import force_list
 from checkov.kubernetes.parser.parser import parse
+
+if TYPE_CHECKING:
+    from checkov.common.typing import _SkippedCheck, _CheckResult, _EntityContext
 
 K8_POSSIBLE_ENDINGS = {".yaml", ".yml", ".json"}
 DEFAULT_NESTED_RESOURCE_TYPE = "Pod"
@@ -239,3 +242,20 @@ def remove_metadata_from_attribute(attribute: dict[str, Any] | None) -> None:
     if isinstance(attribute, dict):
         attribute.pop("__startline__", None)
         attribute.pop("__endline__", None)
+
+
+def create_check_result(check_result: _CheckResult, entity_context: _EntityContext, check_id: str) -> _CheckResult:
+    """Creates a cleaned version of check_result for further usage"""
+
+    clean_check_result: _CheckResult = {
+        "result": check_result["result"],
+        "evaluated_keys": check_result["evaluated_keys"],
+    }
+
+    for skipped_check in entity_context.get("skipped_checks", []):
+        if skipped_check["id"] == check_id:
+            clean_check_result["result"] = CheckResult.SKIPPED
+            clean_check_result["suppress_comment"] = skipped_check["suppress_comment"]
+            break
+
+    return clean_check_result

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -27,6 +27,7 @@ from checkov.kubernetes.kubernetes_utils import (
     get_resource_id,
     K8_POSSIBLE_ENDINGS,
     PARENT_RESOURCE_ID_KEY_NAME,
+    create_check_result,
 )
 from checkov.runner_filter import RunnerFilter
 
@@ -258,10 +259,9 @@ class Runner(ImageReferencerMixin[None], BaseRunner[KubernetesGraphManager]):
                 entity_file_abs_path = _get_entity_abs_path(root_folder, entity_file_path)
                 entity_context = self.get_entity_context(entity=entity, entity_file_path=entity_file_path)
 
-                clean_check_result: _CheckResult = {
-                    "result": check_result["result"],
-                    "evaluated_keys": check_result["evaluated_keys"],
-                }
+                clean_check_result = create_check_result(
+                    check_result=check_result, entity_context=entity_context, check_id=check.id
+                )
 
                 record = Record(
                     check_id=check.id,

--- a/tests/kubernetes/graph/resources/graph_check.yaml
+++ b/tests/kubernetes/graph/resources/graph_check.yaml
@@ -1,0 +1,139 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: internal-proxy-deployment
+  labels:
+    app: internal-proxy
+spec:
+  selector:
+    matchLabels:
+      app: internal-proxy
+  template:
+    metadata:
+      labels:
+        app: internal-proxy
+    spec:
+      containers:
+      - name: internal-api
+        image: madhuakula/k8s-goat-internal-api
+        resources:
+          limits:
+            cpu: 30m
+            memory: 40Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        ports:
+        - containerPort: 3000
+      - name: info-app
+        image: madhuakula/k8s-goat-info-app
+        resources:
+          limits:
+            cpu: 30m
+            memory: 40Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        ports:
+        - containerPort: 5000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-proxy-deployment
+  labels:
+    app: external-proxy
+spec:
+  selector:
+    matchLabels:
+      app: external-proxy
+  template:
+    metadata:
+      labels:
+        app: external-proxy
+    spec:
+      containers:
+      - name: internal-api
+        image: madhuakula/k8s-goat-internal-api
+        resources:
+          limits:
+            cpu: 30m
+            memory: 40Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        ports:
+        - containerPort: 3000
+      - name: info-app
+        image: madhuakula/k8s-goat-info-app
+        resources:
+          limits:
+            cpu: 30m
+            memory: 40Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        ports:
+        - containerPort: 5000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-network-policy
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: internal-proxy
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - podSelector:
+            matchLabels:
+              app: internal-proxy
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skipdeployment
+  annotations:
+    "checkov.io/skip": "CKV2_K8S_6=skip it"
+  labels:
+    app: skip
+spec:
+  selector:
+    matchLabels:
+      app: skip
+  template:
+    metadata:
+      labels:
+        app: skip
+    spec:
+      containers:
+      - name: info-app
+        image: madhuakula/k8s-goat-info-app
+        resources:
+          limits:
+            cpu: 30m
+            memory: 40Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        ports:
+        - containerPort: 5000

--- a/tests/kubernetes/graph/test_running_graph_checks.py
+++ b/tests/kubernetes/graph/test_running_graph_checks.py
@@ -1,27 +1,29 @@
-import itertools
-import os
-import unittest
+from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 
 from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
 
-TEST_DIRNAME = os.path.dirname(os.path.realpath(__file__))
-
-
-class TestRunningGraphChecks(unittest.TestCase):
-    @pytest.mark.skip("Graph checks not written yet for K8s")
-    def test_runner(self):
-        root_dir = os.path.realpath(os.path.join(TEST_DIRNAME, "../runner/resources"))
-        report = Runner().run(root_dir)
-        assert any(
-            check.check_id == "CKV2_K8S_21" for check in itertools.chain(report.failed_checks, report.passed_checks))
-        summary = report.get_summary()
-        self.assertEqual(summary["passed"], 0)
-        self.assertEqual(summary["failed"], 5)
-        self.assertEqual(summary["skipped"], 0)
-        self.assertEqual(summary["parsing_errors"], 0)
+RESOURCES_DIR = Path(__file__).parent / "resources"
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize("graph_framework", ["NETWORKX", "IGRAPH"])
+def test_runner(mocker: MockerFixture, graph_framework):
+    # given
+    test_file_path = RESOURCES_DIR / "graph_check.yaml"
+    runner_filter = RunnerFilter(checks=["CKV2_K8S_6"])
+
+    mocker.patch.dict("os.environ", {"CHECKOV_GRAPH_FRAMEWORK": graph_framework})
+
+    # when
+    report = Runner().run(root_folder=None, files=[str(test_file_path)], runner_filter=runner_filter)
+
+    #  when
+    summary = report.get_summary()
+
+    assert summary["passed"] == 1
+    assert summary["failed"] == 1
+    assert summary["skipped"] == 1
+    assert summary["parsing_errors"] == 0


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added support for skipping graph based checks for Kubernetes

Fixes #4332 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
