### PR TITLE
feat(dockerfile): Add tdnf support for CKV2_DOCKER_9

### DIFF
--- a/checkov/dockerfile/checks/graph_checks/RunYumNoGpgCheck.yaml
+++ b/checkov/dockerfile/checks/graph_checks/RunYumNoGpgCheck.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: "CKV2_DOCKER_9"
-  name: "Ensure that packages with untrusted or missing GPG signatures are not used by dnf or yum via the '--nogpgcheck' option"
+  name: "Ensure that packages with untrusted or missing GPG signatures are not used by dnf, tdnf, or yum via the '--nogpgcheck' option"
   category: "APPLICATION_SECURITY"
 definition:
     cond_type: attribute
@@ -8,4 +8,4 @@ definition:
       - RUN
     attribute: value
     operator: not_regex_match
-    value: ".*(((dnf)|(yum))[^\\|&;]*\\s+--nogpgcheck).*"
+    value: ".*(((t?dnf)|(yum))[^\\|&;]*\\s+--nogpgcheck).*"

--- a/tests/dockerfile/graph_builder/checks/resources/RunYumNoGpgCheck/expected.yaml
+++ b/tests/dockerfile/graph_builder/checks/resources/RunYumNoGpgCheck/expected.yaml
@@ -7,6 +7,10 @@ pass:
   - 'pass/Dockerfile.RUN'
   - 'pass/Dockerfile.RUN'
   - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
+  - 'pass/Dockerfile.RUN'
 fail:
   - 'fail/Dockerfile.yum.RUN'
   - 'fail/Dockerfile.yum.RUN'
@@ -18,5 +22,11 @@ fail:
   - 'fail/Dockerfile.dnf.RUN'
   - 'fail/Dockerfile.dnf.RUN'
   - 'fail/Dockerfile.dnf.RUN'
+  - 'fail/Dockerfile.tdnf.RUN'
+  - 'fail/Dockerfile.tdnf.RUN'
+  - 'fail/Dockerfile.tdnf.RUN'
+  - 'fail/Dockerfile.tdnf.RUN'
+  - 'fail/Dockerfile.tdnf.RUN'
+  - 'fail/Dockerfile.wilderness.RUN'
 evaluated_keys:
   - 'value'

--- a/tests/dockerfile/graph_builder/checks/resources/RunYumNoGpgCheck/fail/Dockerfile.tdnf
+++ b/tests/dockerfile/graph_builder/checks/resources/RunYumNoGpgCheck/fail/Dockerfile.tdnf
@@ -1,0 +1,10 @@
+FROM fedora:rawhide
+RUN tdnf install -y --nogpgcheck python3
+RUN tdnf --nogpgcheck install -y python3
+RUN tdnf \
+    --nogpgcheck \
+    install python3
+RUN tdnf \
+    install -y python3 \
+    --nogpgcheck
+RUN echo "prodsec" && tdnf --nogpgcheck -y install python3

--- a/tests/dockerfile/graph_builder/checks/resources/RunYumNoGpgCheck/fail/Dockerfile.wilderness
+++ b/tests/dockerfile/graph_builder/checks/resources/RunYumNoGpgCheck/fail/Dockerfile.wilderness
@@ -1,0 +1,6 @@
+FROM openjdk:ship
+
+RUN tdnf -y update && \
+    tdnf -y upgrade && \
+    tdnf install -y ${package} shadow-utils --nogpgcheck && \
+    tdnf clean all

--- a/tests/dockerfile/graph_builder/checks/resources/RunYumNoGpgCheck/pass/Dockerfile
+++ b/tests/dockerfile/graph_builder/checks/resources/RunYumNoGpgCheck/pass/Dockerfile
@@ -1,13 +1,19 @@
 FROM fedora:rawhide
 RUN yum install python3
 RUN dnf install -y python3
+RUN tdnf install python3
 RUN yum install python3 | grep "--nogpgcheck"
 RUN dnf install python3 | grep "--nogpgcheck"
+RUN tdnf install python3 | grep "--nogpgcheck"
 RUN yum update && yum upgrade \
     python3
 RUN dnf update && dnf upgrade \
     python3
+RUN tdnf update && tdnf upgrade \
+    python3
 RUN yum update &&\
     echo "--nogpgcheck"
 RUN dnf update ||\
+    echo "--nogpgcheck"
+RUN tdnf update ||\
     echo "--nogpgcheck"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Enhance `CKV2_DOCKER_9` to also support the `tdnf` package manager, a "yum-like" package manager which also supports the [--nogpgcheck](https://github.com/vmware/tdnf/blob/732dbde4e2a21722be71ee2d5ccf99e63c2d307c/tools/cli/lib/help.c) option.

## New/Edited policies
CKV2_DOCKER_9 - edit

### Description
CKV2_DOCKER_9
The `--nogpgcheck` option for dnf, tdnf, and yum allows packages without gpg signatures or with invalid gpg signatures to be installed.

### Fix
Inspect, review, and if approved, import the required public key with `rpm import`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
