### PR TITLE
feat(secrets): remove secrets dependency in generic record

### DIFF
--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -194,16 +194,8 @@ class Record:
 
         status_message = colored("\t{} for resource: {}\n".format(status, self.resource), status_color)
 
-        # Improve this part by leveraging inheritance of SecretsRecord
-        secret_validation_status_string = ""  # nosec
-        if self.check_result["result"] == CheckResult.FAILED and \
-                hasattr(self, 'validation_status') and \
-                os.getenv("CKV_VALIDATE_SECRETS") and \
-                hasattr(self, '_get_secret_validation_status_message'):  # for typing purposes, can't check with isinstance cause of circular dependency
-            secret_validation_status_string = self._get_secret_validation_status_message()
-
         if self.check_result["result"] == CheckResult.FAILED and code_lines and not compact:
-            return f"{check_message}{status_message}{secret_validation_status_string}{severity_message}{detail}{file_details}{caller_file_details}{guideline_message}{code_lines}{evaluation_message}"
+            return f"{check_message}{status_message}{severity_message}{detail}{file_details}{caller_file_details}{guideline_message}{code_lines}{evaluation_message}"
 
         if self.check_result["result"] == CheckResult.SKIPPED:
             return f"{check_message}{status_message}{severity_message}{suppress_comment}{detail}{file_details}{caller_file_details}{guideline_message}"


### PR DESCRIPTION
This PR utilizes the secrets record and provides it with its own to_string method so it can leverage the generic record to_string and also enrich with its own info.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
