### PR TITLE
feat(general): Control check failure logging level

### DIFF
--- a/checkov/common/checks/base_check_registry.py
+++ b/checkov/common/checks/base_check_registry.py
@@ -153,9 +153,6 @@ class BaseCheckRegistry:
             )
             return result
         except Exception:
-            logging.error(f'Failed to run check {check.id} on {scanned_file}:{entity_type}.{entity_name}',
-                          exc_info=True)
-            logging.info(f'Entity configuration: {entity_configuration}')
             return _CheckResult(
                 result=CheckResult.UNKNOWN, suppress_comment="", evaluated_keys=[],
                 results_configuration=entity_configuration, check=check, entity=entity_configuration

--- a/checkov/common/graph/graph_builder/variable_rendering/renderer.py
+++ b/checkov/common/graph/graph_builder/variable_rendering/renderer.py
@@ -54,7 +54,7 @@ class VariableRenderer(ABC, Generic[_LocalGraph]):
                 break
             evaluated_edges_cache.append(edges_to_render)
 
-            logging.info(f"evaluating {len(edges_to_render)} edges")
+            logging.debug(f"evaluating {len(edges_to_render)} edges")
             # group edges that have the same origin and label together
             edges_groups = self.group_edges_by_origin_and_label(edges_to_render)
             if self.run_async:
@@ -88,9 +88,9 @@ class VariableRenderer(ABC, Generic[_LocalGraph]):
                 break
 
         self.local_graph.update_vertices_configs()
-        logging.info("done evaluating edges")
+        logging.debug("done evaluating edges")
         self.evaluate_non_rendered_values()
-        logging.info("done evaluate_non_rendered_values")
+        logging.debug("done evaluate_non_rendered_values")
 
     @abstractmethod
     def _render_variables_from_vertices(self) -> None:

--- a/checkov/common/models/enums.py
+++ b/checkov/common/models/enums.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from enum import Enum, IntEnum
 
 
@@ -52,3 +53,9 @@ class ScanDataFormat(Enum):
 class ErrorStatus(IntEnum):
     SUCCESS = 0
     ERROR = 2
+
+
+@dataclass
+class CheckFailLevel:
+    WARNING = 'WARNING'
+    ERROR = 'ERROR'

--- a/tests/common/checks/test_base_check.py
+++ b/tests/common/checks/test_base_check.py
@@ -1,4 +1,8 @@
+import os
 import unittest
+
+import mock
+from parameterized import parameterized
 
 from checkov.common.checks.base_check import BaseCheck
 from checkov.common.checks.base_check_registry import BaseCheckRegistry
@@ -32,12 +36,13 @@ class TestCheckDetails(BaseCheck):
     # for pytest not to collect this class as tests
     __test__ = False
 
-    def __init__(self):
+    def __init__(self, fail_check=False):
         name = "Another Example check"
         categories = []
         id = "CKV_T_2"
         supported_entities = ["my_resource_type"]
         block_type = "resource"
+        self.fail_check = fail_check
         super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities,
                          block_type=block_type)
 
@@ -48,6 +53,8 @@ class TestCheckDetails(BaseCheck):
         :param conf:
         :return:
         """
+        if self.fail_check:
+            raise Exception("An error")
         if conf.get("value")[0]:
             self.details.append("This check PASSED...")
             return CheckResult.PASSED
@@ -107,6 +114,20 @@ class TestBaseCheck(unittest.TestCase):
         self.assertEqual(CheckResult.FAILED, result["result"])
         self.assertEqual(1, len(check.details))
         self.assertIn("This check FAILED...", check.details)
+
+    @parameterized.expand([
+        ("WARNING",),
+        ("ERROR",)
+    ])
+    def test_check_fail_log_level_error(self, log_level):
+        with self.assertLogs(level=log_level) as log, mock.patch.dict(os.environ,
+                                                                      {'CHECKOV_CHECK_FAIL_LEVEL': log_level}, clear=True):
+            check = TestCheckDetails(fail_check=True)
+            self.assertEqual(0, len(check.details))
+            try:
+                check.run("test.tf", {"value": ["True"]}, "my_resource", "resource", {})
+            except Exception:
+                self.assertEqual(len(log.output), 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- introduce `CHECKOV_CHECK_FAIL_LEVEL`  (which defaults to ERROR) for controlling check failure logging level
- moved variable rendering logs into debug level

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
