### PR TITLE
fix(general): skip scanning invalid resources

### DIFF
--- a/checkov/common/checks/base_check_registry.py
+++ b/checkov/common/checks/base_check_registry.py
@@ -109,10 +109,13 @@ class BaseCheckRegistry:
         runner_filter: RunnerFilter,
         report_type: Optional[str] = None  # allow runners like TF plan to override the type while using the same registry
     ) -> Dict[BaseCheck, _CheckResult]:
-
-        (entity_type, entity_name, entity_configuration) = self.extract_entity_details(entity)
-
         results: Dict[BaseCheck, _CheckResult] = {}
+
+        try:
+            (entity_type, entity_name, entity_configuration) = self.extract_entity_details(entity)
+        except Exception:
+            logging.debug(f"Error in entity details extraction for file {scanned_file}", exc_info=True)
+            return results
 
         if not isinstance(entity_configuration, dict):
             return results

--- a/tests/arm/runner/resources/invalid.json
+++ b/tests/arm/runner/resources/invalid.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "vmName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the VM."
+            }
+        },
+        "resources": [
+            {
+                "apiVersion": "2019-03-01",
+                "type": "Microsoft.Compute/virtualMachines",
+                "name": "[parameters('vmName')]",
+                "location": "[parameters('region')]",
+                "tags": "[parameters('deployTags')]",
+                "properties": {
+                    "hardwareProfile": {
+                        "vmSize": "[parameters('vmSize')]"
+                    },
+                    "osProfile": {
+                        "computerName": "[parameters('vmName')]",
+                        "adminUsername": "[parameters('adminUsername')]",
+                        "adminPassword": "[parameters('adminPassword')]"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/arm/runner/test_runner.py
+++ b/tests/arm/runner/test_runner.py
@@ -14,6 +14,8 @@ from checkov.runner_filter import RunnerFilter
 from checkov.arm.runner import Runner
 from checkov.arm.registry import arm_resource_registry, arm_parameter_registry
 
+RESOURCES_DIR = Path(__file__).parent / "resources"
+
 
 class TestRunnerValid(unittest.TestCase):
 
@@ -303,6 +305,22 @@ class TestRunnerValid(unittest.TestCase):
 
         all_checks = report.failed_checks + report.passed_checks
         self.assertTrue(any(c.check_id == custom_check_id for c in all_checks))
+
+    def test_invalid_file_raises_no_exception(self):
+        # given
+        test_file_path = RESOURCES_DIR / "invalid.json"
+
+        # when
+        report = Runner().run(files=[str(test_file_path)])
+
+        # then
+        summary = report.get_summary()
+
+        assert summary["passed"] == 0
+        assert summary["failed"] == 0
+        assert summary["skipped"] == 0
+        assert summary["parsing_errors"] == 0
+
 
     def tearDown(self):
         arm_resource_registry.checks = self.orig_checks


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added a try/except around the `extract_entity_details` call in the scanning step to be more resilient against kind of broken templates

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
