### PR TITLE
chore: remove Image Referencer experimental flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,13 +279,13 @@ Run an SCA scan of packages in a repo:
 checkov -d . --framework sca_package --bc-api-key ... --repo-id <repo_id(arbitrary)>
 ```
 
-Run a scan of a directory with environment variables removing buffering, adding debug level logs, turning on image referencer:
+Run a scan of a directory with environment variables removing buffering, adding debug level logs:
 ```sh
-PYTHONUNBUFFERED=1 LOG_LEVEL=DEBUG CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING=TRUE checkov -d .
+PYTHONUNBUFFERED=1 LOG_LEVEL=DEBUG checkov -d .
 ```
 OR enable the environment variables for multiple runs
 ```sh
-export PYTHONUNBUFFERED=1 LOG_LEVEL=DEBUG CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING=TRUE
+export PYTHONUNBUFFERED=1 LOG_LEVEL=DEBUG
 checkov -d .
 ```
 

--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -242,37 +242,6 @@ class ImageReferencerMixin(Generic[_Definitions]):
                 report_type=report_type,
                 license_statuses=license_statuses,
             )
-        elif strtobool(os.getenv("CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING", "False")):
-            # experimental flag on running image referencers via local twistcli
-            from checkov.sca_image.runner import Runner as sca_image_runner
-
-            runner = sca_image_runner()
-
-            image_id = ImageReferencer.inspect(image.name)
-            if not image_id:
-                logging.info(f"(IR debug) No image with image.name={image.name} found. hence image_id={image_id}.")
-                return None
-
-            scan_result = runner.scan(image_id, dockerfile_path, runner_filter)
-            if scan_result is None:
-                return None
-
-            self.raw_report = scan_result
-            result = scan_result.get('results', [{}])[0]
-            rootless_file_path_to_report = f"{dockerfile_path} ({image.name} lines:{image.start_line}-" \
-                                           f"{image.end_line} ({image_id}))"
-
-            self._add_vulnerability_records(
-                report=report,
-                result=result,
-                check_class=check_class,
-                dockerfile_path=dockerfile_path,
-                rootless_file_path=rootless_file_path_to_report,
-                image_details=None,
-                runner_filter=runner_filter,
-                report_type=report_type,
-                license_statuses=license_statuses,
-            )
         else:
             logging.info(f"No cache hit for image {image.name}")
 

--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -16,7 +16,6 @@ from checkov.common.bridgecrew.vulnerability_scanning.integrations.docker_image_
     docker_image_scanning_integration
 from checkov.common.output.common import ImageDetails
 from checkov.common.output.report import Report, CheckType
-from checkov.common.runners.base_runner import strtobool
 from checkov.common.sca.commons import should_run_scan
 from checkov.common.sca.output import add_to_report_sca_data, get_license_statuses_async
 from checkov.common.typing import _LicenseStatus

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -284,25 +284,6 @@ class Runner(PackageRunner):
                                            f"{image.end_line} ({image_id}))"
             return self.get_report_from_scan_result(result, dockerfile_path, rootless_file_path_to_report,
                                                     image_details, runner_filter)
-
-        elif strtobool(os.getenv("CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING", "False")):
-            # experimental flag on running image referencers via local twistcli
-            image_id = ImageReferencer.inspect(image.name)
-            if not image_id:
-                logging.info(f"Unable to extract image id from {image.name}")
-                return Report(self.check_type)
-            scan_result = self.scan(image_id, dockerfile_path, runner_filter)
-            if scan_result is None:
-                report = Report(self.check_type)
-                report.set_error_status(ErrorStatus.ERROR)
-                return report
-
-            self.raw_report = scan_result
-            result = scan_result.get('results', [{}])[0]
-            rootless_file_path_to_report = f"{dockerfile_path} ({image.name} lines:{image.start_line}-" \
-                                           f"{image.end_line} ({image_id}))"
-            return self.get_report_from_scan_result(result, dockerfile_path, rootless_file_path_to_report, None,
-                                                    runner_filter)
         else:
             logging.info(f"No cache hit for image {image.name}")
 

--- a/docs/6.Contribution/Implementing ImageReferencer.md
+++ b/docs/6.Contribution/Implementing ImageReferencer.md
@@ -19,7 +19,6 @@ and the derived class: `checkov/github_actions/runner.py`
 
 ## Example CLI command 
 ```bash
-export CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING=True # notice this feature flag will be removed in the future
 checkov -d /checkov/integration_tests/example_workflow_file/.github/workflows/ --framework sca_image --bc-api-key SOME_TOKEN
 ```
 

--- a/integration_tests/prepare_data.sh
+++ b/integration_tests/prepare_data.sh
@@ -33,7 +33,6 @@ if [[ "$2" == "3.7" && "$1" == "ubuntu-latest" ]]
 then
   pipenv run checkov -s -f terragoat/terraform/aws/s3.tf --bc-api-key $BC_KEY > checkov_report_s3_singlefile_api_key_terragoat.txt
   pipenv run checkov -s -d terragoat/terraform/azure/ --bc-api-key $BC_KEY > checkov_report_azuredir_api_key_terragoat.txt
-  export CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING=True
   echo "running image referencing"
   pipenv run checkov -s -d integration_tests/example_workflow_file/.github/workflows/ -o json --bc-api-key $BC_KEY --include-all-checkov-policies > checkov_report_workflow_cve.json
   pipenv run checkov -s -d integration_tests/example_workflow_file/bitbucket/ -o json --bc-api-key $BC_KEY --include-all-checkov-policies > checkov_report_bitbucket_pipelines_cve.json

--- a/integration_tests/run_integration_tests.sh
+++ b/integration_tests/run_integration_tests.sh
@@ -24,7 +24,6 @@ prepare_data () {
 
   python checkov/main.py -s -f repositories/terragoat/terraform/aws/s3.tf --bc-api-key $BC_KEY > checkov_report_s3_singlefile_api_key_terragoat.txt
   python checkov/main.py -s -d repositories/terragoat/terraform/azure/ --bc-api-key $BC_KEY > checkov_report_azuredir_api_key_terragoat.txt
-#  export CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING=True #cant run it on M1 mac, docker image node:14.16 needed
   python checkov/main.py -s -d integration_tests/example_workflow_file/.github/workflows/ -o json --bc-api-key $BC_KEY --include-all-checkov-policies > checkov_report_workflow_cve.json
   python checkov/main.py -s -d integration_tests/example_workflow_file/bitbucket/ -o json --bc-api-key $BC_KEY --include-all-checkov-policies > checkov_report_bitbucket_pipelines_cve.json
   python checkov/main.py --list --bc-api-key $BC_KEY --output-bc-ids > checkov_checks_list.txt


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- removed the env var `CHECKOV_EXPERIMENTAL_IMAGE_REFERENCING` and the code parts related to it, because we mainly leverage our cache for the results

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
