### PR TITLE
fix(terraform): add extra handling around private GitHub Terraform modules

### DIFF
--- a/checkov/common/util/contextmanagers.py
+++ b/checkov/common/util/contextmanagers.py
@@ -1,0 +1,21 @@
+import os
+from contextlib import contextmanager
+from typing import Any, Generator
+
+
+@contextmanager
+def temp_environ(**kwargs: Any) -> Generator[None, None, None]:
+    """Temporarily set environment variables and restores previous values
+
+    copy of https://gist.github.com/igniteflow/7267431?permalink_comment_id=2553451#gistcomment-2553451
+    """
+    original_env = {key: os.getenv(key) for key in kwargs}
+    os.environ.update(kwargs)
+    try:
+        yield
+    finally:
+        for key, value in original_env.items():
+            if value is None:
+                del os.environ[key]
+            else:
+                os.environ[key] = value

--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -62,6 +62,10 @@ class GenericGitLoader(ModuleLoader):
             git_getter.do_get()
         except Exception as e:
             str_e = str(e)
+            if os.getenv("GITHUB_PAT") and not module_params.token and "could not read Username for" in str_e:
+                # we probably try to access a private repository, but a GITHUB_PAT was set,
+                # but the current loader (ex. GithubLoader) is not using it
+                return ModuleContent(dir=None, failed_url=module_params.module_source)
             if 'File exists' not in str_e and 'already exists and is not an empty directory' not in str_e:
                 self.logger.error(f"failed to get {module_params.module_source} because of {e}")
                 return ModuleContent(dir=None, failed_url=module_params.module_source)

--- a/github_action_resources/entrypoint.sh
+++ b/github_action_resources/entrypoint.sh
@@ -125,6 +125,12 @@ echo "BC_RUN_ID=${GITHUB_RUN_NUMBER}"
 echo "BC_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}""
 echo "BC_REPOSITORY_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}""
 
+# Overrides all GitHub URLs with the provided PAT (needed for downloading private modules from GitHub)
+# This is meant to be a last resort, if our internal mechanism doesn't work
+if [ -n "$GITHUB_OVERRIDE_URL" ] && [ "$GITHUB_OVERRIDE_URL" = "true" ]; then
+  git config --global url."https://x-access-token:${GITHUB_PAT}@github.com/".insteadOf "https://github.com/"
+fi
+
 # If Docker image is used, default to that
 if [ -n "$INPUT_DOCKER_IMAGE" ]; then
   DOCKER_IMAGE_FLAG="--docker-image $INPUT_DOCKER_IMAGE"

--- a/tests/common/utils/test_contextmanagers.py
+++ b/tests/common/utils/test_contextmanagers.py
@@ -1,0 +1,26 @@
+import os
+
+from checkov.common.util.contextmanagers import temp_environ
+
+
+def test_temp_environ():
+    # given
+    assert os.getenv("EXAMPLE_ENV_VAR") is None
+
+    # when/then
+    with temp_environ(EXAMPLE_ENV_VAR="example"):
+        assert os.getenv("EXAMPLE_ENV_VAR") == "example"
+
+    assert os.getenv("EXAMPLE_ENV_VAR") is None
+
+
+def test_temp_environ_existing_env():
+    # given
+    os.environ["EXAMPLE_ENV_VAR"] = "example"
+
+    # when/then
+    with temp_environ(EXAMPLE_ENV_VAR="override_example"):
+        assert os.getenv("EXAMPLE_ENV_VAR") == "override_example"
+
+    assert os.environ["EXAMPLE_ENV_VAR"] == "example"
+    del os.environ["EXAMPLE_ENV_VAR"]  # cleanup


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- silenced the Git error log, when using a GitHub PAT, but the normal GitHub module loader tries to download a private module
- added a special override mechanism to be used in the `checkov-action` to override all GitHub URLs with GitHub PAT, this is really meant as a last resort, because our current code should be enough and is working well ,but I think the misleading error message made user worried it is actually not working
- set `GIT_TERMINAL_PROMPT` when we do download  private modules via GIT
- added a context manager, which gives the possibility to set temporarily an env var

Relates to bridgecrewio/checkov-action#101 and bridgecrewio/checkov-action#129

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
