### PR TITLE
feat(ansible): Add checks for the ansible builtin dnf module

### DIFF
--- a/checkov/ansible/checks/graph_checks/DnfDisableGpgCheck.yaml
+++ b/checkov/ansible/checks/graph_checks/DnfDisableGpgCheck.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "CKV2_ANSIBLE_4"
+  name: "Ensure that packages with untrusted or missing GPG signatures are not used by dnf"
+  category: "GENERAL_SECURITY"
+definition:
+  cond_type: attribute
+  resource_types:
+    - tasks.ansible.builtin.dnf
+    - tasks.dnf
+  attribute: disable_gpg_check
+  operator: not_equals
+  value: true

--- a/checkov/ansible/checks/graph_checks/DnfSslVerify.yaml
+++ b/checkov/ansible/checks/graph_checks/DnfSslVerify.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "CKV2_ANSIBLE_5"
+  name: "Ensure that SSL validation isn't disabled with dnf"
+  category: "GENERAL_SECURITY"
+definition:
+  cond_type: attribute
+  resource_types:
+    - tasks.ansible.builtin.dnf
+    - tasks.dnf
+  attribute: sslverify
+  operator: not_equals
+  value: false

--- a/checkov/ansible/checks/graph_checks/DnfValidateCerts.yaml
+++ b/checkov/ansible/checks/graph_checks/DnfValidateCerts.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "CKV2_ANSIBLE_6"
+  name: "Ensure that certificate validation isn't disabled with dnf"
+  category: "GENERAL_SECURITY"
+definition:
+  cond_type: attribute
+  resource_types:
+    - tasks.ansible.builtin.dnf
+    - tasks.dnf
+  attribute: validate_certs
+  operator: not_equals
+  value: false

--- a/tests/ansible/checks/graph_checks/resources/DnfDisableGpgCheck/expected.yaml
+++ b/tests/ansible/checks/graph_checks/resources/DnfDisableGpgCheck/expected.yaml
@@ -1,0 +1,18 @@
+pass:
+  - "tasks.ansible.builtin.dnf.long_unused"
+  - "tasks.dnf.short_unused"
+  - "tasks.ansible.builtin.dnf.long_false"
+  - "tasks.dnf.short_false"
+  - "tasks.ansible.builtin.dnf.long_no"
+  - "tasks.dnf.short_no"
+  - "tasks.ansible.builtin.dnf.long_off"
+  - "tasks.dnf.short_off"
+fail:
+  - "tasks.ansible.builtin.dnf.long_true"
+  - "tasks.dnf.short_true"
+  - "tasks.ansible.builtin.dnf.long_yes"
+  - "tasks.dnf.short_yes"
+  - "tasks.ansible.builtin.dnf.long_YES"
+  - "tasks.dnf.short_TRUE"
+evaluated_keys:
+  - disable_gpg_check

--- a/tests/ansible/checks/graph_checks/resources/DnfDisableGpgCheck/fail.yaml
+++ b/tests/ansible/checks/graph_checks/resources/DnfDisableGpgCheck/fail.yaml
@@ -1,0 +1,40 @@
+---
+- name: Verify tests
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: long_true
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        disable_gpg_check: true
+
+    - name: short_true
+      dnf:
+        name: nikto
+        state: latest
+        disable_gpg_check: true
+
+    - name: long_yes
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        disable_gpg_check: yes
+
+    - name: short_yes
+      dnf:
+        name: nikto
+        state: latest
+        disable_gpg_check: Yes
+    
+    - name: long_YES
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        disable_gpg_check: YES
+
+    - name: short_TRUE
+      dnf:
+        name: nikto
+        state: latest
+        disable_gpg_check: TRUE

--- a/tests/ansible/checks/graph_checks/resources/DnfDisableGpgCheck/pass.yaml
+++ b/tests/ansible/checks/graph_checks/resources/DnfDisableGpgCheck/pass.yaml
@@ -1,0 +1,50 @@
+---
+- name: Verify tests
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: long_unused
+      ansible.builtin.dnf:
+        name: httpd
+        state: latest
+
+    - name: short_unused
+      dnf:
+        name: nikto
+        state: latest
+
+    - name: long_false
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        disable_gpg_check: false
+
+    - name: short_false
+      dnf:
+        name: nikto
+        state: latest
+        disable_gpg_check: False
+
+    - name: long_no
+      ansible.builtin.dnf:
+        name: disable_gpg_check
+        state: latest
+        disable_gpg_check: no
+
+    - name: short_no
+      dnf:
+        name: disable_gpg_check
+        state: latest
+        disable_gpg_check: No
+    
+    - name: long_off
+      ansible.builtin.dnf:
+        name: disable_gpg_check
+        state: latest
+        disable_gpg_check: off
+
+    - name: short_off
+      dnf:
+        name: disable_gpg_check
+        state: latest
+        disable_gpg_check: OFF

