### PR TITLE
feat(terraform): ECS Service should not auto assign public ips

### DIFF
--- a/checkov/terraform/checks/resource/aws/ECSServicePublicIP.py
+++ b/checkov/terraform/checks/resource/aws/ECSServicePublicIP.py
@@ -1,0 +1,33 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+from typing import Any, List
+
+
+class ECSServicePublicIP(BaseResourceNegativeValueCheck):
+    def __init__(self):
+        """
+        NIST.800-53.r5 AC-21, NIST.800-53.r5 AC-3, NIST.800-53.r5 AC-3(7), NIST.800-53.r5 AC-4, NIST.800-53.r5 AC-4(21),
+        NIST.800-53.r5 AC-6, NIST.800-53.r5 SC-7, NIST.800-53.r5 SC-7(11), NIST.800-53.r5 SC-7(16),
+        NIST.800-53.r5 SC-7(20), NIST.800-53.r5 SC-7(21), NIST.800-53.r5 SC-7(3), NIST.800-53.r5 SC-7(4),
+        NIST.800-53.r5 SC-7(9)
+        ECS services should not have public IP addresses assigned to them automatically
+        """
+        name = "Ensure ECS services do not have public IP addresses assigned to them automatically"
+        id = "CKV_AWS_333"
+        supported_resources = ["aws_ecs_service"]
+        categories = [CheckCategories.LOGGING]
+        super().__init__(
+            name=name,
+            id=id,
+            categories=categories,
+            supported_resources=supported_resources,
+        )
+
+    def get_inspected_key(self) -> str:
+        return "network_configuration/[0]/assign_public_ip"
+
+    def get_forbidden_values(self) -> List[Any]:
+        return [True]
+
+
+check = ECSServicePublicIP()

--- a/tests/terraform/checks/resource/aws/example_ECSServicePublicIP/main.tf
+++ b/tests/terraform/checks/resource/aws/example_ECSServicePublicIP/main.tf
@@ -1,0 +1,46 @@
+resource "aws_ecs_service" "pass" {
+  name    = "example"
+  cluster = aws_ecs_cluster.example.id
+
+  alarms {
+    enable   = true
+    rollback = true
+    alarm_names = [
+      aws_cloudwatch_metric_alarm.example.alarm_name
+    ]
+  }
+}
+
+resource "aws_ecs_service" "pass2" {
+  name    = "example"
+  cluster = aws_ecs_cluster.example.id
+
+  alarms {
+    enable   = true
+    rollback = true
+    alarm_names = [
+      aws_cloudwatch_metric_alarm.example.alarm_name
+    ]
+  }
+  network_configuration {
+    subnets = []
+    assign_public_ip = false
+  }
+}
+
+resource "aws_ecs_service" "fail" {
+  name    = "example"
+  cluster = aws_ecs_cluster.example.id
+
+  alarms {
+    enable   = true
+    rollback = true
+    alarm_names = [
+      aws_cloudwatch_metric_alarm.example.alarm_name
+    ]
+  }
+  network_configuration {
+    subnets = []
+    assign_public_ip = true
+  }
+}

--- a/tests/terraform/checks/resource/aws/test_ECSServicePublicIP.py
+++ b/tests/terraform/checks/resource/aws/test_ECSServicePublicIP.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.ECSServicePublicIP import check
+from checkov.terraform.runner import Runner
+
+
+class TestECSServicePublicIP(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_ECSServicePublicIP"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_ecs_service.pass",
+            "aws_ecs_service.pass2",
+        }
+        failing_resources = {
+            "aws_ecs_service.fail",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
