### PR TITLE
fix(terraform): stop evaluating a string ... to the Ellipsis object

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -333,6 +333,9 @@ def evaluate(input_str: str) -> Any:
     if "__" in input_str:
         logging.debug(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")
         return input_str
+    if input_str == "...":
+        # don't create an Ellipsis object
+        return input_str
     evaluated = eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
     return evaluated if not isinstance(evaluated, str) else remove_unicode_null(evaluated)
 

--- a/tests/terraform/graph/variable_rendering/test_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_renderer.py
@@ -427,3 +427,15 @@ class TestRenderer(TestCase):
         resources_vertex = list(filter(lambda v: v.block_type == BlockType.RESOURCE, local_graph.vertices))
         assert resources_vertex[0].attributes.get('protocol')[0] == 'http'
         assert resources_vertex[0].attributes.get('endpoint')[0] == 'http://www.example.com'
+
+    def test_skip_rendering_unsupported_values(self):
+        # given
+        resource_path = Path(TEST_DIRNAME) / "test_resources/skip_renderer"
+
+        # when
+        graph_manager = TerraformGraphManager('m', ['m'])
+        local_graph, _ = graph_manager.build_graph_from_source_directory(str(resource_path), render_variables=True)
+
+        # then
+        local_b = next(vertex for vertex in local_graph.vertices if vertex.block_type == BlockType.LOCALS and vertex.name == "b")
+        assert local_b.attributes["b"] == ["..."]  # not Ellipsis object

--- a/tests/terraform/graph/variable_rendering/test_resources/skip_renderer/ellipsis.tf
+++ b/tests/terraform/graph/variable_rendering/test_resources/skip_renderer/ellipsis.tf
@@ -1,0 +1,8 @@
+
+variable "a" {
+  default = "..."
+}
+
+locals {
+  b = var.a
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- stops evaluating a string `...` to the Python Ellipsis object

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
