### PR TITLE
fix(ansible): support skip check for Ansible Python-based checks

### DIFF
--- a/checkov/common/checks/base_check.py
+++ b/checkov/common/checks/base_check.py
@@ -54,7 +54,7 @@ class BaseCheck(metaclass=MultiSignatureMeta):
         self.details = []
         check_result: _CheckResult = {}
         if skip_info:
-            check_result["result"] = (CheckResult.SKIPPED, entity_configuration)
+            check_result["result"] = CheckResult.SKIPPED
             check_result["suppress_comment"] = skip_info["suppress_comment"]
             message = 'File {}, {} "{}.{}" check "{}" Result: {}, Suppression comment: {} '.format(
                 scanned_file,

--- a/checkov/common/checks/base_check.py
+++ b/checkov/common/checks/base_check.py
@@ -54,7 +54,7 @@ class BaseCheck(metaclass=MultiSignatureMeta):
         self.details = []
         check_result: _CheckResult = {}
         if skip_info:
-            check_result["result"] = CheckResult.SKIPPED
+            check_result["result"] = (CheckResult.SKIPPED, entity_configuration)
             check_result["suppress_comment"] = skip_info["suppress_comment"]
             message = 'File {}, {} "{}.{}" check "{}" Result: {}, Suppression comment: {} '.format(
                 scanned_file,

--- a/checkov/common/checks/object_registry.py
+++ b/checkov/common/checks/object_registry.py
@@ -24,7 +24,7 @@ class Registry(BaseCheckRegistry):
         self,
         scanned_file: str,
         check: BaseCheck,
-        skip_info: _SkippedCheck,
+        skip_info: list[_SkippedCheck],
         entity: dict[str, Any],
         entity_name: str,
         entity_type: str,
@@ -41,7 +41,7 @@ class Registry(BaseCheckRegistry):
                         entity_type,
                         results,
                         scanned_file,
-                        skip_info,
+                        skip_info[0],
                     )
         if isinstance(entity, list):
             for item in entity:
@@ -53,7 +53,7 @@ class Registry(BaseCheckRegistry):
                         entity_type,
                         results,
                         scanned_file,
-                        skip_info,
+                        skip_info[0],
                     )
                     if result == CheckResult.FAILED:
                         break
@@ -62,7 +62,7 @@ class Registry(BaseCheckRegistry):
         self,
         scanned_file: str,
         check: BaseCheck,
-        skip_info: _SkippedCheck,
+        skip_info: list[_SkippedCheck],
         entity: dict[str, Any],
         entity_name: str,
         entity_type: str,
@@ -76,21 +76,21 @@ class Registry(BaseCheckRegistry):
                 entity_type,
                 results,
                 scanned_file,
-                skip_info,
+                skip_info[0],
             )
 
     def _scan_document(
         self,
         scanned_file: str,
         check: BaseCheck,
-        skip_info: _SkippedCheck,
+        skip_info: list[_SkippedCheck],
         entity: dict[str, Any],
         entity_name: str,
         entity_type: str,
         results: dict[str, Any],
     ) -> None:
         self.update_result(
-            check, entity, entity_name, entity_type, results, scanned_file, skip_info
+            check, entity, entity_name, entity_type, results, scanned_file, skip_info[0]
         )
 
     def _scan(
@@ -105,7 +105,7 @@ class Registry(BaseCheckRegistry):
         results: dict[str, Any],
     ) -> None:
         for check in checks:
-            skip_info = ([x for x in skipped_checks if x["id"] == check.id] or [{}])[0]
+            skip_infos = ([x for x in skipped_checks if x["id"] == check.id] or [{}])
 
             if runner_filter.should_run_check(check=check, report_type=self.report_type):
                 scanner = self._scanner.get(check.block_type, self._scan_document)
@@ -124,7 +124,7 @@ class Registry(BaseCheckRegistry):
                 scanner(
                     scanned_file,
                     check,
-                    skip_info,
+                    skip_infos,
                     target,
                     entity_name,
                     entity_type,

--- a/checkov/common/typing.py
+++ b/checkov/common/typing.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 _BaseRunner = TypeVar("_BaseRunner", bound="BaseRunner[Any]")
 
 _ScannerCallableAlias: TypeAlias = Callable[
-    [str, "BaseCheck", "_SkippedCheck", "dict[str, Any]", str, str, "dict[str, Any]"], None
+    [str, "BaseCheck", "list[_SkippedCheck]", "dict[str, Any]", str, str, "dict[str, Any]"], None
 ]
 
 _Resource: TypeAlias = str

--- a/checkov/yaml_doc/base_registry.py
+++ b/checkov/yaml_doc/base_registry.py
@@ -268,7 +268,7 @@ class Registry(BaseCheckRegistry):
                 "check": check,
                 "result": result,
                 "suppress_comment": check_result["suppress_comment"],
-                "results_configuration": None,
+                "results_configuration": entity_configuration,
             }
             return result
 

