### PR TITLE
fix(terraform): stop handle resource `for_each` as dynamic attribute

### DIFF
--- a/checkov/terraform/graph_builder/graph_components/blocks.py
+++ b/checkov/terraform/graph_builder/graph_components/blocks.py
@@ -56,7 +56,10 @@ class TerraformBlock(Block):
         self.module_connections.setdefault(attribute_key, []).append(vertex_id)
 
     def extract_additional_changed_attributes(self, attribute_key: str) -> List[str]:
-        if self.has_dynamic_block:
+        # if the `attribute_key` starts with a `for_each.` we know the attribute can't be a dynamic attribute as it
+        # represents the for_each of the block, so we don't need extract dynamic changed attributes
+        # Fix: https://github.com/bridgecrewio/checkov/issues/4324
+        if self.has_dynamic_block and not attribute_key.startswith('for_each'):
             return self._extract_dynamic_changed_attributes(attribute_key)
         return super().extract_additional_changed_attributes(attribute_key)
 

--- a/tests/terraform/graph/graph_builder/test_graph_builder.py
+++ b/tests/terraform/graph/graph_builder/test_graph_builder.py
@@ -322,3 +322,11 @@ class TestGraphBuilder(TestCase):
         assert resource_2.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS) == 'aws_s3_bucket.example'
         provider = self.get_vertex_by_name_and_type(local_graph, BlockType.PROVIDER, 'aws.test_provider')
         assert provider.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS) == 'aws.test_provider'
+
+    # Related to https://github.com/bridgecrewio/checkov/issues/4324
+    def test_build_graph_for_each_with_variables_and_dynamic_not_crash(self):
+        resources_dir = os.path.join(TEST_DIRNAME, '../resources/for_each')
+
+        graph_manager = TerraformGraphManager(db_connector=NetworkxConnector())
+        # Shouldn't throw exception
+        graph_manager.build_graph_from_source_directory(resources_dir)

--- a/tests/terraform/graph/resources/for_each/main.tf
+++ b/tests/terraform/graph/resources/for_each/main.tf
@@ -1,0 +1,13 @@
+variable "bar" {
+  default = "foo"
+}
+
+resource "null_resource" "this" {
+  for_each = {
+    foobar = var.bar
+  }
+  dynamic "trigger" {
+    for_each = {}
+    content {}
+  }
+}


### PR DESCRIPTION
## Description

This commit fixes an issue where Checkov crashes when a resource has the following fields:
* A `for_each` with at least one variable like `for_each = toset([var.bar])`
* A dynamic block

Check the test resource file `main.tf` that comes with the commit if you want more detail.

Checkov crashes with the following error:

```python
Error
Traceback (most recent call last):
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/tests/terraform/graph/graph_builder/test_graph_builder.py", line 332, in test_build_graph_for_each_with_variables_and_dynamic_not_crash
    graph_manager.build_graph_from_source_directory(resources_dir)
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/checkov/terraform/graph_manager.py", line 48, in build_graph_from_source_directory
    local_graph.build_graph(render_variables=render_variables)
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/checkov/terraform/graph_builder/local_graph.py", line 78, in build_graph
    renderer.render_variables_from_local_graph()
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/checkov/common/graph/graph_builder/variable_rendering/renderer.py", line 34, in render_variables_from_local_graph
    self._render_variables_from_edges()
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/checkov/common/graph/graph_builder/variable_rendering/renderer.py", line 75, in _render_variables_from_edges
    self._edge_evaluation_task([edge_group])
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/checkov/common/graph/graph_builder/variable_rendering/renderer.py", line 109, in _edge_evaluation_task
    self.evaluate_vertex_attribute_from_edge(inner_edges)
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/checkov/terraform/graph_builder/variable_rendering/renderer.py", line 143, in evaluate_vertex_attribute_from_edge
    self.update_evaluated_value(
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/checkov/terraform/graph_builder/variable_rendering/renderer.py", line 265, in update_evaluated_value
    self.local_graph.update_vertex_attribute(
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/checkov/terraform/graph_builder/local_graph.py", line 466, in update_vertex_attribute
    self.vertices[vertex_index].update_attribute(
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/checkov/common/graph/graph_builder/graph_components/blocks.py", line 173, in update_attribute
    additional_changed_attributes = self.extract_additional_changed_attributes(key)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/checkov/terraform/graph_builder/graph_components/blocks.py", line 64, in extract_additional_changed_attributes
    return self._extract_dynamic_changed_attributes(attribute_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/antoine.rouaze/src/github.com/bridgecrewio/checkov/checkov/terraform/graph_builder/graph_components/blocks.py", line 76, in _extract_dynamic_changed_attributes
    dynamic_block_name = dynamic_content_key_parts[-1]
                         ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^
IndexError: list index out of range
```

The issue occurs because the graph builder tries to extract dynamic updated attributes from the resource `for_each`. As it's not a dynamic block, the attribute doesn't have the proper depth (`for_each.my_var` instead of `dynamic.for_each.my_var`), so it fails with an outbound index error.

The commit fixes that by skipping the method `_extract_dynamic_changed_attributes` if the current attribute is the `for_each` of the resource. I might not have placed the precondition in the right place as I don't know Checkov very well, so feel free to tell me to move it—the same thing with the test.

fixes: #4324

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
