### PR TITLE
feat(terraform): check routes are authorised

### DIFF
--- a/checkov/terraform/checks/resource/aws/APIGatewayV2RouteDefinesAuthorizationType.py
+++ b/checkov/terraform/checks/resource/aws/APIGatewayV2RouteDefinesAuthorizationType.py
@@ -1,0 +1,25 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+from typing import Any, List
+
+
+class APIGatewayV2RouteDefinesAuthorizationType(BaseResourceValueCheck):
+
+    def __init__(self):
+        """
+        NIST.800-53.r5 AC-3, NIST.800-53.r5 CM-2, NIST.800-53.r5 CM-2(2)
+        """
+        name = "Ensure API GatewayV2 routes specify an authorization type"
+        id = "CKV_AWS_308"
+        supported_resources = ['aws_apigatewayv2_route']
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "authorization_type"
+
+    def get_expected_values(self) -> List[Any]:
+        return ["AWS_IAM", "CUSTOM", "JWT"]
+
+
+check = APIGatewayV2RouteDefinesAuthorizationType()

--- a/checkov/terraform/checks/resource/aws/APIGatewayV2RouteDefinesAuthorizationType.py
+++ b/checkov/terraform/checks/resource/aws/APIGatewayV2RouteDefinesAuthorizationType.py
@@ -10,7 +10,7 @@ class APIGatewayV2RouteDefinesAuthorizationType(BaseResourceValueCheck):
         NIST.800-53.r5 AC-3, NIST.800-53.r5 CM-2, NIST.800-53.r5 CM-2(2)
         """
         name = "Ensure API GatewayV2 routes specify an authorization type"
-        id = "CKV_AWS_308"
+        id = "CKV_AWS_309"
         supported_resources = ['aws_apigatewayv2_route']
         categories = [CheckCategories.IAM]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/tests/terraform/checks/resource/aws/example_APIGatewayV2RouteDefinesAuthorizationType/main.tf
+++ b/tests/terraform/checks/resource/aws/example_APIGatewayV2RouteDefinesAuthorizationType/main.tf
@@ -1,0 +1,22 @@
+resource "aws_apigatewayv2_route" "fail" {
+  api_id    = aws_apigatewayv2_api.example.id
+  route_key = "$default"
+}
+
+resource "aws_apigatewayv2_route" "fail2" {
+  api_id    = aws_apigatewayv2_api.example.id
+  route_key = "$default"
+  authorization_type = "NONE"
+}
+
+resource "aws_apigatewayv2_route" "pass2" {
+  api_id    = aws_apigatewayv2_api.example.id
+  route_key = "$default"
+  authorization_type = "JWT"
+}
+
+resource "aws_apigatewayv2_route" "pass" {
+  api_id    = aws_apigatewayv2_api.example.id
+  route_key = "$default"
+  authorization_type = "AWS_IAM"
+}

--- a/tests/terraform/checks/resource/aws/test_APIGatewayV2RouteDefinesAuthorizationType.py
+++ b/tests/terraform/checks/resource/aws/test_APIGatewayV2RouteDefinesAuthorizationType.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.aws.APIGatewayV2RouteDefinesAuthorizationType import check
+
+
+class TestAPIGatewayV2RouteDefinesAuthorizationType(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_APIGatewayV2RouteDefinesAuthorizationType")
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_apigatewayv2_route.pass",
+            "aws_apigatewayv2_route.pass2",
+        }
+        failing_resources = {
+            "aws_apigatewayv2_route.fail",
+            "aws_apigatewayv2_route.fail2",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
