### PR TITLE
fix(terraform): refine IAM assume role check CKV_AWS_61

### DIFF
--- a/checkov/terraform/checks/resource/aws/IAMRoleAllowAssumeFromAccount.py
+++ b/checkov/terraform/checks/resource/aws/IAMRoleAllowAssumeFromAccount.py
@@ -1,35 +1,46 @@
+from __future__ import annotations
+
 import re
 
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.common.util.type_forcers import extract_policy_dict
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
-from typing import List
+from typing import Any
+
+ACCOUNT_ACCESS = re.compile(r"\d{12}|arn:aws:iam::\d{12}:root")
 
 
 class IAMRoleAllowAssumeFromAccount(BaseResourceCheck):
-
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure AWS IAM policy does not allow assume role permission across all services"
         id = "CKV_AWS_61"
-        supported_resources = ['aws_iam_role']
-        categories = [CheckCategories.IAM]
+        supported_resources = ("aws_iam_role",)
+        categories = (CheckCategories.IAM,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
         try:
-            assume_role_block = extract_policy_dict(conf['assume_role_policy'][0])
-            if assume_role_block and 'Statement' in assume_role_block.keys() \
-                    and 'Principal' in assume_role_block['Statement'][0] \
-                    and 'AWS' in assume_role_block['Statement'][0]['Principal']:
-                account_access = re.compile(r'\d{12}|arn:aws:iam::\d{12}:root')
-                if re.match(account_access, assume_role_block['Statement'][0]['Principal']['AWS']):
-                    return CheckResult.FAILED
+            assume_role_block = extract_policy_dict(conf["assume_role_policy"][0])
+            if assume_role_block and "Statement" in assume_role_block:
+                for statement in assume_role_block["Statement"]:
+                    if statement.get("Effect") == "Deny":
+                        continue
+                    if "Principal" in statement and "AWS" in statement["Principal"]:
+                        # Can be a string or an array of strings
+                        aws_principals = statement["Principal"]["AWS"]
+                        if isinstance(aws_principals, str) and re.match(ACCOUNT_ACCESS, aws_principals):
+                            return CheckResult.FAILED
+                        elif isinstance(aws_principals, list):
+                            for aws_principal in aws_principals:
+                                if isinstance(aws_principal, str) and re.match(ACCOUNT_ACCESS, aws_principal):
+                                    return CheckResult.FAILED
         except Exception:  # nosec
-            pass
+            return CheckResult.UNKNOWN
+
         return CheckResult.PASSED
 
-    def get_evaluated_keys(self) -> List[str]:
-        return ['assume_role_policy']
+    def get_evaluated_keys(self) -> list[str]:
+        return ["assume_role_policy"]
 
 
 check = IAMRoleAllowAssumeFromAccount()

--- a/tests/terraform/checks/resource/aws/example_IAMRoleAllowAssumeFromAccount/main.tf
+++ b/tests/terraform/checks/resource/aws/example_IAMRoleAllowAssumeFromAccount/main.tf
@@ -29,6 +29,54 @@ resource "aws_iam_role" "fail2" {
 POLICY
 }
 
+resource "aws_iam_role" "fail3" {
+  name               = "fail-default"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          AWS = [
+            "arn:aws:iam::123456789012:role/role-name",
+            "123456789012"
+          ]
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "fail4" {
+  name               = "fail-default"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          AWS = [
+            "arn:aws:iam::123456789012:role/role-name"
+          ]
+        }
+      },
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          AWS = [
+            "123456789012",
+          ]
+        }
+      }
+    ]
+  })
+}
 
 resource "aws_iam_role" "pass2" {
   name               = "pass2-default"
@@ -51,3 +99,31 @@ resource "aws_iam_role" "pass" {
 POLICY
 }
 
+resource "aws_iam_role" "pass3" {
+  name               = "fail-default"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Deny"
+        Sid    = ""
+        Principal = {
+          AWS = [
+            "123456789012"
+          ]
+        }
+      },
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          AWS = [
+            "arn:aws:iam::123456789012:role/role-name",
+          ]
+        }
+      }
+    ]
+  })
+}

--- a/tests/terraform/checks/resource/aws/test_IAMRoleAllowAssumeFromAccount.py
+++ b/tests/terraform/checks/resource/aws/test_IAMRoleAllowAssumeFromAccount.py
@@ -1,4 +1,3 @@
-
 import unittest
 from pathlib import Path
 
@@ -21,17 +20,20 @@ class TestIAMRoleAllowAssumeFromAccount(unittest.TestCase):
         passing_resources = {
             "aws_iam_role.pass",
             "aws_iam_role.pass2",
+            "aws_iam_role.pass3",
         }
         failing_resources = {
             "aws_iam_role.fail",
             "aws_iam_role.fail2",
+            "aws_iam_role.fail3",
+            "aws_iam_role.fail4",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- refined the logic of the IAM assume role check CKV_AWS_61 to incorporate more edge cases, like multiple statements or a `Deny` statement 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
