### PR TITLE
fix(ansible): skip unsupported Ansible resources

### DIFF
--- a/checkov/ansible/graph_builder/local_graph.py
+++ b/checkov/ansible/graph_builder/local_graph.py
@@ -33,8 +33,10 @@ class AnsibleLocalGraph(ObjectLocalGraph):
                 if ResourceType.TASKS in code_block:
                     for task in code_block[ResourceType.TASKS]:
                         self._process_blocks(file_path=file_path, task=task)
-                else:
+                elif ResourceType.BLOCK in code_block:
                     self._process_blocks(file_path=file_path, task=code_block)
+                else:
+                    logging.debug(f"File {file_path} has no supported resources")
 
     def _process_blocks(self, file_path: str, task: Any, prefix: str = "") -> None:
         """Checks for possible block usage"""
@@ -42,11 +44,11 @@ class AnsibleLocalGraph(ObjectLocalGraph):
         if not task or not isinstance(task, dict):
             return
 
-        if "block" in task and isinstance(task["block"], list):
+        if ResourceType.BLOCK in task and isinstance(task[ResourceType.BLOCK], list):
             prefix += f"{ResourceType.BLOCK}."  # with each nested level an extra block prefix is added
             self._create_block_vertices(file_path=file_path, block=task, prefix=prefix)
 
-            for block_task in task["block"]:
+            for block_task in task[ResourceType.BLOCK]:
                 self._process_blocks(file_path=file_path, task=block_task, prefix=prefix)
         else:
             self._create_tasks_vertices(file_path=file_path, task=task, prefix=prefix)

--- a/checkov/ansible/graph_builder/local_graph.py
+++ b/checkov/ansible/graph_builder/local_graph.py
@@ -33,10 +33,8 @@ class AnsibleLocalGraph(ObjectLocalGraph):
                 if ResourceType.TASKS in code_block:
                     for task in code_block[ResourceType.TASKS]:
                         self._process_blocks(file_path=file_path, task=task)
-                elif ResourceType.BLOCK in code_block:
-                    self._process_blocks(file_path=file_path, task=code_block)
                 else:
-                    logging.debug(f"File {file_path} has no supported resources")
+                    self._process_blocks(file_path=file_path, task=code_block)
 
     def _process_blocks(self, file_path: str, task: Any, prefix: str = "") -> None:
         """Checks for possible block usage"""
@@ -66,6 +64,9 @@ class AnsibleLocalGraph(ObjectLocalGraph):
             if name in TASK_RESERVED_KEYWORDS:
                 continue
             if name in (START_LINE, END_LINE):
+                continue
+            if isinstance(config, list):
+                # either it is actually not an Ansible file or a playbook without tasks refs
                 continue
 
             resource_type = f"{ResourceType.TASKS}.{name}"

--- a/tests/ansible/examples/no_tasks.yml
+++ b/tests/ansible/examples/no_tasks.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Sample play
+  hosts:
+    - test
+  roles:
+    - role: somerole

--- a/tests/ansible/test_runner.py
+++ b/tests/ansible/test_runner.py
@@ -229,6 +229,29 @@ def test_runner_with_nested_blocks(graph_connector):
         IgraphConnector,
     ],
 )
+def test_runner_with_nested_blocks(graph_connector):
+    # given
+    test_file = EXAMPLES_DIR / "no_tasks.yml"
+
+    # when
+    report = Runner(db_connector=graph_connector()).run(root_folder="", files=[str(test_file)])
+
+    # then
+    summary = report.get_summary()
+
+    assert summary["passed"] == 0
+    assert summary["failed"] == 0
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0
+
+
+@pytest.mark.parametrize(
+    "graph_connector",
+    [
+        NetworkxConnector,
+        IgraphConnector,
+    ],
+)
 def test_get_resource(graph_connector):
     # given
     file_path = "/example/site.yml"

--- a/tests/ansible/test_runner.py
+++ b/tests/ansible/test_runner.py
@@ -229,7 +229,7 @@ def test_runner_with_nested_blocks(graph_connector):
         IgraphConnector,
     ],
 )
-def test_runner_with_nested_blocks(graph_connector):
+def test_runner_with_no_tasks(graph_connector):
     # given
     test_file = EXAMPLES_DIR / "no_tasks.yml"
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- skip unsupported Ansible resources, which can be files without any blocks or tasks, see example

Fixes #4503 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
