### PR TITLE
chore: add warning when using severity filter without API key

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from _pytest.logging import LogCaptureFixture
 from typing_extensions import Literal
 
 from checkov import main
@@ -77,3 +79,65 @@ def test_run():
 
     assert len(ckv.scan_reports) == 2
     assert {report.check_type for report in ckv.scan_reports} == {"kubernetes", "terraform"}
+
+
+def test_run_with_severity_filter_and_api_key(caplog: LogCaptureFixture):
+    # given
+    caplog.set_level(logging.WARNING)
+    custom_banner = "custom banner"
+    resource_dir = Path(__file__).parent / "common/runner_registry/example_multi_iac"
+    argv = [
+        "-d", str(resource_dir),
+        "--framework", "terraform",
+        "--check", "MEDIUM",
+        "--bc-api-key", "12345678-abcd-1234-abcd-123456789012",
+        "--show-config",  # just set to terminate the run early enough
+    ]
+
+    # when
+    ckv = Checkov()
+    ckv.parse_config(argv=argv)
+    ckv.run(banner=custom_banner)
+
+    # then
+    assert not caplog.messages
+
+
+def test_run_with_severity_filter_without_api_key(caplog: LogCaptureFixture):
+    # given
+    caplog.set_level(logging.WARNING)
+    custom_banner = "custom banner"
+    resource_dir = Path(__file__).parent / "common/runner_registry/example_multi_iac"
+    argv = [
+        "-d", str(resource_dir),
+        "--framework", "terraform",
+        "--check", "MEDIUM",
+    ]
+
+    # when
+    ckv = Checkov()
+    ckv.parse_config(argv=argv)
+    ckv.run(banner=custom_banner)
+
+    # then
+    assert caplog.messages == ["Filtering checks by severity is only possible with an API key"]
+
+
+def test_run_with_severity_skip_filter_without_api_key(caplog: LogCaptureFixture):
+    # given
+    caplog.set_level(logging.WARNING)
+    custom_banner = "custom banner"
+    resource_dir = Path(__file__).parent / "common/runner_registry/example_multi_iac"
+    argv = [
+        "-d", str(resource_dir),
+        "--framework", "terraform",
+        "--skip-check", "MEDIUM",
+    ]
+
+    # when
+    ckv = Checkov()
+    ckv.parse_config(argv=argv)
+    ckv.run(banner=custom_banner)
+
+    # then
+    assert caplog.messages == ["Filtering checks by severity is only possible with an API key"]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added a warning message, if someone uses a severity filter with `--check` or `--skip-check` without an API key, which typically results in an empty report. I didn't want to terminate the run, but I'm open with adding it depending on other opinions.

Fixes #4567 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
