### PR TITLE
feat(secrets): Override secrets validation flag with tenant config

### DIFF
--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -371,8 +371,7 @@ class Runner(BaseRunner[None]):
             logging.debug('Skipping secrets verification as flag skip-download was specified')
             return VerifySecretsResult.INSUFFICIENT_PARAMS
 
-        validate_secrets_tenant_config = bc_integration.customer_run_config_response is not None and \
-                                         bc_integration.customer_run_config_response.get('tenantConfig', {}).get('secretsValidate')
+        validate_secrets_tenant_config = bc_integration.customer_run_config_response is not None and bc_integration.customer_run_config_response.get('tenantConfig', {}).get('secretsValidate')
 
         if validate_secrets_tenant_config is None and not convert_str_to_bool(os.getenv("CKV_VALIDATE_SECRETS", False)):
             logging.debug('Secrets verification is off, enable it via code configuration screen')

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -364,7 +364,7 @@ class Runner(BaseRunner[None]):
     @time_it
     def verify_secrets(self, report: Report, enriched_secrets_s3_path: str) -> VerifySecretsResult:
         if not bc_integration.bc_api_key:
-            logging.debug('Unable to run secrets verification without a bc api key')
+            logging.debug('Secrets verification is available only with a valid API key')
             return VerifySecretsResult.INSUFFICIENT_PARAMS
 
         if bc_integration.skip_download:

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -372,7 +372,7 @@ class Runner(BaseRunner[None]):
             return VerifySecretsResult.INSUFFICIENT_PARAMS
 
         validate_secrets_tenant_config = bc_integration.customer_run_config_response is not None and \
-             bc_integration.customer_run_config_response.get('tenantConfig', {}).get('secretsValidate')
+                                         bc_integration.customer_run_config_response.get('tenantConfig', {}).get('secretsValidate')
 
         if validate_secrets_tenant_config is None and not convert_str_to_bool(os.getenv("CKV_VALIDATE_SECRETS", False)):
             logging.debug('Secrets verification is off, enabled it via code configuration')

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -371,7 +371,9 @@ class Runner(BaseRunner[None]):
             logging.debug('Skipping secrets verification as flag skip-download was specified')
             return VerifySecretsResult.INSUFFICIENT_PARAMS
 
-        validate_secrets_tenant_config = bc_integration.customer_run_config_response is not None and bc_integration.customer_run_config_response.get('tenantConfig', {}).get('secretsValidate')
+        validate_secrets_tenant_config = None
+        if bc_integration.customer_run_config_response is not None:
+            validate_secrets_tenant_config = bc_integration.customer_run_config_response.get('tenantConfig', {}).get('secretsValidate')
 
         if validate_secrets_tenant_config is None and not convert_str_to_bool(os.getenv("CKV_VALIDATE_SECRETS", False)):
             logging.debug('Secrets verification is off, enable it via code configuration screen')

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -372,16 +372,15 @@ class Runner(BaseRunner[None]):
             return VerifySecretsResult.INSUFFICIENT_PARAMS
 
         validate_secrets_tenant_config = bc_integration.customer_run_config_response is not None and \
-             bc_integration.customer_run_config_response.get('tenantConfig', {}).get('secretsValidate', False)
+             bc_integration.customer_run_config_response.get('tenantConfig', {}).get('secretsValidate')
 
-        validate_secrets_flag = convert_str_to_bool(os.getenv("CKV_VALIDATE_SECRETS", False))
-
-        if not validate_secrets_tenant_config and not validate_secrets_flag:
-            logging.debug(
-                'Secrets verification is off, enabled it via env var CKV_VALIDATE_SECRETS or code configuration')
+        if validate_secrets_tenant_config is None and not convert_str_to_bool(os.getenv("CKV_VALIDATE_SECRETS", False)):
+            logging.debug('Secrets verification is off, enabled it via code configuration')
             return VerifySecretsResult.INSUFFICIENT_PARAMS
 
