### PR TITLE
break(gha): adjust the attribute reference for GitHub Actions graph checks

### DIFF
--- a/checkov/github_actions/graph_builder/local_graph.py
+++ b/checkov/github_actions/graph_builder/local_graph.py
@@ -105,11 +105,7 @@ class GitHubActionsLocalGraph(ObjectLocalGraph):
 
         if permissions is None:
             # if 'permissions' is not set in a file, then it is automatically 'write-all'
-            permissions = {
-                "permissions": "write-all",
-                START_LINE: 0,
-                END_LINE: 0,
-            }
+            permissions = "write-all"
 
         if not permissions or not isinstance(permissions, (str, dict)):
             return
@@ -122,7 +118,11 @@ class GitHubActionsLocalGraph(ObjectLocalGraph):
                 END_LINE: 0,
             }
         else:
-            config = permissions
+            config = {
+                "permissions": permissions,
+                START_LINE: permissions[START_LINE],
+                END_LINE: permissions[END_LINE],
+            }
 
         attributes = deepcopy(config)
         attributes[CustomAttributes.RESOURCE_TYPE] = ResourceType.PERMISSIONS
@@ -146,13 +146,17 @@ class GitHubActionsLocalGraph(ObjectLocalGraph):
 
         if isinstance(on, (str, list)):
             # to get the correct line numbers we would need to check the raw definition
-            config = {
+            config: "dict[str, Any]" = {
                 "on": on,
                 START_LINE: 0,
                 END_LINE: 0,
             }
         elif isinstance(on, dict):
-            config = on
+            config = {
+                "on": on,
+                START_LINE: on[START_LINE],
+                END_LINE: on[END_LINE],
+            }
         else:
             return
 

--- a/docs/3.Custom Policies/YAML Custom Policies.md
+++ b/docs/3.Custom Policies/YAML Custom Policies.md
@@ -392,7 +392,7 @@ Following connections are supported
 
 #### Note
 The value for `permissions` can be either a map or a single string.
-Map entries can be referenced via their respective key, but a single string entry can be accessed by using `permissions` as the attribute.
+Map entries should be prefixed with `permissions.` key and a single string entry can be accessed by using `permissions` as the attribute.
 
 ex.
 ```yaml
@@ -405,6 +405,16 @@ value: "write-all"
 ```
 
 The value for `on` can be either a map, a string or a list of strings.
+
+ex.
+```yaml
+cond_type: attribute
+resource_types:
+  - "on"
+attribute: on.push.branches
+operator: contains
+value: main
+```
 
 ### Kubernetes
 All resources can be referenced under `resource_types`.

--- a/tests/github_actions/checks/extra_yaml_checks/OnPush.yaml
+++ b/tests/github_actions/checks/extra_yaml_checks/OnPush.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "CKV2_GHA_CUSTOM_3"
+  name: "Ensure workflow is used on main push"
+  category: "IAM"
+definition:
+  cond_type: attribute
+  resource_types:
+    - "on"
+  attribute: on.push.branches
+  operator: contains
+  value: main

--- a/tests/github_actions/checks/test_extra_checks.py
+++ b/tests/github_actions/checks/test_extra_checks.py
@@ -77,3 +77,36 @@ def test_jobs_steps_connection_check():
     assert summary["parsing_errors"] == 0
 
     assert failed_check_resources == failing_resources
+
+
+def test_on_check():
+    # given
+    test_file = str(RESOURCES_DIR / ".github/workflows/workflow_with_image.yml")
+    runner = Runner()
+
+    # when
+    report = runner.run(
+        files=[test_file],
+        external_checks_dir=[str(EXTRA_YAML_CHECKS_DIR)],
+        runner_filter=RunnerFilter(checks="CKV2_GHA_CUSTOM_3"),
+    )
+
+    # remove all checks
+    runner.graph_registry.checks.clear()
+
+    # then
+    summary = report.get_summary()
+
+
+    passing_resources = {
+        "on",
+    }
+
+    passed_check_resources = {c.resource for c in report.passed_checks}
+
+    assert summary["passed"] == len(passing_resources)
+    assert summary["failed"] == 0
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0
+
+    assert passed_check_resources == passing_resources


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- changing the reference on how to query the attributes for `on` and `permissions` resource in a GHA policies to be always prefixed with `on.` or `permissions.`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
