### PR TITLE
feat(terraform): support variable rendering for default objects in vars

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
@@ -16,7 +16,8 @@ T = TypeVar("T", str, int, bool)
 # %{ some_text }
 DIRECTIVE_EXPR = re.compile(r"\%\{([^\}]*)\}")
 
-COMPARE_REGEX = re.compile(r"^(?P<a>.+?)\s*(?P<operator>==|!=|>=|>|<=|<|&&|\|\|)\s*(?P<b>.+)$")
+# exclude "']" one the right side of the compare via (?!']), this can happen with a base64 encoded string
+COMPARE_REGEX = re.compile(r"^(?P<a>.+?)\s*(?P<operator>==|!=|>=|>|<=|<|&&|\|\|)\s*(?P<b>(?!']).+)$")
 CHECKOV_RENDER_MAX_LEN = force_int(os.getenv("CHECKOV_RENDER_MAX_LEN", "10000"))
 
 

--- a/checkov/terraform/graph_builder/variable_rendering/renderer.py
+++ b/checkov/terraform/graph_builder/variable_rendering/renderer.py
@@ -190,7 +190,7 @@ class TerraformVariableRenderer(VariableRenderer):
                 default_val = self.get_default_placeholder_value(var_type)
             value = None
             if isinstance(default_val, dict):