-
+        if validate_secrets_tenant_config is False:
+            logging.debug('Secrets verification is off, enabled it via code configuration')
+            return VerifySecretsResult.INSUFFICIENT_PARAMS
 
         request_body = {
             "reportS3Path": enriched_secrets_s3_path

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -379,7 +379,7 @@ class Runner(BaseRunner[None]):
             return VerifySecretsResult.INSUFFICIENT_PARAMS
 
         if validate_secrets_tenant_config is False:
-            logging.debug('Secrets verification is off, enabled it via code configuration')
+            logging.debug('Secrets verification is off, enable it via code configuration screen')
             return VerifySecretsResult.INSUFFICIENT_PARAMS
 
         request_body = {

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -375,7 +375,7 @@ class Runner(BaseRunner[None]):
                                          bc_integration.customer_run_config_response.get('tenantConfig', {}).get('secretsValidate')
 
         if validate_secrets_tenant_config is None and not convert_str_to_bool(os.getenv("CKV_VALIDATE_SECRETS", False)):
-            logging.debug('Secrets verification is off, enabled it via code configuration')
+            logging.debug('Secrets verification is off, enable it via code configuration screen')
             return VerifySecretsResult.INSUFFICIENT_PARAMS
 
         if validate_secrets_tenant_config is False:

--- a/tests/secrets/test_secrets_verification.py
+++ b/tests/secrets/test_secrets_verification.py
@@ -59,7 +59,7 @@ def test_verify_secrets_insufficient_params_tenant_config_overrides_true_flag() 
 
 
 @mock.patch.dict(os.environ, {"CKV_VALIDATE_SECRETS": "false"})
-def test_verify_secrets_insufficient_params_tenant_config_overrides_flag_flag() -> None:
+def test_verify_secrets_insufficient_params_tenant_config_overrides_false_flag() -> None:
     from checkov.common.bridgecrew.platform_integration import bc_integration
     bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
     bc_integration.customer_run_config_response = {'tenantConfig': {'secretsValidate': True}}

--- a/tests/secrets/test_secrets_verification.py
+++ b/tests/secrets/test_secrets_verification.py
@@ -4,12 +4,9 @@ import os
 import mock
 import pytest
 import responses
-from checkov.runner_filter import RunnerFilter
 
 from checkov.common.bridgecrew.check_type import CheckType
-from checkov.common.output.report import Report
 from checkov.secrets.consts import VerifySecretsResult
-from checkov.secrets.runner import Runner
 
 
 @mock.patch.dict(os.environ, {"CKV_VALIDATE_SECRETS": "true"})
@@ -18,6 +15,8 @@ def test_verify_secrets_insufficient_params_skip_download() -> None:
     bc_integration.skip_download = True
     bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
 
+    from checkov.secrets.runner import Runner
+    from checkov.common.output.report import Report
     result = Runner().verify_secrets(Report(check_type=CheckType.SECRETS), "")
 
     assert result == VerifySecretsResult.INSUFFICIENT_PARAMS
@@ -28,6 +27,8 @@ def test_verify_secrets_insufficient_params_no_api_key() -> None:
     from checkov.common.bridgecrew.platform_integration import bc_integration
     bc_integration.bc_api_key = None
 
+    from checkov.secrets.runner import Runner
+    from checkov.common.output.report import Report
     result = Runner().verify_secrets(Report(check_type=CheckType.SECRETS), "")
 
     assert result == VerifySecretsResult.INSUFFICIENT_PARAMS
@@ -38,10 +39,37 @@ def test_verify_secrets_insufficient_params_no_flag() -> None:
     from checkov.common.bridgecrew.platform_integration import bc_integration
     bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
 
+    from checkov.secrets.runner import Runner
+    from checkov.common.output.report import Report
     result = Runner().verify_secrets(Report(check_type=CheckType.SECRETS), "")
 
     assert result == VerifySecretsResult.INSUFFICIENT_PARAMS
 
+@mock.patch.dict(os.environ, {"CKV_VALIDATE_SECRETS": "true"})
+def test_verify_secrets_insufficient_params_tenant_config_overrides_false_flag() -> None:
+    from checkov.common.bridgecrew.platform_integration import bc_integration
+    bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
+    bc_integration.customer_run_config_response = {'tenantConfig': {'secretsValidate': False}}
+
+    from checkov.secrets.runner import Runner
+    from checkov.common.output.report import Report
+    result = Runner().verify_secrets(Report(check_type=CheckType.SECRETS), "")
+
+    assert result == VerifySecretsResult.INSUFFICIENT_PARAMS
+
+
+@mock.patch.dict(os.environ, {"CKV_VALIDATE_SECRETS": "false"})
+def test_verify_secrets_insufficient_params_tenant_config_overrides_true_flag() -> None:
+    from checkov.common.bridgecrew.platform_integration import bc_integration
+    bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
+    bc_integration.customer_run_config_response = {'tenantConfig': {'secretsValidate': True}}
+    bc_integration.skip_download = False
+
+    from checkov.secrets.runner import Runner
+    from checkov.common.output.report import Report
+    result = Runner().verify_secrets(Report(check_type=CheckType.SECRETS), "")
+
+    assert result != VerifySecretsResult.INSUFFICIENT_PARAMS
 
 @responses.activate
 @mock.patch.dict(os.environ, {"CKV_VALIDATE_SECRETS": "true"})
@@ -60,6 +88,8 @@ def test_verify_secrets_failure(mock_bc_integration, status_code: int) -> None:
         status=status_code
     )
 
+    from checkov.secrets.runner import Runner
+    from checkov.common.output.report import Report
     result = Runner().verify_secrets(Report(check_type=CheckType.SECRETS), "")
 
     assert result == VerifySecretsResult.FAILURE
@@ -67,7 +97,7 @@ def test_verify_secrets_failure(mock_bc_integration, status_code: int) -> None:
 
 @responses.activate
 @mock.patch.dict(os.environ, {"CKV_VALIDATE_SECRETS": "true"})
-def test_verify_secrets(mock_bc_integration, secrets_report: Report) -> None:
+def test_verify_secrets(mock_bc_integration, secrets_report) -> None:
     violation_id_to_verify_status = {"VIOLATION_1": "Privileged",
                                      "VIOLATION_2": "Valid",
                                      "VIOLATION_3": "Invalid",
@@ -101,6 +131,8 @@ def test_verify_secrets(mock_bc_integration, secrets_report: Report) -> None:
         json={'verificationReportSignedUrl': 'mock'},
         status=200
     )
+
+    from checkov.secrets.runner import Runner
     runner = Runner()
     runner.get_json_verification_report = lambda x: verified_report
     result = runner.verify_secrets(secrets_report, "path/to/enriched/secrets")
@@ -140,11 +172,13 @@ def test_runner_verify_secrets(mock_bc_integration, mock_metadata_integration):
         status=200
     )
 
