### PR TITLE
fix(cloudformation): Updated AWS_CKV_7 to not require rotation on asymmetric keys

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/KMSRotation.py
+++ b/checkov/cloudformation/checks/resource/aws/KMSRotation.py
@@ -19,10 +19,8 @@ class KMSRotation(BaseResourceValueCheck):
             if 'KeySpec' in conf['Properties'].keys():
                 spec = conf['Properties']['KeySpec']
                 if not spec or 'SYMMETRIC_DEFAULT' in spec or 'HMAC' in spec:
-                    print("Symmetric Key")
                     return super().scan_resource_conf(conf)
                 else:
-                    print("Found Assymetric Key")
                     return CheckResult.PASSED
         return super().scan_resource_conf(conf)
 

--- a/checkov/cloudformation/checks/resource/aws/KMSRotation.py
+++ b/checkov/cloudformation/checks/resource/aws/KMSRotation.py
@@ -15,13 +15,12 @@ class KMSRotation(BaseResourceValueCheck):
 
     def scan_resource_conf(self, conf):
         # Only symmetric keys support auto rotation. The attribute is optional and defaults to symmetric.
-        if 'Properties' in conf.keys():
-            if 'KeySpec' in conf['Properties'].keys():
-                spec = conf['Properties']['KeySpec']
-                if not spec or 'SYMMETRIC_DEFAULT' in spec or 'HMAC' in spec:
-                    return super().scan_resource_conf(conf)
-                else:
-                    return CheckResult.PASSED
+        properties = conf.get("Properties")
+        if properties and isinstance(properties, dict):
+            spec = properties.get("KeySpec")
+            if spec and isinstance(spec, str):
+                if 'SYMMETRIC_DEFAULT' not in spec and 'HMAC' not in spec:
+                    return CheckResult.UNKNOWN
         return super().scan_resource_conf(conf)
 
 

--- a/checkov/terraform/checks/resource/aws/KMSRotation.py
+++ b/checkov/terraform/checks/resource/aws/KMSRotation.py
@@ -16,7 +16,7 @@ class KMSRotation(BaseResourceValueCheck):
     def scan_resource_conf(self, conf):
         # Only symmetric keys support auto rotation. The attribute is optional and defaults to symmetric.
         spec = conf.get('customer_master_key_spec')
-        if not spec or 'SYMMETRIC_DEFAULT' in spec:
+        if not spec or 'SYMMETRIC_DEFAULT' in spec or 'HMAC' in spec:
             return super().scan_resource_conf(conf)
         else:
             return CheckResult.PASSED

--- a/checkov/terraform/checks/resource/aws/KMSRotation.py
+++ b/checkov/terraform/checks/resource/aws/KMSRotation.py
@@ -19,7 +19,7 @@ class KMSRotation(BaseResourceValueCheck):
         if not spec or 'SYMMETRIC_DEFAULT' in spec or 'HMAC' in spec:
             return super().scan_resource_conf(conf)
         else:
-            return CheckResult.PASSED
+            return CheckResult.UNKNOWN
 
 
 check = KMSRotation()

--- a/tests/cloudformation/checks/resource/aws/example_KMSRotation/KMSRotation-PASSED-Asymmetric.yml
+++ b/tests/cloudformation/checks/resource/aws/example_KMSRotation/KMSRotation-PASSED-Asymmetric.yml
@@ -1,9 +1,10 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: KMS key example template
 Resources:
-  myKey:
+  AsymmetricKey:
     Type: AWS::KMS::Key
     Properties:
+      KeySpec: RSA_4096
       KeyPolicy:
         Version: '2012-10-17'
         Id: key-default-1
@@ -20,3 +21,4 @@ Resources:
           Action: kms:*
           Resource: '*'
       EnableKeyRotation: true
+  

--- a/tests/cloudformation/checks/resource/aws/example_KMSRotation/KMSRotation-PASSED-Symmetric.yml
+++ b/tests/cloudformation/checks/resource/aws/example_KMSRotation/KMSRotation-PASSED-Symmetric.yml
@@ -19,3 +19,5 @@ Resources:
                 - :root
           Action: kms:*
           Resource: '*'
+      EnableKeyRotation: true
+  

--- a/tests/cloudformation/checks/resource/aws/test_KMSRotation.py
+++ b/tests/cloudformation/checks/resource/aws/test_KMSRotation.py
@@ -16,7 +16,7 @@ class TestKMSRotation(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["passed"], 1)
         self.assertEqual(summary["failed"], 1)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/cloudformation/checks/resource/aws/test_KMSRotation.py
+++ b/tests/cloudformation/checks/resource/aws/test_KMSRotation.py
@@ -13,14 +13,13 @@ class TestKMSRotation(unittest.TestCase):
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
         test_files_dir = current_dir + "/example_KMSRotation"
-        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 1)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/terraform/checks/resource/aws/example_KMSRotation/main.tf
+++ b/tests/terraform/checks/resource/aws/example_KMSRotation/main.tf
@@ -7,14 +7,26 @@ resource "aws_kms_key" "pass1" {
 resource "aws_kms_key" "pass2" {
   description              = "KMS key 1"
   deletion_window_in_days  = 10
-  customer_master_key_spec = "RSA_2096"
-}
-
-resource "aws_kms_key" "pass3" {
-  description              = "KMS key 1"
-  deletion_window_in_days  = 10
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
   enable_key_rotation      = true
+}
+
+resource "aws_kms_key" "unknown1" {
+  description              = "KMS key 1"
+  deletion_window_in_days  = 10
+  customer_master_key_spec = "RSA_2048"
+}
+
+resource "aws_kms_key" "unknown2" {
+  description              = "KMS key 1"
+  deletion_window_in_days  = 10
+  customer_master_key_spec = "RSA_3072"
+}
+
+resource "aws_kms_key" "unknown2" {
+  description              = "KMS key 1"
+  deletion_window_in_days  = 10
+  customer_master_key_spec = "RSA_4096"
 }
 
 resource "aws_kms_key" "fail1" {

--- a/tests/terraform/checks/resource/aws/test_KMSRotation.py
+++ b/tests/terraform/checks/resource/aws/test_KMSRotation.py
@@ -19,19 +19,19 @@ class TestKMSRotation(unittest.TestCase):
         passing_resources = {
             "aws_kms_key.pass1",
             "aws_kms_key.pass2",
-            "aws_kms_key.pass3",
         }
+
         failing_resources = {
             "aws_kms_key.fail1",
             "aws_kms_key.fail2",
             "aws_kms_key.fail3",
             "aws_kms_key.fail4",
         }
-
+    
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["passed"], 2)
         self.assertEqual(summary["failed"], 4)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)

--- a/tests/terraform/checks/resource/aws/test_KMSRotation.py
+++ b/tests/terraform/checks/resource/aws/test_KMSRotation.py
@@ -28,8 +28,6 @@ class TestKMSRotation(unittest.TestCase):
             "aws_kms_key.fail4",
         }
 
-        print(summary)
-
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 

--- a/tests/terraform/checks/resource/aws/test_KMSRotation.py
+++ b/tests/terraform/checks/resource/aws/test_KMSRotation.py
@@ -28,6 +28,8 @@ class TestKMSRotation(unittest.TestCase):
             "aws_kms_key.fail4",
         }
 
+        print(summary)
+
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Updated cloudformation and terraform checks to not expect key rotation for asymmetric keys as listed here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-key.html#cfn-kms-key-keyspec

Fixes #4475 

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
