### PR TITLE
feat(terraform): Support the -1 protocol on SG checks

### DIFF
--- a/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
@@ -73,11 +73,12 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
     def contains_violation(self, conf: dict[str, list[Any]]) -> bool:
         from_port = force_int(force_list(conf.get('from_port', [{-1}]))[0])
         to_port = force_int(force_list(conf.get('to_port', [{-1}]))[0])
-
+        protocol = conf.get('protocol', [])[0]
         if from_port == 0 and to_port == 0:
             to_port = 65535
 
-        if from_port is not None and to_port is not None and (from_port <= self.port <= to_port):
+        if from_port is not None and to_port is not None and (from_port <= self.port <= to_port) or (
+                protocol == '-1' and from_port == 0 and to_port == 65535):
             if conf.get('cidr_blocks'):
                 conf_cidr_blocks = conf.get('cidr_blocks', [[]])
             else:

--- a/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
@@ -73,7 +73,7 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
     def contains_violation(self, conf: dict[str, list[Any]]) -> bool:
         from_port = force_int(force_list(conf.get('from_port', [{-1}]))[0])
         to_port = force_int(force_list(conf.get('to_port', [{-1}]))[0])
-        protocol = conf.get('protocol', [])[0]
+        protocol = conf.get('protocol', [None])[0]
         if from_port == 0 and to_port == 0:
             to_port = 65535
 

--- a/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsSecurityGroupUnrestrictedIngress.py
@@ -73,7 +73,7 @@ class AbsSecurityGroupUnrestrictedIngress(BaseResourceCheck):
     def contains_violation(self, conf: dict[str, list[Any]]) -> bool:
         from_port = force_int(force_list(conf.get('from_port', [{-1}]))[0])
         to_port = force_int(force_list(conf.get('to_port', [{-1}]))[0])
-        protocol = conf.get('protocol', [None])[0]
+        protocol = force_list(conf.get('protocol', [None]))[0]
         if from_port == 0 and to_port == 0:
             to_port = 65535
 

--- a/tests/terraform/checks/resource/aws/example_SecurityGroupUnrestrictedIngressAny/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SecurityGroupUnrestrictedIngressAny/main.tf
@@ -68,6 +68,16 @@ resource "aws_security_group_rule" "fail" {
   type              = "ingress"
 }
 
+resource "aws_security_group_rule" "fail2" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = "sg-123456"
+  description = "Test unfettered access"
+  type              = "ingress"
+}
+
 resource "aws_vpc_security_group_ingress_rule" "fail" {
   security_group_id = aws_security_group.example.id
 

--- a/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngressAny.py
+++ b/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngressAny.py
@@ -27,6 +27,7 @@ class TestSecurityGroupUnrestrictedIngressAny(unittest.TestCase):
             "aws_security_group.fail",
             "aws_security_group_rule.fail",
             "aws_vpc_security_group_ingress_rule.fail"
+            "aws_security_group_rule.fail2"
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}

--- a/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngressAny.py
+++ b/tests/terraform/checks/resource/aws/test_SecurityGroupUnrestrictedIngressAny.py
@@ -26,7 +26,7 @@ class TestSecurityGroupUnrestrictedIngressAny(unittest.TestCase):
         failing_resources = {
             "aws_security_group.fail",
             "aws_security_group_rule.fail",
-            "aws_vpc_security_group_ingress_rule.fail"
+            "aws_vpc_security_group_ingress_rule.fail",
             "aws_security_group_rule.fail2"
         }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Support the "-1" protocol of an ingress rule (according to https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html), which enforces the port range to be all ports 


*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
