### PR TITLE
feat(terraform): default tags test

### DIFF
--- a/checkov/terraform/checks/provider/aws/defaulttags.py
+++ b/checkov/terraform/checks/provider/aws/defaulttags.py
@@ -1,0 +1,20 @@
+
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.provider.base_check import BaseProviderCheck
+
+
+class DefaultTags(BaseProviderCheck):
+    def __init__(self) -> None:
+        name = "Ensure provider defines default tags"
+        id = "CKV_AWS_297"
+        supported_provider = ["aws"]
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_provider=supported_provider)
+
+    def scan_provider_conf(self, conf) :
+        if conf.get("default_tags"):
+            return CheckResult.PASSED
+        return CheckResult.FAILED
+
+
+check = DefaultTags()

--- a/tests/terraform/checks/provider/aws/test_defaulttags.py
+++ b/tests/terraform/checks/provider/aws/test_defaulttags.py
@@ -1,0 +1,39 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.provider.aws.defaulttags import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestCredentials(unittest.TestCase):
+    def test_failure_empty(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "aws" {}
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["aws"]
+        scan_result = check.scan_provider_conf(conf=provider_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads(
+            """
+            provider "aws" {
+                region = "us-west-2"
+                default_tags = {
+                    tags = {
+                        pike="permissions"
+                    }
+                }
+            }
+            """
+        )
+        provider_conf = hcl_res["provider"][0]["aws"]
+        scan_result = check.scan_provider_conf(conf=provider_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
