### PR TITLE
fix(terraform): fix CKV2_AWS_46 (false positive on connection with s3 via logging_config)

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/CLoudFrontS3OriginConfigWithOAI.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/CLoudFrontS3OriginConfigWithOAI.yaml
@@ -4,18 +4,12 @@ metadata:
   category: "IAM"
 definition:
   or:
-    - and:
-        - cond_type: filter
-          attribute: resource_type
-          operator: within
-          value:
-            - aws_cloudfront_distribution
-        - cond_type: connection
-          resource_types:
-            - aws_cloudfront_distribution
-          connected_resource_types:
-            - aws_s3_bucket
-          operator: not_exists
+    - cond_type: attribute
+      resource_types:
+        - aws_cloudfront_distribution
+      attribute: "origin.*.domain_name"
+      operator: not_contains
+      value: "aws_s3_bucket."
     - cond_type: attribute
       resource_types:
         - aws_cloudfront_distribution
@@ -26,5 +20,3 @@ definition:
         - aws_cloudfront_distribution
       attribute: "origin.*.origin_access_control_id"
       operator: "exists"         
-        
-    

--- a/tests/terraform/graph/checks/resources/CLoudFrontS3OriginConfigWithOAI/expected.yaml
+++ b/tests/terraform/graph/checks/resources/CLoudFrontS3OriginConfigWithOAI/expected.yaml
@@ -3,3 +3,4 @@ fail:
 pass:
   - "aws_cloudfront_distribution.pass_1"
   - "aws_cloudfront_distribution.pass_2"
+  - "aws_cloudfront_distribution.pass_3"

--- a/tests/terraform/graph/checks/resources/CLoudFrontS3OriginConfigWithOAI/main.tf
+++ b/tests/terraform/graph/checks/resources/CLoudFrontS3OriginConfigWithOAI/main.tf
@@ -236,9 +236,6 @@ resource "aws_cloudfront_distribution" "fail" {
     
   }
 
-  
-
-
   enabled             = true
   is_ipv6_enabled     = true
   comment             = "Some comment"
@@ -246,7 +243,7 @@ resource "aws_cloudfront_distribution" "fail" {
 
   logging_config {
     include_cookies = false
-    bucket          = "mylogs.s3.amazonaws.com"
+    bucket          = aws_s3_bucket.cloudfront_logs.bucket_domain_name
     prefix          = "myprefix"
   }
 
@@ -322,6 +319,103 @@ resource "aws_cloudfront_distribution" "fail" {
     geo_restriction {
       restriction_type = "whitelist"
       locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  tags = {
+    Environment = "production"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+  web_acl_id = aws_wafv2_web_acl.example.arn
+}
+
+resource "aws_s3_bucket" "cloudfront_logs" {
+  bucket = "mybucket-for-cf-logs"
+
+  tags = {
+    Name        = "My bucket"
+  }
+}
+
+resource "aws_cloudfront_distribution" "pass_3" {
+
+  origin {
+    domain_name = "somename.example.com"
+    origin_id   = "somename"
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols = [
+        "TLSv1.1",
+        "TLSv1.2",
+      ]
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = ""
+
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.cloudfront_logs.bucket_domain_name
+    prefix          = "myprefix"
+  }
+
+  aliases = ["mysite.example.com", "yoursite.example.com"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  ordered_cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
     }
   }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

False positive on:
`aws_cloudfront_distribution` with origin **other** than S3, but _connected_ via `logging_config` with `aws_s3_bucket`.

## Edited policies:
```
  id: "CKV2_AWS_46"
  name: "Ensure AWS Cloudfront Distribution with S3 have Origin Access set to enabled"
```

### Fix
Changed too wide _connection_ condition to specific attribute:

```
attribute: "origin.*.domain_name"
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