-                value = find_in_dict(input_dict=default_val, key_path="/".join(key_path[1:]))
+                value = find_in_dict(input_dict=default_val, key_path=create_variable_key_path(key_path))
             elif (
                 isinstance(var_type, str)
                 and var_type.startswith("${object")
@@ -577,3 +577,12 @@ def get_lookup_value(block_content, dynamic_argument) -> str:
     elif 'True' in block_content[dynamic_argument]:
         lookup_value = 'true'
     return lookup_value
+
+
+def create_variable_key_path(key_path: list[str]) -> str:
+    """Returns the key_path without the var prefix
+
+    ex.
+    ["var", "properties", "region"] -> "properties/region"
+    """
+    return "/".join(key_path[1:])

--- a/checkov/terraform/graph_builder/variable_rendering/renderer.py
+++ b/checkov/terraform/graph_builder/variable_rendering/renderer.py
@@ -17,6 +17,7 @@ from lark.tree import Tree
 from checkov.common.graph.graph_builder import Edge
 from checkov.common.graph.graph_builder.utils import join_trimmed_strings
 from checkov.common.graph.graph_builder.variable_rendering.renderer import VariableRenderer
+from checkov.common.util.data_structures_utils import find_in_dict
 from checkov.common.util.type_forcers import force_int
 from checkov.common.graph.graph_builder.graph_components.attribute_names import CustomAttributes, reserved_attribute_names
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
@@ -189,7 +190,7 @@ class TerraformVariableRenderer(VariableRenderer):
                 default_val = self.get_default_placeholder_value(var_type)
             value = None
             if isinstance(default_val, dict):
-                value = self.extract_value_from_vertex(key_path, default_val)
+                value = find_in_dict(input_dict=default_val, key_path="/".join(key_path[1:]))
             elif (
                 isinstance(var_type, str)
                 and var_type.startswith("${object")
@@ -201,7 +202,7 @@ class TerraformVariableRenderer(VariableRenderer):
                         value = self.extract_value_from_vertex(key_path, default_val_eval)
                 except Exception:
                     logging.debug(f"cant evaluate this rendered value: {default_val}")
-            return default_val if not value else value
+            return default_val if value is None else value
         if attributes.get(CustomAttributes.BLOCK_TYPE) == BlockType.OUTPUT:
             return attributes.get("value")
         return None

--- a/tests/terraform/checks/provider/panos/resources/api_key/fail1.tf
+++ b/tests/terraform/checks/provider/panos/resources/api_key/fail1.tf
@@ -1,3 +1,3 @@
 provider "panos" {
-  api_key = var.nested_var.apikey
+  api_key = var.nested_var.base64_enc_apikey
 }

--- a/tests/terraform/checks/provider/panos/resources/api_key/variables.tf
+++ b/tests/terraform/checks/provider/panos/resources/api_key/variables.tf
@@ -1,5 +1,5 @@
 variable "nested_var" {
   default = {
-    apikey = "LUFRPT1yWFdyMFg5NlZxZ1ViU2ZhMTh6aGVEbDJ1UFU9ck9vc2tGcmlHV0tDbWRFa2cxcGUxSU8wMlVjaE9ReU0yYWN5SU1rL2pEOGhDcE50WEt5ABlHQWZoTm8xNG1SQQ=="
+    base64_enc_apikey = "LUFRPT1yWFdyMFg5NlZxZ1ViU2ZhMTh6aGVEbDJ1UFU9ck9vc2tGcmlHV0tDbWRFa2cxcGUxSU8wMlVjaE9ReU0yYWN5SU1rL2pEOGhDcE50WEt5ABlHQWZoTm8xNG1SQQ=="
   }
 }

--- a/tests/terraform/checks/provider/panos/resources/api_key/variables.tf
+++ b/tests/terraform/checks/provider/panos/resources/api_key/variables.tf
@@ -1,5 +1,5 @@
 variable "nested_var" {
   default = {
-    apikey = ""
+    apikey = "LUFRPT1yWFdyMFg5NlZxZ1ViU2ZhMTh6aGVEbDJ1UFU9ck9vc2tGcmlHV0tDbWRFa2cxcGUxSU8wMlVjaE9ReU0yYWN5SU1rL2pEOGhDcE50WEt5ABlHQWZoTm8xNG1SQQ=="
   }
 }

--- a/tests/terraform/graph/variable_rendering/test_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_renderer.py
@@ -439,3 +439,20 @@ class TestRenderer(TestCase):
         # then
         local_b = next(vertex for vertex in local_graph.vertices if vertex.block_type == BlockType.LOCALS and vertex.name == "b")
         assert local_b.attributes["b"] == ["..."]  # not Ellipsis object
+
+    def test_default_map_value(self):
+        # given
+        resource_path = Path(TEST_DIRNAME) / "test_resources/default_map_value"
+
+        # when
+        graph_manager = TerraformGraphManager('m', ['m'])
+        local_graph, _ = graph_manager.build_graph_from_source_directory(str(resource_path), render_variables=True)
+
+        # then
+        key_vault = next(vertex for vertex in local_graph.vertices if vertex.block_type == BlockType.RESOURCE and vertex.name == "azurerm_key_vault.this")
+        assert key_vault.attributes["network_acls"] == {
+            "bypass": "AzureServices",
+            "default_action": "Deny",
+            "ip_rules": [],
+            "virtual_network_subnet_ids": []
+        }

--- a/tests/terraform/graph/variable_rendering/test_resources/default_map_value/main.tf
+++ b/tests/terraform/graph/variable_rendering/test_resources/default_map_value/main.tf
@@ -1,0 +1,30 @@
+resource "azurerm_key_vault" "this" {
+    name = var.kv_properties.name
+    network_acls {
+        bypass = var.kv_properties.nacl.bypass
+        default_action = var.kv_properties.nacl.default_action
+        ip_rules = var.kv_properties.nacl.ip_rules
+        virtual_network_subnet_ids = var.kv_properties.nacl.virtual_network_subnet_ids
+    }
+}
+
+variable "kv_properties" {
+  type = object({
+    name = string
+    nacl = object({
+        bypass = string
+        default_action = string
+        ip_rules = list(string)
+        virtual_network_subnet_ids = list(string)
+    })
+  })
+  default = {
+    name = "checkov_test"
+    nacl = {
+      bypass = "AzureServices"
+      default_action = "Deny"
+      ip_rules = []
+      virtual_network_subnet_ids = []
+    }
+  }
+}

--- a/tests/terraform/graph/variable_rendering/test_string_evaluation.py
+++ b/tests/terraform/graph/variable_rendering/test_string_evaluation.py
@@ -464,6 +464,11 @@ class TestTerraformEvaluation(TestCase):
         expected = "{for val in ['k', 'v'] : val.name :> true}"
         self.assertEqual(expected, evaluate_terraform(input_str))
 
+    def test_base64_value(self):
+        input_str = "\"['dGVzdA==']\""
+        expected = ["dGVzdA=="]
+        self.assertEqual(expected, evaluate_terraform(input_str))
+
 
 @pytest.mark.parametrize(
     "origin_str,str_to_replace,new_value,expected",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- adds support for default object values in variables
- fixes an issue with base64 encode default values bing treated as an equal condition 

Fixes #4395

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
