### PR TITLE
feat(secrets): log and filter potential uuid case

### DIFF
--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -183,7 +183,7 @@ class Runner(BaseRunner[None]):
                     logging.debug(f'Secret was filtered - no check_id for line_number {secret.line_number}')
                     continue
                 secret_key = f'{secret.filename}_{secret.line_number}_{secret.secret_hash}'
-                if is_potential_uuid(secret.secret_value):
+                if secret.secret_value and is_potential_uuid(secret.secret_value):
                     logging.info(f"Removing secret due to UUID filtering: {hashlib.sha256(secret.secret_value.encode('utf-8')).hexdigest()}")
                     continue
                 if secret_key in secrets_duplication:


### PR DESCRIPTION
This PR adds capability to secrets runner to log potential uuid secrets so we can get an idea on the frequency of findings.
The filtering of UUIDs still takes effect, but a little later in the flow.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
