### PR TITLE
fix(terraform): skip loading module that calls to the same dir

### DIFF
--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -445,6 +445,9 @@ class Parser:
                     if not isinstance(source, str):
                         logging.debug(f"Skipping loading of {module_call_name} as source is not a string, it is: {source}")
                         continue
+                    elif source in ['./', '.']:
+                        logging.debug(f"Skipping loading of {module_call_name} as source is the current dir")
+                        continue
 
                     # Special handling for local sources to make sure we aren't double-parsing
                     if source.startswith("./") or source.startswith("../"):

--- a/tests/terraform/runner/resources/resource_ids_nested_modules/main.tf
+++ b/tests/terraform/runner/resources/resource_ids_nested_modules/main.tf
@@ -7,6 +7,9 @@ module "s3_module" {
   acl    = "public-read"
 }
 
+module "recursive_module" {
+  source = "./"
+}
 
 resource "aws_s3_bucket" "example" {
   bucket = "example"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
skip loading modules with the current dir as the source.
when the source of a module is `./` we got into an endless recursive loop in the parser phase while loading the modules.
add a recursive module in a test.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
