### PR TITLE
fix(secrets): Compare abs paths in SecretsOmitter

### DIFF
--- a/checkov/common/util/secrets_omitter.py
+++ b/checkov/common/util/secrets_omitter.py
@@ -80,9 +80,11 @@ class SecretsOmitter:
         files_with_secrets: set[str] = {secret_check.get("file_path", "") for secret_check in self._secret_check()}
         for check in self._non_secret_check():
             check_file_path = check.file_path
+            check_abs_file_path = check.file_abs_path
             check_line_range = check.file_line_range
 
-            if check_file_path not in files_with_secrets or not check_line_range or None in check_line_range:
+            if (check_file_path not in files_with_secrets and check_abs_file_path not in files_with_secrets)\
+                    or not check_line_range or None in check_line_range:
                 continue
 
             for secret_check in self._secret_check():
@@ -91,7 +93,7 @@ class SecretsOmitter:
                 if secret_check_line_range == [-1, -1]:
                     continue
 
-                if secret_check_file_path != check_file_path or \
+                if secret_check_file_path not in (check_file_path, check_abs_file_path) or \
                         not self._line_range_overlaps(secret_check_line_range, check_line_range):
                     continue
 

--- a/tests/common/secrets_omitter/test_secrets_omitter.py
+++ b/tests/common/secrets_omitter/test_secrets_omitter.py
@@ -96,3 +96,26 @@ def test_omit_should_skip():
 
     # Asserting code block is unchanged
     assert report.passed_checks[0].code_block == [(2, 'SECRET'), (3, 'SECRET'), (4, 'abcd'), (5, 'abc')]
+
+def test_omit_with_abs_file_path():
+    abs_file_path = 'abs/filepath'
+    failed_secrets_record = Record(check_id='a', check_name='a', check_result={"result": CheckResult.FAILED},
+                                   code_block=[(1, 'ab***'), (2, 'bc*'), (3, 'efg******'), (4, 'abcd'), (5, 'abc')],
+                                   file_path=abs_file_path, file_line_range=[], resource='', evaluations={}, check_class='',
+                                   file_abs_path=abs_file_path
+                                   )
+    secrets_report = Report(CheckType.SECRETS)
+    secrets_report.add_record(failed_secrets_record)
+
+    record = Record(check_id='b', check_name='b', check_result={"result": CheckResult.PASSED},
+                    code_block=[(2, 'SECRET'), (3, 'SECRET'), (4, 'abcd'), (5, 'abc')],
+                    file_path='different_file_path', file_line_range=[2, 5], resource='', evaluations={}, check_class='',
+                    file_abs_path=abs_file_path
+                    )
+    report = Report(CheckType.GITHUB_ACTIONS)
+    report.add_record(record)
+
+    res = SecretsOmitter([secrets_report, report]).omit()
+
+    assert res == SecretsOmitterStatus.SUCCESS
+    assert report.passed_checks[0].code_block == [(2, 'bc*'), (3, 'efg******'), (4, 'abcd'), (5, 'abc')]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Before, we only compared by relative path, which might be easily affected by how each framework saves the record.
Now we also compare the absolute path of the record, which solves a bug where secrets were not omitted from a terraform record.

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
