### PR TITLE
fix(secrets): only check secrets framework when scanning history

### DIFF
--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from typing import Any, Set, Optional, Union, List, TYPE_CHECKING, Dict, DefaultDict, cast
 import re
 
+from checkov.common.bridgecrew.check_type import CheckType
 from checkov.secrets.consts import ValidationStatus
 
 from checkov.common.bridgecrew.code_categories import CodeCategoryMapping, CodeCategoryConfiguration, CodeCategoryType
@@ -133,6 +134,8 @@ class RunnerFilter(object):
         self.enable_git_history_secret_scan: bool = enable_git_history_secret_scan
         if self.enable_git_history_secret_scan:
             self.git_history_timeout = convert_to_seconds(git_history_timeout)
+            self.framework = [CheckType.SECRETS]
+            logging.debug(f"Scan secrets history was enabled ignoring oter frameworks")
 
     @staticmethod
     def _load_resource_attr_to_omit(resource_attr_to_omit_input: Optional[Dict[str, Set[str]]]) -> DefaultDict[str, Set[str]]:

--- a/tests/common/test_runner_filter.py
+++ b/tests/common/test_runner_filter.py
@@ -802,6 +802,14 @@ class TestRunnerFilter(unittest.TestCase):
         for k, v in combined_file_real_parsed_content.items():
             assert v == runner_filter.resource_attr_to_omit.get(k)
 
+    def test_scan_secrets_history_limits_to_secrets_framework(self):
+        # when
+        filter = RunnerFilter(enable_git_history_secret_scan=True)
+
+        # then
+        assert filter.enable_git_history_secret_scan is True
+        assert filter.framework == [CheckType.SECRETS]
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- limiting to secrets framework, when `--scan-secrets-history` flag is used

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