+    from checkov.secrets.runner import Runner
     runner = Runner()
     mock_bc_integration.persist_enriched_secrets = lambda x: 'mock'
     mock_bc_integration.bc_api_key = 'mock'
     runner.get_json_verification_report = lambda x: verified_report
 
+    from checkov.runner_filter import RunnerFilter
     report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
                         runner_filter=RunnerFilter(framework=['secrets']))
 

--- a/tests/secrets/test_secrets_verification.py
+++ b/tests/secrets/test_secrets_verification.py
@@ -46,7 +46,7 @@ def test_verify_secrets_insufficient_params_no_flag() -> None:
     assert result == VerifySecretsResult.INSUFFICIENT_PARAMS
 
 @mock.patch.dict(os.environ, {"CKV_VALIDATE_SECRETS": "true"})
-def test_verify_secrets_insufficient_params_tenant_config_overrides_false_flag() -> None:
+def test_verify_secrets_insufficient_params_tenant_config_overrides_true_flag() -> None:
     from checkov.common.bridgecrew.platform_integration import bc_integration
     bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
     bc_integration.customer_run_config_response = {'tenantConfig': {'secretsValidate': False}}
@@ -59,10 +59,36 @@ def test_verify_secrets_insufficient_params_tenant_config_overrides_false_flag()
 
 
 @mock.patch.dict(os.environ, {"CKV_VALIDATE_SECRETS": "false"})
-def test_verify_secrets_insufficient_params_tenant_config_overrides_true_flag() -> None:
+def test_verify_secrets_insufficient_params_tenant_config_overrides_flag_flag() -> None:
     from checkov.common.bridgecrew.platform_integration import bc_integration
     bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
     bc_integration.customer_run_config_response = {'tenantConfig': {'secretsValidate': True}}
+    bc_integration.skip_download = False
+
+    from checkov.secrets.runner import Runner
+    from checkov.common.output.report import Report
+    result = Runner().verify_secrets(Report(check_type=CheckType.SECRETS), "")
+
+    assert result != VerifySecretsResult.INSUFFICIENT_PARAMS
+
+@mock.patch.dict(os.environ, {"CKV_VALIDATE_SECRETS": "false"})
+def test_verify_secrets_insufficient_params_tenant_config_missing_false_flag() -> None:
+    from checkov.common.bridgecrew.platform_integration import bc_integration
+    bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
+    bc_integration.customer_run_config_response = {'tenantConfig': {'mock': True}}
+    bc_integration.skip_download = False
+
+    from checkov.secrets.runner import Runner
+    from checkov.common.output.report import Report
+    result = Runner().verify_secrets(Report(check_type=CheckType.SECRETS), "")
+
+    assert result == VerifySecretsResult.INSUFFICIENT_PARAMS
+
+@mock.patch.dict(os.environ, {"CKV_VALIDATE_SECRETS": "true"})
+def test_verify_secrets_insufficient_params_tenant_config_missing_true_flag() -> None:
+    from checkov.common.bridgecrew.platform_integration import bc_integration
+    bc_integration.bc_api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
+    bc_integration.customer_run_config_response = {'tenantConfig': {'mock': True}}
     bc_integration.skip_download = False
 
     from checkov.secrets.runner import Runner

--- a/tests/secrets/test_secrets_verification_suppressions.py
+++ b/tests/secrets/test_secrets_verification_suppressions.py
@@ -4,10 +4,6 @@ import mock
 import responses
 from checkov.common.models.enums import CheckResult
 
-from checkov.runner_filter import RunnerFilter
-
-from checkov.secrets.runner import Runner
-
 
 @responses.activate
 @mock.patch.dict(os.environ, {"CKV_VALIDATE_SECRETS": "true"})
