### PR TITLE
fix(general): Custom policies integration correct check IDs filtering

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -117,8 +117,12 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
                 new_record.severity = cloned_policy['severity']
                 new_record.check_name = cloned_policy['title']
                 records.append(new_record)
-        records = [record for record in records if record.bc_check_id not in self.policy_level_suppression]  # Filter out policy level suppressions after cloned policy is added
+        policy_level_suppression_check_ids = self.convert_suppression_ids_to_bc_check_ids()
+        records = [record for record in records if record.bc_check_id not in policy_level_suppression_check_ids]  # Filter out policy level suppressions after cloned policy is added
         return records
+
+    def convert_suppression_ids_to_bc_check_ids(self):
+        return ["_".join(policy.split('_')[:-1]) for policy in self.policy_level_suppression]
 
     def pre_runner(self, runner: _BaseRunner) -> None:
         # not used

--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -121,7 +121,7 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
         records = [record for record in records if record.bc_check_id not in policy_level_suppression_check_ids]  # Filter out policy level suppressions after cloned policy is added
         return records
 
-    def convert_suppression_ids_to_bc_check_ids(self):
+    def convert_suppression_ids_to_bc_check_ids(self) -> List[str]:
         return ["_".join(policy.split('_')[:-1]) for policy in self.policy_level_suppression]
 
     def pre_runner(self, runner: _BaseRunner) -> None:

--- a/tests/common/integration_features/test_custom_policies_integration.py
+++ b/tests/common/integration_features/test_custom_policies_integration.py
@@ -282,7 +282,7 @@ class TestCustomPoliciesIntegration(unittest.TestCase):
         )
 
         scan_reports.failed_checks.append(record)
-        custom_policies_integration.policy_level_suppression = ['BC_AWS_ELASTICSEARCH_3']
+        custom_policies_integration.policy_level_suppression = ['BC_AWS_ELASTICSEARCH_3_80341358308']
         custom_policies_integration.post_runner(scan_reports)
         self.assertEqual(1, len(scan_reports.failed_checks))
         self.assertEqual('mikepolicies_cloned_AWS_1625063607541', scan_reports.failed_checks[0].check_id)
@@ -324,7 +324,7 @@ class TestCustomPoliciesIntegration(unittest.TestCase):
         failed_cloned_policy_record.check_name = failed_cloned_policy['title']
 
         scan_reports.failed_checks.append(failed_cloned_policy_record)
-        custom_policies_integration.policy_level_suppression = ['mikepolicies_cloned_AWS_1625063607541']
+        custom_policies_integration.policy_level_suppression = ['mikepolicies_cloned_AWS_1625063607541_80341358308']
         custom_policies_integration.post_runner(scan_reports)
         self.assertEqual(1, len(scan_reports.failed_checks))
         self.assertEqual('CKV_AWS_5', scan_reports.failed_checks[0].check_id)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fix the filtering the cloned policy check IDs from the new suppression IDs structure

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
