### PR TITLE
docs(terraform): Document no private registry

### DIFF
--- a/docs/7.Scan Examples/Terraform.md
+++ b/docs/7.Scan Examples/Terraform.md
@@ -46,7 +46,7 @@ checkov -d . --download-external-modules true --external-modules-download-path e
 
 ### Scanning Private Terraform Modules
 
-In case third-party modules are stored in a private repository or a private Terraform Cloud registry, you can provide access tokens as environment variables for checkov to attempt to clone those modules. 
+In case third-party modules are stored in a private repository or a private Terraform Cloud registry, you can provide access tokens as environment variables for checkov to attempt to clone those modules. Private registries are not yet supported unless downloaded locally.
 
 | Variable Name          | Description                                                                |
 |------------------------|----------------------------------------------------------------------------|

--- a/docs/7.Scan Examples/Terraform.md
+++ b/docs/7.Scan Examples/Terraform.md
@@ -46,7 +46,7 @@ checkov -d . --download-external-modules true --external-modules-download-path e
 
 ### Scanning Private Terraform Modules
 
-In case third-party modules are stored in a private repository or a private Terraform Cloud registry, you can provide access tokens as environment variables for checkov to attempt to clone those modules. Private registries are not yet supported unless downloaded locally.
+In case third-party modules are stored in a private repository or a private Terraform Cloud registry, you can provide access tokens as environment variables for checkov to attempt to clone those modules. Private modules hosted in self-hosted registries, such as Terraform Enterprise, are not yet supported.
 
 | Variable Name          | Description                                                                |
 |------------------------|----------------------------------------------------------------------------|


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Document that private registries are not yet supported
