### PR TITLE
feat(ansible): Ansible panos int mgmt checks

### DIFF
--- a/checkov/ansible/checks/graph_checks/PanosInterfaceMgmtProfileNoHTTP.yaml
+++ b/checkov/ansible/checks/graph_checks/PanosInterfaceMgmtProfileNoHTTP.yaml
@@ -1,0 +1,17 @@
+metadata:
+  id: "CKV_PAN_2"
+  name: "Ensure plain-text management HTTP is not enabled for an Interface Management Profile"
+  category: "NETWORKING"
+definition:
+  or:
+  - cond_type: attribute
+    resource_types:
+      - tasks.paloaltonetworks.panos.panos_management_profile
+    attribute: http
+    operator: not_exists
+  - cond_type: attribute
+    resource_types:
+      - tasks.paloaltonetworks.panos.panos_management_profile
+    attribute: http
+    operator: not_equals
+    value: true

--- a/checkov/ansible/checks/graph_checks/PanosInterfaceMgmtProfileNoTelnet.yaml
+++ b/checkov/ansible/checks/graph_checks/PanosInterfaceMgmtProfileNoTelnet.yaml
@@ -1,0 +1,17 @@
+metadata:
+  id: "CKV_PAN_3"
+  name: "Ensure plain-text management Telnet is not enabled for an Interface Management Profile"
+  category: "NETWORKING"
+definition:
+  or:
+  - cond_type: attribute
+    resource_types:
+      - tasks.paloaltonetworks.panos.panos_management_profile
+    attribute: telnet
+    operator: not_exists
+  - cond_type: attribute
+    resource_types:
+      - tasks.paloaltonetworks.panos.panos_management_profile
+    attribute: telnet
+    operator: not_equals
+    value: true

--- a/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoHTTP/expected.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoHTTP/expected.yaml
@@ -1,0 +1,8 @@
+pass:
+  - "tasks.paloaltonetworks.panos.panos_management_profile.Interface_mgmt_profile_pass_1"
+  - "tasks.paloaltonetworks.panos.panos_management_profile.Interface_mgmt_profile_pass_2"
+fail:
+  - "tasks.paloaltonetworks.panos.panos_management_profile.Interface_mgmt_profile_fail_1"
+  - "tasks.paloaltonetworks.panos.panos_management_profile.Interface_mgmt_profile_fail_2"
+evaluated_keys:
+  - "http"

--- a/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoHTTP/fail.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoHTTP/fail.yaml
@@ -1,0 +1,27 @@
+---
+- name: Verify tests
+  hosts: all
+  connection: local
+  gather_facts: false
+
+  vars:
+    device:
+      ip_address: "{{ ip_address }}"
+      username: "{{ username | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      api_key: "{{ api_key | default(omit) }}"
+
+  tasks:
+    - name: Interface_mgmt_profile_fail_1
+      paloaltonetworks.panos.panos_management_profile:
+        provider: '{{ provider }}'
+        name: 'Test profile'
+        http: true # http defined as true, which is a fail
+
+    - name: Interface_mgmt_profile_fail_2
+      paloaltonetworks.panos.panos_management_profile:
+        provider: '{{ provider }}'
+        name: 'Test profile'
+        ping: true
+        http: true # http defined as true, which is a fail
+        ssh: true

--- a/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoHTTP/pass.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoHTTP/pass.yaml
@@ -1,0 +1,29 @@
+---
+- name: Verify tests
+  hosts: all
+  connection: local
+  gather_facts: false
+
+  vars:
+    device:
+      ip_address: "{{ ip_address }}"
+      username: "{{ username | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      api_key: "{{ api_key | default(omit) }}"
+
+  tasks:
+    - name: Interface_mgmt_profile_pass_1
+      paloaltonetworks.panos.panos_management_profile:
+        provider: '{{ provider }}'
+        name: 'Test profile'
+        ping: true
+        ssh: true
+        # http not defined, defaults to false, which is a pass
+
+    - name: Interface_mgmt_profile_pass_2
+      paloaltonetworks.panos.panos_management_profile:
+        provider: '{{ provider }}'
+        name: 'Test profile'
+        ping: true
+        ssh: true
+        http: false # http defined as false, which is a pass

