### PR TITLE
fix(ansible): support nested blocks and empty module values

### DIFF
--- a/checkov/ansible/checks/base_ansible_task_check.py
+++ b/checkov/ansible/checks/base_ansible_task_check.py
@@ -33,6 +33,12 @@ class BaseAnsibleTaskCheck(BaseCheck):
                 f'[?"{module}" != null][]',
                 f'[].tasks[].block[?"{module}" != null][]',
                 f'[].block[?"{module}" != null][]',
+                f'[].tasks[].block[].block[?"{module}" != null][]',
+                f'[].block[].block[?"{module}" != null][]',
+                # in theory, it can be more nested, but let's stop at 3 levels
+                # jmespath lib doesn't support recursive search https://github.com/jmespath/jmespath.py/issues/110
+                f'[].tasks[].block[].block[].block[?"{module}" != null][]',
+                f'[].block[].block[].block[?"{module}" != null][]',
             )
         ]
 

--- a/checkov/ansible/graph_builder/local_graph.py
+++ b/checkov/ansible/graph_builder/local_graph.py
@@ -72,6 +72,13 @@ class AnsibleLocalGraph(ObjectLocalGraph):
                 # this happens when modules have no parameters and are directly used with the user input
                 # ex. ansible.builtin.command: cat /etc/passwd
                 config = {SELF_REFERENCE: config}
+            elif config is None:
+                # this happens when modules have no parameters and are passed no value
+                # ex. amazon.aws.ec2_instance_info:
+                config = {
+                    START_LINE: task[START_LINE],
+                    END_LINE: task[END_LINE],
+                }
 
             attributes = deepcopy(config)
             attributes[CustomAttributes.RESOURCE_TYPE] = resource_type

--- a/checkov/ansible/graph_builder/local_graph.py
+++ b/checkov/ansible/graph_builder/local_graph.py
@@ -36,21 +36,22 @@ class AnsibleLocalGraph(ObjectLocalGraph):
                 else:
                     self._process_blocks(file_path=file_path, task=code_block)
 
-    def _process_blocks(self, file_path: str, task: Any) -> None:
+    def _process_blocks(self, file_path: str, task: Any, prefix: str = "") -> None:
         """Checks for possible block usage"""
 
         if not task or not isinstance(task, dict):
             return
 
         if "block" in task and isinstance(task["block"], list):
-            self._create_block_vertices(file_path=file_path, block=task)
+            prefix += f"{ResourceType.BLOCK}."  # with each nested level an extra block prefix is added
+            self._create_block_vertices(file_path=file_path, block=task, prefix=prefix)
 
             for block_task in task["block"]:
-                self._create_tasks_vertices(file_path=file_path, task=block_task)
+                self._process_blocks(file_path=file_path, task=block_task, prefix=prefix)
         else:
-            self._create_tasks_vertices(file_path=file_path, task=task)
+            self._create_tasks_vertices(file_path=file_path, task=task, prefix=prefix)
 
-    def _create_tasks_vertices(self, file_path: str, task: Any) -> None:
+    def _create_tasks_vertices(self, file_path: str, task: Any, prefix: str = "") -> None:
         """Creates tasks vertices"""
 
         if not task or not isinstance(task, dict):
@@ -66,7 +67,6 @@ class AnsibleLocalGraph(ObjectLocalGraph):
                 continue
 
             resource_type = f"{ResourceType.TASKS}.{name}"
-            block_name = f"{resource_type}.{task_name}"
 
             if isinstance(config, str):
                 # this happens when modules have no parameters and are directly used with the user input
@@ -83,12 +83,12 @@ class AnsibleLocalGraph(ObjectLocalGraph):
 
             self.vertices.append(
                 Block(
-                    name=block_name,
+                    name=f"{resource_type}.{task_name}",
                     config=config,
                     path=file_path,
                     block_type=BlockType.RESOURCE,
                     attributes=attributes,
-                    id=block_name,
+                    id=f"{resource_type}.{prefix}{task_name}",
                     source=self.source,
                 )
             )
@@ -96,11 +96,11 @@ class AnsibleLocalGraph(ObjectLocalGraph):
             # no need to further check
             break
 
-    def _create_block_vertices(self, file_path: str, block: dict[str, Any]) -> None:
+    def _create_block_vertices(self, file_path: str, block: dict[str, Any], prefix: str = "") -> None:
         """Creates block vertices"""
 
         # grab the block name, if it exists