--- a/checkov/yaml_doc/base_registry.py
+++ b/checkov/yaml_doc/base_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, List, cast
 
 from checkov.common.checks.base_check import BaseCheck
@@ -24,9 +25,14 @@ class Registry(BaseCheckRegistry):
         }
 
     def _scan_yaml_array(
-            self, scanned_file: str, check: BaseCheck, skip_info: _SkippedCheck, entity: Dict[str, Any],
-            entity_name: str,
-            entity_type: str, results: Dict[str, Any]
+        self,
+        scanned_file: str,
+        check: BaseCheck,
+        skip_infos: list[_SkippedCheck],
+        entity: Dict[str, Any],
+        entity_name: str,
+        entity_type: str,
+        results: Dict[str, Any],
     ) -> None:
         if isinstance(entity, dict):
             analyzed_entities = jmespath.search(entity_type, entity)
@@ -40,13 +46,18 @@ class Registry(BaseCheckRegistry):
                             entity_type=entity_type,
                             results=results,
                             scanned_file=scanned_file,
-                            skip_info=skip_info,
+                            skip_info=skip_infos[0],
                         )
             if isinstance(analyzed_entities, list):
                 for item in analyzed_entities:
                     if isinstance(item, str):
                         item = self.set_lines_for_item(item)
                     if STARTLINE_MARK != item and ENDLINE_MARK != item:
