### PR TITLE
feat(terraform): Used parentheses in key for foreach attributes but not count

### DIFF
--- a/checkov/terraform/graph_builder/foreach_handler.py
+++ b/checkov/terraform/graph_builder/foreach_handler.py
@@ -241,10 +241,15 @@ class ForeachHandler(object):
     @staticmethod
     def _add_index_to_block_properties(block: TerraformBlock, idx: str | int) -> None:
         block_type, block_name = block.name.split('.')
-        block.id = f"{block.id}[{idx}]"
-        block.name = f"{block.name}[{idx}]"
+        # Note it is important to use `\"` inside the string,
+        # as the string `["` is the separator for `foreach` in terraform.
+        # In `count` it is just `[`
+        idx_with_separator = f'\"{idx}\"' if isinstance(idx, str) else f'{idx}'
+
+        block.id = f"{block.id}[{idx_with_separator}]"
+        block.name = f"{block.name}[{idx_with_separator}]"
         if block.config.get(block_type) and block.config.get(block_type, {}).get(block_name):
-            block.config[block_type][f"{block_name}[{idx}]"] = block.config[block_type].pop(block_name)
+            block.config[block_type][f"{block_name}[{idx_with_separator}]"] = block.config[block_type].pop(block_name)
 
     def _create_new_resources(self, block_index_to_statement: FOR_EACH_BLOCK_TYPE) -> None:
         for block_idx, statement in block_index_to_statement.items():

--- a/tests/terraform/checks/resource/aws/test_EC2PublicIP.py
+++ b/tests/terraform/checks/resource/aws/test_EC2PublicIP.py
@@ -20,16 +20,16 @@ class TestEC2PublicIP(unittest.TestCase):
             "aws_instance.private",
             "aws_launch_template.default",
             "aws_launch_template.private",
-            "aws_instance.public_foreach[key2]",
-            "aws_instance.public_foreach_loop_list[k]",
-            "aws_instance.public_foreach_loop_list[v]",
+            "aws_instance.public_foreach[\"key2\"]",
+            "aws_instance.public_foreach_loop_list[\"k\"]",
+            "aws_instance.public_foreach_loop_list[\"v\"]",
         }
         failing_resources = {
             "aws_instance.public",
             "aws_launch_template.public",
-            "aws_instance.public_foreach[key1]",
-            "aws_instance.public_foreach_loop[key3]",
-            "aws_instance.public_foreach_loop[key4]",
+            "aws_instance.public_foreach[\"key1\"]",
+            "aws_instance.public_foreach_loop[\"key3\"]",
+            "aws_instance.public_foreach_loop[\"key4\"]",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}