-        block_name = f'{ResourceType.BLOCK}.{block.get("name") or "unknown"}'
+        block_name = block.get("name") or "unknown"
 
         config = block
         attributes = deepcopy(config)
@@ -109,12 +109,12 @@ class AnsibleLocalGraph(ObjectLocalGraph):
 
         self.vertices.append(
             Block(
-                name=block_name,
+                name=f"{ResourceType.BLOCK}.{block_name}",
                 config=config,
                 path=file_path,
                 block_type=BlockType.RESOURCE,
                 attributes=attributes,
-                id=block_name,
+                id=f"{prefix}{block_name}",
                 source=self.source,
             )
         )

--- a/checkov/ansible/runner.py
+++ b/checkov/ansible/runner.py
@@ -96,14 +96,26 @@ class Runner(YamlRunner):
 
         return resource_key
 
-    def _handle_block_tasks(self, start_line: int, end_line: int, code_block: dict[str, Any]) -> str | None:
+    def _handle_block_tasks(
+        self, start_line: int, end_line: int, code_block: dict[str, Any], prefix: str = ""
+    ) -> str | None:
         for block_task in code_block[ResourceType.BLOCK]:
             if block_task[START_LINE] <= start_line <= end_line <= block_task[END_LINE]:
-                return self._generate_resource_name(task=block_task, in_block=True)
+                prefix += f"{ResourceType.BLOCK}."  # with each nested level an extra block prefix is added
+                if ResourceType.BLOCK in block_task:
+                    resource_name = self._handle_block_tasks(
+                        start_line=start_line,
+                        end_line=end_line,
+                        code_block=block_task,
+                        prefix=prefix,
+                    )
+                    if resource_name is not None:
+                        return resource_name
+                return self._generate_resource_name(task=block_task, prefix=prefix)
 
         return None
 
-    def _generate_resource_name(self, task: dict[str, Any], in_block: bool = False) -> str | None:
+    def _generate_resource_name(self, task: dict[str, Any], prefix: str = "") -> str | None:
         # grab the task name at the beginning before trying to find the actual module name
         task_name = task.get("name") or "unknown"
 
@@ -111,9 +123,9 @@ class Runner(YamlRunner):
             if name in TASK_RESERVED_KEYWORDS:
                 continue
 
-            if in_block:
+            if prefix:
                 # if the task is found in a block, then prefix the module name with 'block'
-                name = f"block.{name}"
+                name = f"{prefix}{name}"
 
             return f"{ResourceType.TASKS}.{name}.{task_name}"
 

--- a/tests/ansible/examples/nested_blocks.yml
+++ b/tests/ansible/examples/nested_blocks.yml
@@ -1,0 +1,34 @@
+---
+
+- name: Verify tests
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: 1st level block
+      block:
+        - name: 2nd level block
+          block:
+            - name: 3rd level block
+              block:
+                - name: 4th level block
+                  block:
+                    - name: 5th level block
+                      block:
+                        - name: 6th level uri
+                          ansible.builtin.uri:
+                            url: https://www.example.com
+                    - name: 5th level uri
+                      ansible.builtin.uri:
+                        url: https://www.example.com
+                - name: 4th level uri
+                  ansible.builtin.uri:
+                    url: https://www.example.com
+            - name: 3rd level uri
+              ansible.builtin.uri:
+                url: https://www.example.com
+        - name: 2nd level uri
+          ansible.builtin.uri:
+            url: https://www.example.com
+    - name: 1st level uri
+      ansible.builtin.uri:
+        url: https://www.example.com

--- a/tests/ansible/examples/site.yml
+++ b/tests/ansible/examples/site.yml
@@ -4,6 +4,10 @@
   hosts: all
   gather_facts: False
   tasks:
+    - name: Get Running instance Info
+      amazon.aws.ec2_instance_info:
+      register: ec2info
+
     - name: enabled
       amazon.aws.ec2_instance:
         name: "public-compute-instance"

--- a/tests/ansible/graph_builder/test_local_graph.py
+++ b/tests/ansible/graph_builder/test_local_graph.py
@@ -27,8 +27,8 @@ def test_build_graph():
     local_graph.build_graph(render_variables=False)
 
     # then
