### PR TITLE
fix(cloudformation): KMSKeyWildCardPrincipal modification - Check for wildcards inside of lists

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
+++ b/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
@@ -49,7 +49,7 @@ class KMSKeyWildCardPrincipal(BaseResourceValueCheck):
                 for principal in principals_list:
                     if isinstance(principal, dict):
                         for principal_value in principal.values():
-                            if principal_value == '*':
+                            if principal_value == '*' or '*' in principal_value:
                                 return CheckResult.FAILED
                     else:
                         if principal == '*':

--- a/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
+++ b/checkov/cloudformation/checks/resource/aws/KMSKeyWildCardPrincipal.py
@@ -49,7 +49,7 @@ class KMSKeyWildCardPrincipal(BaseResourceValueCheck):
                 for principal in principals_list:
                     if isinstance(principal, dict):
                         for principal_value in principal.values():
-                            if principal_value == '*' or '*' in principal_value:
+                            if principal_value == '*' or (isinstance(principal_value, list) and '*' in principal_value):
                                 return CheckResult.FAILED
                     else:
                         if principal == '*':

--- a/tests/cloudformation/checks/resource/aws/example_KMSKeyWildCardPrincipal/KMSKeyWildCardPrincipal-FAILED-AWS-Wildcard.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_KMSKeyWildCardPrincipal/KMSKeyWildCardPrincipal-FAILED-AWS-Wildcard.yaml
@@ -15,3 +15,18 @@ Resources:
           Action: kms:*
           Resource: '*'
       EnableKeyRotation: true
+  SomeKmsKey:
+    Type: 'AWS::KMS::Key'
+    Properties:
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: key-default-1
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: 
+                - '*' # <-- wildcarded principal tucked inside of a list
+                - 'arn:aws:iam::123456789012:root'
+            Action: 'kms:*'
+            Resource: '*'

--- a/tests/cloudformation/checks/resource/aws/test_KMSKeyWildCardPrincipal.py
+++ b/tests/cloudformation/checks/resource/aws/test_KMSKeyWildCardPrincipal.py
@@ -17,7 +17,7 @@ class TestKMSKeyWildCardPrincipal(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['failed'], 3)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
My company just found a case of a dev using a wildcard inside of an AWS principal list to evade this rule.  Since the `principal_value` in this code could be either a string or a list, checking for membership as well as equality would prevent the circumnavigation of the rule.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"
# cloudformation: KMSKeyWildCardPrincipal modification - Check for wildcards inside of lists

## Description

My company just found a case of a dev using a wildcard inside of an AWS principal list to evade this rule.  Since the `principal_value` in this code could be either a string or a list, checking for membership as well as equality would prevent the circumnavigation of the rule.

Fixes # (issue)

Ability to skate by the check by placing the wildcard within a list

### Description
It undermines the rule

### Fix
Check for membership as well

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