--- a/tests/terraform/graph/variable_rendering/expected_data_foreach.json
+++ b/tests/terraform/graph/variable_rendering/expected_data_foreach.json
@@ -1,7 +1,7 @@
 {
   "breadcrumbs": {
     "depend_resources/main.tf": {
-      "aws_s3_bucket.foreach_map[bucket_a]": {
+      "aws_s3_bucket.foreach_map[\"bucket_a\"]": {
         "location": [
           {
             "type": "variable",
@@ -11,7 +11,7 @@
           }
         ]
       },
-      "aws_s3_bucket.foreach_map[bucket_b]": {
+      "aws_s3_bucket.foreach_map[\"bucket_b\"]": {
         "location": [
           {
             "type": "variable",
@@ -55,39 +55,39 @@
       "resource": [
         {
           "aws_s3_bucket": {
-            "foreach_map[bucket_a]": {
+            "foreach_map[\"bucket_a\"]": {
               "__end_line__": 6,
               "__start_line__": 1,
               "location": [
                 "test"
               ],
               "name": [
-                "us-west-2"
-              ],
-              "region": [
                 "bucket_a"
               ],
-              "foreach_attrs": ["name", "region"],
-              "__address__": "aws_s3_bucket.foreach_map[bucket_a]"
+              "region": [
+                "us-west-2"
+              ],
+              "foreach_attrs": ["region", "name"],
+              "__address__": "aws_s3_bucket.foreach_map[\"bucket_a\"]"
             }
           }
         },
         {
           "aws_s3_bucket": {
-            "foreach_map[bucket_b]": {
+            "foreach_map[\"bucket_b\"]": {
               "__end_line__": 6,
               "__start_line__": 1,
               "location": [
                 "test"
               ],
               "name": [
-                "us-east-2"
-              ],
-              "region": [
                 "bucket_b"
               ],
-              "foreach_attrs": ["name", "region"],
-              "__address__": "aws_s3_bucket.foreach_map[bucket_b]"
+              "region": [
+                "us-east-2"
+              ],
+              "foreach_attrs": ["region", "name"],
+              "__address__": "aws_s3_bucket.foreach_map[\"bucket_b\"]"
             }
           }
         }

--- a/tests/terraform/graph/variable_rendering/resources/foreach_examples/depend_resources/main.tf
+++ b/tests/terraform/graph/variable_rendering/resources/foreach_examples/depend_resources/main.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "foreach_map" {
   for_each = var.foreach_map
-  name     = each.value
-  region   = each.key
+  name     = each.key
+  region   = each.value
   location = var.test
 }

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -134,10 +134,10 @@ def test_new_resources_foreach():
     foreach_handler = ForeachHandler(local_graph)
     foreach_handler.handle_foreach_rendering({'resource': [0, 1], 'module': []})
     for resource in [local_graph.vertices[0], local_graph.vertices[1], local_graph.vertices[5], local_graph.vertices[6]]:
-        assert resource.name.endswith("[bucket_a]") or resource.name.endswith("[bucket_b]")
-        assert resource.id.endswith("[bucket_a]") or resource.id.endswith("[bucket_b]")
+        assert resource.name.endswith("[\"bucket_a\"]") or resource.name.endswith("[\"bucket_b\"]")
+        assert resource.id.endswith("[\"bucket_a\"]") or resource.id.endswith("[\"bucket_b\"]")
         config_name = list(resource.config['aws_s3_bucket'].keys())[0]
-        assert config_name.endswith("[bucket_a]") or config_name.endswith("[bucket_b]")
+        assert config_name.endswith("[\"bucket_a\"]") or config_name.endswith("[\"bucket_b\"]")
 
 
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_FOREACH_HANDLING": "True"})
@@ -148,7 +148,7 @@ def test_resources_flow():
     assert local_graph.vertices_by_block_type['resource'] == [0, 3]
 
     assert local_graph.vertices_block_name_map['variable'] == {'foreach_map': [1], 'test': [2]}
-    assert local_graph.vertices_block_name_map['resource'] == {'aws_s3_bucket.foreach_map[bucket_a]': [0], 'aws_s3_bucket.foreach_map[bucket_b]': [3]}
+    assert local_graph.vertices_block_name_map['resource'] == {'aws_s3_bucket.foreach_map[\"bucket_a\"]': [0], 'aws_s3_bucket.foreach_map[\"bucket_b\"]': [3]}
 
     assert local_graph.edges[0].dest == 2
     assert local_graph.edges[0].origin == 0
@@ -162,15 +162,15 @@ def test_resources_flow():
     resources = [ver for ver in local_graph.vertices if ver.block_type == 'resource']
     assert len(resources) == 2
 
-    resource_a_name = 'aws_s3_bucket.foreach_map[bucket_a]'
+    resource_a_name = 'aws_s3_bucket.foreach_map[\"bucket_a\"]'
     assert resources[0].name == resource_a_name
     assert resources[0].id == resource_a_name
     assert resources[0].attributes.get('__address__') == resource_a_name
-    assert resources[0].config.get('aws_s3_bucket').get('foreach_map[bucket_a]').get('__address__') == resource_a_name
+    assert resources[0].config.get('aws_s3_bucket').get('foreach_map[\"bucket_a\"]').get('__address__') == resource_a_name
     assert resources[0].attributes.get('location') == ["test"]
-    assert resources[0].attributes.get('name') == ["us-west-2"]
-    assert resources[0].attributes.get('region') == ["bucket_a"]
-    assert list(resources[0].config.get('aws_s3_bucket').keys())[0] == 'foreach_map[bucket_a]'
+    assert resources[0].attributes.get('name') == ["bucket_a"]
+    assert resources[0].attributes.get('region') == ["us-west-2"]
+    assert list(resources[0].config.get('aws_s3_bucket').keys())[0] == 'foreach_map[\"bucket_a\"]'
 
 
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_FOREACH_HANDLING": "True"})
@@ -191,7 +191,7 @@ def test_tf_definitions_and_breadcrumbs():
     assert len(breadcrumbs) == len(expected_breadcrumbs)
     assert len(breadcrumbs[list(breadcrumbs.keys())[0]]) == len(expected_breadcrumbs[list(expected_breadcrumbs.keys())[0]])
 
-    for name in ['[bucket_a]', '[bucket_b]']:
+    for name in ['["bucket_a"]', '["bucket_b"]']:
         assert f'aws_s3_bucket.foreach_map{name}' in breadcrumbs[list(breadcrumbs.keys())[0]]
 
         location_var = 'location'


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

In terraform, `foreach` resource key looks like `["{key}"]` and `count` resource key looks like `[{key}]`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
