### PR TITLE
feat(terraform): Ensure that RDS clusters are encrypted using a CMK

### DIFF
--- a/checkov/terraform/checks/resource/aws/RDSClusterEncryptedWithCMK.py
+++ b/checkov/terraform/checks/resource/aws/RDSClusterEncryptedWithCMK.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.consts import ANY_VALUE
+
+
+class RDSClusterEncryptedWithCMK(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure RDS Clusters are encrypted using KMS CMKs"
+        id = "CKV_AWS_327"
+        supported_resources = ['aws_rds_cluster']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'kms_key_id'
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = RDSClusterEncryptedWithCMK()

--- a/tests/terraform/checks/resource/aws/example_RDSClusterEncryptedWithCMK/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSClusterEncryptedWithCMK/main.tf
@@ -1,0 +1,17 @@
+# pass
+
+resource "aws_rds_cluster" "pass" {
+  master_username = "username"
+  master_password = "password"
+  storage_encrypted = true
+  iam_database_authentication_enabled = true
+  kms_key_id = aws_kms_key.pike.arn
+}
+
+# failure
+
+resource "aws_rds_cluster" "fail" {
+  master_username = "username"
+  master_password = "password"
+}
+

--- a/tests/terraform/checks/resource/aws/test_RDSClusterEncryptedWithCMK.py
+++ b/tests/terraform/checks/resource/aws/test_RDSClusterEncryptedWithCMK.py
@@ -1,0 +1,36 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.RDSClusterEncryptedWithCMK import check
+from checkov.terraform.runner import Runner
+
+
+class TestRDSClusterEncryptedWithCMK(unittest.TestCase):
+    def test(self):
+        test_files_dir = Path(__file__).parent / "example_RDSClusterEncryptedWithCMK"
+
+        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_rds_cluster.pass",
+        }
+        failing_resources = {
+            "aws_rds_cluster.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
