### PR TITLE
fix(terraform): Move get_module back to parser

### DIFF
--- a/checkov/terraform/modules/module_utils.py
+++ b/checkov/terraform/modules/module_utils.py
@@ -287,20 +287,3 @@ def clean_parser_types_lst(values: list[Any]) -> list[Any]:
 
 def serialize_definitions(tf_definitions: dict[str, _Hcl2Payload]) -> dict[str, _Hcl2Payload]:
     return json.loads(json.dumps(tf_definitions, cls=CustomJSONEncoder))
-
-
-def get_new_module(
-        source_dir: str,
-        module_dependency_map: dict[str, list[list[str]]],
-        module_address_map: dict[tuple[str, str], str],
-        external_modules_source_map: dict[tuple[str, str], str],
-        dep_index_mapping: dict[tuple[str, str], list[str]],
-) -> Module:
-    from checkov.terraform.graph_builder.graph_components.module import Module
-    return Module(
-        source_dir=source_dir,
-        module_dependency_map=module_dependency_map,
-        module_address_map=module_address_map,
-        external_modules_source_map=external_modules_source_map,
-        dep_index_mapping=dep_index_mapping
-    )

--- a/checkov/terraform/modules/module_utils.py
+++ b/checkov/terraform/modules/module_utils.py
@@ -19,7 +19,6 @@ from checkov.common.util.json_utils import CustomJSONEncoder
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
-    from checkov.terraform.graph_builder.graph_components.module import Module
 
 from checkov.terraform.checks.utils.dependency_path_handler import unify_dependency_path
 from checkov.terraform.graph_builder.utils import remove_module_dependency_in_path

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -641,7 +641,6 @@ class Parser:
             external_modules_source_map: dict[tuple[str, str], str],
             dep_index_mapping: dict[tuple[str, str], list[str]],
     ) -> Module:
-        from checkov.terraform.graph_builder.graph_components.module import Module
         return Module(
             source_dir=source_dir,
             module_dependency_map=module_dependency_map,

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -21,7 +21,7 @@ from checkov.common.util.parser_utils import get_tf_definition_key_from_module_d
     TERRAFORM_NESTED_MODULE_PATH_ENDING, is_acceptable_module_param
 from checkov.terraform.modules.module_utils import load_or_die_quietly, safe_index, \
     remove_module_dependency_from_path, get_module_dependency_map, get_module_dependency_map_support_nested_modules, \
-    clean_parser_types, serialize_definitions, get_new_module
+    clean_parser_types, serialize_definitions
 
 
 def _filter_ignored_paths(root: str, paths: list[str], excluded_paths: list[str] | None) -> None:
@@ -583,7 +583,7 @@ class Parser:
             module_dependency_map, tf_definitions, dep_index_mapping = get_module_dependency_map_support_nested_modules(tf_definitions)
         else:
             module_dependency_map, tf_definitions, dep_index_mapping = get_module_dependency_map(tf_definitions)
-        module = get_new_module(
+        module = self.get_new_module(
             source_dir=source_dir,
             module_dependency_map=module_dependency_map,
             module_address_map=self.module_address_map,
@@ -632,3 +632,20 @@ class Parser:
             dirname_path = os.path.dirname(path)
             self.dirname_cache[path] = dirname_path
         return dirname_path
+
+    @staticmethod
+    def get_new_module(
+            source_dir: str,
+            module_dependency_map: dict[str, list[list[str]]],
+            module_address_map: dict[tuple[str, str], str],
+            external_modules_source_map: dict[tuple[str, str], str],
+            dep_index_mapping: dict[tuple[str, str], list[str]],
+    ) -> Module:
+        from checkov.terraform.graph_builder.graph_components.module import Module
+        return Module(
+            source_dir=source_dir,
+            module_dependency_map=module_dependency_map,
+            module_address_map=module_address_map,
+            external_modules_source_map=external_modules_source_map,
+            dep_index_mapping=dep_index_mapping
+        )


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Move get_module function back to the parser.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