-    assert len(local_graph.vertices) == 3
-    assert len(local_graph.vertices_by_block_type[BlockType.RESOURCE]) == 3
+    assert len(local_graph.vertices) == 4
+    assert len(local_graph.vertices_by_block_type[BlockType.RESOURCE]) == 4
 
     tasks_ids = [
         vertex.id
@@ -36,6 +36,7 @@ def test_build_graph():
         if vertex.attributes.get(CustomAttributes.RESOURCE_TYPE).startswith(ResourceType.TASKS)
     ]
     assert tasks_ids == [
+        "tasks.amazon.aws.ec2_instance_info.Get Running instance Info",
         "tasks.amazon.aws.ec2_instance.enabled",
         "tasks.uri.Check that you can connect (GET) to a page",
         "tasks.ansible.builtin.get_url.Download foo.conf",

--- a/tests/ansible/test_graph_manager.py
+++ b/tests/ansible/test_graph_manager.py
@@ -23,7 +23,7 @@ def test_build_graph_from_definitions():
     )
 
     # then
-    assert len(local_graph.vertices) == 1
+    assert len(local_graph.vertices) == 2
 
     task_idx = local_graph.vertices_by_path_and_name[(test_file, "tasks.amazon.aws.ec2_instance.enabled")]
     task = local_graph.vertices[task_idx]
@@ -32,17 +32,17 @@ def test_build_graph_from_definitions():
     assert task.id == "tasks.amazon.aws.ec2_instance.enabled"
     assert task.source == "Ansible"
     assert task.attributes[CustomAttributes.RESOURCE_TYPE] == "tasks.amazon.aws.ec2_instance"
-    assert task.attributes[START_LINE] == 7
-    assert task.attributes[END_LINE] == 18
+    assert task.attributes[START_LINE] == 11
+    assert task.attributes[END_LINE] == 22
     assert task.config == {
         "name": "public-compute-instance",
         "key_name": "prod-ssh-key",
         "vpc_subnet_id": "subnet-5ca1ab1e",
         "instance_type": "c5.large",
         "security_group": "default",
-        "network": {"assign_public_ip": True, "__startline__": 15, "__endline__": 16},
+        "network": {"assign_public_ip": True, "__startline__": 19, "__endline__": 20},
         "image_id": "ami-123456",
         "ebs_optimized": True,
-        "__startline__": 9,
-        "__endline__": 18,
+        "__startline__": 13,
+        "__endline__": 22,
     }

--- a/tests/ansible/test_runner.py
+++ b/tests/ansible/test_runner.py
@@ -181,6 +181,54 @@ def test_runner_with_block(graph_connector):
         IgraphConnector,
     ],
 )
+def test_runner_with_nested_blocks(graph_connector):
+    # given
+    test_file = EXAMPLES_DIR / "nested_blocks.yml"
+    checks = ["CKV_ANSIBLE_1", "CKV2_ANSIBLE_3"]
+
+    # when
+    report = Runner(db_connector=graph_connector()).run(
+        root_folder="", files=[str(test_file)], runner_filter=RunnerFilter(checks=checks)
+    )
+
+    # then
+    summary = report.get_summary()
+
+    # if we increase the level of nested block levels for Python checks, then this goes up to 6
+    assert summary["passed"] == 4
+    assert summary["failed"] == 5
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0
+
+    passing_resources = {
+        "tasks.ansible.builtin.uri.1st level uri",
+        "tasks.block.ansible.builtin.uri.2nd level uri",
+        "tasks.block.block.ansible.builtin.uri.3rd level uri",
+        "tasks.block.block.block.ansible.builtin.uri.4th level uri",
+    }
+
+    failing_resources = {
+        "block.1st level block",
+        "block.block.2nd level block",
+        "block.block.block.3rd level block",
+        "block.block.block.block.4th level block",
+        "block.block.block.block.block.5th level block",
+    }
+
+    passed_check_resources = {check.resource for check in report.passed_checks}
+    failed_check_resources = {check.resource for check in report.failed_checks}
+
+    assert passing_resources == passed_check_resources
+    assert failing_resources == failed_check_resources
+
+
+@pytest.mark.parametrize(
+    "graph_connector",
+    [
+        NetworkxConnector,
+        IgraphConnector,
+    ],
+)
 def test_get_resource(graph_connector):
     # given
     file_path = "/example/site.yml"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- support nested blocks in Ansible playbooks up to 3 levels, because of jmespaths limitation
- support empty values for Ansible modules

Fixes #4471 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
