### PR TITLE
fix(terraform): refine S3 lifecycle check CKV_AWS_300

### DIFF
--- a/checkov/terraform/checks/resource/aws/S3AbortIncompleteUploads.py
+++ b/checkov/terraform/checks/resource/aws/S3AbortIncompleteUploads.py
@@ -1,28 +1,36 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class S3AbortIncompleteUploads(BaseResourceCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         """
         If you don't set this value in a lifecycle configuration you'll end up paying for s3
         resources you never could use
         """
         name = "Ensure S3 lifecycle configuration sets period for aborting failed uploads"
         id = "CKV_AWS_300"
-        supported_resources = ('aws_s3_bucket_lifecycle_configuration',)
+        supported_resources = ("aws_s3_bucket_lifecycle_configuration",)
         categories = (CheckCategories.GENERAL_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
         self.evaluated_keys = ["rule"]
         rules = conf.get("rule")
         if rules and isinstance(rules, list):
             for idx_rule, rule in enumerate(rules):
-                if not rule.get("abort_incomplete_multipart_upload"):
-                    self.evaluated_keys = [f"rule/[{idx_rule}]/"]
-                    return CheckResult.FAILED
-            return CheckResult.PASSED
+                if (
+                    rule.get("abort_incomplete_multipart_upload")
+                    and rule.get("status") == ["Enabled"]
+                    and not rule.get("filter")
+                ):
+                    self.evaluated_keys = [f"rule/[{idx_rule}]/abort_incomplete_multipart_upload"]
+                    return CheckResult.PASSED
+
         return CheckResult.FAILED
 
 

--- a/tests/terraform/checks/resource/aws/example_S3AbortIncompleteUploads/main.tf
+++ b/tests/terraform/checks/resource/aws/example_S3AbortIncompleteUploads/main.tf
@@ -1,3 +1,5 @@
+# fail
+
 resource "aws_s3_bucket_lifecycle_configuration" "fail" {
   # Must have bucket versioning enabled first
   depends_on = [aws_s3_bucket_versioning.versioning]
@@ -81,6 +83,21 @@ resource "aws_s3_bucket_lifecycle_configuration" "fail2" {
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "fail3" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+    id = "log"
+
+    status = "Disabled"
+  }
+}
+
+# pass
+
 resource "aws_s3_bucket_lifecycle_configuration" "pass2" {
   bucket = aws_s3_bucket.bucket.id
 
@@ -92,17 +109,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "pass2" {
 
     expiration {
       days = 90
-    }
-
-    filter {
-      and {
-        prefix = "log/"
-
-        tags = {
-          rule      = "log"
-          autoclean = "true"
-        }
-      }
     }
 
     status = "Enabled"
@@ -118,6 +124,14 @@ resource "aws_s3_bucket_lifecycle_configuration" "pass2" {
     }
   }
 
+  rule {
+    id     = "id-2"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+  }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "pass" {
@@ -162,10 +176,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "pass" {
       days_after_initiation = 7
     }
     id = "tmp"
-
-    filter {
-      prefix = "tmp/"
-    }
 
     expiration {
       date = "2023-01-13T00:00:00Z"

--- a/tests/terraform/checks/resource/aws/test_S3AbortIncompleteUploads.py
+++ b/tests/terraform/checks/resource/aws/test_S3AbortIncompleteUploads.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from pathlib import Path
 
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.S3AbortIncompleteUploads import check
@@ -8,11 +9,13 @@ from checkov.terraform.runner import Runner
 
 class TestS3AbortIncompleteUploads(unittest.TestCase):
     def test(self):
-        runner = Runner()
-        current_dir = os.path.dirname(os.path.realpath(__file__))
+        # given
+        test_files_dir = Path(__file__).parent / "example_S3AbortIncompleteUploads"
 
-        test_files_dir = current_dir + "/example_S3AbortIncompleteUploads"
-        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
         summary = report.get_summary()
 
         passing_resources = {
@@ -22,10 +25,11 @@ class TestS3AbortIncompleteUploads(unittest.TestCase):
         failing_resources = {
             "aws_s3_bucket_lifecycle_configuration.fail",
             "aws_s3_bucket_lifecycle_configuration.fail2",
+            "aws_s3_bucket_lifecycle_configuration.fail3",
         }
 
-        passed_check_resources = set([c.resource for c in report.passed_checks])
-        failed_check_resources = set([c.resource for c in report.failed_checks])
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
 
         self.assertEqual(summary["passed"], len(passing_resources))
         self.assertEqual(summary["failed"], len(failing_resources))


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- refined the S3 lifecycle check `CKV_AWS_300` to incorporate more edge cases 

Fixes #4733

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
