### PR TITLE
fix(terraform): fix getting the module for resource named 'module'

### DIFF
--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -371,7 +371,7 @@ class Runner(ImageReferencerMixin[None], BaseRunner[TerraformGraphManager]):
                 module, _ = get_module_from_full_path(full_file_path)
                 if module:
                     full_definition_path = entity_id.split('.')
-                    module_name_index = len(full_definition_path) - full_definition_path[::-1].index(BlockType.MODULE)  # the next item after the last 'module' prefix is the module name
+                    module_name_index = len(full_definition_path) - full_definition_path[::-1][1:].index(BlockType.MODULE) - 1  # the next item after the last 'module' prefix is the module name
                     module_name = full_definition_path[module_name_index]
                     caller_context = definition_context[module].get(BlockType.MODULE, {}).get(module_name)
                     caller_file_line_range = [caller_context.get('start_line'), caller_context.get('end_line')]

--- a/tests/terraform/runner/resources/nested_modules_caller_file/main.tf
+++ b/tests/terraform/runner/resources/nested_modules_caller_file/main.tf
@@ -1,0 +1,3 @@
+module "test_module" {
+  source = "./module"
+}

--- a/tests/terraform/runner/resources/nested_modules_caller_file/module/module.tf
+++ b/tests/terraform/runner/resources/nested_modules_caller_file/module/module.tf
@@ -1,0 +1,8 @@
+# Bucket that will fail (no encryption) defined INSIDE a module
+resource "aws_s3_bucket" "module" {
+  bucket = "inside-bucket"
+
+  object_lock_configuration {
+    object_lock_enabled = "Disabled"
+  }
+}

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -1114,6 +1114,19 @@ class TestRunnerValid(unittest.TestCase):
         self.assertFalse(found_inside)
         self.assertFalse(found_outside)
 
+    @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_NESTED_MODULES": "True"})
+    def test_nested_modules_caller_file(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        report = Runner(db_connector=self.db_connector()).run(
+            root_folder=f"{current_dir}/resources/nested_modules_caller_file",
+            external_checks_dir=None,
+            runner_filter=RunnerFilter(checks="CKV_AWS_143"))  # bucket encryption
+        self.assertEqual(len(report.failed_checks), 1)
+        self.assertEqual(len(report.passed_checks), 0)
+        record = report.failed_checks[0]
+        self.assertIsNotNone(record.caller_file_path)
+        self.assertIsNotNone(record.caller_file_line_range)
+
     def test_module_failure_reporting_772(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
fix finding caller module for a resource named 'module'

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
