### PR TITLE
fix(kustomize): remove redundant error in kustomize runner

### DIFF
--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -158,9 +158,11 @@ class K8sKustomizeRunner(K8sRunner):
         # Moves report generation logic out of run() method in Runner class.
         # Allows function overriding of a much smaller function than run() for other "child" frameworks such as Kustomize, Helm
         # Where Kubernetes CHECKS are needed, but the specific file references are to another framework for the user output (or a mix of both).
-        if not self.context:
+        if self.context is None:
             # this shouldn't happen
             logging.error("Context for Kustomize runner was not set")
+            return report
+        if not self.context:
             return report
 
         kustomize_metadata = self.report_mutator_data['kustomizeMetadata'],

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -158,11 +158,10 @@ class K8sKustomizeRunner(K8sRunner):
         # Moves report generation logic out of run() method in Runner class.
         # Allows function overriding of a much smaller function than run() for other "child" frameworks such as Kustomize, Helm
         # Where Kubernetes CHECKS are needed, but the specific file references are to another framework for the user output (or a mix of both).
-        if self.context is None:
-            # this shouldn't happen
-            logging.error("Context for Kustomize runner was not set")
-            return report
         if not self.context:
+            if self.context is None:
+                # this shouldn't happen
+                logging.error("Context for Kustomize runner was not set")
             return report
 
         kustomize_metadata = self.report_mutator_data['kustomizeMetadata'],


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**


## Description
log error of 'Context for Kustomize runner was not set' only if the context is None and not if it's empty

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
