### PR TITLE
feat(terraform): support more json encoded objects as part of terraform resource and fix evaluation of true/false in json

### DIFF
--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -218,8 +218,10 @@ class BaseAttributeSolver(BaseSolver):
         }
         """
         try:
-            value_to_check = json.loads(value_to_check)
-            return value_to_check
+            # Check if the value looks like a json object, and if it is try to parse it
+            if isinstance(value_to_check, str) and value_to_check.strip().startswith('{'):
+                value_to_check = json.loads(value_to_check)
+                return value_to_check
         except Exception as e:
             logging.info(f'cant parse policy str to object, {str(e)}')
         return value_to_check

--- a/checkov/terraform/checks/resource/aws/EMRClusterIsEncryptedKMS.py
+++ b/checkov/terraform/checks/resource/aws/EMRClusterIsEncryptedKMS.py
@@ -16,7 +16,7 @@ class EMRClusterIsEncryptedKMS(BaseResourceCheck):
         if 'configuration' not in conf:
             return CheckResult.SKIPPED
         configuration = conf['configuration'][0]
-        if "SSE-KMS" in configuration:
+        if "SSE-KMS" in str(configuration):
             return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/checkov/terraform/checks/resource/aws/SSMSessionManagerDocumentEncryption.py
+++ b/checkov/terraform/checks/resource/aws/SSMSessionManagerDocumentEncryption.py
@@ -28,6 +28,8 @@ class SSMSessionManagerDocumentEncryption(BaseResourceCheck):
             inputs = json.loads(content).get("inputs", {})
         elif doc_format == ["YAML"] and is_yaml(content):
             inputs = yaml.safe_load(content).get("inputs", {})
+        elif isinstance(content, dict):
+            inputs = content.get("inputs", None)
 
         if inputs and not inputs.get("kmsKeyId"):
             return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/aws/SSMSessionManagerDocumentLogging.py
+++ b/checkov/terraform/checks/resource/aws/SSMSessionManagerDocumentLogging.py
@@ -28,6 +28,8 @@ class SSMSessionManagerDocumentLogging(BaseResourceCheck):
             inputs = json.loads(content).get("inputs", {})
         elif doc_format == ["YAML"] and is_yaml(content):
             inputs = yaml.safe_load(content).get("inputs", {})
+        elif isinstance(content, dict):
+            inputs = content.get("inputs", None)
 
         if inputs:
             if inputs.get("s3BucketName") and inputs.get("s3EncryptionEnabled"):

--- a/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
@@ -64,7 +64,12 @@ def _try_evaluate(input_str: Union[str, bool]) -> Any:
         try:
             return evaluate(f'"{input_str}"')
         except Exception:
-            return input_str
+            try:
+                # Terraform's true value is with small t while python is with capital T,
+                # which makes eval fail if we get a value containing true
+                return evaluate(input_str.replace('true', 'True'))
+            except Exception:
+                return input_str
 
 
 def replace_string_value(original_str: Any, str_to_replace: str, replaced_value: str, keep_origin: bool = True) -> Any:

--- a/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -65,9 +66,12 @@ def _try_evaluate(input_str: Union[str, bool]) -> Any:
             return evaluate(f'"{input_str}"')
         except Exception:
             try:
-                # Terraform's true value is with small t while python is with capital T,
-                # which makes eval fail if we get a value containing true
-                return evaluate(input_str.replace('true', 'True'))
+                # Sometimes eval can fail on correct terraform input like 'true'/'false',
+                # as python's values are with capital T/F.
+                # However, json does know how to handle it, so we use it instead.
+                if isinstance(input_str, str):
+                    return json.loads(input_str)
+                return input_str
             except Exception:
                 return input_str
 

--- a/tests/terraform/graph/checks/custom_policies/CustomAwsEMRSecurityConfiguration.yaml
+++ b/tests/terraform/graph/checks/custom_policies/CustomAwsEMRSecurityConfiguration.yaml
@@ -1,0 +1,35 @@
+metadata:
+ name: "Elastic Testing"
+ category: "general"
+ id: "emrbackup1"
+ guidelines: "testing"
+ severity: "high"
+scope:
+  provider: "aws"
+definition:
+  or:
+    - cond_type: "filter"
+      attribute: "resource_type"
+      operator: "within"
+      value:
+        - "aws_emr_cluster"
+    - or:
+        - cond_type: "connection"
+          resource_types:
+            - "aws_emr_cluster"
+          connected_resource_types:
+            - "aws_emr_security_configuration"
+          operator: "not_exists"
+        - and:
+            - cond_type: "connection"
+              resource_types:
+                - "aws_emr_cluster"
+              connected_resource_types:
+                - "aws_emr_security_configuration"
+              operator: "exists"
+            - cond_type: attribute
+              resource_types:
+                - aws_emr_security_configuration
+              attribute: configuration.EncryptionConfiguration.EnableInTransitEncryption
+              operator: equals
+              value: true

--- a/tests/terraform/graph/checks/resources/CustomAwsEMRSecurityConfiguration/expected.yaml
+++ b/tests/terraform/graph/checks/resources/CustomAwsEMRSecurityConfiguration/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "aws_emr_cluster.passing_cluster"
+fail:
+  - "aws_emr_cluster.failing_cluster"

--- a/tests/terraform/graph/checks/resources/CustomAwsEMRSecurityConfiguration/expected.yaml
+++ b/tests/terraform/graph/checks/resources/CustomAwsEMRSecurityConfiguration/expected.yaml
@@ -1,4 +1,5 @@
 pass:
   - "aws_emr_cluster.passing_cluster"
+  - "aws_emr_cluster.also_passing_cluster"
 fail:
   - "aws_emr_cluster.failing_cluster"

--- a/tests/terraform/graph/checks/resources/CustomAwsEMRSecurityConfiguration/main.tf
+++ b/tests/terraform/graph/checks/resources/CustomAwsEMRSecurityConfiguration/main.tf
@@ -1,0 +1,91 @@
+provider "aws" {
+    region="us-east-1"
+}
+
+resource "aws_emr_cluster" "passing_cluster" {
+  name          = "good"
+  release_label = "release"
+  applications  = ["Spark"]
+  security_configuration = aws_emr_security_configuration.good_config.name
+  ec2_attributes {
+    subnet_id = aws_subnet.main.id
+    instance_profile = aws_iam_instance_profile.emr_profile.arn
+  }
+
+  master_instance_group {
+    instance_type = "m5.xlarge"
+  }
+
+  core_instance_group {
+    instance_count = 1
+    instance_type  = "m5.xlarge"
+  }
+  service_role = aws_iam_role.iam_emr_service_role.arn
+}
+
+
+resource "aws_emr_security_configuration" "good_config" {
+  name = "good"
+# compliant case EncryptionConfiguration.EnableAtRestEncryption is true and LocalDiskEncryptionConfiguration exists
+# Compliant EnableInTransitEncryption is true
+# Compliant securityConfiguration exists and attaced with cluster
+  configuration = <<EOF
+{
+  "EncryptionConfiguration": {
+      "AtRestEncryptionConfiguration": {
+            "LocalDiskEncryptionConfiguration": {
+                "EncryptionKeyProviderType": "AwsKms",
+                "AwsKmsKey": "${aws_kms_key.test.arn}"
+            }
+        },
+        "EnableInTransitEncryption": "true",
+        "EnableAtRestEncryption": "true"
+    }
+}
+EOF
+}
+
+
+resource "aws_emr_cluster" "failing_cluster" {
+  name          = "bad"
+  release_label = "release"
+  applications  = ["Spark"]
+  security_configuration = aws_emr_security_configuration.bad_config.name
+  ec2_attributes {
+    subnet_id = aws_subnet.main.id
+    instance_profile = aws_iam_instance_profile.emr_profile.arn
+  }
+
+  master_instance_group {
+    instance_type = "m5.xlarge"
+  }
+
+  core_instance_group {
+    instance_count = 1
+    instance_type  = "m5.xlarge"
+  }
+  service_role = aws_iam_role.iam_emr_service_role.arn
+}
+
+
+resource "aws_emr_security_configuration" "bad_config" {
+  name = "bad"
+# compliant case EncryptionConfiguration.EnableAtRestEncryption is true and LocalDiskEncryptionConfiguration exists
+# Compliant EnableInTransitEncryption is true
+# Compliant securityConfiguration exists and attaced with cluster
+  configuration = <<EOF
+{
+  "EncryptionConfiguration": {
+      "AtRestEncryptionConfiguration": {
+            "LocalDiskEncryptionConfiguration": {
+                "EncryptionKeyProviderType": "AwsKms",
+                "AwsKmsKey": "${aws_kms_key.test.arn}"
+            }
+        },
+        "EnableInTransitEncryption": "false",
+        "EnableAtRestEncryption": "true"
+    }
+}
+EOF
+}
+

--- a/tests/terraform/graph/checks/resources/CustomAwsEMRSecurityConfiguration/main.tf
+++ b/tests/terraform/graph/checks/resources/CustomAwsEMRSecurityConfiguration/main.tf
@@ -38,8 +38,8 @@ resource "aws_emr_security_configuration" "good_config" {
                 "AwsKmsKey": "${aws_kms_key.test.arn}"
             }
         },
-        "EnableInTransitEncryption": "true",
-        "EnableAtRestEncryption": "true"
+        "EnableInTransitEncryption": true,
+        "EnableAtRestEncryption": true
     }
 }
 EOF
@@ -82,8 +82,8 @@ resource "aws_emr_security_configuration" "bad_config" {
                 "AwsKmsKey": "${aws_kms_key.test.arn}"
             }
         },
-        "EnableInTransitEncryption": "false",
-        "EnableAtRestEncryption": "true"
+        "EnableInTransitEncryption": false,
+        "EnableAtRestEncryption": true
     }
 }
 EOF

--- a/tests/terraform/graph/checks/resources/CustomAwsEMRSecurityConfiguration/main.tf
+++ b/tests/terraform/graph/checks/resources/CustomAwsEMRSecurityConfiguration/main.tf
@@ -46,6 +46,51 @@ EOF
 }
 
 
+
+resource "aws_emr_cluster" "also_passing_cluster" {
+  name          = "good"
+  release_label = "release"
+  applications  = ["Spark"]
+  security_configuration = aws_emr_security_configuration.also_good_config.name
+  ec2_attributes {
+    subnet_id = aws_subnet.main.id
+    instance_profile = aws_iam_instance_profile.emr_profile.arn
+  }
+
+  master_instance_group {
+    instance_type = "m5.xlarge"
+  }
+
+  core_instance_group {
+    instance_count = 1
+    instance_type  = "m5.xlarge"
+  }
+  service_role = aws_iam_role.iam_emr_service_role.arn
+}
+
+
+resource "aws_emr_security_configuration" "also_good_config" {
+  name = "good"
+  data_retention = "5"
+# compliant case EncryptionConfiguration.EnableAtRestEncryption is true and LocalDiskEncryptionConfiguration exists
+# Compliant EnableInTransitEncryption is true
+# Compliant securityConfiguration exists and attaced with cluster
+  configuration = <<EOF
+{
+  "EncryptionConfiguration": {
+      "AtRestEncryptionConfiguration": {
+            "LocalDiskEncryptionConfiguration": {
+                "EncryptionKeyProviderType": "AwsKms",
+                "AwsKmsKey": "${aws_kms_key.test.arn}"
+            }
+        },
+        "EnableInTransitEncryption": "true",
+        "EnableAtRestEncryption": "true"
+    }
+}
+EOF
+}
+
 resource "aws_emr_cluster" "failing_cluster" {
   name          = "bad"
   release_label = "release"

--- a/tests/terraform/graph/checks/test_custom_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_custom_yaml_policies.py
@@ -20,6 +20,9 @@ class TestCustomYamlPolicies(unittest.TestCase):
     def test_CustomPolicy1(self):
         self.go("CustomPolicy1")
 
+    def test_CustomAwsEMRSecurityConfiguration(self):
+        self.go('CustomAwsEMRSecurityConfiguration')
+
     def go(self, dir_name: str, check_name: str | None = None) -> None:
         dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), f"resources/{dir_name}")
         check_name = dir_name if check_name is None else check_name


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Changed `base_attribute_solver` to always try to load a json object. Up until now we only did it for `policy` attribute, but as many places could have this behavior I changed it to be the default.
I also added a new test that checks it using a custom policy for `aws_emr_cluster`

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