--- a/tests/ansible/checks/graph_checks/resources/DnfSslVerify/expected.yaml
+++ b/tests/ansible/checks/graph_checks/resources/DnfSslVerify/expected.yaml
@@ -1,0 +1,18 @@
+pass:
+  - "tasks.ansible.builtin.dnf.long_unused"
+  - "tasks.dnf.short_unused"
+  - "tasks.ansible.builtin.dnf.long_true"
+  - "tasks.dnf.short_true"
+  - "tasks.ansible.builtin.dnf.long_yes"
+  - "tasks.dnf.short_yes"
+  - "tasks.ansible.builtin.dnf.long_on"
+  - "tasks.dnf.short_on"
+fail:
+  - "tasks.ansible.builtin.dnf.long_false"
+  - "tasks.dnf.short_false"
+  - "tasks.ansible.builtin.dnf.long_no"
+  - "tasks.dnf.short_no"
+  - "tasks.ansible.builtin.dnf.long_NO"
+  - "tasks.dnf.short_FALSE"
+evaluated_keys:
+  - sslverify

--- a/tests/ansible/checks/graph_checks/resources/DnfSslVerify/fail.yaml
+++ b/tests/ansible/checks/graph_checks/resources/DnfSslVerify/fail.yaml
@@ -1,0 +1,40 @@
+---
+- name: Verify tests
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: long_false
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        sslverify: false
+
+    - name: short_false
+      dnf:
+        name: nikto
+        state: latest
+        sslverify: false
+
+    - name: long_no
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        sslverify: no
+
+    - name: short_no
+      dnf:
+        name: nikto
+        state: latest
+        sslverify: No
+    
+    - name: long_NO
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        sslverify: NO
+
+    - name: short_FALSE
+      dnf:
+        name: nikto
+        state: latest
+        sslverify: FALSE

--- a/tests/ansible/checks/graph_checks/resources/DnfSslVerify/pass.yaml
+++ b/tests/ansible/checks/graph_checks/resources/DnfSslVerify/pass.yaml
@@ -1,0 +1,50 @@
+---
+- name: Verify tests
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: long_unused
+      ansible.builtin.dnf:
+        name: httpd
+        state: latest
+
+    - name: short_unused
+      dnf:
+        name: nikto
+        state: latest
+
+    - name: long_true
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        sslverify: true
+
+    - name: short_true
+      dnf:
+        name: nikto
+        state: latest
+        sslverify: True
+
+    - name: long_yes
+      ansible.builtin.dnf:
+        name: sslverify
+        state: latest
+        sslverify: yes
+
+    - name: short_yes
+      dnf:
+        name: sslverify
+        state: latest
+        sslverify: Yes
+    
+    - name: long_on
+      ansible.builtin.dnf:
+        name: sslverify
+        state: latest
+        sslverify: on
+
+    - name: short_on
+      dnf:
+        name: sslverify
+        state: latest
+        sslverify: ON

--- a/tests/ansible/checks/graph_checks/resources/DnfValidateCerts/expected.yaml
+++ b/tests/ansible/checks/graph_checks/resources/DnfValidateCerts/expected.yaml
@@ -1,0 +1,18 @@
+pass:
+  - "tasks.ansible.builtin.dnf.long_unused"
+  - "tasks.dnf.short_unused"
+  - "tasks.ansible.builtin.dnf.long_true"
+  - "tasks.dnf.short_true"
+  - "tasks.ansible.builtin.dnf.long_yes"
+  - "tasks.dnf.short_yes"
+  - "tasks.ansible.builtin.dnf.long_on"
+  - "tasks.dnf.short_ON"
+fail:
+  - "tasks.ansible.builtin.dnf.long_false"
+  - "tasks.dnf.short_false"
+  - "tasks.ansible.builtin.dnf.long_no"
+  - "tasks.dnf.short_no"
+  - "tasks.ansible.builtin.dnf.long_NO"
+  - "tasks.dnf.short_FALSE"
+evaluated_keys:
+  - validate_certs

