### PR TITLE
feat(gitlab): fix gitlab ci yaml file processing

### DIFF
--- a/checkov/common/runners/object_runner.py
+++ b/checkov/common/runners/object_runner.py
@@ -178,6 +178,9 @@ class Runner(BaseRunner[ObjectGraphManager]):  # if a graph is added, Any needs 
                 # result record
                 if result_config:
                     end, start = self.get_start_end_lines(end, result_config, start)
+                    if start == -1 and end == -1:
+                        logging.info(f"Skipping line in file path {file_path} in key {key}")
+                        continue
                 if platform.system() == "Windows":
                     root_folder = os.path.split(file_path)[0]
 

--- a/checkov/yaml_doc/runner.py
+++ b/checkov/yaml_doc/runner.py
@@ -51,6 +51,8 @@ class Runner(ObjectRunner):
             start = result_config[0]["__startline__"] - 1
             end = result_config[len(result_config) - 1]["__endline__"]
         elif result_config and isinstance(result_config, dict):
+            if "__startline__" not in result_config or "__endline__" not in result_config:
+                return -1, -1
             start = result_config["__startline__"]
             end = result_config["__endline__"]
         return end, start

--- a/tests/gitlab_ci/resources/alternative/.gitlab-ci.yml
+++ b/tests/gitlab_ci/resources/alternative/.gitlab-ci.yml
@@ -1,0 +1,13 @@
+image: registry.gitlab.com/myimage/builder-base-image:stable
+
+stop-dev:
+  stage: destroy
+  script:
+    - terraform-pipeline destroy
+      --application-state-key $APPLICATION_STATE_KEY
+      --environment $AWS_ENVIRONMENT
+    - rm -rf ./aws/terraform/.terraform
+  variables:
+    AWS_ENVIRONMENT: dev
+  environment:
+    name: $CI_COMMIT_REF_NAME-DEV

--- a/tests/gitlab_ci/test_runner.py
+++ b/tests/gitlab_ci/test_runner.py
@@ -21,7 +21,7 @@ class TestRunnerValid(unittest.TestCase):
         )
         self.assertEqual(len(report.failed_checks), 5)
         self.assertEqual(report.parsing_errors, [])
-        self.assertEqual(len(report.passed_checks), 6)
+        self.assertEqual(len(report.passed_checks), 7)
         self.assertEqual(report.skipped_checks, [])
         report.print_console()
 


### PR DESCRIPTION
This PR handles cases in which __startline__/__endline__ is not present in the file representation we build for gitlab-ci.yaml. 
We skip those cases for now, and future work needs to be done to ensure we build a representation which correctly reflects the yaml structure of the file.
  
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