@@ -32,6 +28,8 @@ def test_runner_verify_secrets_skip_invalid_suppressed(mock_bc_integration, mock
         status=200
     )
 
+    from checkov.runner_filter import RunnerFilter
+    from checkov.secrets.runner import Runner
     runner = Runner()
     mock_bc_integration.persist_enriched_secrets = lambda x: 'mock'
     mock_bc_integration.bc_api_key = 'mock'
@@ -78,6 +76,8 @@ def test_runner_verify_secrets_skip_all_no_effect(mock_bc_integration, mock_meta
         status=200
     )
 
+    from checkov.runner_filter import RunnerFilter
+    from checkov.secrets.runner import Runner
     runner = Runner()
     mock_bc_integration.persist_enriched_secrets = lambda x: 'mock'
     mock_bc_integration.bc_api_key = 'mock'
@@ -100,6 +100,7 @@ def test_runner_verify_secrets_skip_all_no_effect(mock_bc_integration, mock_meta
 
 
 def test_modify_invalid_secrets_check_result_to_skipped(secrets_report_invalid_status) -> None:
+    from checkov.secrets.runner import Runner
     Runner()._modify_invalid_secrets_check_result_to_skipped(secrets_report_invalid_status)
 
     assert len(secrets_report_invalid_status.failed_checks) == 0

--- a/tests/secrets/test_secrets_verification_suppressions.py
+++ b/tests/secrets/test_secrets_verification_suppressions.py
@@ -35,7 +35,7 @@ def test_runner_verify_secrets_skip_invalid_suppressed(mock_bc_integration, mock
     runner = Runner()
     mock_bc_integration.persist_enriched_secrets = lambda x: 'mock'
     mock_bc_integration.bc_api_key = 'mock'
-    mock_bc_integration.customer_run_config_response = {'tenantConfig': {'mock': True}}
+    mock_bc_integration.customer_run_config_response = {'tenantConfig': {'secretsValidate': True}}
     runner.get_json_verification_report = lambda x: verified_report
 
     report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
@@ -81,7 +81,7 @@ def test_runner_verify_secrets_skip_all_no_effect(mock_bc_integration, mock_meta
     runner = Runner()
     mock_bc_integration.persist_enriched_secrets = lambda x: 'mock'
     mock_bc_integration.bc_api_key = 'mock'
-    mock_bc_integration.customer_run_config_response = {'tenantConfig': {'mock': True}}
+    mock_bc_integration.customer_run_config_response = {'tenantConfig': {'secretsValidate': True}}
 
     runner.get_json_verification_report = lambda x: verified_report
 

--- a/tests/secrets/test_secrets_verification_suppressions.py
+++ b/tests/secrets/test_secrets_verification_suppressions.py
@@ -33,7 +33,6 @@ def test_runner_verify_secrets_skip_invalid_suppressed(mock_bc_integration, mock
     runner = Runner()
     mock_bc_integration.persist_enriched_secrets = lambda x: 'mock'
     mock_bc_integration.bc_api_key = 'mock'
-    mock_bc_integration.customer_run_config_response = {'tenantConfig': {'secretsValidate': True}}
     runner.get_json_verification_report = lambda x: verified_report
 
     report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
@@ -81,7 +80,6 @@ def test_runner_verify_secrets_skip_all_no_effect(mock_bc_integration, mock_meta
     runner = Runner()
     mock_bc_integration.persist_enriched_secrets = lambda x: 'mock'
     mock_bc_integration.bc_api_key = 'mock'
-    mock_bc_integration.customer_run_config_response = {'tenantConfig': {'secretsValidate': True}}
 
     runner.get_json_verification_report = lambda x: verified_report
 

--- a/tests/secrets/test_secrets_verification_suppressions.py
+++ b/tests/secrets/test_secrets_verification_suppressions.py
@@ -35,6 +35,7 @@ def test_runner_verify_secrets_skip_invalid_suppressed(mock_bc_integration, mock
     runner = Runner()
     mock_bc_integration.persist_enriched_secrets = lambda x: 'mock'
     mock_bc_integration.bc_api_key = 'mock'
+    mock_bc_integration.customer_run_config_response = {'tenantConfig': {'mock': True}}
     runner.get_json_verification_report = lambda x: verified_report
 
     report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
@@ -80,6 +81,8 @@ def test_runner_verify_secrets_skip_all_no_effect(mock_bc_integration, mock_meta
     runner = Runner()
     mock_bc_integration.persist_enriched_secrets = lambda x: 'mock'
     mock_bc_integration.bc_api_key = 'mock'
+    mock_bc_integration.customer_run_config_response = {'tenantConfig': {'mock': True}}
+
     runner.get_json_verification_report = lambda x: verified_report
 
     report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
