### PR TITLE
feat(terraform): AWS ensure Sagemaker Notebook users are not Root

### DIFF
--- a/checkov/terraform/checks/resource/aws/SagemakerNotebookRoot.py
+++ b/checkov/terraform/checks/resource/aws/SagemakerNotebookRoot.py
@@ -1,0 +1,26 @@
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class SagemakerNotebookRoot(BaseResourceValueCheck):
+    def __init__(self):
+        """
+        NIST.800-53.r5 AC-2(1), NIST.800-53.r5 AC-3(15), NIST.800-53.r5 AC-3(7), NIST.800-53.r5 AC-6, NIST.800-53.r5
+        AC-6(10), NIST.800-53.r5 AC-6(2)
+        """
+        name = "Ensure SageMaker Users should not have root access to SageMaker notebook instances"
+        id = "CKV_AWS_307"
+        supported_resources = ['aws_sagemaker_notebook_instance']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
+                         missing_block_result=CheckResult.FAILED)
+
+    def get_inspected_key(self):
+        return 'root_access'
+
+    def get_expected_value(self):
+        return "Disabled"
+
+
+check = SagemakerNotebookRoot()

--- a/tests/terraform/checks/resource/aws/example_SagemakerNotebookRoot/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SagemakerNotebookRoot/main.tf
@@ -1,0 +1,32 @@
+resource "aws_sagemaker_notebook_instance" "fail" {
+  name                    = "my-notebook-instance"
+  role_arn                = aws_iam_role.role.arn
+  instance_type           = "ml.t2.medium"
+  default_code_repository = aws_sagemaker_code_repository.example.code_repository_name
+  root_access = "Enabled"
+  tags = {
+    Name = "foo"
+  }
+}
+
+resource "aws_sagemaker_notebook_instance" "fail2" {
+  name                    = "my-notebook-instance"
+  role_arn                = aws_iam_role.role.arn
+  instance_type           = "ml.t2.medium"
+  default_code_repository = aws_sagemaker_code_repository.example.code_repository_name
+  tags = {
+    Name = "foo"
+  }
+}
+
+resource "aws_sagemaker_notebook_instance" "pass" {
+  name                    = "my-notebook-instance"
+  role_arn                = aws_iam_role.role.arn
+  instance_type           = "ml.t2.medium"
+  subnet_id = aws_subnet.pike.id
+  default_code_repository = aws_sagemaker_code_repository.example.code_repository_name
+  root_access = "Disabled"
+  tags = {
+    Name = "foo"
+  }
+}

--- a/tests/terraform/checks/resource/aws/test_SagemakerNotebookRoot.py
+++ b/tests/terraform/checks/resource/aws/test_SagemakerNotebookRoot.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.SagemakerNotebookRoot import check
+from checkov.terraform.runner import Runner
+
+
+class TestSagemakerNotebookRoot(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_SagemakerNotebookRoot"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_sagemaker_notebook_instance.pass",
+        }
+        failing_resources = {
+            "aws_sagemaker_notebook_instance.fail",
+            "aws_sagemaker_notebook_instance.fail2",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
