### PR TITLE
chore(general): upload logs and run metadata to support bucket

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -352,7 +352,7 @@ class BcPlatformIntegration:
                 response = json.loads(request.data.decode("utf8"))
 
         repo_full_path = response["path"]
-        support_path = response["supportPath"]
+        support_path = response.get("supportPath")
         return repo_full_path, support_path, response
 
     def is_integration_configured(self) -> bool:

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -499,7 +499,7 @@ class BcPlatformIntegration:
             logging.error(f"Something went wrong: bucket {self.bucket}, repo path {self.repo_path}")
             return
         persist_run_metadata(run_metadata, self.s3_client, self.bucket, self.repo_path, True)
-        if self.support_bucket and self.support_repo_path or not self.s3_support_client:
+        if self.support_bucket and self.support_repo_path and self.s3_support_client:
             logging.debug('Also uploading run_metadata.json to support bucket')
             persist_run_metadata(run_metadata, self.s3_support_client, self.support_bucket, self.support_repo_path, False)
 

--- a/checkov/common/bridgecrew/wrapper.py
+++ b/checkov/common/bridgecrew/wrapper.py
@@ -98,9 +98,9 @@ def persist_checks_results(
 
 
 def persist_run_metadata(
-        run_metadata: dict[str, str | list[str]], s3_client: S3Client, bucket: str, full_repo_object_key: str
+        run_metadata: dict[str, str | list[str]], s3_client: S3Client, bucket: str, full_repo_object_key: str, use_checkov_results: bool = True
 ) -> None:
-    object_path = f'{full_repo_object_key}/{checkov_results_prefix}/run_metadata.json'
+    object_path = f'{full_repo_object_key}/{checkov_results_prefix}/run_metadata.json' if use_checkov_results else f'{full_repo_object_key}/run_metadata.json'
     try:
         s3_client.put_object(Bucket=bucket, Key=object_path, Body=json.dumps(run_metadata, indent=2))
 
@@ -111,7 +111,7 @@ def persist_run_metadata(
 
 def persist_logs_stream(logs_stream: StringIO, s3_client: S3Client, bucket: str, full_repo_object_key: str) -> None:
     file_io = compress_string_io_tar(logs_stream)
-    object_path = f'{full_repo_object_key}/{checkov_results_prefix}/logs_file.tar.gz'
+    object_path = f'{full_repo_object_key}/logs_file.tar.gz'
     try:
         s3_client.put_object(Bucket=bucket, Key=object_path, Body=file_io)
     except Exception:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -220,6 +220,9 @@ class Checkov:
             if self.config.output is None:
                 self.config.output = ['cli']
 
+            if self.config.support:
+                bc_integration.support_flag_enabled = True
+
             if self.config.bc_api_key and not self.config.include_all_checkov_policies:
                 if self.config.skip_download and not self.config.external_checks_dir:
                     print('You are using an API key along with --skip-download but not --include-all-checkov-policies or --external-checks-dir. '


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

When `--support` is used, upload the logs and run metadata to a dedicated path specified by the platform (presumably a different bucket). Still also uploads the run_metadata alongside the source.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
