### PR TITLE
chore: don't use the root logger

### DIFF
--- a/checkov/ansible/checks/base_ansible_task_check.py
+++ b/checkov/ansible/checks/base_ansible_task_check.py
@@ -13,6 +13,8 @@ from checkov.common.models.enums import CheckResult
 if TYPE_CHECKING:
     from checkov.common.models.enums import CheckCategories
 
+logger = logging.getLogger(__name__)
+
 
 class BaseAnsibleTaskCheck(BaseCheck):
     def __init__(
@@ -66,7 +68,7 @@ class BaseAnsibleTaskCheck(BaseCheck):
         module_conf = next((conf[module] for module in self.supported_modules if module in conf), None)
         if not module_conf:
             # this should actually never happen, but better to be safe, than sorry
-            logging.info(f"Failed to find supported module {self.supported_modules} in {json.dumps(conf)}")
+            logger.info(f"Failed to find supported module {self.supported_modules} in {json.dumps(conf)}")
             return CheckResult.UNKNOWN, conf
 
         return self.scan_conf(module_conf)

--- a/checkov/ansible/graph_builder/local_graph.py
+++ b/checkov/ansible/graph_builder/local_graph.py
@@ -14,6 +14,8 @@ from checkov.common.util.consts import START_LINE, END_LINE
 from checkov.ansible.graph_builder.graph_components.resource_types import ResourceType
 from checkov.ansible.utils import get_scannable_file_paths, TASK_RESERVED_KEYWORDS, parse_file
 
+logger = logging.getLogger(__name__)
+
 
 class AnsibleLocalGraph(ObjectLocalGraph):
     def __init__(self, definitions: dict[str | Path, dict[str, Any] | list[dict[str, Any]]]) -> None:
@@ -24,7 +26,7 @@ class AnsibleLocalGraph(ObjectLocalGraph):
     def _create_vertices(self) -> None:
         for file_path, definition in self.definitions.items():
             if not isinstance(definition, list):
-                logging.debug(f"definition of file {file_path} has the wrong type {type(definition)}")
+                logger.debug(f"definition of file {file_path} has the wrong type {type(definition)}")
                 continue
 
             file_path = str(file_path)

--- a/checkov/arm/context_parser.py
+++ b/checkov/arm/context_parser.py
@@ -18,6 +18,8 @@ COMMENT_REGEX = re.compile(r'([A-Z_\d]+)(:[^\n]+)?')
 PARAMETERS_PATTERN = re.compile(r"\[parameters\('|'\)]")
 VARIABLES_PATTERN = re.compile(r"\[variables\('|'\)]")
 
+logger = logging.getLogger(__name__)
+
 
 class ContextParser:
     """
@@ -59,10 +61,10 @@ class ContextParser:
                     self._get_from_dict(dict(self.arm_template), key_entry[:-1])[key_entry[-1]],  # type:ignore[index]  # this will be a str
                 )
                 if param in parameter_defaults:
-                    logging.debug(f"Replacing parameter {param} in file {self.arm_file} with default value: {parameter_defaults[param]}")
+                    logger.debug(f"Replacing parameter {param} in file {self.arm_file} with default value: {parameter_defaults[param]}")
                     self._set_in_dict(dict(self.arm_template), key_entry, parameter_defaults[param])
             except TypeError:
-                logging.debug(f"Failed to evaluate param in {self.arm_file}", exc_info=True)
+                logger.debug(f"Failed to evaluate param in {self.arm_file}", exc_info=True)
 
         for key_entry in keys_w_vars:
             try:
@@ -73,13 +75,13 @@ class ContextParser:
                 )
                 if param in variable_values.keys():
                     self._set_in_dict(dict(self.arm_template), key_entry, variable_values[param])
-                    logging.debug(
+                    logger.debug(
                         "Replacing variable {} in file {} with default value: {}".format(param, self.arm_file,
                                                                                          variable_values[param]))
                 else:
-                    logging.debug("Variable {} not found in evaluated variables in file {}".format(param, self.arm_file))
+                    logger.debug("Variable {} not found in evaluated variables in file {}".format(param, self.arm_file))
             except TypeError:
-                logging.debug(f"Failed to evaluate param in {self.arm_file}", exc_info=True)
+                logger.debug(f"Failed to evaluate param in {self.arm_file}", exc_info=True)
 
     @staticmethod
     def extract_arm_resource_id(arm_resource: dict[str, Any]) -> str | None:

--- a/checkov/arm/graph_builder/local_graph.py
+++ b/checkov/arm/graph_builder/local_graph.py
@@ -14,6 +14,8 @@ from checkov.common.util.consts import START_LINE, END_LINE
 if TYPE_CHECKING:
     from checkov.common.graph.graph_builder.local_graph import _Block
 
+logger = logging.getLogger(__name__)
+
 
 class ArmLocalGraph(LocalGraph[ArmBlock]):
     def __init__(self, definitions: dict[str, dict[str, Any]]) -> None:
@@ -24,10 +26,10 @@ class ArmLocalGraph(LocalGraph[ArmBlock]):
 
     def build_graph(self, render_variables: bool = False) -> None:
         self._create_vertices()
-        logging.debug(f"[ArmLocalGraph] created {len(self.vertices)} vertices")
+        logger.debug(f"[ArmLocalGraph] created {len(self.vertices)} vertices")
 
         self._create_edges()
-        logging.debug(f"[ArmLocalGraph] created {len(self.edges)} edges")
+        logger.debug(f"[ArmLocalGraph] created {len(self.edges)} edges")
 
     def _create_vertices(self) -> None:
         for file_path, definition in self.definitions.items():
@@ -47,7 +49,7 @@ class ArmLocalGraph(LocalGraph[ArmBlock]):
             if name in (START_LINE, END_LINE):
                 continue
             if not isinstance(config, dict):
-                logging.debug(f"[ArmLocalGraph] parameter {name} has wrong type {type(config)}")
+                logger.debug(f"[ArmLocalGraph] parameter {name} has wrong type {type(config)}")
                 continue
 
             attributes = deepcopy(config)

--- a/checkov/arm/parser/parser.py
+++ b/checkov/arm/parser/parser.py
@@ -12,7 +12,7 @@ from checkov.common.parsers.json import parse as json_parse
 from checkov.common.parsers.yaml import loader
 
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def parse(filename: str) -> tuple[dict[str, Any], list[tuple[int, str]]] | tuple[None, None]:
@@ -24,13 +24,13 @@ def parse(filename: str) -> tuple[dict[str, Any], list[tuple[int, str]]] | tuple
         template, template_lines = load(filename)
     except IOError as e:
         if e.errno == 2:
-            LOGGER.error(f"Template file not found: {filename}")
+            logger.error(f"Template file not found: {filename}")
         elif e.errno == 21:
-            LOGGER.error(f"Template references a directory, not a file: {filename}")
+            logger.error(f"Template references a directory, not a file: {filename}")
         elif e.errno == 13:
-            LOGGER.error(f"Permission denied when accessing template file: {filename}")
+            logger.error(f"Permission denied when accessing template file: {filename}")
     except UnicodeDecodeError:
-        LOGGER.error(f"Cannot read file contents: {filename}")
+        logger.error(f"Cannot read file contents: {filename}")
     except ScannerError as err:
         if err.problem in ("found character '\\t' that cannot start any token", "found unknown escape character"):
             try:
@@ -41,8 +41,8 @@ def parse(filename: str) -> tuple[dict[str, Any], list[tuple[int, str]]] | tuple
                         # should not happen and is more relevant for type safety
                         template = template[0]
             except Exception:
-                LOGGER.error(f"Template {filename} is malformed: {err.problem}")
-                LOGGER.error(f"Tried to parse {filename} as JSON", exc_info=True)
+                logger.error(f"Template {filename} is malformed: {err.problem}")
+                logger.error(f"Tried to parse {filename} as JSON", exc_info=True)
     except YAMLError:
         pass
 
@@ -62,7 +62,7 @@ def load(filename: Path | str) -> tuple[dict[str, Any], list[tuple[int, str]]]:
     try:
         content = file_path.read_text()
     except UnicodeDecodeError:
-        logging.debug(f"Encoding for file {file_path} is not UTF-8, trying to detect it")
+        logger.debug(f"Encoding for file {file_path} is not UTF-8, trying to detect it")
         content = str(from_path(file_path).best())
 
     if not all(key in content for key in ("$schema", "contentVersion")):

--- a/checkov/arm/runner.py
+++ b/checkov/arm/runner.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from checkov.common.graph.checks_infra.registry import BaseRegistry
     from checkov.common.typing import LibraryGraphConnector, _CheckResult
 
+logger = logging.getLogger(__name__)
+
 
 class Runner(BaseRunner[ArmGraphManager]):
     check_type = CheckType.ARM  # noqa: CCE003  # a static attribute
@@ -89,9 +91,9 @@ class Runner(BaseRunner[ArmGraphManager]):
         self.definitions, self.definitions_raw = get_files_definitions(files_list, filepath_fn)
 
         if CHECKOV_CREATE_GRAPH and self.graph_registry and self.graph_manager:
-            logging.info("Creating ARM graph")
+            logger.info("Creating ARM graph")
             local_graph = self.graph_manager.build_graph_from_definitions(definitions=self.definitions)
-            logging.info("Successfully created ARM graph")
+            logger.info("Successfully created ARM graph")
 
             self.graph_manager.save_graph(local_graph)
 
@@ -124,7 +126,7 @@ class Runner(BaseRunner[ArmGraphManager]):
 
             if isinstance(self.definitions[arm_file], dict):
                 arm_context_parser = ContextParser(arm_file, self.definitions[arm_file], self.definitions_raw[arm_file])
-                logging.debug(f"Template Dump for {arm_file}: {self.definitions[arm_file]}")
+                logger.debug(f"Template Dump for {arm_file}: {self.definitions[arm_file]}")
 
                 if ArmElements.RESOURCES in self.definitions[arm_file]:
                     arm_context_parser.evaluate_default_parameters()
@@ -149,7 +151,7 @@ class Runner(BaseRunner[ArmGraphManager]):
                         resource_id = arm_context_parser.extract_arm_resource_id(resource)
                         resource_name = arm_context_parser.extract_arm_resource_name(resource)
                         if resource_id is None or resource_name is None:
-                            logging.info(f"Could not determine 'resource_id' of Resource {resource}")
+                            logger.info(f"Could not determine 'resource_id' of Resource {resource}")
                             continue
 
                         report.add_resource(f"{arm_file}:{resource_id}")

--- a/checkov/bicep/graph_builder/local_graph.py
+++ b/checkov/bicep/graph_builder/local_graph.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
 
 BicepElementsAlias: TypeAlias = Literal["globals", "parameters", "variables", "resources", "modules", "outputs"]
 
+logger = logging.getLogger(__name__)
+
 
 class BicepElements(str, Enum):
     GLOBALS: Literal["globals"] = "globals"
@@ -52,9 +54,9 @@ class BicepLocalGraph(LocalGraph[BicepBlock]):
 
     def build_graph(self, render_variables: bool) -> None:
         self._create_vertices()
-        logging.info(f"[BicepLocalGraph] created {len(self.vertices)} vertices")
+        logger.info(f"[BicepLocalGraph] created {len(self.vertices)} vertices")
         self._create_edges()
-        logging.info(f"[BicepLocalGraph] created {len(self.edges)} edges")
+        logger.info(f"[BicepLocalGraph] created {len(self.edges)} edges")
 
         if render_variables:
             renderer = BicepVariableRenderer(self)

--- a/checkov/bicep/parser.py
+++ b/checkov/bicep/parser.py
@@ -11,6 +11,8 @@ from pycep import BicepParser
 if TYPE_CHECKING:
     from pycep.typing import BicepJson
 
+logger = logging.getLogger(__name__)
+
 
 class Parser:
     def __init__(self) -> None:
@@ -22,7 +24,7 @@ class Parser:
         try:
             template = self.bicep_parser.parse(text=content)
         except Exception:
-            logging.debug(f"[bicep] Couldn't parse {file_path}", exc_info=True)
+            logger.debug(f"[bicep] Couldn't parse {file_path}", exc_info=True)
             return None, None
 
         file_lines = [(idx + 1, line) for idx, line in enumerate(content.splitlines(keepends=True))]
@@ -32,7 +34,7 @@ class Parser:
     def get_files_definitions(
         self, file_paths: "Collection[Path]"
     ) -> tuple[dict[Path, BicepJson], dict[Path, list[tuple[int, str]]], list[str]]:
-        logging.info(f"[bicep] start to parse {len(file_paths)} files")
+        logger.info(f"[bicep] start to parse {len(file_paths)} files")
 
         definitions: dict[Path, BicepJson] = {}
         definitions_raw: dict[Path, list[tuple[int, str]]] = {}
@@ -46,6 +48,6 @@ class Parser:
             else:
                 parsing_errors.append(os.path.normpath(file_path.absolute()))
 
-        logging.info(f"[bicep] successfully parsed {len(definitions)} files")
+        logger.info(f"[bicep] successfully parsed {len(definitions)} files")
 
         return definitions, definitions_raw, parsing_errors

--- a/checkov/bicep/runner.py
+++ b/checkov/bicep/runner.py
@@ -41,6 +41,8 @@ if TYPE_CHECKING:
     from typing_extensions import Literal
 
 
+logger = logging.getLogger(__name__)
+
 class Runner(ImageReferencerMixin[None], BaseRunner[BicepGraphManager]):
     check_type = CheckType.BICEP  # noqa: CCE003  # a static attribute
 
@@ -108,9 +110,9 @@ class Runner(ImageReferencerMixin[None], BaseRunner[BicepGraphManager]):
             self.context = build_definitions_context(definitions=self.definitions, definitions_raw=self.definitions_raw)
 
             if CHECKOV_CREATE_GRAPH:
-                logging.info("Creating Bicep graph")
+                logger.info("Creating Bicep graph")
                 local_graph = self.graph_manager.build_graph_from_definitions(self.definitions)
-                logging.info("Successfully created Bicep graph")
+                logger.info("Successfully created Bicep graph")
 
                 self.graph_manager.save_graph(local_graph)
                 self.definitions, self.breadcrumbs = convert_graph_vertices_to_tf_definitions(

--- a/checkov/bicep/utils.py
+++ b/checkov/bicep/utils.py
@@ -19,6 +19,8 @@ BICEP_POSSIBLE_ENDINGS = [".bicep"]
 BICEP_START_LINE = "__start_line__"
 BICEP_END_LINE = "__end_line__"
 
+logger = logging.getLogger(__name__)
+
 
 def get_scannable_file_paths(
     root_folder: str | Path | None = None, files: list[str] | None = None, excluded_paths: list[str] | None = None
@@ -85,7 +87,7 @@ def create_definitions(
         definitions, definitions_raw, parsing_errors = get_folder_definitions(root_folder, runner_filter.excluded_paths)
 
     if parsing_errors:
-        logging.warning(f"[bicep] found errors while parsing definitions: {parsing_errors}")
+        logger.warning(f"[bicep] found errors while parsing definitions: {parsing_errors}")
 
     return definitions, definitions_raw
 

--- a/checkov/bitbucket/dal.py
+++ b/checkov/bitbucket/dal.py
@@ -9,6 +9,8 @@ import requests
 from checkov.common.runners.base_runner import strtobool
 from checkov.common.vcs.base_vcs_dal import BaseVCSDAL
 
+logger = logging.getLogger(__name__)
+
 
 class Bitbucket(BaseVCSDAL):
     def setup_conf_dir(self) -> None:
@@ -51,7 +53,7 @@ class Bitbucket(BaseVCSDAL):
             else:
                 request.raise_for_status()
         except Exception:
-            logging.debug(f"Query failed to run by returning code of {url_endpoint}", exc_info=True)
+            logger.debug(f"Query failed to run by returning code of {url_endpoint}", exc_info=True)
 
         return None
 
@@ -64,7 +66,7 @@ class Bitbucket(BaseVCSDAL):
             branch_restrictions = self._request(endpoint=f"repositories/{self.current_repository}/branch-restrictions",
                                                 allowed_status_codes=[200])
             return branch_restrictions
-        logging.debug("Environment variable BITBUCKET_REPO_FULL_NAME was not set. Cannot fetch branch restrictions.")
+        logger.debug("Environment variable BITBUCKET_REPO_FULL_NAME was not set. Cannot fetch branch restrictions.")
         return None
 
     def persist_branch_restrictions(self) -> None:

--- a/checkov/circleci_pipelines/runner.py
+++ b/checkov/circleci_pipelines/runner.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from checkov.common.checks.base_check_registry import BaseCheckRegistry
     from networkx import DiGraph
 
+logger = logging.getLogger(__name__)
+
 WORKFLOW_DIRECTORY = "circleci"
 
 
@@ -55,7 +57,7 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, Any] | list[dict[str, Any
             orbs.{orbs: @}
         """
         if len(list(supported_entities)) > 1:
-            logging.debug("order of entities might cause extracting the wrong key for resource_id")
+            logger.debug("order of entities might cause extracting the wrong key for resource_id")
         new_key = key
         definition = self.definitions.get(file_path, {})
         if not definition or not isinstance(definition, dict):

--- a/checkov/cloudformation/cfn_utils.py
+++ b/checkov/cloudformation/cfn_utils.py
@@ -19,6 +19,8 @@ from checkov.common.models.consts import YAML_COMMENT_MARK
 CF_POSSIBLE_ENDINGS = frozenset((".yml", ".yaml", ".json", ".template"))
 TAG_FIELD_NAMES = ("Key", "Value")
 
+logger = logging.getLogger(__name__)
+
 
 def get_resource_tags(entity: dict[str, dict[str, Any]], registry: Registry = cfn_registry) -> Optional[Dict[str, str]]:
     entity_details = registry.extract_entity_details(entity)
@@ -38,7 +40,7 @@ def get_resource_tags(entity: dict[str, dict[str, Any]], registry: Registry = cf
             if tags:
                 return parse_entity_tags(tags)
     except Exception:
-        logging.warning(f"Failed to parse tags for entity {entity}")
+        logger.warning(f"Failed to parse tags for entity {entity}")
 
     return None
 
@@ -213,10 +215,10 @@ def get_files_definitions(
                     out_parsing_errors.update({file: 'Resource Properties is not a dictionary'})
             else:
                 if parsing_errors:
-                    logging.debug(f'File {file} had the following parsing errors: {parsing_errors}')
-                logging.debug(f"Parsed file {file} incorrectly {template}")
+                    logger.debug(f'File {file} had the following parsing errors: {parsing_errors}')
+                logger.debug(f"Parsed file {file} incorrectly {template}")
         except (TypeError, ValueError):
-            logging.warning(f"CloudFormation skipping {file} as it is not a valid CF template")
+            logger.warning(f"CloudFormation skipping {file} as it is not a valid CF template")
             continue
 
     return definitions, definitions_raw

--- a/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
+++ b/checkov/cloudformation/checks/resource/BaseCloudsplainingIAMCheck.py
@@ -14,6 +14,8 @@ from checkov.common.multi_signature import multi_signature
 from checkov.cloudformation.checks.utils.iam_cloudformation_document_to_policy_converter import \
     convert_cloudformation_conf_to_iam_policy
 
+logger = logging.getLogger(__name__)
+
 
 class BaseCloudsplainingIAMCheck(BaseResourceCheck):
     # creating a PolicyDocument is computational expensive,
@@ -68,11 +70,11 @@ class BaseCloudsplainingIAMCheck(BaseResourceCheck):
                             self.policy_document_cache[self.entity_path][policy.get("PolicyName")] = policy_statement
                     violations = self.cloudsplaining_analysis(policy_statement)
                     if violations:
-                        logging.debug(f"detailed cloudsplaining finding: {json.dumps(violations)}")
+                        logger.debug(f"detailed cloudsplaining finding: {json.dumps(violations)}")
                         return CheckResult.FAILED
                 except Exception:
                     # this might occur with templated iam policies where ARN is not in place or similar
-                    logging.debug(f"could not run cloudsplaining analysis on policy {conf}")
+                    logger.debug(f"could not run cloudsplaining analysis on policy {conf}")
                     return CheckResult.UNKNOWN
             return CheckResult.PASSED
 

--- a/checkov/cloudformation/checks/resource/aws/ECRPolicy.py
+++ b/checkov/cloudformation/checks/resource/aws/ECRPolicy.py
@@ -9,6 +9,8 @@ from checkov.cloudformation.checks.resource.base_resource_check import BaseResou
 from checkov.common.models.consts import SLS_DEFAULT_VAR_PATTERN
 from checkov.common.models.enums import CheckResult, CheckCategories
 
+logger = logging.getLogger(__name__)
+
 
 class ECRPolicy(BaseResourceCheck):
     def __init__(self) -> None:
@@ -39,9 +41,9 @@ class ECRPolicy(BaseResourceCheck):
                 if re.match(SLS_DEFAULT_VAR_PATTERN, str(policy_text)):
                     # Case where the template is a sub-CFN configuration inside a serverless configuration,
                     # and the policy is a variable expression
-                    logging.info(f"Encountered variable expression {str(policy_text)} in resource ${self.entity_path}")
+                    logger.info(f"Encountered variable expression {str(policy_text)} in resource ${self.entity_path}")
                 else:
-                    logging.error(
+                    logger.error(
                         f"Malformed policy configuration {str(policy_text)} of resource {self.entity_path}\n{e}"
                     )
                 return CheckResult.UNKNOWN

--- a/checkov/cloudformation/context_parser.py
+++ b/checkov/cloudformation/context_parser.py
@@ -14,6 +14,8 @@ from checkov.common.util.suppression import collect_suppressions_for_context
 ENDLINE = "__endline__"
 STARTLINE = "__startline__"
 
+logger = logging.getLogger(__name__)
+
 
 class ContextParser:
     """
@@ -36,7 +38,7 @@ class ContextParser:
             # TODO refactor into evaluations
             default_value = self.cf_template.get("Parameters", {}).get(refname, {}).get("Properties", {}).get("Default")
             if default_value is not None:
-                logging.debug(
+                logger.debug(
                     "Replacing Ref {} in file {} with default parameter value: {}".format(
                         refname, self.cf_file, default_value
                     )
@@ -127,7 +129,7 @@ class ContextParser:
                         skip_id = skip.get("id")
                         skip_comment = skip.get("comment", "No comment provided")
                         if skip_id is None:
-                            logging.warning("Check suppression is missing key 'id'")
+                            logger.warning("Check suppression is missing key 'id'")
                             continue
 
                         skipped_check: "_SkippedCheck" = {"id": skip_id, "suppress_comment": skip_comment}

--- a/checkov/cloudformation/graph_builder/graph_components/blocks.py
+++ b/checkov/cloudformation/graph_builder/graph_components/blocks.py
@@ -6,6 +6,8 @@ from typing import List, Dict, Any, Optional
 from checkov.common.graph.graph_builder.graph_components.blocks import Block
 from checkov.common.graph.graph_builder.variable_rendering.breadcrumb_metadata import BreadcrumbMetadata
 
+logger = logging.getLogger(__name__)
+
 
 class CloudformationBlock(Block):
     __slots__ = ("condition", "metadata")
@@ -71,7 +73,7 @@ class CloudformationBlock(Block):
             if isinstance(obj_to_update, (dict, list)):
                 obj_to_update[key_to_update] = attribute_value
             else:
-                logging.info(f"Failed to update an attribute, values: {obj_to_update}, {key_to_update}, {attribute_value}")
+                logger.info(f"Failed to update an attribute, values: {obj_to_update}, {key_to_update}, {attribute_value}")
 
     def update_inner_attribute(
         self, attribute_key: str, nested_attributes: list[Any] | dict[str, Any], value_to_update: Any

--- a/checkov/cloudformation/graph_builder/local_graph.py
+++ b/checkov/cloudformation/graph_builder/local_graph.py
@@ -22,6 +22,8 @@ from checkov.cloudformation.graph_builder.graph_components.generic_resource_encr
 if TYPE_CHECKING:
     from checkov.common.graph.graph_builder.graph_components.blocks import Block
 
+logger = logging.getLogger(__name__)
+
 TOKENIZED_FIELD_PATTERN = re.compile(r'\${([a-zA-Z0-9.]*)}')
 
 
@@ -48,12 +50,12 @@ class CloudformationLocalGraph(LocalGraph[CloudformationBlock]):
 
     def build_graph(self, render_variables: bool) -> None:
         self._create_vertices()
-        logging.info(f"[CloudformationLocalGraph] created {len(self.vertices)} vertices")
+        logger.info(f"[CloudformationLocalGraph] created {len(self.vertices)} vertices")
         self._add_sam_globals()
         self._create_edges()
-        logging.info(f"[CloudformationLocalGraph] created {len(self.edges)} edges")
+        logger.info(f"[CloudformationLocalGraph] created {len(self.edges)} edges")
         if render_variables:
-            logging.info(f"Rendering variables, graph has {len(self.vertices)} vertices and {len(self.edges)} edges")
+            logger.info(f"Rendering variables, graph has {len(self.vertices)} vertices and {len(self.edges)} edges")
             renderer = CloudformationVariableRenderer(self)
             renderer.render_variables_from_local_graph()
             self.update_vertices_breadcrumbs()
@@ -194,12 +196,12 @@ class CloudformationLocalGraph(LocalGraph[CloudformationBlock]):
                             if dest_vertex_index is not None:
                                 self._create_edge(origin_node_index, dest_vertex_index, label=attribute)
                         else:
-                            logging.debug(
+                            logger.debug(
                                 f"[CloudformationLocalGraph] didnt create edge for target_id {target_id}"
                                 f"and vertex_path {vertex_path} as target_id is not a string"
                             )
                 else:
-                    logging.debug(
+                    logger.debug(
                         f"[CloudformationLocalGraph] didnt create edge for target_ids {target_ids}"
                         f"and vertex_path {vertex_path} as target_ids is not a list"
                     )
@@ -238,7 +240,7 @@ class CloudformationLocalGraph(LocalGraph[CloudformationBlock]):
             Search for a key in all parts of the template.
             :return if searchText is "Ref", an array like ['Resources', 'myInstance', 'Properties', 'ImageId', 'Ref', 'Ec2ImageId']
         """
-        logging.debug(f'Search for key {searchText} as far down as the template goes')
+        logger.debug(f'Search for key {searchText} as far down as the template goes')
 
         results: "list[list[int | str]]" = []
         results.extend(search_deep_keys(searchText, cfndict, []))

--- a/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 _EdgeEvaluationMethodsEntry: TypeAlias = "dict[str, Callable[[Any, dict[str, Any]], tuple[str | None, str | None]]]"
 _VertexEvaluationMethodsEntry: TypeAlias = "dict[str, Callable[[Any], str | None]]"
 
+logger = logging.getLogger(__name__)
+
 
 class _EvaluatedEdge(TypedDict):
     vertex_index: int
@@ -303,7 +305,7 @@ class CloudformationVariableRenderer(VariableRenderer["CloudformationLocalGraph"
                         dest_vertex_attributes.get(CustomAttributes.BLOCK_TYPE) == BlockType.RESOURCE:
                     return str(evaluated_value), attribute_at_dest
         except TypeError as e:
-            logging.debug(f"unable to _evaluate_getatt_connection: {e}")
+            logger.debug(f"unable to _evaluate_getatt_connection: {e}")
 
         return None, None
 
@@ -365,7 +367,7 @@ class CloudformationVariableRenderer(VariableRenderer["CloudformationLocalGraph"
             operand_if_true = value[1]
             operand_if_false = value[2]
         except KeyError:
-            logging.info(f'Unexpected input for cfn if evaluation: {value}. '
+            logger.info(f'Unexpected input for cfn if evaluation: {value}. '
                          f'Template: {condition_vertex_attributes[CustomAttributes.FILE_PATH]}'
                          f'Block: {condition_vertex_attributes[CustomAttributes.BLOCK_NAME]}')
             return evaluated_value, evaluated_value_hierarchy
@@ -454,7 +456,7 @@ class CloudformationVariableRenderer(VariableRenderer["CloudformationLocalGraph"
                     (evaluated_value, changed_origin_id, attribute_at_dest) = self._evaluate_cfn_function(
                         edge, origin_vertex, cfn_evaluation_function, val_to_eval, dest_vertex_attributes)
                 except KeyError:
-                    logging.info(f'Failed to evalue cfn function. val_to_eval: {val_to_eval}')
+                    logger.info(f'Failed to evalue cfn function. val_to_eval: {val_to_eval}')
                     continue
 
                 if evaluated_value and evaluated_value != original_value:

--- a/checkov/cloudformation/graph_manager.py
+++ b/checkov/cloudformation/graph_manager.py
@@ -14,6 +14,8 @@ from checkov.common.graph.graph_manager import GraphManager
 if TYPE_CHECKING:
     from checkov.common.typing import LibraryGraphConnector
 
+logger = logging.getLogger(__name__)
+
 
 class CloudformationGraphManager(GraphManager[CloudformationLocalGraph, "dict[str, dict[str, Any]]"]):
     def __init__(self, db_connector: LibraryGraphConnector, source: str = GraphSource.CLOUDFORMATION) -> None:
@@ -28,7 +30,7 @@ class CloudformationGraphManager(GraphManager[CloudformationLocalGraph, "dict[st
         download_external_modules: bool = False,
         excluded_paths: Optional[List[str]] = None,
     ) -> Tuple[CloudformationLocalGraph, dict[str, dict[str, Any]]]:
-        logging.info(f"[CloudformationGraphManager] Parsing files in source dir {source_dir}")
+        logger.info(f"[CloudformationGraphManager] Parsing files in source dir {source_dir}")
         parsing_errors = {} if parsing_errors is None else parsing_errors
         definitions, definitions_raw = get_folder_definitions(source_dir, excluded_paths, parsing_errors)  # type:ignore[arg-type]
         local_graph = self.build_graph_from_definitions(definitions, render_variables)
@@ -40,7 +42,7 @@ class CloudformationGraphManager(GraphManager[CloudformationLocalGraph, "dict[st
             file_definition_raw = definitions_raw.get(cf_file, None)
             if file_definition is not None and file_definition_raw is not None:
                 cf_context_parser = ContextParser(cf_file, file_definition, file_definition_raw)
-                logging.debug(
+                logger.debug(
                     f"Template Dump for {cf_file}: {json.dumps(file_definition, indent=2, default=str)}"
                 )
                 cf_context_parser.evaluate_default_refs()

--- a/checkov/cloudformation/parser/__init__.py
+++ b/checkov/cloudformation/parser/__init__.py
@@ -9,7 +9,7 @@ from checkov.cloudformation.parser.cfn_keywords import TemplateSections
 from yaml.scanner import ScannerError
 from yaml import YAMLError
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def parse(
@@ -30,26 +30,26 @@ def parse(
     except IOError as err:
         if err.errno == 2:
             error = f"Template file not found: {filename} - {err}"
-            LOGGER.error(error)
+            logger.error(error)
         elif err.errno == 21:
             error = f"Template references a directory, not a file: {filename} - {err}"
-            LOGGER.error(error)
+            logger.error(error)
         elif err.errno == 13:
             error = f"Permission denied when accessing template file: {filename} - {err}"
-            LOGGER.error(error)
+            logger.error(error)
     except UnicodeDecodeError as err:
         error = f"Cannot read file contents: {filename} - {err}"
-        LOGGER.error(error)
+        logger.error(error)
     except cfn_yaml.CfnParseError as err:
         if "Null value at" in err.message:
-            LOGGER.info(f"Null values do not exist in CFN templates: {filename} - {err}")
+            logger.info(f"Null values do not exist in CFN templates: {filename} - {err}")
             return None, None
 
         error = f"Parsing error in file: {filename} - {err}"
-        LOGGER.info(error)
+        logger.info(error)
     except ValueError as err:
         error = f"Parsing error in file: {filename} - {err}"
-        LOGGER.info(error)
+        logger.info(error)
     except ScannerError as err:
         if err.problem in ["found character '\\t' that cannot start any token", "found unknown escape character"]:
             try:
@@ -58,7 +58,7 @@ def parse(
                     template, template_lines = result
             except Exception as json_err:  # pylint: disable=W0703
                 error = f"Template {filename} is malformed: {err.problem}. Tried to parse {filename} as JSON but got error: {json_err}"
-                LOGGER.info(error)
+                logger.info(error)
     except YAMLError as err:
         if hasattr(err, 'problem') and err.problem in ["expected ',' or '}', but got '<scalar>'"]:
             try:
@@ -67,10 +67,10 @@ def parse(
                     template, template_lines = result
             except Exception as json_err:  # pylint: disable=W0703
                 error = f"Template {filename} is malformed: {err.problem}. Tried to parse {filename} as JSON but got error: {json_err}"
-                LOGGER.info(error)
+                logger.info(error)
         else:
             error = f"Parsing error in file: {filename} - {err}"
-            LOGGER.info(error)
+            logger.info(error)
 
     if error:
         out_parsing_errors[filename] = error

--- a/checkov/cloudformation/parser/cfn_yaml.py
+++ b/checkov/cloudformation/parser/cfn_yaml.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 UNCONVERTED_SUFFIXES = ['Ref', 'Condition']
 FN_PREFIX = 'Fn::'
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class ContentType(str, Enum):
@@ -250,23 +250,23 @@ def load(filename: str | Path, content_type: ContentType) -> tuple[dict[str, Any
         try:
             content = str(from_path(file_path).best())
         except UnicodeDecodeError as e:
-            LOGGER.error(f"Encoding for file {file_path} could not be detected or read. Please try encoding the file as UTF-8.")
+            logger.error(f"Encoding for file {file_path} could not be detected or read. Please try encoding the file as UTF-8.")
             raise e
     else:
         try:
             content = file_path.read_text()
         except UnicodeDecodeError:
-            LOGGER.info(f"Encoding for file {file_path} is not UTF-8, trying to detect it")
+            logger.info(f"Encoding for file {file_path} is not UTF-8, trying to detect it")
             content = str(from_path(file_path).best())
 
     if content_type == ContentType.CFN and "Resources" not in content:
-        logging.debug(f'File {file_path} is expected to be a CFN template but has no Resources attribute')
+        logger.debug(f'File {file_path} is expected to be a CFN template but has no Resources attribute')
         return {}, []
     elif content_type == ContentType.SLS and "provider" not in content:
-        logging.debug(f'File {file_path} is expected to be an SLS template but has no provider attribute')
+        logger.debug(f'File {file_path} is expected to be an SLS template but has no provider attribute')
         return {}, []
     elif content_type == ContentType.TFPLAN and "planned_values" not in content:
-        logging.debug(f'File {file_path} is expected to be a TFPLAN file but has no planned_values attribute')
+        logger.debug(f'File {file_path} is expected to be a TFPLAN file but has no planned_values attribute')
         return {}, []
 
     file_lines = [(idx + 1, line) for idx, line in enumerate(content.splitlines(keepends=True))]
@@ -276,7 +276,7 @@ def load(filename: str | Path, content_type: ContentType) -> tuple[dict[str, Any
         if file_size > MAX_IAC_FILE_SIZE:
             # large JSON files take too much time, when parsed with `pyyaml`, compared to a normal 'json.loads()'
             # with start/end line numbers of 0 takes only a few seconds
-            logging.info(
+            logger.info(
                 f"File {file_path} has a size of {file_size} which is bigger than the supported 50mb, "
                 "therefore file lines will default to 0."
                 "This limit can be adjusted via the environment variable 'CHECKOV_MAX_IAC_FILE_SIZE'."

--- a/checkov/cloudformation/runner.py
+++ b/checkov/cloudformation/runner.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
     from checkov.common.checks_infra.registry import Registry
     from checkov.common.images.image_referencer import Image
 
+logger = logging.getLogger(__name__)
+
 
 class Runner(ImageReferencerMixin[None], BaseRunner[CloudformationGraphManager]):
     check_type = CheckType.CLOUDFORMATION  # noqa: CCE003  # a static attribute
@@ -90,9 +92,9 @@ class Runner(ImageReferencerMixin[None], BaseRunner[CloudformationGraphManager])
             self.context = build_definitions_context(self.definitions, self.definitions_raw)
 
             if CHECKOV_CREATE_GRAPH:
-                logging.info("creating CloudFormation graph")
+                logger.info("creating CloudFormation graph")
                 local_graph = self.graph_manager.build_graph_from_definitions(self.definitions)
-                logging.info("Successfully created CloudFormation graph")
+                logger.info("Successfully created CloudFormation graph")
 
                 for vertex in local_graph.vertices:
                     if vertex.block_type == BlockType.RESOURCE:
@@ -109,7 +111,7 @@ class Runner(ImageReferencerMixin[None], BaseRunner[CloudformationGraphManager])
             file_definition_raw = self.definitions_raw.get(cf_file, None)
             if file_definition is not None and file_definition_raw is not None:
                 cf_context_parser = ContextParser(cf_file, file_definition, file_definition_raw)
-                logging.debug(
+                logger.debug(
                     "Template Dump for {}: {}".format(cf_file, json.dumps(file_definition, indent=2, default=str))
                 )
                 cf_context_parser.evaluate_default_refs()

--- a/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from checkov.common.output.report import Report
     from checkov.common.typing import _BaseRunner
 
+logger = logging.getLogger(__name__)
+
 
 class PolicyMetadataIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
@@ -41,7 +43,7 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
             elif self.bc_integration.public_metadata_response:
                 self._handle_public_metadata(self.bc_integration.public_metadata_response)
             else:
-                logging.debug('In the pre-scan for policy metadata, but nothing was fetched from the platform')
+                logger.debug('In the pre-scan for policy metadata, but nothing was fetched from the platform')
                 self.integration_feature_failures = True
                 return
 
@@ -77,7 +79,7 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
                     check.bc_id = None
         except Exception:
             self.integration_feature_failures = True
-            logging.debug('An error occurred loading policy metadata. Some metadata may be missing from the run.', exc_info=True)
+            logger.debug('An error occurred loading policy metadata. Some metadata may be missing from the run.', exc_info=True)
 
     def get_bc_id(self, checkov_id: str) -> str:
         return cast(str, self.check_metadata.get(checkov_id, {}).get('id'))
@@ -148,7 +150,7 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
     def _handle_customer_prisma_policy_metadata(self, prisma_policy_metadata: list[dict[str, Any]]) -> None:
         if isinstance(prisma_policy_metadata, list):
             for metadata in prisma_policy_metadata:
-                logging.debug(f"Parsing filtered_policy_ids from metadata: {json.dumps(metadata)}")
+                logger.debug(f"Parsing filtered_policy_ids from metadata: {json.dumps(metadata)}")
                 pc_id = metadata.get('policyId')
                 if pc_id:
                     ckv_id = self.get_ckv_id_from_pc_id(pc_id)

--- a/checkov/common/bridgecrew/integration_features/features/repo_config_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/repo_config_integration.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from checkov.common.output.report import Report
     from checkov.common.typing import _BaseRunner
 
+logger = logging.getLogger(__name__)
+
 
 class RepoConfigIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
@@ -32,7 +34,7 @@ class RepoConfigIntegration(BaseIntegrationFeature):
     def pre_scan(self) -> None:
         try:
             if not self.bc_integration.customer_run_config_response:
-                logging.debug('In the pre-scan for repo config settings, but nothing was fetched from the platform')
+                logger.debug('In the pre-scan for repo config settings, but nothing was fetched from the platform')
                 self.integration_feature_failures = True
                 return
 
@@ -46,7 +48,7 @@ class RepoConfigIntegration(BaseIntegrationFeature):
 
         except Exception:
             self.integration_feature_failures = True
-            logging.debug("Scanning without applying scanning configs from the platform.", exc_info=True)
+            logger.debug("Scanning without applying scanning configs from the platform.", exc_info=True)
 
     @staticmethod
     def _get_code_category_object(code_category_config: dict[str, Any],
@@ -61,10 +63,10 @@ class RepoConfigIntegration(BaseIntegrationFeature):
         for section in vcs_config['scannedFiles']['sections']:
             repos = section['repos']
             if any(repo for repo in repos if self.bc_integration.repo_matches(repo)):
-                logging.debug(f'Found path exclusion config section for repo: {section}')
+                logger.debug(f'Found path exclusion config section for repo: {section}')
                 self.skip_paths.update(section['rule']['excludePaths'])
 
-        logging.debug(f'Skipping the following paths based on platform settings: {self.skip_paths}')
+        logger.debug(f'Skipping the following paths based on platform settings: {self.skip_paths}')
 
     def _set_enforcement_rules(self, enforcement_rules_config: dict[str, Any]) -> None:
         rules = enforcement_rules_config['rules']
@@ -78,7 +80,7 @@ class RepoConfigIntegration(BaseIntegrationFeature):
                 matched_rules.append(rule)
 
         if len(matched_rules) > 1:
-            logging.warning(f'Found {len(matched_rules)} enforcement rules for the specified repo. This likely means '
+            logger.warning(f'Found {len(matched_rules)} enforcement rules for the specified repo. This likely means '
                             f'that one rule was created for the VCS repo, and another rule for the CLI repo. You '
                             f'should update the configurations in the platform to ensure that the following repos '
                             f'are all in the same rule group:')
@@ -87,29 +89,29 @@ class RepoConfigIntegration(BaseIntegrationFeature):
                 for repo in rule['repositories']:
                     repo_name = repo['accountName']
                     if self.bc_integration.repo_matches(repo_name):
-                        logging.warning(f'- {repo_name}')
+                        logger.warning(f'- {repo_name}')
                         if repo_name == self.bc_integration.repo_id:
                             if exact_match_rule:
-                                logging.debug('Found multiple rules that exactly match --repo-id - likely the same '
+                                logger.debug('Found multiple rules that exactly match --repo-id - likely the same '
                                               'name across multiple VCSes. Using the first one.')
                             else:
                                 exact_match_rule = rule
 
             if not exact_match_rule:
-                logging.debug('Did not find any rules with a repo name that exactly matched --repo-id; taking the '
+                logger.debug('Did not find any rules with a repo name that exactly matched --repo-id; taking the '
                               'first one.')
 
             self.enforcement_rule = exact_match_rule or matched_rules[0]
         elif len(matched_rules) == 0:
-            logging.info('Did not find any enforcement rules for the specified repo; using the default rule')
+            logger.info('Did not find any enforcement rules for the specified repo; using the default rule')
             self.enforcement_rule = default_rule
         else:
-            logging.info('Found exactly one matching enforcement rule for the specified repo')
+            logger.info('Found exactly one matching enforcement rule for the specified repo')
             self.enforcement_rule = matched_rules[0]
 
-        logging.debug(
+        logger.debug(
             'Selected the following enforcement rule (it will not be applied unless --use-enforcement-rules is specified):')
-        logging.debug(json.dumps(self.enforcement_rule, indent=2))
+        logger.debug(json.dumps(self.enforcement_rule, indent=2))
 
         for code_category_type in [e.value for e in CodeCategoryType]:
             config = RepoConfigIntegration._get_code_category_object(self.enforcement_rule['codeCategories'],

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from checkov.common.output.record import Record
     from checkov.common.typing import _BaseRunner
 
+logger = logging.getLogger(__name__)
+
 
 class SuppressionsIntegration(BaseIntegrationFeature):
     def __init__(self, bc_integration: BcPlatformIntegration) -> None:
@@ -45,7 +47,7 @@ class SuppressionsIntegration(BaseIntegrationFeature):
     def pre_scan(self) -> None:
         try:
             if not self.bc_integration.customer_run_config_response:
-                logging.debug('In the pre-scan for suppressions, but nothing was fetched from the platform')
+                logger.debug('In the pre-scan for suppressions, but nothing was fetched from the platform')
                 self.integration_feature_failures = True
                 return
 
@@ -63,12 +65,12 @@ class SuppressionsIntegration(BaseIntegrationFeature):
             # group and map by policy ID
             self.suppressions = {policy_id: list(sup) for policy_id, sup in
                                  groupby(suppressions, key=lambda s: s['checkovPolicyId'])}
-            logging.debug(f'Found {len(self.suppressions)} valid suppressions from the platform.')
-            logging.debug('The found suppression rules are:')
-            logging.debug(self.suppressions)
+            logger.debug(f'Found {len(self.suppressions)} valid suppressions from the platform.')
+            logger.debug('The found suppression rules are:')
+            logger.debug(self.suppressions)
         except Exception:
             self.integration_feature_failures = True
-            logging.debug("Scanning without applying suppressions configured in the platform.", exc_info=True)
+            logger.debug("Scanning without applying suppressions configured in the platform.", exc_info=True)
 
     def post_runner(self, scan_report: Report) -> None:
         self._apply_suppressions_to_report(scan_report)
@@ -91,7 +93,7 @@ class SuppressionsIntegration(BaseIntegrationFeature):
             applied_suppression = self._check_suppressions(check, relevant_suppressions) if relevant_suppressions else None
             if applied_suppression:
                 suppress_comment = applied_suppression['comment']
-                logging.debug(f'Applying suppression to the check {check.check_id} with the comment: {suppress_comment}')
+                logger.debug(f'Applying suppression to the check {check.check_id} with the comment: {suppress_comment}')
                 check.check_result = {
                     'result': CheckResult.SKIPPED,
                     'suppress_comment': suppress_comment

--- a/checkov/common/bridgecrew/integration_features/integration_feature_registry.py
+++ b/checkov/common/bridgecrew/integration_features/integration_feature_registry.py
@@ -8,17 +8,19 @@ if TYPE_CHECKING:
     from checkov.common.output.report import Report
     from checkov.common.typing import _BaseRunner
 
+logger = logging.getLogger(__name__)
+
 
 class IntegrationFeatureRegistry:
     def __init__(self) -> None:
         self.features: list[BaseIntegrationFeature] = []
 
     def register(self, integration_feature: BaseIntegrationFeature) -> None:
-        logging.debug(f"Adding the IntegrationFeatureRegistry {integration_feature} with order {integration_feature.order}")
+        logger.debug(f"Adding the IntegrationFeatureRegistry {integration_feature} with order {integration_feature.order}")
         self.features.append(integration_feature)
         self.features.sort(key=lambda f: f.order)
-        logging.debug("self.features after the sort:")
-        logging.debug(self.features)
+        logger.debug("self.features after the sort:")
+        logger.debug(self.features)
 
     def run_pre_scan(self) -> None:
         for integration in self.features:

--- a/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
@@ -29,6 +29,8 @@ TWISTCLI_FILE_NAME = 'twistcli'
 DOCKER_IMAGE_SCAN_RESULT_FILE_NAME = 'docker-image-scan-results.json'
 CHECKOV_SEC_IN_WEEK = 604800
 
+logger = logging.getLogger(__name__)
+
 
 def generate_image_name() -> str:
     return f'repository/image{str(time.time() * 1000)}'
@@ -40,7 +42,7 @@ def _get_docker_image_name(docker_image_id: str) -> str:
         image_name: str = docker_client.images.get(docker_image_id).attrs['RepoDigests'][0].split('@')[0]
         return image_name
     except Exception:
-        logging.info("Failed to fetch image name.", exc_info=True)
+        logger.info("Failed to fetch image name.", exc_info=True)
         return generate_image_name()
 
 
@@ -49,10 +51,10 @@ def _get_dockerfile_content(dockerfile_path: Union[str, "os.PathLike[str]"]) -> 
         with open(dockerfile_path) as f:
             return f.read()
     except FileNotFoundError:
-        logging.error("Path to Dockerfile is invalid", exc_info=True)
+        logger.error("Path to Dockerfile is invalid", exc_info=True)
         raise
     except Exception:
-        logging.error("Failed to read Dockerfile content", exc_info=True)
+        logger.error("Failed to read Dockerfile content", exc_info=True)
         raise
 
 
@@ -81,19 +83,19 @@ class ImageScanner:
     def cleanup_scan(self) -> None:
         if self.twistcli_path.exists():
             os.remove(self.twistcli_path)
-            logging.info('twistcli file removed')
+            logger.info('twistcli file removed')
 
     def run_image_scan(self, docker_image_id: str) -> Dict[str, Any]:
         command = f"./{self.twistcli_path} images scan --address {docker_image_scanning_integration.get_proxy_address()} --token {docker_image_scanning_integration.get_bc_api_key()} --details --output-file \"{DOCKER_IMAGE_SCAN_RESULT_FILE_NAME}\" {docker_image_id}"
-        logging.debug(f"TwistCLI: {command}")
+        logger.debug(f"TwistCLI: {command}")
         try:
             subprocess.run([command], check=True, shell=True)  # nosec
         except Exception as exc:
-            logging.error("Failed to scan image", exc_info=True)
+            logger.error("Failed to scan image", exc_info=True)
             self.cleanup_scan()
             raise Exception(f"Failed to scan image {docker_image_id}") from exc
         self.cleanup_scan()
-        logging.info(f'TwistCLI ran successfully on image {docker_image_id}')
+        logger.info(f'TwistCLI ran successfully on image {docker_image_id}')
 
         with open(DOCKER_IMAGE_SCAN_RESULT_FILE_NAME) as docker_image_scan_result_file:
             scan_result: dict[str, Any] = json.load(docker_image_scan_result_file)
@@ -116,10 +118,10 @@ class ImageScanner:
                 )
             )
 
-            logging.info('Docker image scanning results reported to the platform')
+            logger.info('Docker image scanning results reported to the platform')
             return exit_code
         except Exception:
-            logging.error("Failed to scan docker image", exc_info=True)
+            logger.error("Failed to scan docker image", exc_info=True)
             return 1
 
     @staticmethod
@@ -134,7 +136,7 @@ class ImageScanner:
             return ImageScanner._extract_cache_results_for_image(image_id, response_json)
 
         except Exception:
-            logging.debug(
+            logger.debug(
                 "Unexpected failure happened during retrieving image scanning result from cache. details are below.\n"
                 "Note that the scan is still running. if it is repeated, please report.", exc_info=True)
             return None
@@ -155,17 +157,17 @@ class ImageScanner:
             return ImageScanner._extract_cache_results_for_image(image_id, response_json)
 
         except Exception as e:
-            logging.info(f"(IR debug) an Error is raised in (get_scan_results_from_cache_async) for {image_id}.")
-            logging.info(
+            logger.info(f"(IR debug) an Error is raised in (get_scan_results_from_cache_async) for {image_id}.")
+            logger.info(
                 "Unexpected failure happened during retrieving image scanning result from cache. details are below.\n"
                 "Note that the scan is still running. if it is repeated, please report.")
-            logging.info(str(e))
+            logger.info(str(e))
             return {}
 
     @staticmethod
     def _extract_cache_results_for_image(image_id: str, response_json: dict[str, str]) -> dict[str, Any]:
         output_type = response_json.get("outputType")
-        logging.info(f"output_type={output_type} returned from cache for image_id={image_id}")
+        logger.info(f"output_type={output_type} returned from cache for image_id={image_id}")
         if output_type == "Result":
             result: dict[str, Any] = json.loads(
                 decompress_file_gzip_base64(
@@ -174,9 +176,9 @@ class ImageScanner:
             )
             return result
         if output_type is None or output_type == "Error":
-            logging.error(response_json.get("outputData"))
+            logger.error(response_json.get("outputData"))
             return {}
-        logging.info(f"Got an empty result for image={image_id}")
+        logger.info(f"Got an empty result for image={image_id}")
         return {}
 
     def should_download(self) -> bool:

--- a/checkov/common/bridgecrew/vulnerability_scanning/integrations/docker_image_scanning.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/integrations/docker_image_scanning.py
@@ -11,6 +11,8 @@ from checkov.common.util.str_utils import removeprefix
 if TYPE_CHECKING:
     from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
 
+logger = logging.getLogger(__name__)
+
 
 class DockerImageScanningIntegration(TwistcliIntegration):
     async def report_results_async(
@@ -41,7 +43,7 @@ class DockerImageScanningIntegration(TwistcliIntegration):
         root_folder: str | Path | None = None
     ) -> dict[str, Any]:
         if not bc_platform_integration.bc_source:
-            logging.error("Source was not set")
+            logger.error("Source was not set")
             return {}
 
         results_dict = self._get_results_dict(twistcli_scan_result)

--- a/checkov/common/bridgecrew/vulnerability_scanning/integrations/package_scanning.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/integrations/package_scanning.py
@@ -9,6 +9,8 @@ from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
 from checkov.common.bridgecrew.vulnerability_scanning.integrations.twistcli import TwistcliIntegration
 from checkov.common.util.str_utils import removeprefix
 
+logger = logging.getLogger(__name__)
+
 
 class PackageScanningIntegration(TwistcliIntegration):
     def create_report(
@@ -19,7 +21,7 @@ class PackageScanningIntegration(TwistcliIntegration):
         **kwargs: Any,
     ) -> dict[str, Any]:
         if not bc_platform_integration.bc_source:
-            logging.error("Source was not set")
+            logger.error("Source was not set")
             return {}
 
         payload: dict[str, Any] = {

--- a/checkov/common/bridgecrew/vulnerability_scanning/integrations/twistcli.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/integrations/twistcli.py
@@ -15,6 +15,8 @@ from checkov.common.util.http_utils import get_default_post_headers, request_wra
 if TYPE_CHECKING:
     from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
 
+logger = logging.getLogger(__name__)
+
 
 class TwistcliIntegration(ABC):
     vulnerabilities_base_path = "/api/v1/vulnerabilities"  # noqa: CCE003  # a static attribute
@@ -37,10 +39,10 @@ class TwistcliIntegration(ABC):
 
             cli_file_name_path.write_bytes(response.content)
             cli_file_name_path.chmod(cli_file_name_path.stat().st_mode | stat.S_IEXEC)
-            logging.debug("twistcli downloaded and has execute permission")
+            logger.debug("twistcli downloaded and has execute permission")
             return True
         except Exception:
-            logging.debug(
+            logger.debug(
                 "Unexpected failure happened during downloading twistcli. details are below.\n"
                 "scanning is terminating. please try again. if it is repeated, please report.\n", exc_info=True)
             return False
@@ -53,10 +55,10 @@ class TwistcliIntegration(ABC):
         file_path: Path,
         **kwargs: Any,
     ) -> int:
-        logging.info(f"Start to send report for package file {file_path}")
+        logger.info(f"Start to send report for package file {file_path}")
 
         if not bc_platform_integration.bc_source:
-            logging.error("Source was not set")
+            logger.error("Source was not set")
             return 1
 
         payload = self.create_report(
@@ -71,11 +73,11 @@ class TwistcliIntegration(ABC):
         )
         url = f"{bc_integration.api_url}{self.vulnerabilities_base_path}/results"
 
-        logging.info(f"[twistcli](report_results_async) - reporting results to the server for the file \'{file_path}\'")
+        logger.info(f"[twistcli](report_results_async) - reporting results to the server for the file \'{file_path}\'")
         status: int = await aiohttp_client_session_wrapper(url, headers, payload)
 
         if status == 1:
-            logging.error(f"[twistcli](report_results_async) - Failed to send report for package file {file_path}"
+            logger.error(f"[twistcli](report_results_async) - Failed to send report for package file {file_path}"
                           f"\nerror message appears above")
         return status
 

--- a/checkov/common/bridgecrew/vulnerability_scanning/report.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/report.py
@@ -14,6 +14,8 @@ from checkov.common.bridgecrew.vulnerability_scanning.integrations.package_scann
 if TYPE_CHECKING:
     from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
 
+logger = logging.getLogger(__name__)
+
 
 async def _report_results_to_bridgecrew_async(
     scan_results: Iterable[dict[str, Any]],
@@ -26,7 +28,7 @@ async def _report_results_to_bridgecrew_async(
     if os.getenv("PYCHARM_HOSTED") == "1":
         # PYCHARM_HOSTED env variable equals 1 when running via Pycharm.
         # it avoids us from crashing, which happens when using multiprocessing via Pycharm's debug-mode
-        logging.warning("reporting the results in sequence for avoiding crashing when running via Pycharm")
+        logger.warning("reporting the results in sequence for avoiding crashing when running via Pycharm")
         exit_codes = []
         for curr_arg in args:
             exit_codes.append(await package_scanning_int.report_results_async(*curr_arg))

--- a/checkov/common/bridgecrew/wrapper.py
+++ b/checkov/common/bridgecrew/wrapper.py
@@ -28,6 +28,8 @@ check_reduced_keys = (
 secrets_check_reduced_keys = check_reduced_keys + ('validation_status',)
 check_metadata_keys = ('evaluations', 'code_block', 'workflow_name', 'triggers', 'job')
 
+logger = logging.getLogger(__name__)
+
 
 def _is_scanned_file(file: str) -> bool:
     file_ending = os.path.splitext(file)[1]
@@ -38,7 +40,7 @@ def _put_json_object(s3_client: BaseClient, json_obj: Any, bucket: str, object_p
     try:
         s3_client.put_object(Bucket=bucket, Key=object_path, Body=json.dumps(json_obj, cls=CustomJSONEncoder))
     except Exception:
-        logging.error(f"failed to persist object into S3 bucket {bucket}", exc_info=True)
+        logger.error(f"failed to persist object into S3 bucket {bucket}", exc_info=True)
         raise
 
 
@@ -105,7 +107,7 @@ def persist_run_metadata(
         s3_client.put_object(Bucket=bucket, Key=object_path, Body=json.dumps(run_metadata, indent=2))
 
     except Exception:
-        logging.error(f"failed to persist run metadata into S3 bucket {bucket}", exc_info=True)
+        logger.error(f"failed to persist run metadata into S3 bucket {bucket}", exc_info=True)
         raise
 
 
@@ -115,7 +117,7 @@ def persist_logs_stream(logs_stream: StringIO, s3_client: BaseClient, bucket: st
     try:
         s3_client.put_object(Bucket=bucket, Key=object_path, Body=file_io)
     except Exception:
-        logging.error(f"failed to persist logs stream into S3 bucket {bucket}", exc_info=True)
+        logger.error(f"failed to persist logs stream into S3 bucket {bucket}", exc_info=True)
         raise
 
 

--- a/checkov/common/checks/base_check.py
+++ b/checkov/common/checks/base_check.py
@@ -11,6 +11,8 @@ from checkov.common.util.type_forcers import force_list
 from checkov.common.models.enums import CheckResult, CheckCategories, CheckFailLevel
 from checkov.common.multi_signature import MultiSignatureMeta, multi_signature
 
+logger = logging.getLogger(__name__)
+
 
 class BaseCheck(metaclass=MultiSignatureMeta):
     def __init__(
@@ -39,7 +41,7 @@ class BaseCheck(metaclass=MultiSignatureMeta):
         self.severity = None
         self.bc_category = None
         if self.guideline:
-            logging.debug(f'Found custom guideline for check {id}')
+            logger.debug(f'Found custom guideline for check {id}')
         self.details: List[str] = []
         self.check_fail_level = os.environ.get('CHECKOV_CHECK_FAIL_LEVEL', CheckFailLevel.ERROR)
 
@@ -114,8 +116,8 @@ class BaseCheck(metaclass=MultiSignatureMeta):
     def log_check_error(self, scanned_file: str, entity_type: str, entity_name: str,
                         entity_configuration: Dict[str, List[Any]]) -> None:
         if self.check_fail_level == CheckFailLevel.ERROR:
-            logging.error(f'Failed to run check {self.id} on {scanned_file}:{entity_type}.{entity_name}',
+            logger.error(f'Failed to run check {self.id} on {scanned_file}:{entity_type}.{entity_name}',
                           exc_info=True)
         if self.check_fail_level == CheckFailLevel.WARNING:
-            logging.warning(f'Failed to run check {self.id} on {scanned_file}:{entity_type}.{entity_name}')
-        logging.info(f'Entity configuration: {entity_configuration}')
+            logger.warning(f'Failed to run check {self.id} on {scanned_file}:{entity_type}.{entity_name}')
+        logger.info(f'Entity configuration: {entity_configuration}')

--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -148,6 +148,8 @@ condition_type_to_solver_type = {
 
 JSONPATH_PREFIX = "jsonpath_"
 
+logger = logging.getLogger(__name__)
+
 
 class GraphCheckParser(BaseGraphCheckParser):
     def validate_check_config(self, file_path: str, raw_check: dict[str, dict[str, Any]]) -> bool:
@@ -170,13 +172,13 @@ class GraphCheckParser(BaseGraphCheckParser):
             missing_fields.append("definition")
 
         if missing_fields:
-            logging.warning(f"Custom policy {file_path} is missing required fields {', '.join(missing_fields)}")
+            logger.warning(f"Custom policy {file_path} is missing required fields {', '.join(missing_fields)}")
             return False
 
         # check if definition block is not obviously invalid
         definition = raw_check["definition"]
         if not isinstance(definition, (list, dict)):
-            logging.warning(
+            logger.warning(
                 f"Custom policy {file_path} has an invalid 'definition' block type '{type(definition).__name__}', "
                 "needs to be either a 'list' or 'dict'"
             )

--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 SUPPORTED_BLOCK_TYPES = {BlockType.RESOURCE, TerraformBlockType.DATA, TerraformBlockType.MODULE}
 WILDCARD_PATTERN = re.compile(r"(\S+[.][*][.]*)+")
 
+logger = logging.getLogger(__name__)
+
 
 class BaseAttributeSolver(BaseSolver):
     operator = ""  # noqa: CCE003  # a static attribute
@@ -162,7 +164,7 @@ class BaseAttributeSolver(BaseSolver):
 
             return attribute_matches
         except Exception:
-            logging.debug('Error parsing or evaluating jsonpath expression', exc_info=True)
+            logger.debug('Error parsing or evaluating jsonpath expression', exc_info=True)
             raise
 
     @staticmethod
@@ -223,5 +225,5 @@ class BaseAttributeSolver(BaseSolver):
                 value_to_check = json.loads(value_to_check)
                 return value_to_check
         except Exception as e:
-            logging.info(f'cant parse policy str to object, {str(e)}')
+            logger.info(f'cant parse policy str to object, {str(e)}')
         return value_to_check

--- a/checkov/common/checks_infra/solvers/attribute_solvers/regex_match_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/regex_match_attribute_solver.py
@@ -5,6 +5,8 @@ from typing import Optional, Any, Dict
 from checkov.common.graph.checks_infra.enums import Operators
 from checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver import BaseAttributeSolver
 
+logger = logging.getLogger(__name__)
+
 
 class RegexMatchAttributeSolver(BaseAttributeSolver):
     operator = Operators.REGEX_MATCH  # noqa: CCE003  # a static attribute
@@ -14,5 +16,5 @@ class RegexMatchAttributeSolver(BaseAttributeSolver):
         try:
             return re.match(str(self.value), str(attr)) is not None
         except re.error as e:
-            logging.warning(f'failed to run regex {self.value} for attribute: {attr}, {str(e)}')
+            logger.warning(f'failed to run regex {self.value} for attribute: {attr}, {str(e)}')
             return False

--- a/checkov/common/graph/checks_infra/registry.py
+++ b/checkov/common/graph/checks_infra/registry.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
     from checkov.common.graph.checks_infra.base_parser import BaseGraphCheckParser
     from checkov.common.typing import _CheckResult, LibraryGraph
 
+logger = logging.getLogger(__name__)
+
 
 class BaseRegistry:
     def __init__(self, parser: BaseGraphCheckParser) -> None:
@@ -36,7 +38,7 @@ class BaseRegistry:
             self, check: BaseGraphCheck, check_results: dict[BaseGraphCheck, list[_CheckResult]],
             graph_connector: LibraryGraph
     ) -> None:
-        logging.debug(f'Running graph check: {check.id}')
+        logger.debug(f'Running graph check: {check.id}')
         passed, failed, unknown = check.run(graph_connector)
         evaluated_keys = check.get_evaluated_keys()
         check_result = self._process_check_result(passed, [], CheckResult.PASSED, evaluated_keys)

--- a/checkov/common/graph/graph_builder/variable_rendering/renderer.py
+++ b/checkov/common/graph/graph_builder/variable_rendering/renderer.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 _LocalGraph = TypeVar("_LocalGraph", bound="LocalGraph[Any]")
 
+logger = logging.getLogger(__name__)
+
 
 class VariableRenderer(ABC, Generic[_LocalGraph]):
     MAX_NUMBER_OF_LOOPS = 50
@@ -56,11 +58,11 @@ class VariableRenderer(ABC, Generic[_LocalGraph]):
             if match_percent > self.duplicate_percent:
                 duplicates_count += 1
             if duplicates_count > self.duplicate_iter_count:
-                logging.info(f"Reached too many edge duplications of {self.duplicate_percent}% for {self.duplicate_iter_count} iterations. breaking.")
+                logger.info(f"Reached too many edge duplications of {self.duplicate_percent}% for {self.duplicate_iter_count} iterations. breaking.")
                 break
             evaluated_edges_cache.append(edges_to_render)
 
-            logging.debug(f"evaluating {len(edges_to_render)} edges")
+            logger.debug(f"evaluating {len(edges_to_render)} edges")
             # group edges that have the same origin and label together
             edges_groups = self.group_edges_by_origin_and_label(edges_to_render)
             if self.run_async:
@@ -90,15 +92,15 @@ class VariableRenderer(ABC, Generic[_LocalGraph]):
 
             loops += 1
             if loops >= self.MAX_NUMBER_OF_LOOPS:
-                logging.warning("Reached 50 graph edge iterations, breaking.")
+                logger.warning("Reached 50 graph edge iterations, breaking.")
                 break
 
         if self.vertices_index_to_render:
             return
         self.local_graph.update_vertices_configs()
-        logging.debug("done evaluating edges")
+        logger.debug("done evaluating edges")
         self.evaluate_non_rendered_values()
-        logging.debug("done evaluate_non_rendered_values")
+        logger.debug("done evaluate_non_rendered_values")
 
     @abstractmethod
     def _render_variables_from_vertices(self) -> None:

--- a/checkov/common/output/csv.py
+++ b/checkov/common/output/csv.py
@@ -43,6 +43,8 @@ CTA_NO_API_KEY = (
     "https://www.bridgecrew.cloud/login/signUp and add your API key to include those findings. "
 )
 
+logger = logging.getLogger(__name__)
+
 
 class CSVSBOM:
     def __init__(self) -> None:
@@ -70,7 +72,7 @@ class CSVSBOM:
     def add_sca_package_resources(self, resource: Record | ExtraResource, git_org: str, git_repository: str, check_type: str) -> None:
         if not resource.vulnerability_details:
             # this shouldn't happen
-            logging.error(f"Resource {resource.resource} doesn't have 'vulnerability_details' set")
+            logger.error(f"Resource {resource.resource} doesn't have 'vulnerability_details' set")
             return
 
         severity = None

--- a/checkov/common/output/cyclonedx.py
+++ b/checkov/common/output/cyclonedx.py
@@ -58,6 +58,8 @@ if TYPE_CHECKING:
     from checkov.common.output.record import Record
     from checkov.common.output.report import Report
 
+logger = logging.getLogger(__name__)
+
 
 class CycloneDX:
     def __init__(self, reports: list[Report], repo_id: str | None, export_iac_only: bool = False) -> None:
@@ -192,7 +194,7 @@ class CycloneDX:
 
         if not resource.vulnerability_details:
             # this shouldn't happen
-            logging.error(f"Resource {resource.resource} doesn't have 'vulnerability_details' set")
+            logger.error(f"Resource {resource.resource} doesn't have 'vulnerability_details' set")
             return Component(name="unknown")
         qualifiers = None
         file_name = Path(resource.file_path).name
@@ -358,7 +360,7 @@ class CycloneDX:
 
         if not resource.vulnerability_details:
             # this shouldn't happen
-            logging.error(f"Resource {resource.resource} doesn't have 'vulnerability_details' set")
+            logger.error(f"Resource {resource.resource} doesn't have 'vulnerability_details' set")
             return Vulnerability()
 
         severity = VulnerabilitySeverity.UNKNOWN

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -44,6 +44,8 @@ SEVERITY_TO_SARIF_LEVEL = {
     "none": "none",
 }
 
+logger = logging.getLogger(__name__)
+
 
 class Report:
     def __init__(self, check_type: str):
@@ -137,14 +139,14 @@ class Report:
         """
 
         hard_fail_on_parsing_errors = os.getenv(PARSE_ERROR_FAIL_FLAG, "false").lower() == 'true'
-        logging.debug(f'In get_exit_code; exit code thresholds: {exit_code_thresholds}, hard_fail_on_parsing_errors: {hard_fail_on_parsing_errors}')
+        logger.debug(f'In get_exit_code; exit code thresholds: {exit_code_thresholds}, hard_fail_on_parsing_errors: {hard_fail_on_parsing_errors}')
 
         if self.parsing_errors and hard_fail_on_parsing_errors:
-            logging.debug('hard_fail_on_parsing_errors is True and there were parsing errors - returning 1')
+            logger.debug('hard_fail_on_parsing_errors is True and there were parsing errors - returning 1')
             return 1
 
         if not self.failed_checks:
-            logging.debug('No failed checks in this report - returning 0')
+            logger.debug('No failed checks in this report - returning 0')
             return 0
 
         # we will have two different sets of logic in this method, determined by this variable.
@@ -182,7 +184,7 @@ class Report:
                 )
                 for c in sca_thresholds.keys()
             ):
-                logging.debug(
+                logger.debug(
                     'No failed checks, or soft_fail is True and soft_fail_on and hard_fail_on are empty for all SCA types - returning 0')
                 return 0
 
@@ -190,7 +192,7 @@ class Report:
                 not has_soft_fail_values and not (hard_fail_threshold[c] or hard_fail_on_checks) and failed_checks_by_category[cast(CodeCategoryType, c)]
                 for c in sca_thresholds.keys()
             ):
-                logging.debug('There are failed checks and all soft/hard fail args are empty for one or more SCA reports - returning 1')
+                logger.debug('There are failed checks and all soft/hard fail args are empty for one or more SCA reports - returning 1')
                 return 1
         else:
             non_sca_thresholds = cast(_ExitCodeThresholds, exit_code_thresholds)
@@ -204,10 +206,10 @@ class Report:
             has_hard_fail_values = hard_fail_threshold or hard_fail_on_checks
 
             if not has_soft_fail_values and not has_hard_fail_values and soft_fail:
-                logging.debug('Soft_fail is True and soft_fail_on and hard_fail_on are empty - returning 0')
+                logger.debug('Soft_fail is True and soft_fail_on and hard_fail_on are empty - returning 0')
                 return 0
             elif not has_soft_fail_values and not has_hard_fail_values:
-                logging.debug('There are failed checks and all soft/hard fail args are empty - returning 1')
+                logger.debug('There are failed checks and all soft/hard fail args are empty - returning 1')
                 return 1
 
         for failed_check in self.failed_checks:
@@ -243,10 +245,10 @@ class Report:
             if explicit_hard_fail or \
                     (hard_fail_severity and not explicit_soft_fail) or \
                     (implicit_hard_fail and not implicit_soft_fail and not sf):
-                logging.debug(f'Check {check_id} (BC ID: {bc_check_id}, severity: {severity.level if severity else None} triggered hard fail - returning 1')
+                logger.debug(f'Check {check_id} (BC ID: {bc_check_id}, severity: {severity.level if severity else None} triggered hard fail - returning 1')
                 return 1
 
-        logging.debug('No failed check triggered hard fail - returning 0')
+        logger.debug('No failed check triggered hard fail - returning 0')
         return 0
 
     def is_empty(self, full: bool = False) -> bool:
@@ -495,7 +497,7 @@ class Report:
                     continue
                 if not record.vulnerability_details:
                     # this shouldn't normally happen
-                    logging.warning(f"Vulnerability check without details {record.file_path}")
+                    logger.warning(f"Vulnerability check without details {record.file_path}")
                     continue
 
                 check_id = record.vulnerability_details["id"]
@@ -596,7 +598,7 @@ class Report:
                 )
             else:
                 # this shouldn't normally happen
-                logging.warning(f"Vulnerability check without details {record.file_path}")
+                logger.warning(f"Vulnerability check without details {record.file_path}")
 
         failure_output.extend(
             [

--- a/checkov/common/output/secrets_record.py
+++ b/checkov/common/output/secrets_record.py
@@ -23,6 +23,8 @@ TEXT_BY_SECRET_VALIDATION_STATUS = {
     ValidationStatus.UNAVAILABLE.value: ''
 }
 
+logger = logging.getLogger(__name__)
+
 
 class SecretsRecord(Record):
     def __init__(self,
@@ -101,6 +103,6 @@ class SecretsRecord(Record):
             message = TEXT_BY_SECRET_VALIDATION_STATUS.get(self.validation_status)
 
             if not message and self.validation_status != ValidationStatus.UNAVAILABLE.value:
-                logging.debug(f'Got empty message for secret validation status = {self.validation_status}')
+                logger.debug(f'Got empty message for secret validation status = {self.validation_status}')
 
         return message or ''

--- a/checkov/common/parallelizer/parallel_runner.py
+++ b/checkov/common/parallelizer/parallel_runner.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 _T = TypeVar("_T")
 
+logger = logging.getLogger(__name__)
+
 
 class ParallelRunner:
     def __init__(self, workers_number: int | None = None) -> None:
@@ -38,7 +40,7 @@ class ParallelRunner:
                 try:
                     result = original_func(item)
                 except Exception:
-                    logging.error(
+                    logger.error(
                         f"Failed to invoke function {func.__code__.co_filename.replace('.py', '')}.{func.__name__} with {item}"
                         , exc_info=True
                     )

--- a/checkov/common/parsers/json/__init__.py
+++ b/checkov/common/parsers/json/__init__.py
@@ -14,7 +14,7 @@ from charset_normalizer import from_path
 from checkov.common.parsers.json.decoder import Decoder
 from checkov.common.parsers.json.errors import DecodeError
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def load(
@@ -29,7 +29,7 @@ def load(
             file_path = filename if isinstance(filename, Path) else Path(filename)
             content = file_path.read_text()
     except UnicodeDecodeError:
-        LOGGER.info(f"Encoding for file {filename} is not UTF-8, trying to detect it")
+        logger.info(f"Encoding for file {filename} is not UTF-8, trying to detect it")
         content = str(from_path(filename).best())  # type:ignore[arg-type]  # somehow str is not recognized as PathLike
 
     file_lines = [(idx + 1, line) for idx, line in enumerate(content.splitlines(keepends=True))]
@@ -47,17 +47,17 @@ def parse(
     try:
         return load(filename=filename, allow_nulls=allow_nulls, content=file_content)
     except DecodeError as e:
-        logging.debug(f'Got DecodeError parsing file {filename}', exc_info=True)
+        logger.debug(f'Got DecodeError parsing file {filename}', exc_info=True)
         error = e
     except json.JSONDecodeError as e:
         # Most parsing errors will get caught by the exception above. But, if the file
         # is totally empty, and perhaps in other specific cases, the json library will
         # not even begin parsing with our custom logic that throws the exception above,
         # and will fail with this exception instead.
-        logging.debug(f'Got JSONDecodeError parsing file {filename}', exc_info=True)
+        logger.debug(f'Got JSONDecodeError parsing file {filename}', exc_info=True)
         error = e
     except UnicodeDecodeError as e:
-        logging.debug(f'Got UnicodeDecodeError parsing file {filename}', exc_info=True)
+        logger.debug(f'Got UnicodeDecodeError parsing file {filename}', exc_info=True)
         error = e
 
     if error:

--- a/checkov/common/parsers/json/decoder.py
+++ b/checkov/common/parsers/json/decoder.py
@@ -11,6 +11,8 @@ from json.scanner import NUMBER_RE  # type:ignore[import]  # is not explicitly e
 from checkov.common.parsers.node import StrNode, DictNode, ListNode
 from checkov.common.parsers.json.errors import NullError, DuplicateError, DecodeError
 
+logger = logging.getLogger(__name__)
+
 
 class SimpleDecoder(JSONDecoder):
     def __init__(
@@ -349,7 +351,7 @@ class Decoder(JSONDecoder):
             try:
                 value, end = scan_once(s, end)
             except StopIteration as err:
-                logging.debug("Failed to scan string", exc_info=True)
+                logger.debug("Failed to scan string", exc_info=True)
                 raise DecodeError('Expecting value', s, end_mark.line) from err
             key_str = StrNode(key, beg_mark, end_mark)
             pairs_append((key_str, value))

--- a/checkov/common/parsers/node.py
+++ b/checkov/common/parsers/node.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from checkov.common.parsers.json.decoder import Mark
 
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class TemplateAttributeError(AttributeError):

--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
 _GraphManager = TypeVar("_GraphManager", bound="GraphManager[Any, Any]|None")
 
+logger = logging.getLogger(__name__)
+
 
 def strtobool(val: str) -> int:
     """Convert a string representation of truth to true (1) or false (0).
@@ -126,7 +128,7 @@ class BaseRunner(ABC, Generic[_GraphManager]):
         checks_results: "dict[BaseGraphCheck, list[_CheckResult]]" = {}
         if not self.graph_manager or not self.graph_registry:
             # should not happen
-            logging.warning("Graph components were not initialized")
+            logger.warning("Graph components were not initialized")
             return checks_results
 
         for r in itertools.chain(self.external_registries or [], [self.graph_registry]):

--- a/checkov/common/runners/graph_builder/local_graph.py
+++ b/checkov/common/runners/graph_builder/local_graph.py
@@ -9,6 +9,8 @@ from checkov.common.graph.graph_builder import Edge
 from checkov.common.graph.graph_builder.graph_components.blocks import Block
 from checkov.common.graph.graph_builder.local_graph import LocalGraph
 
+logger = logging.getLogger(__name__)
+
 
 class ObjectLocalGraph(LocalGraph[Block]):
     def __init__(self, definitions: dict[str | Path, dict[str, Any] | list[dict[str, Any]]]) -> None:
@@ -19,7 +21,7 @@ class ObjectLocalGraph(LocalGraph[Block]):
 
     def build_graph(self, render_variables: bool = False) -> None:
         self._create_vertices()
-        logging.debug(f"[{self.__class__.__name__}] created {len(self.vertices)} vertices")
+        logger.debug(f"[{self.__class__.__name__}] created {len(self.vertices)} vertices")
 
         for i, vertex in enumerate(self.vertices):
             self.vertices_by_block_type[vertex.block_type].append(i)
@@ -30,7 +32,7 @@ class ObjectLocalGraph(LocalGraph[Block]):
             self.out_edges[i] = []
 
         self._create_edges()
-        logging.debug(f"[{self.__class__.__name__}] created {len(self.edges)} edges")
+        logger.debug(f"[{self.__class__.__name__}] created {len(self.edges)} edges")
 
     @abstractmethod
     def _create_vertices(self) -> None:

--- a/checkov/common/runners/object_runner.py
+++ b/checkov/common/runners/object_runner.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from checkov.common.checks.base_check_registry import BaseCheckRegistry
     from checkov.common.runners.graph_builder.local_graph import ObjectLocalGraph
 
+logger = logging.getLogger(__name__)
+
 
 class GhaMetadata(TypedDict):
     triggers: set[str]
@@ -105,11 +107,11 @@ class Runner(BaseRunner[ObjectGraphManager]):  # if a graph is added, Any needs 
         report = Report(self.check_type)
 
         if not files and not root_folder:
-            logging.debug("No resources to scan.")
+            logger.debug("No resources to scan.")
             return report
 
         if not external_checks_dir and self.require_external_checks():
-            logging.debug("The runner requires that external checks are defined.")
+            logger.debug("The runner requires that external checks are defined.")
             return report
         if external_checks_dir:
             for directory in external_checks_dir:
@@ -132,16 +134,16 @@ class Runner(BaseRunner[ObjectGraphManager]):  # if a graph is added, Any needs 
                     self._load_files(files_to_load=files_to_load)
 
             if CHECKOV_CREATE_GRAPH and self.graph_registry and self.graph_manager:
-                logging.info(f"Creating {self.source} graph")
+                logger.info(f"Creating {self.source} graph")
                 local_graph = self.graph_manager.build_graph_from_definitions(
                     definitions=self.definitions, graph_class=self.graph_class  # type:ignore[arg-type]  # the paths are just `str`
                 )
 
-                logging.info(f"Successfully created {self.source} graph")
+                logger.info(f"Successfully created {self.source} graph")
 
                 self.graph_manager.save_graph(local_graph)
         else:
-            logging.info("Going to use existing graph")
+            logger.info("Going to use existing graph")
             self.populate_metadata_dict()
 
         self.pbar.initiate(len(self.definitions))
@@ -179,7 +181,7 @@ class Runner(BaseRunner[ObjectGraphManager]):  # if a graph is added, Any needs 
                 if result_config:
                     end, start = self.get_start_end_lines(end, result_config, start)
                     if start == -1 and end == -1:
-                        logging.info(f"Skipping line in file path {file_path} in key {key}")
+                        logger.info(f"Skipping line in file path {file_path} in key {key}")
                         continue
                 if platform.system() == "Windows":
                     root_folder = os.path.split(file_path)[0]
@@ -329,7 +331,7 @@ class Runner(BaseRunner[ObjectGraphManager]):  # if a graph is added, Any needs 
                 triggers_set = {key for key in triggers.keys() if key != START_LINE and key != END_LINE}
 
         except Exception as e:
-            logging.info(f"failed to parse workflow triggers due to:{str(e)}")
+            logger.info(f"failed to parse workflow triggers due to:{str(e)}")
         return triggers_set
 
     def _get_jobs(self, definition: dict[str, Any]) -> dict[int, str]:

--- a/checkov/common/sca/output.py
+++ b/checkov/common/sca/output.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
     from checkov.common.output.report import Report
     from checkov.common.typing import _LicenseStatus, _CheckResult
 
+logger = logging.getLogger(__name__)
+
 
 def create_report_license_record(
         rootless_file_path: str,
@@ -522,7 +524,7 @@ def get_license_statuses(packages: list[dict[str, Any]]) -> list[_LicenseStatus]
             "failing when trying to get licenses-violations. it is apparently some unexpected "
             "connection issue. please try later. in case it keep happening. please report."
         )
-        logging.info(error_message, exc_info=True)
+        logger.info(error_message, exc_info=True)
 
     return []
 
@@ -550,7 +552,7 @@ async def get_license_statuses_async(session: ClientSession, packages: list[dict
             "connection issue. please try later. in case it keeps happening, please report."
             f"Error: {str(e)}"
         )
-        logging.info(error_message, exc_info=True)
+        logger.info(error_message, exc_info=True)
 
         return {'image_name': image_name, 'licenses': []}
 

--- a/checkov/common/util/data_structures_utils.py
+++ b/checkov/common/util/data_structures_utils.py
@@ -5,6 +5,8 @@ from typing import Any, TypeVar
 
 _T = TypeVar("_T")
 
+logger = logging.getLogger(__name__)
+
 
 def get_inner_dict(source_dict: dict[str, Any], path_as_list: list[str]) -> dict[str, Any]:
     result = source_dict
@@ -82,7 +84,7 @@ def find_in_dict(input_dict: dict[str, Any], key_path: str) -> Any:
             if value is None:
                 return None
     except (AttributeError, IndexError, KeyError, TypeError, ValueError):
-        logging.debug(f"Could not find {key_path} in dict")
+        logger.debug(f"Could not find {key_path} in dict")
         return None
 
     return value

--- a/checkov/common/util/decorators.py
+++ b/checkov/common/util/decorators.py
@@ -11,6 +11,8 @@ from typing_extensions import ParamSpec
 T = TypeVar("T")
 P = ParamSpec("P")
 
+logger = logging.getLogger(__name__)
+
 
 def time_it(func: Callable[P, T]) -> Callable[P, T]:
     """Prints the time it took to execute the function"""
@@ -22,7 +24,7 @@ def time_it(func: Callable[P, T]) -> Callable[P, T]:
         end = default_timer()
 
         func_path = f"{func.__code__.co_filename.replace('.py', '')}.{func.__name__}"
-        logging.info(f"'{func_path}' took: {timedelta(seconds=end - start)}")
+        logger.info(f"'{func_path}' took: {timedelta(seconds=end - start)}")
 
         return output
     return wrapper

--- a/checkov/common/util/file_utils.py
+++ b/checkov/common/util/file_utils.py
@@ -5,6 +5,8 @@ import gzip
 import io
 import logging
 
+logger = logging.getLogger(__name__)
+
 
 def convert_to_unix_path(path: str) -> str:
     return path.replace('\\', '/')
@@ -66,7 +68,7 @@ def read_file_safe(file_path: str) -> str:
             file_content = f.read()
             return file_content
     except Exception:
-        logging.warning(
+        logger.warning(
             "Could not open file",
             extra={"file_path": file_path}
         )
@@ -77,7 +79,7 @@ def get_file_size_safe(file_path: str) -> int:
     try:
         return os.path.getsize(file_path)
     except Exception:
-        logging.warning(
+        logger.warning(
             "Could not obtain file size",
             extra={"file_path": file_path}
         )

--- a/checkov/common/util/runner_dependency_handler.py
+++ b/checkov/common/util/runner_dependency_handler.py
@@ -41,10 +41,10 @@ class RunnerDependencyHandler():
                         runner_names.append(result)
                         runners_with_unmatched_deps.append(runner)
             else:
-                logging.debug(f"{runner.check_type}_runner declares no system dependency checks required.")
+                logger.debug(f"{runner.check_type}_runner declares no system dependency checks required.")
                 continue
 
         if runners_with_unmatched_deps:
-            logging.info(f"The following frameworks will automatically be disabled due to missing system dependencies: {','.join(runner_names)}")
+            logger.info(f"The following frameworks will automatically be disabled due to missing system dependencies: {','.join(runner_names)}")
             for runner in runners_with_unmatched_deps:
                 self.runner_registry.remove_runner(runner)

--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -71,6 +71,8 @@ _patterns['all'] = list(itertools.chain.from_iterable(_patterns.values()))
 
 _hash_patterns = list(map(lambda regex: re.compile(regex, re.IGNORECASE), ['^[a-f0-9]{32}$', '^[a-f0-9]{40}$']))
 
+logger = logging.getLogger(__name__)
+
 
 def is_hash(s: str) -> bool:
     """
@@ -166,7 +168,7 @@ def omit_secret_value_from_checks(
                 secrets.add(secret[0])
 
     if not secrets:
-        logging.debug(f"Secret was not saved in {check.id}, can't omit")
+        logger.debug(f"Secret was not saved in {check.id}, can't omit")
         return entity_code_lines
 
     for idx, line in entity_code_lines:
@@ -210,7 +212,7 @@ def omit_secret_value_from_graph_checks(
                         secrets.add(secret[0])
 
     if not secrets:
-        logging.debug(f"Secret was not saved in {check.id}, can't omit")
+        logger.debug(f"Secret was not saved in {check.id}, can't omit")
         return entity_code_lines
 
     for idx, line in entity_code_lines:

--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
     from checkov.common.output.record import Record
     from checkov.common.output.report import Report
 
+logger = logging.getLogger(__name__)
+
 
 class SecretsOmitterStatus(Enum):
     SUCCESS = 0
@@ -74,7 +76,7 @@ class SecretsOmitter:
 
     def omit(self) -> SecretsOmitterStatus:
         if not self.reports or not self.secrets_report:
-            logging.debug("Insufficient reports to omit secrets")
+            logger.debug("Insufficient reports to omit secrets")
             return SecretsOmitterStatus.INSUFFICIENT_REPORTS
 
         files_with_secrets: set[str] = {secret_check.get("file_path", "") for secret_check in self._secret_check()}
@@ -96,7 +98,7 @@ class SecretsOmitter:
                     continue
 
                 if len(secrets_check_lines) != secret_check_line_range[1] - secret_check_line_range[0] + 1:
-                    logging.error("Secrets lines does not match the length of the line range, sanity check failed")
+                    logger.error("Secrets lines does not match the length of the line range, sanity check failed")
                     continue
 
                 for secret_line_index, omitted_line in \

--- a/checkov/common/util/type_forcers.py
+++ b/checkov/common/util/type_forcers.py
@@ -9,6 +9,8 @@ import yaml
 
 T = TypeVar("T")
 
+logger = logging.getLogger(__name__)
+
 
 @overload
 def force_list(var: list[T]) -> list[T]:
@@ -72,7 +74,7 @@ def is_json(data: str) -> bool:
         parsed = json.loads(data)
         return isinstance(parsed, dict)
     except (TypeError, ValueError):
-        logging.debug(f"could not parse json data: {data}")
+        logger.debug(f"could not parse json data: {data}")
         return False
 
 
@@ -81,7 +83,7 @@ def is_yaml(data: str) -> bool:
         parsed = yaml.safe_load(data)
         return isinstance(parsed, dict)
     except yaml.YAMLError:
-        logging.debug(f"could not parse yaml data: {data}")
+        logger.debug(f"could not parse yaml data: {data}")
         return False
 
 
@@ -142,5 +144,5 @@ def convert_prisma_policy_filter_to_dict(filter_string: str) -> Dict[Any, Any]:
                 f_name, f_value = f.split('=')
                 filter_params[f_name] = f_value
         except (IndexError, ValueError) as e:
-            logging.debug(f"Invalid filter format: {e}")
+            logger.debug(f"Invalid filter format: {e}")
     return filter_params

--- a/checkov/common/vcs/base_vcs_dal.py
+++ b/checkov/common/vcs/base_vcs_dal.py
@@ -12,6 +12,8 @@ import urllib3
 from checkov.common.util.data_structures_utils import merge_dicts
 from checkov.common.util.http_utils import get_user_agent_header
 
+logger = logging.getLogger(__name__)
+
 
 class BaseVCSDAL:
     def __init__(self) -> None:
@@ -80,7 +82,7 @@ class BaseVCSDAL:
                         return None
                     return data
         except Exception:
-            logging.debug(f"Query failed to run by returning code of {url_endpoint}", exc_info=True)
+            logger.debug(f"Query failed to run by returning code of {url_endpoint}", exc_info=True)
         return None
 
     @abstractmethod
@@ -103,19 +105,19 @@ class BaseVCSDAL:
                 if request.status == 200:
                     data = json.loads(request.data.decode("utf8"))
                     if isinstance(data, dict) and 'errors' in data.keys():
-                        logging.debug("received errors %s", data)
+                        logger.debug("received errors %s", data)
                         return None
                     return data
                 else:
-                    logging.debug("Query failed to run by returning code of {}. {}".format(request.data, query))
+                    logger.debug("Query failed to run by returning code of {}. {}".format(request.data, query))
         except Exception:
-            logging.debug(f"Query failed {query}", exc_info=True)
+            logger.debug(f"Query failed {query}", exc_info=True)
 
     @staticmethod
     def persist(path: str | Path, conf: dict[str, Any] | list[dict[str, Any]]) -> None:
         BaseVCSDAL.ensure_dir(path)
         with open(path, "w+", encoding='utf-8') as f:
-            logging.debug(f"Persisting to {path}")
+            logger.debug(f"Persisting to {path}")
             json.dump(conf, f, ensure_ascii=False, indent=4)
 
     @staticmethod

--- a/checkov/common/vcs/vcs_schema.py
+++ b/checkov/common/vcs/vcs_schema.py
@@ -6,6 +6,8 @@ from typing import Any
 import jsonschema
 from jsonschema import validate
 
+logger = logging.getLogger(__name__)
+
 
 class VCSSchema():
     def __init__(self, schema: dict[str, Any]) -> None:
@@ -15,6 +17,6 @@ class VCSSchema():
         try:
             validate(instance=data, schema=self.schema)
         except jsonschema.exceptions.ValidationError:
-            logging.debug("validation error", exc_info=True)
+            logger.debug("validation error", exc_info=True)
             return False
         return True

--- a/checkov/contributor_metrics.py
+++ b/checkov/contributor_metrics.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def report_contributor_metrics(repository: str, source: str,
                                bc_integration: BcPlatformIntegration) -> None:  # ignore: type
-    logging.debug(f"Attempting to get log history for repository {repository} under source {source}")
+    logger.debug(f"Attempting to get log history for repository {repository} under source {source}")
     request_body = parse_gitlog(repository, source)
     number_of_attempts = 1
     contributors_report_api_url = f"{bc_integration.api_url}/api/v2/contributors/report"
@@ -24,7 +24,7 @@ def report_contributor_metrics(repository: str, source: str,
                 headers=bc_integration.get_default_headers("POST"), data=json.dumps(request_body)
             )
             if response.status_code < 300:
-                logging.debug(
+                logger.debug(
                     f"Successfully uploaded contributor metrics with status: {response.status_code}. number of attempts: {number_of_attempts}")
                 break
             else:
@@ -33,7 +33,7 @@ def report_contributor_metrics(repository: str, source: str,
                     'message': f"Failed to upload contributor metrics with: {response.status_code} - {response.reason}. number of attempts: {number_of_attempts}",
                     'timestamp': str(datetime.datetime.now())}
                 request_body['failedAttempts'].append(failed_attempt)
-                logging.info(f"Failed to upload contributor metrics with: {response.status_code} - {response.reason}")
+                logger.info(f"Failed to upload contributor metrics with: {response.status_code} - {response.reason}")
                 number_of_attempts += 1
 
 

--- a/checkov/dockerfile/graph_builder/local_graph.py
+++ b/checkov/dockerfile/graph_builder/local_graph.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     from dockerfile_parse.parser import _Instruction  # only in extra_stubs
     from checkov.common.graph.graph_builder.local_graph import _Block
 
+logger = logging.getLogger(__name__)
+
 
 class DockerfileLocalGraph(LocalGraph[Block]):
     def __init__(self, definitions: dict[str, dict[str, list[_Instruction]]]) -> None:
@@ -27,7 +29,7 @@ class DockerfileLocalGraph(LocalGraph[Block]):
 
     def build_graph(self, render_variables: bool = False) -> None:
         self._create_vertices()
-        logging.debug(f"[DockerfileLocalGraph] created {len(self.vertices)} vertices")
+        logger.debug(f"[DockerfileLocalGraph] created {len(self.vertices)} vertices")
 
         for i, vertex in enumerate(self.vertices):
             self.vertices_by_block_type[vertex.block_type].append(i)
@@ -38,7 +40,7 @@ class DockerfileLocalGraph(LocalGraph[Block]):
             self.out_edges[i] = []
 
         self._create_edges()
-        logging.debug(f"[DockerfileLocalGraph] created {len(self.edges)} edges")
+        logger.debug(f"[DockerfileLocalGraph] created {len(self.edges)} edges")
 
     def _create_vertices(self) -> None:
         for file_path, definition in self.definitions.items():
@@ -61,7 +63,7 @@ class DockerfileLocalGraph(LocalGraph[Block]):
         for instruction in instructions:
             resource_type = ResourceType.__dict__.get(instruction_type)
             if not resource_type:
-                logging.warning(f"An unsupported instruction {instruction_type} was used in {file_path}")
+                logger.warning(f"An unsupported instruction {instruction_type} was used in {file_path}")
                 continue
 
             config = {

--- a/checkov/dockerfile/runner.py
+++ b/checkov/dockerfile/runner.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
     from checkov.common.graph.checks_infra.base_check import BaseGraphCheck
     from checkov.common.images.image_referencer import Image
 
+logger = logging.getLogger(__name__)
+
 
 class Runner(ImageReferencerMixin["dict[str, dict[str, list[_Instruction]]]"], BaseRunner[DockerfileGraphManager]):
     check_type = CheckType.DOCKERFILE  # noqa: CCE003  # a static attribute
@@ -100,9 +102,9 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, list[_Instruction]]]"], B
         self.definitions, self.definitions_raw = get_files_definitions(files_list, filepath_fn)
 
         if CHECKOV_CREATE_GRAPH and self.graph_registry and self.graph_manager:
-            logging.info("Creating Dockerfile graph")
+            logger.info("Creating Dockerfile graph")
             local_graph = self.graph_manager.build_graph_from_definitions(definitions=self.definitions)
-            logging.info("Successfully created Dockerfile graph")
+            logger.info("Successfully created Dockerfile graph")
 
             self.graph_manager.save_graph(local_graph)
 

--- a/checkov/dockerfile/utils.py
+++ b/checkov/dockerfile/utils.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 DOCKERFILE_STARTLINE: Literal["startline"] = "startline"
 DOCKERFILE_ENDLINE: Literal["endline"] = "endline"
 
+logger = logging.getLogger(__name__)
+
 
 def get_scannable_file_paths(
     root_folder: str | Path | None = None, excluded_paths: list[str] | None = None
@@ -53,9 +55,9 @@ def get_files_definitions(
             path = filepath_fn(file) if filepath_fn else file
             definitions[path], definitions_raw[path] = result
         except TypeError:
-            logging.info(f"Dockerfile skipping {file} as it is not a valid dockerfile template")
+            logger.info(f"Dockerfile skipping {file} as it is not a valid dockerfile template")
         except UnicodeDecodeError:
-            logging.info(f"Dockerfile skipping {file} as it can't be read as text file")
+            logger.info(f"Dockerfile skipping {file} as it can't be read as text file")
 
     return definitions, definitions_raw
 

--- a/checkov/github_actions/graph_builder/local_graph.py
+++ b/checkov/github_actions/graph_builder/local_graph.py
@@ -15,6 +15,8 @@ from checkov.common.util.consts import START_LINE, END_LINE
 from checkov.github_actions.graph_builder.graph_components.resource_types import ResourceType
 from checkov.github_actions.utils import get_scannable_file_paths, parse_file
 
+logger = logging.getLogger(__name__)
+
 
 class GitHubActionsLocalGraph(ObjectLocalGraph):
     def __init__(self, definitions: dict[str | Path, dict[str, Any] | list[dict[str, Any]]]) -> None:
@@ -26,7 +28,7 @@ class GitHubActionsLocalGraph(ObjectLocalGraph):
     def _create_vertices(self) -> None:
         for file_path, definition in self.definitions.items():
             if not isinstance(definition, dict):
-                logging.debug(f"definition of file {file_path} has the wrong type {type(definition)}")
+                logger.debug(f"definition of file {file_path} has the wrong type {type(definition)}")
                 return
 
             file_path = str(file_path)

--- a/checkov/github_actions/runner.py
+++ b/checkov/github_actions/runner.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
     from checkov.common.runners.graph_manager import ObjectGraphManager
     from networkx import DiGraph
 
+logger = logging.getLogger(__name__)
+
 
 class Runner(ImageReferencerMixin["dict[str, dict[str, Any] | list[dict[str, Any]]]"], YamlRunner):
     check_type = CheckType.GITHUB_ACTIONS  # noqa: CCE003  # a static attribute
@@ -79,7 +81,7 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, Any] | list[dict[str, Any
 
         """
         if len(list(supported_entities)) > 1:
-            logging.debug("order of entities might cause extracting the wrong key for resource_id")
+            logger.debug("order of entities might cause extracting the wrong key for resource_id")
         new_key = key
         definition = self.definitions.get(file_path, {})
         if not definition or not isinstance(definition, dict):

--- a/checkov/github_actions/utils.py
+++ b/checkov/github_actions/utils.py
@@ -21,6 +21,8 @@ from checkov.runner_filter import RunnerFilter
 WORKFLOW_DIRECTORY = ".github/workflows/"
 WIN_WORKFLOW_DIRECTORY = ".github\\workflows\\"
 
+logger = logging.getLogger(__name__)
+
 
 def get_scannable_file_paths(root_folder: str | Path) -> set[Path]:
     """Finds yaml files"""
@@ -78,7 +80,7 @@ def is_schema_valid(config: dict[str, Any] | list[dict[str, Any]]) -> bool:
             validate(config_dict, gha_schema)
             return True
         except ValidationError:
-            logging.info(
+            logger.info(
                 "Given entity configuration does not match the schema\n" f"config={json.dumps(config_dict, indent=4)}\n"
             )
 

--- a/checkov/kubernetes/checks/resource/base_container_check.py
+++ b/checkov/kubernetes/checks/resource/base_container_check.py
@@ -7,6 +7,8 @@ from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.kubernetes.checks.resource.base_spec_check import BaseK8Check
 from checkov.kubernetes.checks.resource.registry import registry
 
+logger = logging.getLogger(__name__)
+
 
 class BaseK8sContainerCheck(BaseK8Check):
     TEMPLATE_ENTITIES = (
@@ -58,7 +60,7 @@ class BaseK8sContainerCheck(BaseK8Check):
                 spec = conf["spec"]
                 metadata = conf.get("metadata", {})
             except KeyError:
-                logging.info(f"failed to extract {evaluated_key_prefix} for {self.entity_path}")
+                logger.info(f"failed to extract {evaluated_key_prefix} for {self.entity_path}")
                 return CheckResult.UNKNOWN
         elif self.entity_type in "PodTemplate":
             evaluated_key_prefix = "template/spec"
@@ -66,7 +68,7 @@ class BaseK8sContainerCheck(BaseK8Check):
                 spec = conf["template"]["spec"]
                 metadata = conf["template"].get("metadata", {})
             except KeyError:
-                logging.info(f"failed to extract {evaluated_key_prefix} for {self.entity_path}")
+                logger.info(f"failed to extract {evaluated_key_prefix} for {self.entity_path}")
                 return CheckResult.UNKNOWN
         elif self.entity_type in BaseK8sContainerCheck.TEMPLATE_ENTITIES:
             evaluated_key_prefix = "spec/template/spec"
@@ -83,7 +85,7 @@ class BaseK8sContainerCheck(BaseK8Check):
             except (KeyError, TypeError):
                 return CheckResult.UNKNOWN
         else:
-            logging.info(f"entity type {self.entity_type} not supported")
+            logger.info(f"entity type {self.entity_type} not supported")
             return CheckResult.UNKNOWN
 
         containers: List[Dict[str, Any]] = (

--- a/checkov/kubernetes/graph_builder/local_graph.py
+++ b/checkov/kubernetes/graph_builder/local_graph.py
@@ -16,6 +16,8 @@ from checkov.kubernetes.graph_builder.graph_components.edge_builders.LabelSelect
 from checkov.kubernetes.graph_builder.graph_components.edge_builders.KeywordEdgeBuilder import KeywordEdgeBuilder
 from checkov.kubernetes.graph_builder.graph_components.edge_builders.NetworkPolicyEdgeBuilder import NetworkPolicyEdgeBuilder
 
+logger = logging.getLogger(__name__)
+
 
 class KubernetesLocalGraph(LocalGraph[KubernetesBlock]):
     def __init__(self, definitions: dict[str, list[dict[str, Any]]]) -> None:
@@ -44,13 +46,13 @@ class KubernetesLocalGraph(LocalGraph[KubernetesBlock]):
 
                 if resource_type == DEFAULT_NESTED_RESOURCE_TYPE:
                     if is_invalid_k8_pod_definition(resource):
-                        logging.info(f"failed to create a vertex in file {file_path}")
+                        logger.info(f"failed to create a vertex in file {file_path}")
                         file_conf.remove(resource)
                         continue
 
                 else:
                     if is_invalid_k8_definition(resource) or not metadata.get('name'):
-                        logging.info(f"failed to create a vertex in file {file_path}")
+                        logger.info(f"failed to create a vertex in file {file_path}")
                         file_conf.remove(resource)
                         continue
 

--- a/checkov/kubernetes/kubernetes_utils.py
+++ b/checkov/kubernetes/kubernetes_utils.py
@@ -26,6 +26,8 @@ PARENT_RESOURCE_KEY_NAME = "_parent_resource"
 PARENT_RESOURCE_ID_KEY_NAME = "_parent_resource_id"
 FILTERED_RESOURCES_FOR_EDGE_BUILDERS = ["NetworkPolicy"]
 
+logger = logging.getLogger(__name__)
+
 
 def get_folder_definitions(
         root_folder: str, excluded_paths: list[str] | None
@@ -61,7 +63,7 @@ def _parse_file(filename: str) -> tuple[str, tuple[list[dict[str, Any]], list[tu
     try:
         return filename, parse(filename)
     except (TypeError, ValueError):
-        logging.warning(f"Kubernetes skipping {filename} as it is not a valid Kubernetes template", exc_info=True)
+        logger.warning(f"Kubernetes skipping {filename} as it is not a valid Kubernetes template", exc_info=True)
 
     return None
 
@@ -79,7 +81,7 @@ def get_skipped_checks(entity_conf: dict[str, Any]) -> list[_SkippedCheck]:
             metadata["annotations"] = force_list(metadata["annotations"])
         for annotation in metadata["annotations"]:
             if not isinstance(annotation, dict):
-                logging.debug(f"Parse of Annotation Failed for {annotation}: {entity_conf}")
+                logger.debug(f"Parse of Annotation Failed for {annotation}: {entity_conf}")
                 continue
             for key in annotation:
                 skipped_item: "_SkippedCheck" = {}
@@ -99,7 +101,7 @@ def get_skipped_checks(entity_conf: dict[str, Any]) -> list[_SkippedCheck]:
                             skipped_item["bc_id"] = metadata_integration.get_bc_id(skipped_item["id"])
                         skipped.append(skipped_item)
                     else:
-                        logging.debug(f"Parse of Annotation Failed for {metadata['annotations'][key]}: {entity_conf}")
+                        logger.debug(f"Parse of Annotation Failed for {metadata['annotations'][key]}: {entity_conf}")
                         continue
     return skipped
 

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
     from checkov.common.images.image_referencer import Image
     from checkov.common.typing import _CheckResult, _EntityContext
 
+logger = logging.getLogger(__name__)
+
 
 class TimeoutError(Exception):
     pass
@@ -103,9 +105,9 @@ class Runner(ImageReferencerMixin[None], BaseRunner[KubernetesGraphManager]):
             self.spread_list_items()
 
             if CHECKOV_CREATE_GRAPH and self.graph_manager:
-                logging.info("creating Kubernetes graph")
+                logger.info("creating Kubernetes graph")
                 local_graph = self.graph_manager.build_graph_from_definitions(deepcopy(self.definitions))
-                logging.info("Successfully created Kubernetes graph")
+                logger.info("Successfully created Kubernetes graph")
 
                 for vertex in local_graph.vertices:
                     file_abs_path = _get_entity_abs_path(root_folder, vertex.path)
@@ -197,7 +199,7 @@ class Runner(ImageReferencerMixin[None], BaseRunner[KubernetesGraphManager]):
         if results:
             if not self.context:
                 # this shouldn't happen
-                logging.error("Context for Kubernetes runner was not set")
+                logger.error("Context for Kubernetes runner was not set")
                 return report
 
             for check, check_result in results.items():
@@ -295,7 +297,7 @@ class Runner(ImageReferencerMixin[None], BaseRunner[KubernetesGraphManager]):
                 # self.context not being None is checked in the caller method
                 entity_context = self.context[entity_file_path][entity[PARENT_RESOURCE_ID_KEY_NAME]]  # type:ignore[index]
             else:
-                logging.info(
+                logger.info(
                     "Unsupported nested resource type for Kubernetes graph edges. "
                     f"Type: {entity[CustomAttributes.RESOURCE_TYPE]} Parent: {entity[PARENT_RESOURCE_ID_KEY_NAME]}"
                 )

--- a/checkov/kustomize/utils.py
+++ b/checkov/kustomize/utils.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 import subprocess  # nosec
 
+logger = logging.getLogger(__name__)
+
 
 def get_kustomize_version(kustomize_command: str) -> str | None:
     try:
@@ -20,6 +22,6 @@ def get_kustomize_version(kustomize_command: str) -> str | None:
 
         return kustomize_version
     except Exception:
-        logging.debug(f"An error occured testing the {kustomize_command} command:", exc_info=True)
+        logger.debug(f"An error occured testing the {kustomize_command} command:", exc_info=True)
 
     return None

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -125,7 +125,7 @@ def commit_repository(config: Namespace) -> str | None:
     try:
         return bc_integration.commit_repository(config.branch)
     except Exception:
-        logging.debug("commit_repository failed, exiting", exc_info=True)
+        logger.debug("commit_repository failed, exiting", exc_info=True)
         exit_run(config.no_fail_on_crash)
         return ""
 
@@ -636,7 +636,7 @@ class Checkov:
                     (self.config.check and any(check in severities for check in self.config.check))
                     or (self.config.skip_check and any(check in severities for check in self.config.skip_check))
                 ):
-                    logging.warning("Filtering checks by severity is only possible with an API key")
+                    logger.warning("Filtering checks by severity is only possible with an API key")
 
             excluded_paths = self.config.skip_path or []
 
@@ -948,7 +948,7 @@ class Checkov:
                 bc_integration.onboarding()
             return None
         except BaseException:
-            logging.error("Exception traceback:", exc_info=True)
+            logger.error("Exception traceback:", exc_info=True)
             raise
 
         finally:
@@ -962,7 +962,7 @@ class Checkov:
         try:
             return bc_integration.commit_repository(self.config.branch)
         except Exception:
-            logging.debug("commit_repository failed, exiting", exc_info=True)
+            logger.debug("commit_repository failed, exiting", exc_info=True)
             self.exit_run()
             return ""
 

--- a/checkov/policies_3d/output.py
+++ b/checkov/policies_3d/output.py
@@ -17,6 +17,8 @@ from checkov.policies_3d.record import Policy3dRecord
 
 TABLE_WIDTH = 136
 
+logger = logging.getLogger(__name__)
+
 
 def merge_line_with_previous_table(line: str, table: PrettyTable) -> str:
     # hack to make multiple package tables look like one
@@ -85,7 +87,7 @@ def create_cli_output(*records: list[Policy3dRecord]) -> str:
 def render_cve_output(record: Policy3dRecord) -> str | None:
     if not record.vulnerabilities:
         #  this shouldn't happen
-        logging.error(f"'vulnerabilities' is not set for {record.check_id}")
+        logger.error(f"'vulnerabilities' is not set for {record.check_id}")
         return None
 
     package_cves_details_map: dict[str, dict[str, Any]] = defaultdict(dict)
@@ -192,7 +194,7 @@ def create_package_overview_table_part(
 def render_iac_violations_table(record: Policy3dRecord) -> str | None:
     if not record.iac_records:
         #  this shouldn't happen
-        logging.error(f"'iac_records' is not set for {record.check_id}")
+        logger.error(f"'iac_records' is not set for {record.check_id}")
         return None
 
     resource_violation_details_map: dict[str, dict[str, Any]] = defaultdict(dict)

--- a/checkov/policies_3d/runner.py
+++ b/checkov/policies_3d/runner.py
@@ -15,6 +15,8 @@ from checkov.policies_3d.record import Policy3dRecord
 from checkov.policies_3d.checks_infra.base_check import Base3dPolicyCheck
 from checkov.runner_filter import RunnerFilter
 
+logger = logging.getLogger(__name__)
+
 
 class CVECheckAttribute(str, Enum):
     RISK_FACTORS = "risk_factors"
@@ -48,7 +50,7 @@ class Policy3dRunner(BasePostRunner):
         report = Report(self.check_type)
 
         if not checks or not scan_reports:
-            logging.debug("No checks or reports scan.")
+            logger.debug("No checks or reports scan.")
             return report
 
         self.pbar.initiate(len(checks))
@@ -116,7 +118,7 @@ class Policy3dRunner(BasePostRunner):
                             image_related_resource = image_result.get('relatedResourceId')
                             image_name = image_result.get('dockerImageName')
                             if not image_related_resource or not image_name:
-                                logging.debug(
+                                logger.debug(
                                     "[policies3d/runner](solve_check_cve) Found vulnerabilities of an image without a related resource or image name, skipping")
                                 break
                             for cve in matching_cves:

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from checkov.common.checks.base_check import BaseCheck
     from checkov.common.graph.checks_infra.base_check import BaseGraphCheck
 
+logger = logging.getLogger(__name__)
+
 
 class RunnerFilter(object):
     # NOTE: This needs to be static because different filters may be used at load time versus runtime
@@ -112,7 +114,7 @@ class RunnerFilter(object):
                 self.framework = set(runners) - set(skip_framework)
             else:
                 self.framework = set(self.framework) - set(skip_framework)
-        logging.debug(f"Resultant set of frameworks (removing skipped frameworks): {','.join(self.framework)}")
+        logger.debug(f"Resultant set of frameworks (removing skipped frameworks): {','.join(self.framework)}")
 
         self.download_external_modules = download_external_modules
         self.external_modules_download_path = external_modules_download_path
@@ -135,7 +137,7 @@ class RunnerFilter(object):
         if self.enable_git_history_secret_scan:
             self.git_history_timeout = convert_to_seconds(git_history_timeout)
             self.framework = [CheckType.SECRETS]
-            logging.debug("Scan secrets history was enabled ignoring other frameworks")
+            logger.debug("Scan secrets history was enabled ignoring other frameworks")
 
     @staticmethod
     def _load_resource_attr_to_omit(resource_attr_to_omit_input: Optional[Dict[str, Set[str]]]) -> DefaultDict[str, Set[str]]:
@@ -195,7 +197,7 @@ class RunnerFilter(object):
         else:
             if self.use_enforcement_rules:
                 # this is a warning for us (but there is nothing the user can do about it)
-                logging.debug(f'Use enforcement rules is true, but check {check_id} was not passed to the runner filter with a report type')
+                logger.debug(f'Use enforcement rules is true, but check {check_id} was not passed to the runner filter with a report type')
             check_threshold = self.check_threshold
             skip_check_threshold = self.skip_check_threshold
 
@@ -214,13 +216,13 @@ class RunnerFilter(object):
         )
 
         if not should_run_check:
-            logging.debug(f'Should run check {check_id}: False')
+            logger.debug(f'Should run check {check_id}: False')
             return False
 
         # If a policy is not present in the list of filtered policies, it should not be run - implicitly or explicitly.
         # It can, however, be skipped.
         if not is_policy_filtered:
-            logging.debug(f'not is_policy_filtered {check_id}: should_run_check = False')
+            logger.debug(f'not is_policy_filtered {check_id}: should_run_check = False')
             should_run_check = False
 
         skip_severity = severity and skip_check_threshold and severity.level <= skip_check_threshold.level
@@ -233,19 +235,19 @@ class RunnerFilter(object):
             (not bc_check_id and not self.include_all_checkov_policies and not is_external and not explicit_run) or
             (bc_check_id in self.suppressed_policies and bc_check_id not in self.bc_cloned_checks)
         )
-        logging.debug(f'skip_severity = {skip_severity}, explicit_skip = {explicit_skip}, regex_match = {regex_match}, suppressed_policies: {self.suppressed_policies}')
-        logging.debug(
+        logger.debug(f'skip_severity = {skip_severity}, explicit_skip = {explicit_skip}, regex_match = {regex_match}, suppressed_policies: {self.suppressed_policies}')
+        logger.debug(
             f'bc_check_id = {bc_check_id}, include_all_checkov_policies = {self.include_all_checkov_policies}, is_external = {is_external}, explicit_run: {explicit_run}')
 
         if should_skip_check:
             result = False
-            logging.debug(f'should_skip_check {check_id}: {should_skip_check}')
+            logger.debug(f'should_skip_check {check_id}: {should_skip_check}')
         elif should_run_check:
             result = True
-            logging.debug(f'should_run_check {check_id}: {result}')
+            logger.debug(f'should_run_check {check_id}: {result}')
         else:
             result = False
-            logging.debug(f'default {check_id}: {result}')
+            logger.debug(f'default {check_id}: {result}')
 
         return result
 
@@ -271,7 +273,7 @@ class RunnerFilter(object):
                 if any(re.search(full_regex_pattern, path) for path in file_origin_paths):
                     return True
             except Exception as exc:
-                logging.error(
+                logger.error(
                     "Invalid regex pattern has been supplied",
                     extra={"regex_pattern": pattern, "exc": str(exc)}
                 )
@@ -359,5 +361,5 @@ class RunnerFilter(object):
         return runner_filter
 
     def set_suppressed_policies(self, policy_level_suppressions: List[str]) -> None:
-        logging.debug(f"Received the following policy-level suppressions, that will be skipped from running: {policy_level_suppressions}")
+        logger.debug(f"Received the following policy-level suppressions, that will be skipped from running: {policy_level_suppressions}")
         self.suppressed_policies = policy_level_suppressions

--- a/checkov/sca_package/output.py
+++ b/checkov/sca_package/output.py
@@ -17,6 +17,9 @@ from checkov.common.sca.commons import UNFIXABLE_VERSION
 from checkov.common.typing import _LicenseStatus
 
 
+logger = logging.getLogger(__name__)
+
+
 @dataclass
 class CveCount:
     total: int = 0
@@ -80,7 +83,7 @@ def create_cli_output(fixable: bool = True, *cve_records: list[Record]) -> str:
     for record in itertools.chain(*cve_records):
         if not record.vulnerability_details:
             #  this shouldn't happen
-            logging.error(f"'vulnerability_details' is not set for {record.check_id}")
+            logger.error(f"'vulnerability_details' is not set for {record.check_id}")
             continue
 
         group_by_file_path_package_map[record.file_path].setdefault(
@@ -99,7 +102,7 @@ def create_cli_output(fixable: bool = True, *cve_records: list[Record]) -> str:
             for record in records:
                 if not record.vulnerability_details:
                     #  this shouldn't happen
-                    logging.error(f"'vulnerability_details' is not set for {record.check_id}")
+                    logger.error(f"'vulnerability_details' is not set for {record.check_id}")
                     continue
 
                 if record.check_name == SCA_PACKAGE_SCAN_CHECK_NAME:

--- a/checkov/sca_package/runner.py
+++ b/checkov/sca_package/runner.py
@@ -16,6 +16,8 @@ from checkov.common.runners.base_runner import BaseRunner, ignored_directories
 from checkov.runner_filter import RunnerFilter
 from checkov.sca_package.scanner import Scanner
 
+logger = logging.getLogger(__name__)
+
 
 class Runner(BaseRunner[None]):
     check_type = CheckType.SCA_PACKAGE  # noqa: CCE003  # a static attribute
@@ -42,10 +44,10 @@ class Runner(BaseRunner[None]):
             return []
 
         if not bc_integration.bc_api_key:
-            logging.info("The --bc-api-key flag needs to be set to run SCA package scanning")
+            logger.info("The --bc-api-key flag needs to be set to run SCA package scanning")
             return []
 
-        logging.info("SCA package scanning searching for scannable files")
+        logger.info("SCA package scanning searching for scannable files")
 
         self._code_repo_path = Path(root_folder) if root_folder else None
 
@@ -64,7 +66,7 @@ class Runner(BaseRunner[None]):
             # no packages found
             return []
 
-        logging.info(f"SCA package scanning will scan {len(input_paths)} files")
+        logger.info(f"SCA package scanning will scan {len(input_paths)} files")
 
         scanner = Scanner(self.pbar, root_folder)
         self._check_class = f"{scanner.__module__}.{scanner.__class__.__qualname__}"
@@ -72,7 +74,7 @@ class Runner(BaseRunner[None]):
         # it will be None in case of unexpected failure during the scanning
         scan_results: Sequence[dict[str, Any]] | None = scanner.scan(input_paths)
         if scan_results is not None:
-            logging.info(f"SCA package scanning successfully scanned {len(scan_results)} files")
+            logger.info(f"SCA package scanning successfully scanned {len(scan_results)} files")
         return scan_results
 
     def run(
@@ -164,7 +166,7 @@ class Runner(BaseRunner[None]):
         for file in files or []:
             file_path = Path(file)
             if not file_path.exists():
-                logging.warning(f"File {file_path} doesn't exist")
+                logger.warning(f"File {file_path} doesn't exist")
                 continue
 
             input_paths.add(file_path)

--- a/checkov/sca_package_2/output.py
+++ b/checkov/sca_package_2/output.py
@@ -16,6 +16,8 @@ from checkov.common.sca.commons import UNFIXABLE_VERSION, get_package_alias
 from checkov.common.typing import _LicenseStatus
 from checkov.common.output.common import compare_table_items_severity
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class CveCount:
@@ -80,7 +82,7 @@ def create_cli_output(fixable: bool = True, *cve_records: list[Record]) -> str:
     for record in itertools.chain(*cve_records):
         if not record.vulnerability_details:
             #  this shouldn't happen
-            logging.error(f"'vulnerability_details' is not set for {record.check_id}")
+            logger.error(f"'vulnerability_details' is not set for {record.check_id}")
             continue
 
         if record.vulnerability_details.get("root_package_name"):
@@ -106,7 +108,7 @@ def create_cli_output(fixable: bool = True, *cve_records: list[Record]) -> str:
             for record in records:
                 if not record.vulnerability_details:
                     #  this shouldn't happen
-                    logging.error(f"'vulnerability_details' is not set for {record.check_id}")
+                    logger.error(f"'vulnerability_details' is not set for {record.check_id}")
                     continue
 
                 package_name = record.vulnerability_details["package_name"]

--- a/checkov/secrets/plugins/custom_regex_detector.py
+++ b/checkov/secrets/plugins/custom_regex_detector.py
@@ -18,6 +18,8 @@ MAX_CHARACTERS = 100
 if TYPE_CHECKING:
     from detect_secrets.util.code_snippet import CodeSnippet
 
+logger = logging.getLogger(__name__)
+
 
 class CustomRegexDetector(RegexBasedDetector):
     secret_type = "Regex Detector"  # noqa: CCE003 # nosec
@@ -144,7 +146,7 @@ class CustomRegexDetector(RegexBasedDetector):
             elif len(cast(str, ps.secret_value)) in range(MIN_CHARACTERS, MAX_CHARACTERS) or not regex_data['isCustom']:
                 output.add(ps)
             else:
-                logging.info(
+                logger.info(
                     f'Finding for check {ps.check_id} are not 5-100 characters in length, was ignored')  # type: ignore
 
     def analyze_string(self, string: str, **kwargs: Optional[Dict[str, Any]]) -> Generator[Tuple[str, Pattern[str]], None, None]:  # type:ignore[override]

--- a/checkov/secrets/plugins/load_detectors.py
+++ b/checkov/secrets/plugins/load_detectors.py
@@ -7,6 +7,8 @@ import yaml
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.util.file_utils import decompress_file_gzip_base64
 
+logger = logging.getLogger(__name__)
+
 
 def load_detectors() -> list[dict[str, Any]]:
     detectors: List[dict[str, Any]] = []
@@ -16,19 +18,19 @@ def load_detectors() -> list[dict[str, Any]]:
         if customer_run_config_response:
             policies_list = customer_run_config_response.get('secretsPolicies', [])
     except Exception as e:
-        logging.error(f"Failed to get detectors from customer_run_config_response, error: {e}")
+        logger.error(f"Failed to get detectors from customer_run_config_response, error: {e}")
         return []
 
     if policies_list:
         detectors = modify_secrets_policy_to_detectors(policies_list)
     if detectors:
-        logging.info(f"Successfully loaded {len(detectors)} detectors from bc_integration")
+        logger.info(f"Successfully loaded {len(detectors)} detectors from bc_integration")
     return detectors
 
 
 def modify_secrets_policy_to_detectors(policies_list: List[dict[str, Any]]) -> List[dict[str, Any]]:
     secrets_list = transforms_policies_to_detectors_list(policies_list)
-    logging.debug(f"(modify_secrets_policy_to_detectors) len secrets_list = {len(secrets_list)}")
+    logger.debug(f"(modify_secrets_policy_to_detectors) len secrets_list = {len(secrets_list)}")
     return secrets_list
 
 
@@ -96,7 +98,7 @@ def transforms_policies_to_detectors_list(custom_secrets: List[Dict[str, Any]]) 
         elif code:
             parsed = add_detectors_from_code(custom_detectors, code, secret_policy, check_id)
         if not parsed:
-            logging.info(f"policy : {secret_policy} could not be parsed")
+            logger.info(f"policy : {secret_policy} could not be parsed")
     return custom_detectors
 
 
@@ -116,5 +118,5 @@ def get_runnable_plugins(policies: List[Dict[str, Any]]) -> Dict[str, str]:
                         name: str = policy['title']
                         runnables[name] = decoded_payload.decode('utf8')
             except Exception as e:
-                logging.warning(f"Could not parse runnable policy {policy['title']} due to: {e}")
+                logger.warning(f"Could not parse runnable policy {policy['title']} due to: {e}")
     return runnables

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -44,6 +44,8 @@ SINGLE_ITEM_SECTIONS = [
     ("service", service_registry)
 ]
 
+logger = logging.getLogger(__name__)
+
 
 class Runner(BaseRunner):
     check_type = CheckType.SERVERLESS  # noqa: CCE003  # a static attribute
@@ -119,7 +121,7 @@ class Runner(BaseRunner):
                 cf_sub_resources = cf_sub_template.get("Resources")
                 if cf_sub_resources and isinstance(cf_sub_resources, dict):
                     cf_context_parser = CfnContextParser(sls_file, cf_sub_template, definitions_raw[sls_file])
-                    logging.debug(f"Template Dump for {sls_file}: {sls_file_data}")
+                    logger.debug(f"Template Dump for {sls_file}: {sls_file_data}")
                     cf_context_parser.evaluate_default_refs()
                     for resource_name, resource in cf_sub_resources.items():
                         if not isinstance(resource, DictNode):

--- a/checkov/terraform/checks/resource/base_resource_value_check.py
+++ b/checkov/terraform/checks/resource/base_resource_value_check.py
@@ -13,6 +13,8 @@ from checkov.terraform.graph_builder.utils import get_referenced_vertices_in_val
 from checkov.terraform.parser_functions import handle_dynamic_values
 
 
+logger = logging.getLogger(__name__)
+
 class BaseResourceValueCheck(BaseResourceCheck):
     def __init__(
         self,
@@ -64,7 +66,7 @@ class BaseResourceValueCheck(BaseResourceCheck):
             if value in expected_values:
                 return CheckResult.PASSED
             if not isinstance(value, str) and str(value) in expected_values:
-                logging.debug(f"Check {self.id} is set to pass even though the type of value {value} is not str (it is {type(value)}), while {str(value)} is an expected value")
+                logger.debug(f"Check {self.id} is set to pass even though the type of value {value} is not str (it is {type(value)}), while {str(value)} is an expected value")
                 return CheckResult.PASSED
             if get_referenced_vertices_in_value(value=value, aliases={}, resources_types=[]):
                 # we don't provide resources_types as we want to stay provider agnostic

--- a/checkov/terraform/checks/utils/base_cloudsplaining_iam_scanner.py
+++ b/checkov/terraform/checks/utils/base_cloudsplaining_iam_scanner.py
@@ -11,6 +11,8 @@ from checkov.common.models.enums import CheckResult
 if typing.TYPE_CHECKING:
     from cloudsplaining.scan.policy_document import PolicyDocument
 
+logger = logging.getLogger(__name__)
+
 
 class BaseTerraformCloudsplainingIAMScanner:
     # creating a PolicyDocument is computational expensive,
@@ -28,10 +30,10 @@ class BaseTerraformCloudsplainingIAMScanner:
                 )
             except Exception:
                 # this might occur with templated iam policies where ARN is not in place or similar
-                logging.debug(f"could not run cloudsplaining analysis on policy {conf}")
+                logger.debug(f"could not run cloudsplaining analysis on policy {conf}")
                 return CheckResult.UNKNOWN
             if violations:
-                logging.debug(f"detailed cloudsplainging finding: {json.dumps(violations, indent=2, default=str)}")
+                logger.debug(f"detailed cloudsplainging finding: {json.dumps(violations, indent=2, default=str)}")
                 return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/checkov/terraform/context_parsers/base_parser.py
+++ b/checkov/terraform/context_parsers/base_parser.py
@@ -19,6 +19,8 @@ from checkov.terraform.context_parsers.registry import parser_registry
 OPEN_CURLY = "{"
 CLOSE_CURLY = "}"
 
+logger = logging.getLogger(__name__)
+
 
 class BaseContextParser(ABC):
     def __init__(self, definition_type: str) -> None:
@@ -115,7 +117,7 @@ class BaseContextParser(ABC):
                 if k in entity_context:
                     entity_context = entity_context[k]
                 else:
-                    logging.warning(f'Failed to find context for {".".join(entity_context_path)}')
+                    logger.warning(f'Failed to find context for {".".join(entity_context_path)}')
                     found = False
                     break
             if not found:

--- a/checkov/terraform/context_parsers/parsers/provider_context_parser.py
+++ b/checkov/terraform/context_parsers/parsers/provider_context_parser.py
@@ -6,6 +6,8 @@ from hcl2 import START_LINE, END_LINE
 
 from checkov.terraform.context_parsers.base_parser import BaseContextParser
 
+logger = logging.getLogger(__name__)
+
 
 class ProviderContextParser(BaseContextParser):
     def __init__(self) -> None:
@@ -50,7 +52,7 @@ class ProviderContextParser(BaseContextParser):
                 )
             )["provider"][0]
         except Exception as e:
-            logging.info(f'got exception while loading file {self.tf_file}\n {e}')
+            logger.info(f'got exception while loading file {self.tf_file}\n {e}')
             return False
         alias = provider_obj[provider_type].get("alias", ["default"])
         return super()._is_block_signature(line_num, line_tokens + alias, entity_context_path)

--- a/checkov/terraform/context_parsers/tf_plan/__init__.py
+++ b/checkov/terraform/context_parsers/tf_plan/__init__.py
@@ -4,19 +4,19 @@ from typing import Dict
 from checkov.cloudformation.parser.cfn_yaml import ContentType
 from checkov.cloudformation.parser import cfn_yaml
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def parse(filename, out_parsing_errors: Dict[str, str]):
     """
         Decode filename into an object
     """
-    logging.debug(f"[tf_plan] - Parsing file {filename}")
+    logger.debug(f"[tf_plan] - Parsing file {filename}")
 
     try:
         template, template_lines = cfn_yaml.load(filename, ContentType.TFPLAN)
     except Exception as e:
-        logging.debug(f"[tf_plan] - Failed to parse file {filename}", exc_info=True)
+        logger.debug(f"[tf_plan] - Failed to parse file {filename}", exc_info=True)
         out_parsing_errors[filename] = str(e)
         return None, None
 
@@ -26,9 +26,9 @@ def parse(filename, out_parsing_errors: Dict[str, str]):
         and 'terraform_version' in template
         and 'planned_values' in template
     ):
-        logging.debug(f"[tf_plan] - Successfully parsed file {filename}")
+        logger.debug(f"[tf_plan] - Successfully parsed file {filename}")
 
         return template, template_lines
 
-    logging.debug(f"[tf_plan] - Missing required fields in file {filename}")
+    logger.debug(f"[tf_plan] - Missing required fields in file {filename}")
     return None, None

--- a/checkov/terraform/deep_analysis_plan_graph_manager.py
+++ b/checkov/terraform/deep_analysis_plan_graph_manager.py
@@ -7,6 +7,8 @@ from checkov.common.output.report import Report
 from checkov.terraform.plan_parser import TF_PLAN_RESOURCE_ADDRESS
 from typing import Dict
 
+logger = logging.getLogger(__name__)
+
 
 class DeepAnalysisGraphManager:
     def __init__(self, tf_graph: TerraformLocalGraph, tf_plan_graph: TerraformLocalGraph) -> None:
@@ -32,7 +34,7 @@ class DeepAnalysisGraphManager:
         for address, tf_plan_vertex in self._address_to_tf_plan_vertex_map.items():
             tf_vertex = self._address_to_tf_vertex_map.get(address)
             if not tf_vertex:
-                logging.info(f'Cant find this address: {address} in tf graph')
+                logger.info(f'Cant find this address: {address} in tf graph')
                 continue
             tf_vertex.attributes = {**tf_vertex.attributes, **tf_plan_vertex.attributes}
             tf_vertex.path = tf_plan_vertex.path

--- a/checkov/terraform/graph_builder/foreach_handler.py
+++ b/checkov/terraform/graph_builder/foreach_handler.py
@@ -20,6 +20,8 @@ COUNT_KEY = 'count.index'
 EACH_KEY = 'each.key'
 EACH_VALUE = 'each.value'
 
+logger = logging.getLogger(__name__)
+
 
 class ForeachHandler(object):
     def __init__(self, local_graph: l_graph.TerraformLocalGraph) -> None:
@@ -54,7 +56,7 @@ class ForeachHandler(object):
             else:
                 return None
         except Exception as e:
-            logging.info(f"Cant get foreach statement for block: {self.local_graph.vertices[block_index]}, error: {str(e)}")
+            logger.info(f"Cant get foreach statement for block: {self.local_graph.vertices[block_index]}, error: {str(e)}")
             return None
 
     def _is_static_foreach_statement(self, statement: list[str] | dict[str, Any]) -> bool:

--- a/checkov/terraform/graph_builder/utils.py
+++ b/checkov/terraform/graph_builder/utils.py
@@ -22,6 +22,8 @@ from checkov.terraform.graph_builder.variable_rendering.vertex_reference import 
 MODULE_DEPENDENCY_PATTERN_IN_PATH = re.compile(r"\(\[\{.+\#\*\#.+\}\]\)")
 CHECKOV_RENDER_MAX_LEN = force_int(os.getenv("CHECKOV_RENDER_MAX_LEN", "10000"))
 
+logger = logging.getLogger(__name__)
+
 
 def is_local_path(root_dir: str, source: str) -> bool:
     # https://www.terraform.io/docs/modules/sources.html#local-paths
@@ -200,7 +202,7 @@ def get_referenced_vertices_in_value(
     if isinstance(value, str):
         value_len = len(value)
         if CHECKOV_RENDER_MAX_LEN and 0 < CHECKOV_RENDER_MAX_LEN < value_len:
-            logging.debug(f'Rendering was skipped for a {value_len}-character-long string. If you wish to have it '
+            logger.debug(f'Rendering was skipped for a {value_len}-character-long string. If you wish to have it '
                           f'evaluated, please set the environment variable CHECKOV_RENDER_MAX_LEN '
                           f'to {str(value_len + 1)} or to 0 to allow rendering of any length')
         else:

--- a/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
@@ -19,10 +19,12 @@ DIRECTIVE_EXPR = re.compile(r"\%\{([^\}]*)\}")
 COMPARE_REGEX = re.compile(r"^(?P<a>.+?)\s*(?P<operator>==|!=|>=|>|<=|<|&&|\|\|)\s*(?P<b>.+)$")
 CHECKOV_RENDER_MAX_LEN = force_int(os.getenv("CHECKOV_RENDER_MAX_LEN", "10000"))
 
+logger = logging.getLogger(__name__)
+
 
 def evaluate_terraform(input_str: Any, keep_interpolations: bool = True) -> Any:
     if isinstance(input_str, str) and CHECKOV_RENDER_MAX_LEN and 0 < CHECKOV_RENDER_MAX_LEN < len(input_str):
-        logging.debug(f'Rendering was skipped for a {len(input_str)}-character-long string. If you wish to have it '
+        logger.debug(f'Rendering was skipped for a {len(input_str)}-character-long string. If you wish to have it '
                       f'evaluated, please set the environment variable CHECKOV_RENDER_MAX_LEN '
                       f'to {str(len(input_str) + 1)} or to 0 to allow rendering of any length')
         return input_str

--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -19,6 +19,8 @@ https://www.terraform.io/docs/configuration/functions.html
 Not all of the functions are implemented yet. If a function doesn't exist, the original value is returned.
 """
 
+logger = logging.getLogger(__name__)
+
 
 def _find_regex_groups(pattern: str, input_str: str) -> Optional[Union[Dict[str, str], List[str]]]:
     match = re.match(pattern, input_str)
@@ -331,7 +333,7 @@ SAFE_EVAL_DICT["formatdate"] = formatdate
 
 def evaluate(input_str: str) -> Any:
     if "__" in input_str:
-        logging.debug(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")
+        logger.debug(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")
         return input_str
     evaluated = eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
     return evaluated if not isinstance(evaluated, str) else remove_unicode_null(evaluated)

--- a/checkov/terraform/graph_manager.py
+++ b/checkov/terraform/graph_manager.py
@@ -12,6 +12,8 @@ from checkov.common.graph.graph_manager import GraphManager
 if TYPE_CHECKING:
     from checkov.common.typing import LibraryGraphConnector
 
+logger = logging.getLogger(__name__)
+
 
 class TerraformGraphManager(GraphManager[TerraformLocalGraph, "dict[str, dict[str, Any]]"]):
     def __init__(self, db_connector: LibraryGraphConnector, source: str = "") -> None:
@@ -29,7 +31,7 @@ class TerraformGraphManager(GraphManager[TerraformLocalGraph, "dict[str, dict[st
         vars_files: list[str] | None = None,
         create_graph: bool = True,
     ) -> tuple[TerraformLocalGraph | None, dict[str, dict[str, Any]]]:
-        logging.info("Parsing HCL files in source dir")
+        logger.info("Parsing HCL files in source dir")
         module, tf_definitions = self.parser.parse_hcl_module(
             source_dir=source_dir,
             source=self.source,
@@ -43,7 +45,7 @@ class TerraformGraphManager(GraphManager[TerraformLocalGraph, "dict[str, dict[st
 
         local_graph = None
         if create_graph and module:
-            logging.info("Building graph from parsed module")
+            logger.info("Building graph from parsed module")
             local_graph = local_graph_class(module)
             local_graph.build_graph(render_variables=render_variables)
 

--- a/checkov/terraform/module_loading/loaders/local_path_loader.py
+++ b/checkov/terraform/module_loading/loaders/local_path_loader.py
@@ -7,6 +7,8 @@ from checkov.terraform.module_loading.content import ModuleContent
 from checkov.terraform.module_loading.loader import ModuleLoader
 from checkov.terraform.module_loading.module_params import ModuleParams
 
+logger = logging.getLogger(__name__)
+
 
 class LocalPathLoader(ModuleLoader):
     def __init__(self) -> None:
@@ -26,7 +28,7 @@ class LocalPathLoader(ModuleLoader):
             return True
 
         if platform.system() == "Windows":
-            logging.debug("Platform: Windows")
+            logger.debug("Platform: Windows")
             if re.match(re.compile("[a-zA-Z]:\\\\"), module_params.module_source):
                 return True
 

--- a/checkov/terraform/module_loading/loaders/registry_loader.py
+++ b/checkov/terraform/module_loading/loaders/registry_loader.py
@@ -16,6 +16,8 @@ from checkov.terraform.module_loading.loaders.versions_parser import (
 )
 from checkov.terraform.module_loading.module_params import ModuleParams
 
+logger = logging.getLogger(__name__)
+
 
 class RegistryLoader(ModuleLoader):
     modules_versions_cache: Dict[str, List[str]] = {}  # noqa: CCE003  # public data
@@ -83,7 +85,7 @@ class RegistryLoader(ModuleLoader):
             return ModuleContent(dir=module_params.dest_dir)
 
         best_version = module_params.best_version
-        logging.debug(
+        logger.debug(
             f"Best version for {module_params.module_source} is {best_version} based on the version constraint {module_params.version}")
         request_download_url = "/".join((module_params.REGISTRY_URL_PREFIX, module_params.module_source, best_version, "download"))
         try:

--- a/checkov/terraform/module_loading/registry.py
+++ b/checkov/terraform/module_loading/registry.py
@@ -33,10 +33,10 @@ information, see `loader.ModuleLoader.load`.
         """
         module_address = f'{source}:{source_version}'
         if module_address in self.module_content_cache:
-            logging.debug(f'Used the cache for module {module_address}')
+            logger.debug(f'Used the cache for module {module_address}')
             return self.module_content_cache[module_address]
         else:
-            logging.debug(f'Cache miss for {module_address}')
+            logger.debug(f'Cache miss for {module_address}')
 
         if os.name == 'nt':
             # For windows, due to limitations in the allowed characters for path names, the hash of the source is used.
@@ -67,7 +67,7 @@ information, see `loader.ModuleLoader.load`.
                                                  inner_module=inner_module)
                     content = loader.load(module_params)
                 except Exception as e:
-                    logging.warning(f'Module {module_address} failed to load via {loader.__class__}')
+                    logger.warning(f'Module {module_address} failed to load via {loader.__class__}')
                     last_exception = e
                     continue
                 if content.next_url:

--- a/checkov/terraform/modules/module_utils.py
+++ b/checkov/terraform/modules/module_utils.py
@@ -30,6 +30,8 @@ RESOLVED_MODULE_PATTERN = re.compile(r"\[.+\#.+\]")
 _Hcl2Payload: TypeAlias = "dict[str, list[dict[str, Any]]]"
 external_modules_download_path = os.environ.get('EXTERNAL_MODULES_DIR', DEFAULT_EXTERNAL_MODULES_DIR)
 
+logger = logging.getLogger(__name__)
+
 
 def is_valid_block(block: Any) -> bool:
     if not isinstance(block, dict):
@@ -64,7 +66,7 @@ Load JSON or HCL, depending on filename.
     file_name = os.path.basename(file_path)
 
     try:
-        logging.debug(f"Parsing {file_path}")
+        logger.debug(f"Parsing {file_path}")
 
         with open(file_path, "r", encoding="utf-8-sig") as f:
             if file_name.endswith(".json"):
@@ -77,7 +79,7 @@ Load JSON or HCL, depending on filename.
                 else:
                     return non_malformed_definitions
     except Exception as e:
-        logging.debug(f'failed while parsing file {file_path}', exc_info=True)
+        logger.debug(f'failed while parsing file {file_path}', exc_info=True)
         parsing_errors[file_path] = e
         return None
 
@@ -97,7 +99,7 @@ def safe_index(sequence_hopefully: Sequence[Any], index: int) -> Any:
     try:
         return sequence_hopefully[index]
     except IndexError:
-        logging.debug(f'Failed to parse index int ({index}) out of {sequence_hopefully}', exc_info=True)
+        logger.debug(f'Failed to parse index int ({index}) out of {sequence_hopefully}', exc_info=True)
         return None
 
 

--- a/checkov/terraform/parser.py
+++ b/checkov/terraform/parser.py
@@ -23,6 +23,8 @@ from checkov.terraform.modules.module_utils import load_or_die_quietly, safe_ind
     remove_module_dependency_from_path, get_module_dependency_map, get_module_dependency_map_support_nested_modules, \
     clean_parser_types, serialize_definitions
 
+logger = logging.getLogger(__name__)
+
 
 def _filter_ignored_paths(root: str, paths: list[str], excluded_paths: list[str] | None) -> None:
     filter_ignored_paths(root, paths, excluded_paths)
@@ -300,7 +302,7 @@ class Parser:
         #          and there are still modules to be loaded, they will be forced on the next pass.
         force_final_module_load = False
         for i in range(0, 10):  # circuit breaker - no more than 10 loops
-            logging.debug("Module load loop %d", i)
+            logger.debug("Module load loop %d", i)
 
             # Stage 4a: Load eligible modules
             # Add directory to self._parsed_directories to avoid loading it as sub dir
@@ -421,10 +423,10 @@ class Parser:
                         continue
                     source = source[0]
                     if not isinstance(source, str):
-                        logging.debug(f"Skipping loading of {module_call_name} as source is not a string, it is: {source}")
+                        logger.debug(f"Skipping loading of {module_call_name} as source is not a string, it is: {source}")
                         continue
                     elif source in ['./', '.']:
-                        logging.debug(f"Skipping loading of {module_call_name} as source is the current dir")
+                        logger.debug(f"Skipping loading of {module_call_name} as source is the current dir")
                         continue
 
                     # Special handling for local sources to make sure we aren't double-parsing
@@ -438,7 +440,7 @@ class Parser:
                     try:
                         content = module_loader_registry.load(root_dir, source, version)
                         if not content.loaded():
-                            logging.info(f'Got no content for {source}:{version}')
+                            logger.info(f'Got no content for {source}:{version}')
                             continue
 
                         new_nested_modules_data = {'module_index': module_index, 'file': file,
@@ -514,7 +516,7 @@ class Parser:
 
                         self.external_modules_source_map[(source, version)] = content.path()
                     except Exception as e:
-                        logging.warning("Unable to load module (source=\"%s\" version=\"%s\"): %s",
+                        logger.warning("Unable to load module (source=\"%s\" version=\"%s\"): %s",
                                         source, version, e)
 
         if all_module_definitions:
@@ -597,8 +599,8 @@ class Parser:
                 try:
                     module.add_blocks(block_type, blocks[block_type], file_path, source)
                 except Exception as e:
-                    logging.warning(f'Failed to add block {blocks[block_type]}. Error:')
-                    logging.warning(e, exc_info=False)
+                    logger.warning(f'Failed to add block {blocks[block_type]}. Error:')
+                    logger.warning(e, exc_info=False)
         return module, tf_definitions
 
     def get_file_key_with_nested_data(self, file, nested_data):

--- a/checkov/terraform/parser_functions.py
+++ b/checkov/terraform/parser_functions.py
@@ -20,6 +20,8 @@ from checkov.common.util.parser_utils import eval_string, split_merge_args, stri
 
 FUNCTION_FAILED = "____FUNCTION_FAILED____"
 
+logger = logging.getLogger(__name__)
+
 
 def merge(original, var_resolver, **_):
     # https://www.terraform.io/docs/language/functions/merge.html
@@ -51,7 +53,7 @@ def concat(original, var_resolver, **_):
         if arg.startswith("["):
             value = eval_string(arg)
             if value is None:
-                logging.debug("Unable to convert to list: %s", arg)
+                logger.debug("Unable to convert to list: %s", arg)
                 return FUNCTION_FAILED
         else:
             value = var_resolver(arg)

--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -24,6 +24,8 @@ RESOURCE_TYPES_JSONIFY = {
     "aws_ssoadmin_permission_set_inline_policy": "inline_policy",
 }
 
+logger = logging.getLogger(__name__)
+
 
 def _is_simple_type(obj: Any) -> bool:
     if obj is None:
@@ -124,7 +126,7 @@ def jsonify(obj: dict[str, Any], resource_type: str) -> None:
         try:
             obj[jsonify_key] = json.loads(obj[jsonify_key])
         except json.JSONDecodeError:
-            logging.debug(
+            logger.debug(
                 f"Attribute {jsonify_key} of resource type {resource_type} is not json encoded {obj[jsonify_key]}"
             )
 

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -63,6 +63,8 @@ RESOURCE_ATTRIBUTES_TO_OMIT = {
     'google_kms_secret_ciphertext': ['plaintext']
 }
 
+logger = logging.getLogger(__name__)
+
 
 class Runner(TerraformRunner):
     check_type = CheckType.TERRAFORM_PLAN  # noqa: CCE003  # a static attribute
@@ -192,7 +194,7 @@ class Runner(TerraformRunner):
                 scanned_file = f"/{os.path.relpath(full_file_path,temp)}"
             else:
                 scanned_file = f"/{os.path.relpath(full_file_path, root_folder)}"
-            logging.debug(f"Scanning file: {scanned_file}")
+            logger.debug(f"Scanning file: {scanned_file}")
             for block_type in definition.keys():
                 if block_type in self.block_type_registries.keys():
                     self.run_block(definition[block_type], None, full_file_path, root_folder, report, scanned_file,

--- a/checkov/terraform/plan_utils.py
+++ b/checkov/terraform/plan_utils.py
@@ -15,6 +15,8 @@ from checkov.runner_filter import RunnerFilter
 if TYPE_CHECKING:
     from checkov.common.parsers.node import DictNode
 
+logger = logging.getLogger(__name__)
+
 
 def create_definitions(
     root_folder: str,
@@ -39,13 +41,13 @@ def create_definitions(
                             try:
                                 content = json.load(f)
                             except UnicodeDecodeError:
-                                logging.debug(f"Encoding for file {file_path} is not UTF-8, trying to detect it")
+                                logger.debug(f"Encoding for file {file_path} is not UTF-8, trying to detect it")
                                 content = str(from_fp(f).best())
 
                         if isinstance(content, dict) and content.get('terraform_version'):
                             files.append(file_path)
                     except Exception as e:
-                        logging.debug(f'Failed to load json file {file_path}, skipping', stack_info=True)
+                        logger.debug(f'Failed to load json file {file_path}, skipping', stack_info=True)
                         out_parsing_errors[file_path] = str(e)
 
     tf_definitions = {}
@@ -59,7 +61,7 @@ def create_definitions(
                     tf_definitions[file] = current_tf_definitions
                     definitions_raw[file] = current_definitions_raw
             else:
-                logging.debug(f'Failed to load {file} as is not a .json file, skipping')
+                logger.debug(f'Failed to load {file} as is not a .json file, skipping')
     return tf_definitions, definitions_raw
 
 
@@ -91,7 +93,7 @@ def get_entity_context(definitions, definitions_raw, definition_path, full_file_
     entity_context = {}
 
     if full_file_path not in definitions:
-        logging.debug(
+        logger.debug(
             f'Tried to look up file {full_file_path} in TF plan entity definitions, but it does not exist')
         return entity_context
 

--- a/checkov/terraform/tf_parser.py
+++ b/checkov/terraform/tf_parser.py
@@ -24,6 +24,8 @@ from checkov.terraform.modules.module_utils import load_or_die_quietly, safe_ind
     clean_parser_types, serialize_definitions
 from checkov.terraform.modules.module_objects import TFModule, TFDefinitionKey
 
+logger = logging.getLogger(__name__)
+
 
 def _filter_ignored_paths(root: str, paths: list[str], excluded_paths: list[str] | None) -> None:
     filter_ignored_paths(root, paths, excluded_paths)
@@ -158,7 +160,7 @@ class TFParser:
 
         force_final_module_load = False
         for i in range(0, 10):
-            logging.debug(f"Module load loop {i}")
+            logger.debug(f"Module load loop {i}")
             dir_filter(directory)
             has_more_modules = self._load_modules(
                 directory, module_loader_registry, dir_filter,
@@ -295,7 +297,7 @@ class TFParser:
 
                         self.external_modules_source_map[(source, version)] = content_path
                     except Exception as e:
-                        logging.warning(f"Unable to load module - source: {source}, version: {version}, error: {str(e)}")
+                        logger.warning(f"Unable to load module - source: {source}, version: {version}, error: {str(e)}")
 
         if all_module_definitions:
             deep_merge.merge(self.out_definitions, all_module_definitions)
@@ -375,8 +377,8 @@ class TFParser:
                 try:
                     module.add_blocks(block_type, blocks[block_type], file_path, source)
                 except Exception as e:
-                    logging.warning(f'Failed to add block {blocks[block_type]}. Error:')
-                    logging.warning(e, exc_info=False)
+                    logger.warning(f'Failed to add block {blocks[block_type]}. Error:')
+                    logger.warning(e, exc_info=False)
         return module, tf_definitions
 
     def get_file_key_with_nested_data(self, file: str, nested_data: Optional[dict[str, Any]]) -> str:
@@ -519,10 +521,10 @@ class TFParser:
     @staticmethod
     def is_valid_source(source: Any, module_call_name: str) -> bool:
         if not isinstance(source, str):
-            logging.debug(f"Skipping loading of {module_call_name} as source is not a string, it is: {source}")
+            logger.debug(f"Skipping loading of {module_call_name} as source is not a string, it is: {source}")
             return False
         elif source in ['./', '.']:
-            logging.debug(f"Skipping loading of {module_call_name} as source is the current dir")
+            logger.debug(f"Skipping loading of {module_call_name} as source is the current dir")
             return False
         return True
 
@@ -549,7 +551,7 @@ class TFParser:
     def get_content_path(module_loader_registry: ModuleLoaderRegistry, root_dir: str, source: str, version: str) -> Optional[str]:
         content = module_loader_registry.load(root_dir, source, version)
         if not content.loaded():
-            logging.info(f'Got no content for {source}:{version}')
+            logger.info(f'Got no content for {source}:{version}')
             return
         return content.path()
 

--- a/checkov/yaml_doc/base_registry.py
+++ b/checkov/yaml_doc/base_registry.py
@@ -12,8 +12,9 @@ from checkov.yaml_doc.enums import BlockType
 import jmespath
 
 STARTLINE_MARK = "__startline__"
-
 ENDLINE_MARK = "__endline__"
+
+logger = logging.getLogger(__name__)
 
 
 class Registry(BaseCheckRegistry):
@@ -171,7 +172,7 @@ class Registry(BaseCheckRegistry):
                     if skip["id"] == check.id and e[STARTLINE_MARK] <= skip['line_number'] <= e[ENDLINE_MARK]
                 ] or [{}]
             else:
-                logging.info(f"Unexpected entity type {type(entity)} for {entity}")
+                logger.info(f"Unexpected entity type {type(entity)} for {entity}")
 
             if runner_filter.should_run_check(check=check, report_type=self.report_type):
                 scanner = self._scanner.get(check.block_type, self._scan_yaml_document)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Don't use the root logger by default. This allows for proper control of the log messages, esp when a runner is called directly from other python code instead of being run standalone.

Already in various places, a named logger was used. This has now been applied everywhere. The only additional change is to make `logger` all lowercase (was mixed upper and lowercase), and remove an additional blank line between two UPPERCASE definitions (conforming it to another case with the same definitions involved).

No changes have been made regarding log level, log message (or how it's formatted), reformat of the code line, or the use of logger as a class property.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

Re local testing:
- Pipenv.lock is causing installation issues on mac/ma (arm1). Likely because of the CPython bits involved.
- Before/after the change lots of local test failures. As I only changed the logging aspect, focused on making sure those changes are not the cause of the failures.