+                        skip_info: "_SkippedCheck" = {}
+                        if skip_infos and skip_infos[0]:
+                            # multiple items could be found, so we need to skip the correct one(s)
+                            skip_info = ([skip for skip in skip_infos if item[STARTLINE_MARK] <= skip["line_number"] <= item[ENDLINE_MARK]] or [{}])[0]
+
                         self.update_result(
                             check,
                             item,
@@ -63,6 +74,11 @@ class Registry(BaseCheckRegistry):
                     if isinstance(item, str):
                         item = self.set_lines_for_item(item)
                     if STARTLINE_MARK != item and ENDLINE_MARK != item:
+                        skip_info = {}
+                        if skip_infos and skip_infos[0]:
+                            # multiple items could be found, so we need to skip the correct one(s)
+                            skip_info = ([skip for skip in skip_infos if item[STARTLINE_MARK] <= skip["line_number"] <= item[ENDLINE_MARK]] or [{}])[0]
+
                         self.update_result(
                             check,
                             item,
@@ -82,15 +98,20 @@ class Registry(BaseCheckRegistry):
                             entity_type,
                             results,
                             scanned_file,
-                            skip_info
+                            skip_infos[0]
                         )
                         if result == CheckResult.FAILED:
                             break
 
     def _scan_yaml_object(
-            self, scanned_file: str, check: BaseCheck, skip_info: _SkippedCheck, entity: Dict[str, Any],
-            entity_name: str,
-            entity_type: str, results: Dict[str, Any]
+        self,
+        scanned_file: str,
+        check: BaseCheck,
+        skip_infos: list[_SkippedCheck],
+        entity: Dict[str, Any],
+        entity_name: str,
+        entity_type: str,
+        results: Dict[str, Any],
     ) -> None:
         if entity_name in entity:
             self.update_result(
@@ -100,16 +121,27 @@ class Registry(BaseCheckRegistry):
                 entity_type,
                 results,
                 scanned_file,
-                skip_info
+                skip_infos[0]
             )
 
     def _scan_yaml_document(
-            self, scanned_file: str, check: BaseCheck, skip_info: _SkippedCheck, entity: Dict[str, Any],
-            entity_name: str,
-            entity_type: str, results: Dict[str, Any]
+        self,
+        scanned_file: str,
+        check: BaseCheck,
+        skip_info: list[_SkippedCheck],
+        entity: Dict[str, Any],
+        entity_name: str,
+        entity_type: str,
+        results: Dict[str, Any],
     ) -> None:
         self.update_result(
-            check, entity, entity_name, entity_type, results, scanned_file, skip_info
+            check,
+            entity,
+            entity_name,
+            entity_type,
+            results,
+            scanned_file,
+            skip_info[0]
         )
 
     def _scan_yaml(
@@ -124,7 +156,22 @@ class Registry(BaseCheckRegistry):
             results: Dict[str, Any],
     ) -> None:
         for check in checks:
-            skip_info = ([x for x in skipped_checks if (x["id"] == check.id and entity[STARTLINE_MARK] <= x['line_number'] <= entity[ENDLINE_MARK])] or [{}])[0]
+            skip_infos: "list[_SkippedCheck]" = [{}]
+            if isinstance(entity, dict):
+                skip_infos = [
+                    skip
+                    for skip in skipped_checks
+                    if skip["id"] == check.id and entity[STARTLINE_MARK] <= skip["line_number"] <= entity[ENDLINE_MARK]
+                ] or [{}]
+            elif isinstance(entity, list):
+                skip_infos = [
+                    skip
+                    for skip in skipped_checks
+                    for e in entity
+                    if skip["id"] == check.id and e[STARTLINE_MARK] <= skip['line_number'] <= e[ENDLINE_MARK]
+                ] or [{}]
+            else:
+                logging.info(f"Unexpected entity type {type(entity)} for {entity}")
 
             if runner_filter.should_run_check(check=check, report_type=self.report_type):
                 scanner = self._scanner.get(check.block_type, self._scan_yaml_document)
@@ -143,7 +190,7 @@ class Registry(BaseCheckRegistry):
                 scanner(
                     scanned_file,
                     check,
-                    skip_info,
+                    skip_infos,
                     target,
                     entity_name,
                     entity_type,

--- a/tests/ansible/examples/skip.yml
+++ b/tests/ansible/examples/skip.yml
@@ -1,0 +1,22 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Launch ec2 instances 1
+      #checkov:skip=CKV_AWS_135
+      amazon.aws.ec2_instance:
+        name: "bc-office-hours"
+        vpc_subnet_id: subnet-012d94ee641ab4277
+        instance_type: t3.micro
+        security_group: sg-04acc4e02a5b71244
+        image_id: "{{ ami_latest.image_id }}"
+        state: running
+
+    - name: Launch ec2 instances 2
+      amazon.aws.ec2_instance:
+        #checkov:skip=CKV_AWS_88
+        name: "bc-office-hours"
+        vpc_subnet_id: subnet-012d94ee641ab4277
+        instance_type: t3.micro
+        security_group: sg-04acc4e02a5b71244
+        image_id: "{{ ami_latest.image_id }}"
+        state: running

--- a/tests/ansible/test_runner.py
+++ b/tests/ansible/test_runner.py
@@ -101,6 +101,38 @@ def test_runner_failing_check(graph_connector):
         IgraphConnector,
     ],
 )
+def test_runner_skipping_check(graph_connector):
+    # given
+    test_file = EXAMPLES_DIR / "skip.yml"
+
+    # when
+    report = Runner(db_connector=graph_connector()).run(
+        root_folder="", files=[str(test_file)], runner_filter=RunnerFilter(checks=["CKV_AWS_88", "CKV_AWS_135"])
+    )
+
+    # then
+    summary = report.get_summary()
+
+    assert summary["passed"] == 0
+    assert summary["failed"] == 2
+    assert summary["skipped"] == 2
+    assert summary["parsing_errors"] == 0
+
+    assert {check.check_id for check in report.skipped_checks} == {"CKV_AWS_88", "CKV_AWS_135"}
+
+    check_88 = next(check for check in report.skipped_checks if check.check_id == "CKV_AWS_88")
+    check_135 = next(check for check in report.skipped_checks if check.check_id == "CKV_AWS_135")
+    assert check_88.resource == "tasks.amazon.aws.ec2_instance.Launch ec2 instances 2"
+    assert check_135.resource == "tasks.amazon.aws.ec2_instance.Launch ec2 instances 1"
+
+
+@pytest.mark.parametrize(
+    "graph_connector",
+    [
+        NetworkxConnector,
+        IgraphConnector,
+    ],
+)
 def test_runner_with_flat_tasks(graph_connector):
     # given
     test_file = EXAMPLES_DIR / "tasks.yml"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- fixed support for skip comments (only Python based checks) in Ansible playbooks
- also fixed the resource name for skipped checks, which had the cryptic jmespath query

Fixes #4532 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
