### PR TITLE
feat(terraform): RDS Cluster - make sure rds cluster defined defaults for logging and audit logging

### DIFF
--- a/checkov/terraform/checks/resource/aws/ElastiCacheHasCustomSubnet.py
+++ b/checkov/terraform/checks/resource/aws/ElastiCacheHasCustomSubnet.py
@@ -1,0 +1,27 @@
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class ElastiCacheHasCustomSubnet(BaseResourceValueCheck):
+
+    def __init__(self):
+        """
+        NIST.800-53.r5 AC-4, NIST.800-53.r5 AC-4(21), NIST.800-53.r5 SC-7, NIST.800-53.r5 SC-7(11),
+        NIST.800-53.r5 SC-7(16), NIST.800-53.r5 SC-7(21), NIST.800-53.r5 SC-7(4), NIST.800-53.r5 SC-7(5)
+        ElastiCache clusters should not use the default subnet group
+        """
+        name = "Ensure ElastiCache clusters do not use the default subnet group"
+        id = "CKV_AWS_323"
+        supported_resources = ['aws_elasticache_cluster']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "subnet_group_name"
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = ElastiCacheHasCustomSubnet()

--- a/checkov/terraform/checks/resource/aws/RDSClusterAuditLogging.py
+++ b/checkov/terraform/checks/resource/aws/RDSClusterAuditLogging.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class RDSClusterAuditLogging(BaseResourceValueCheck):
+    def __init__(self):
+        """
+        NIST.800-53.r5 AC-2(4), NIST.800-53.r5 AC-4(26), NIST.800-53.r5 AC-6(9), NIST.800-53.r5 AU-10,
+        NIST.800-53.r5 AU-12, NIST.800-53.r5 AU-2, NIST.800-53.r5 AU-3, NIST.800-53.r5 AU-6(3), NIST.800-53.r5 AU-6(4),
+        NIST.800-53.r5 CA-7, NIST.800-53.r5 SC-7(10), NIST.800-53.r5 SC-7(9), NIST.800-53.r5 SI-3(8),
+        NIST.800-53.r5 SI-4(20), NIST.800-53.r5 SI-7(8)
+        Database logging should be enabled
+        """
+        name = "Ensure that RDS Cluster audit logging is enabled"
+        id = "CKV_AWS_325"
+        supported_resources = ["aws_rds_cluster"]
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "enabled_cloudwatch_logs_exports/[0]"
+
+    def get_expected_value(self) -> Any:
+        return "audit"
+
+
+check = RDSClusterAuditLogging()

--- a/checkov/terraform/checks/resource/aws/RDSClusterLogging.py
+++ b/checkov/terraform/checks/resource/aws/RDSClusterLogging.py
@@ -1,0 +1,36 @@
+from typing import Any, Dict, List
+
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class DBInstanceLogging(BaseResourceValueCheck):
+    def __init__(self):
+        """
+        NIST.800-53.r5 AC-2(4), NIST.800-53.r5 AC-4(26), NIST.800-53.r5 AC-6(9), NIST.800-53.r5 AU-10,
+        NIST.800-53.r5 AU-12, NIST.800-53.r5 AU-2, NIST.800-53.r5 AU-3, NIST.800-53.r5 AU-6(3), NIST.800-53.r5 AU-6(4),
+        NIST.800-53.r5 CA-7, NIST.800-53.r5 SC-7(10), NIST.800-53.r5 SC-7(9), NIST.800-53.r5 SI-3(8),
+        NIST.800-53.r5 SI-4(20), NIST.800-53.r5 SI-7(8)
+        Database logging should be enabled
+        """
+        name = "Ensure that RDS Cluster log capture is enabled"
+        id = "CKV_AWS_324"
+        supported_resources = ["aws_rds_cluster"]
+        categories = [CheckCategories.LOGGING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "enabled_cloudwatch_logs_exports/[0]"
+
+    def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
+        logs_exports = conf.get('enabled_cloudwatch_logs_exports', [[]])
+        if not logs_exports:
+            return CheckResult.FAILED
+        return CheckResult.PASSED if logs_exports[0] else CheckResult.FAILED
+
+    def get_expected_value(self) -> Any:
+        return ANY_VALUE
+
+
+check = DBInstanceLogging()

--- a/tests/terraform/checks/resource/aws/example_ElastiCacheHasCustomSubnet/main.tf
+++ b/tests/terraform/checks/resource/aws/example_ElastiCacheHasCustomSubnet/main.tf
@@ -1,0 +1,20 @@
+# pass
+
+resource "aws_elasticache_cluster" "pass" {
+  cluster_id           = "cluster"
+  engine               = "redis"
+  node_type            = "cache.m5.large"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis6.x"
+  subnet_group_name    = "mysubnet"
+  snapshot_retention_limit = 5
+}
+
+resource "aws_elasticache_cluster" "fail" {
+  cluster_id           = "cluster"
+  engine               = "redis"
+  node_type            = "cache.m5.large"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis6.x"
+  snapshot_retention_limit = 0
+}

--- a/tests/terraform/checks/resource/aws/example_RDSClusterAuditLogging/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSClusterAuditLogging/main.tf
@@ -1,0 +1,20 @@
+# pass
+
+resource "aws_rds_cluster" "pass" {
+  master_username = "username"
+  master_password = "password"
+  enabled_cloudwatch_logs_exports = ["audit"]
+  iam_database_authentication_enabled = true
+}
+
+resource "aws_rds_cluster" "fail" {
+  master_username = "username"
+  master_password = "password"
+}
+
+resource "aws_rds_cluster" "fail2" {
+  master_username = "username"
+  master_password = "password"
+  enabled_cloudwatch_logs_exports = ["error", "general", "slowquery"]
+  iam_database_authentication_enabled = false
+}

--- a/tests/terraform/checks/resource/aws/example_RDSClusterLogging/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSClusterLogging/main.tf
@@ -1,0 +1,13 @@
+
+resource "aws_rds_cluster" "pass" {
+  master_username = "username"
+  master_password = "password"
+  enabled_cloudwatch_logs_exports = ["audit"]
+  iam_database_authentication_enabled = true
+}
+
+resource "aws_rds_cluster" "fail" {
+  master_username = "username"
+  master_password = "password"
+}
+

--- a/tests/terraform/checks/resource/aws/test_RDSClusterAuditLogging.py
+++ b/tests/terraform/checks/resource/aws/test_RDSClusterAuditLogging.py
@@ -1,0 +1,37 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.RDSClusterAuditLogging import check
+from checkov.terraform.runner import Runner
+
+
+class TestRDSClusterAuditLogging(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_RDSClusterAuditLogging"
+
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_rds_cluster.pass",
+        }
+        failing_resources = {
+            "aws_rds_cluster.fail",
+            "aws_rds_cluster.fail2",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/aws/test_RDSClusterLogging.py
+++ b/tests/terraform/checks/resource/aws/test_RDSClusterLogging.py
@@ -1,0 +1,36 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.RDSClusterLogging import check
+from checkov.terraform.runner import Runner
+
+
+class TestRDSClusterLogging(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_RDSClusterLogging"
+
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_rds_cluster.pass",
+        }
+        failing_resources = {
+            "aws_rds_cluster.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
