### PR TITLE
fix(terraform): Handle type error in `_handle_for_loop_in_dict`

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
@@ -245,7 +245,10 @@ def _handle_for_loop_in_dict(object_to_run_on: str, statement: str, start_expres
     rendered_result = {}
     for obj in object_to_run_on:
         val_to_assign = obj if statement.startswith(f'{renderer.LEFT_CURLY}{renderer.FOR_LOOP} {v_expression}') else evaluate_terraform(v_expression)
-        rendered_result[obj[k_expression]] = val_to_assign
+        try:
+            rendered_result[obj[k_expression]] = val_to_assign
+        except TypeError:
+            return
     return json.dumps(rendered_result)
 
 

--- a/tests/terraform/graph/variable_rendering/test_string_evaluation.py
+++ b/tests/terraform/graph/variable_rendering/test_string_evaluation.py
@@ -456,3 +456,7 @@ class TestTerraformEvaluation(TestCase):
         input_str = "[for val in ['k', 'v'] : val]"
         expected = ['k', 'v']
         self.assertEqual(expected, evaluate_terraform(input_str))
+
+        input_str = "{for val in ['k', 'v'] : val.name => true}"
+        expected = "{for val in ['k', 'v'] : val.name :> true}"
+        self.assertEqual(expected, evaluate_terraform(input_str))


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Handle type error in `_handle_for_loop_in_dict`

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
