### PR TITLE
fix(gha): fix output flag for usage in checkov-action

### DIFF
--- a/github_action_resources/entrypoint.sh
+++ b/github_action_resources/entrypoint.sh
@@ -19,7 +19,6 @@ export BC_SOURCE=githubActions
 #
 [[ -n "$INPUT_SKIP_CHECK" ]] && SKIP_CHECK_FLAG="--skip-check $INPUT_SKIP_CHECK"
 [[ -n "$INPUT_FRAMEWORK" ]] && FRAMEWORK_FLAG="--framework $INPUT_FRAMEWORK"
-[[ -n "$INPUT_OUTPUT_FORMAT" ]] && OUTPUT_FLAG="--output $INPUT_OUTPUT_FORMAT"
 [[ -n "$INPUT_OUTPUT_FILE_PATH" ]] && OUTPUT_FILE_PATH_FLAG="--output-file-path $INPUT_OUTPUT_FILE_PATH"
 [[ -n "$INPUT_BASELINE" ]] && BASELINE_FLAG="--baseline $INPUT_BASELINE"
 [[ -n "$INPUT_CONFIG_FILE" ]] && CONFIG_FILE_FLAG="--config-file $INPUT_CONFIG_FILE"
@@ -53,6 +52,9 @@ if [ -n "$INPUT_LOG_LEVEL" ]; then
   export LOG_LEVEL=$INPUT_LOG_LEVEL
 fi
 
+#
+# Following inputs need to be separated by comma and added via multiple flags
+#
 EXTCHECK_DIRS_FLAG=""
 if [ -n "$INPUT_EXTERNAL_CHECKS_DIRS" ]; then
   IFS=', ' read -r -a extchecks_dir <<< "$INPUT_EXTERNAL_CHECKS_DIRS"
@@ -77,6 +79,15 @@ if [ -n "$INPUT_EXTERNAL_CHECKS_REPOS" ]; then
   for repo in "${extchecks_git[@]}"
   do
     EXTCHECK_REPOS_FLAG="$EXTCHECK_REPOS_FLAG --external-checks-git $repo"
+  done
+fi
+
+OUTPUT_FLAG=""
+if [ -n "$INPUT_OUTPUT_FORMAT" ]; then
+  IFS=', ' read -r -a output_format <<< "$INPUT_OUTPUT_FORMAT"
+  for format in "${output_format[@]}"
+  do
+    OUTPUT_FLAG="$OUTPUT_FLAG --output $format"
   done
 fi
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- the `--output` flag needs to be set multiple times, if someone sets multiple outputs in `checkov-action`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
