### PR TITLE
feat(gitlab_ci): fix wrong resource in gitlab-ci

### DIFF
--- a/checkov/gitlab_ci/common/resource_id_utils.py
+++ b/checkov/gitlab_ci/common/resource_id_utils.py
@@ -13,9 +13,7 @@ def generate_resource_key_recursive(conf: dict[str, Any] | list[str] | str, key:
         if isinstance(value, dict) and value[START_LINE] <= start_line <= end_line <= value[END_LINE]:
             next_key = f'{key}.{k}' if key else k
             return generate_resource_key_recursive(value, next_key, start_line, end_line)
-        if isinstance(value, list):
-            return f'{key}.{k}' if key else k
-        if isinstance(value, str):
-            return key
+        if isinstance(value, list) or isinstance(value, str):
+            continue
 
     return key

--- a/tests/gitlab_ci/resources/resource_images/.gitlab-ci.yml
+++ b/tests/gitlab_ci/resources/resource_images/.gitlab-ci.yml
@@ -1,0 +1,21 @@
+dummy_list:
+  - first
+  - second
+  - third
+
+prebuild:
+  image: "nginx: 14.6"
+  script: "ant build ."
+
+build:
+  image:
+    name: "docker:latest"
+  script: SKIP
+
+
+deploy:
+  before_script:
+    bundle exec rake spec
+  services:
+    - postgresql:14.3
+    - redis:latest

--- a/tests/gitlab_ci/test_runner.py
+++ b/tests/gitlab_ci/test_runner.py
@@ -21,7 +21,7 @@ class TestRunnerValid(unittest.TestCase):
         )
         self.assertEqual(len(report.failed_checks), 5)
         self.assertEqual(report.parsing_errors, [])
-        self.assertEqual(len(report.passed_checks), 7)
+        self.assertEqual(len(report.passed_checks), 9)
         self.assertEqual(report.skipped_checks, [])
         report.print_console()
 
@@ -55,8 +55,25 @@ class TestRunnerValid(unittest.TestCase):
         )
         self.assertEqual(len(report.failed_checks), 0)
         self.assertEqual(report.parsing_errors, [])
+        self.assertEqual(len(report.passed_checks), 8)
+        self.assertEqual(report.skipped_checks, [])
+
+    def test_runner_image_resources(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = os.path.join(current_dir, "resources/resource_images")
+        runner = Runner()
+        report = runner.run(
+            root_folder=valid_dir_path,
+            runner_filter=RunnerFilter(framework=['gitlab_ci'], checks=['CKV_GITLABCI_3'])
+        )
+        self.assertEqual(len(report.failed_checks), 0)
+        self.assertEqual(report.parsing_errors, [])
         self.assertEqual(len(report.passed_checks), 4)
         self.assertEqual(report.skipped_checks, [])
+        self.assertEqual(report.passed_checks[0].resource, 'prebuild')
+        self.assertEqual(report.passed_checks[1].resource, 'build.image')
+        self.assertEqual(report.passed_checks[2].resource, 'deploy')
+        self.assertEqual(report.passed_checks[3].resource, 'deploy')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes wrong resource given to gitlab_ci findings.
We now skip string/list findings in resource generation of gitlab_ci and require only jobs(i.e. dicts) to be processed.
Note - multiple images per resource are not handled in this PR and will need to be handled in a future task. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