--- a/tests/ansible/checks/graph_checks/resources/DnfValidateCerts/fail.yaml
+++ b/tests/ansible/checks/graph_checks/resources/DnfValidateCerts/fail.yaml
@@ -1,0 +1,40 @@
+---
+- name: Verify tests
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: long_false
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        validate_certs: false
+
+    - name: short_false
+      dnf:
+        name: nikto
+        state: latest
+        validate_certs: false
+
+    - name: long_no
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        validate_certs: no
+
+    - name: short_no
+      dnf:
+        name: nikto
+        state: latest
+        validate_certs: No
+    
+    - name: long_NO
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        validate_certs: NO
+
+    - name: short_FALSE
+      dnf:
+        name: nikto
+        state: latest
+        validate_certs: FALSE

--- a/tests/ansible/checks/graph_checks/resources/DnfValidateCerts/pass.yaml
+++ b/tests/ansible/checks/graph_checks/resources/DnfValidateCerts/pass.yaml
@@ -1,0 +1,50 @@
+---
+- name: Verify tests
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: long_unused
+      ansible.builtin.dnf:
+        name: httpd
+        state: latest
+
+    - name: short_unused
+      dnf:
+        name: nikto
+        state: latest
+
+    - name: long_true
+      ansible.builtin.dnf:
+        name: nikto
+        state: latest
+        validate_certs: true
+
+    - name: short_true
+      dnf:
+        name: nikto
+        state: latest
+        validate_certs: True
+
+    - name: long_yes
+      ansible.builtin.dnf:
+        name: validate_certs
+        state: latest
+        validate_certs: yes
+
+    - name: short_yes
+      dnf:
+        name: validate_certs
+        state: latest
+        validate_certs: Yes
+    
+    - name: long_on
+      ansible.builtin.dnf:
+        name: validate_certs
+        state: latest
+        validate_certs: on
+
+    - name: short_ON
+      dnf:
+        name: validate_certs
+        state: latest
+        validate_certs: ON

--- a/tests/ansible/checks/graph_checks/test_yaml_policies.py
+++ b/tests/ansible/checks/graph_checks/test_yaml_policies.py
@@ -56,6 +56,12 @@ class TestYamlPolicies(TestYamlPoliciesBase):
     def test_DnfDisableGpgCheck(self):
         self.go("DnfDisableGpgCheck", local_graph_class=AnsibleLocalGraph)
 
+    def test_DnfSslVerify(self):
+        self.go("DnfSslVerify", local_graph_class=AnsibleLocalGraph)
+
+    def test_DnfValidateCerts(self):
+        self.go("DnfValidateCerts", local_graph_class=AnsibleLocalGraph)
+
     def test_registry_load(self):
         registry = self.get_checks_registry()
         self.assertGreater(len(registry.checks), 0)

--- a/tests/ansible/checks/graph_checks/test_yaml_policies.py
+++ b/tests/ansible/checks/graph_checks/test_yaml_policies.py
@@ -53,6 +53,9 @@ class TestYamlPolicies(TestYamlPoliciesBase):
     def test_UriHttpsOnly(self):
         self.go("UriHttpsOnly", local_graph_class=AnsibleLocalGraph)
 
+    def test_DnfDisableGpgCheck(self):
+        self.go("DnfDisableGpgCheck", local_graph_class=AnsibleLocalGraph)
+
     def test_registry_load(self):
         registry = self.get_checks_registry()
         self.assertGreater(len(registry.checks), 0)

--- a/tests/ansible/checks/task/builtin/AptAllowUnauthenticated/fail.yaml
+++ b/tests/ansible/checks/task/builtin/AptAllowUnauthenticated/fail.yaml
@@ -7,7 +7,7 @@
       ansible.builtin.apt:
         name: openssl
         state: latest
-        allow_unauthenticated: true
+        allow_unauthenticated: yes
 
     - name: short_unsafe
       apt:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Add some new policies related to the ansible builtin module for the DNF package manager.

## New/Edited policies
CKV2_ANSIBLE_4
CKV2_ANSIBLE_5
CKV2_ANSIBLE_6

### Description
CKV2_ANSIBLE_4
The `disable_gpg_check` parameter disables GPG signature checking.
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/dnf_module.html#ansible-collections-ansible-builtin-dnf-module

CKV2_ANSIBLE_5
The `sslverify` parameter disables SSL certificate validation while installing packages.
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/dnf_module.html#ansible-collections-ansible-builtin-dnf-module

CKV2_ANSIBLE_6
The `validate_certs` parameter disables SSL certificate validation while installing packages.
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/dnf_module.html#ansible-collections-ansible-builtin-dnf-module

### Fix
CKV2_ANSIBLE_4
Verify the GPG key used to sign the packages being installed.

CKV2_ANSIBLE_5 + CKV2_ANSIBLE_6
Verify the custom/self-signed certificates encountered when installing packages.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