--- a/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoTelnet/expected.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoTelnet/expected.yaml
@@ -1,0 +1,8 @@
+pass:
+  - "tasks.paloaltonetworks.panos.panos_management_profile.Interface_mgmt_profile_pass_1"
+  - "tasks.paloaltonetworks.panos.panos_management_profile.Interface_mgmt_profile_pass_2"
+fail:
+  - "tasks.paloaltonetworks.panos.panos_management_profile.Interface_mgmt_profile_fail_1"
+  - "tasks.paloaltonetworks.panos.panos_management_profile.Interface_mgmt_profile_fail_2"
+evaluated_keys:
+  - "telnet"

--- a/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoTelnet/fail.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoTelnet/fail.yaml
@@ -1,0 +1,27 @@
+---
+- name: Verify tests
+  hosts: all
+  connection: local
+  gather_facts: false
+
+  vars:
+    device:
+      ip_address: "{{ ip_address }}"
+      username: "{{ username | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      api_key: "{{ api_key | default(omit) }}"
+
+  tasks:
+    - name: Interface_mgmt_profile_fail_1
+      paloaltonetworks.panos.panos_management_profile:
+        provider: '{{ provider }}'
+        name: 'Test profile'
+        telnet: true # telnet defined as true, which is a fail
+
+    - name: Interface_mgmt_profile_fail_2
+      paloaltonetworks.panos.panos_management_profile:
+        provider: '{{ provider }}'
+        name: 'Test profile'
+        ping: true
+        telnet: true # telnet defined as true, which is a fail
+        ssh: true

--- a/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoTelnet/pass.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosInterfaceMgmtProfileNoTelnet/pass.yaml
@@ -1,0 +1,29 @@
+---
+- name: Verify tests
+  hosts: all
+  connection: local
+  gather_facts: false
+
+  vars:
+    device:
+      ip_address: "{{ ip_address }}"
+      username: "{{ username | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      api_key: "{{ api_key | default(omit) }}"
+
+  tasks:
+    - name: Interface_mgmt_profile_pass_1
+      paloaltonetworks.panos.panos_management_profile:
+        provider: '{{ provider }}'
+        name: 'Test profile'
+        ping: true
+        ssh: true
+        # telnet not defined, defaults to false, which is a pass
+
+    - name: Interface_mgmt_profile_pass_2
+      paloaltonetworks.panos.panos_management_profile:
+        provider: '{{ provider }}'
+        name: 'Test profile'
+        ping: true
+        ssh: true
+        telnet: false # telnet defined as false, which is a pass

--- a/tests/ansible/checks/graph_checks/test_yaml_policies.py
+++ b/tests/ansible/checks/graph_checks/test_yaml_policies.py
@@ -78,6 +78,12 @@ class TestYamlPolicies(TestYamlPoliciesBase):
     def test_PanosPolicyNoSrcAnyDstAny(self):
         self.go("PanosPolicyNoSrcAnyDstAny", local_graph_class=AnsibleLocalGraph)
 
+    def test_PanosInterfaceMgmtProfileNoHTTP(self):
+        self.go("PanosInterfaceMgmtProfileNoHTTP", local_graph_class=AnsibleLocalGraph)
+
+    def test_PanosInterfaceMgmtProfileNoTelnet(self):
+        self.go("PanosInterfaceMgmtProfileNoTelnet", local_graph_class=AnsibleLocalGraph)
+
     def test_registry_load(self):
         registry = self.get_checks_registry()
         self.assertGreater(len(registry.checks), 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
More Ansible checks for PAN-OS, this PR focuses on checks for management services on the firewall's network interfaces.

## New/Edited policies
Added Ansible to existing Terraform CKV_PAN_2 and CKV_PAN_2

### Description
These checks are from the NGFW best practices

### Fix
N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules