### PR TITLE
fix(general): handle Ellipsis in CustomJSONEncoder

### DIFF
--- a/checkov/common/util/json_utils.py
+++ b/checkov/common/util/json_utils.py
@@ -30,6 +30,8 @@ class CustomJSONEncoder(json.JSONEncoder):
             return o.__dict__
         elif isinstance(o, type_of_function):
             return str(o)
+        elif o == Ellipsis:
+            return "..."
         else:
             return json.JSONEncoder.default(self, o)
 

--- a/tests/common/utils/test_json_utils.py
+++ b/tests/common/utils/test_json_utils.py
@@ -15,9 +15,11 @@ from checkov.common.util.json_utils import CustomJSONEncoder
         ({"key": datetime.now()}),
         ({"key": Tree("data", ["child_1", "child_2"])}),
         ({"key": lambda x: x}),
+        ({"key": Ellipsis})
     ],
-    ids=["set", "date", "lark_tree", "function"],
+    ids=["set", "date", "lark_tree", "function", "str"],
 )
+
 def test_custom_json_encoder(input_dict: Dict[str, Any]):
     # when
     result = json.dumps(input_dict, cls=CustomJSONEncoder)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

handle a case where `CustomJSONEncoder` is trying to dump an `Ellipsis` python object

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
