### PR TITLE
fix(kubernetes): Don't require ImagePullPolicy when digest (#4776)

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/ImagePullPolicyAlways.py
+++ b/checkov/kubernetes/checks/resource/k8s/ImagePullPolicyAlways.py
@@ -29,6 +29,9 @@ class ImagePullPolicyAlways(BaseK8sContainerCheck):
                 return CheckResult.UNKNOWN
             if "@" in image_val:
                 image_val = image_val[0 : image_val.index("@")]
+                has_digest = True
+            else:
+                has_digest = False
             if "imagePullPolicy" not in conf:
                 image_tag_match = re.findall(DOCKER_IMAGE_REGEX, image_val)
                 if len(image_tag_match) != 1:
@@ -38,11 +41,13 @@ class ImagePullPolicyAlways(BaseK8sContainerCheck):
                 if tag == "latest" or tag == "":
                     # Default imagePullPolicy = Always
                     return CheckResult.PASSED
+                elif has_digest:
+                    return CheckResult.PASSED
                 else:
                     # Default imagePullPolicy = IfNotPresent
                     return CheckResult.FAILED
             else:
-                if conf["imagePullPolicy"] != "Always":
+                if not has_digest and conf["imagePullPolicy"] != "Always":
                     return CheckResult.FAILED
 
         else:

--- a/checkov/terraform/checks/resource/kubernetes/ImagePullPolicyAlways.py
+++ b/checkov/terraform/checks/resource/kubernetes/ImagePullPolicyAlways.py
@@ -7,7 +7,7 @@ class ImagePullPolicyAlways(BaseResourceCheck):
     def __init__(self):
         """
         Image pull policy should be set to always to ensure you get the correct image and imagePullSecrets are correct
-        Default is 'IfNotPresent' unless image tag is omitted or :latest
+        Default is 'IfNotPresent' unless image tag/digest is omitted or :latest
         https://kubernetes.io/docs/concepts/configuration/overview/#container-images
 
         An admission controller could be used to enforce imagePullPolicy
@@ -46,6 +46,8 @@ class ImagePullPolicyAlways(BaseResourceCheck):
                     if container.get("image"):
                         name = container.get("image")[0]
                         if "latest" in name:
+                            break
+                        if "@" in name:
                             break
                 self.evaluated_keys = [f'{evaluated_keys_path}/[0]/container/[{idx}]']
                 return CheckResult.FAILED

--- a/tests/kubernetes/checks/example_ImagePullPolicy/imageWithDigest-DefaultPullPolicy-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ImagePullPolicy/imageWithDigest-DefaultPullPolicy-PASSED.yaml
@@ -1,0 +1,117 @@
+# Source: https://kubernetes.io/docs/tutorials/stateful-application/cassandra/
+# https://github.com/kubernetes/examples/tree/master/cassandra
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: cassandra
+  name: cassandra
+spec:
+  clusterIP: None
+  ports:
+  - port: 9042
+  selector:
+    app: cassandra
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cassandra
+  labels:
+    app: cassandra
+spec:
+  serviceName: cassandra
+  replicas: 3
+  selector:
+    matchLabels:
+      app: cassandra
+  template:
+    metadata:
+      labels:
+        app: cassandra
+    spec:
+      terminationGracePeriodSeconds: 1800
+      containers:
+      - name: cassandra
+        image: gcr.io/google-samples/cassandra@sha256:12345678
+        ports:
+        - containerPort: 7000
+          name: intra-node
+        - containerPort: 7001
+          name: tls-intra-node
+        - containerPort: 7199
+          name: jmx
+        - containerPort: 9042
+          name: cql
+        resources:
+          limits:
+            cpu: "500m"
+            memory: 1Gi
+          requests:
+            cpu: "500m"
+            memory: 1Gi
+        securityContext:
+          capabilities:
+            add:
+              - IPC_LOCK
+        lifecycle:
+          preStop:
+            exec:
+              command: 
+              - /bin/sh
+              - -c
+              - nodetool drain
+        env:
+          - name: MAX_HEAP_SIZE
+            value: 512M
+          - name: HEAP_NEWSIZE
+            value: 100M
+          - name: CASSANDRA_SEEDS
+            value: "cassandra-0.cassandra.default.svc.cluster.local"
+          - name: CASSANDRA_CLUSTER_NAME
+            value: "K8Demo"
+          - name: CASSANDRA_DC
+            value: "DC1-K8Demo"
+          - name: CASSANDRA_RACK
+            value: "Rack1-K8Demo"
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /ready-probe.sh
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        # These volume mounts are persistent. They are like inline claims,
+        # but not exactly because the names need to match exactly one of
+        # the stateful pod volumes.
+        volumeMounts:
+        - name: cassandra-data
+          mountPath: /cassandra_data
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above.
+  # do not use these in production until ssd GCEPersistentDisk or other ssd pd
+  volumeClaimTemplates:
+  - metadata:
+      name: cassandra-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: fast
+      resources:
+        requests:
+          storage: 1Gi
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast
+provisioner: k8s.io/minikube-hostpath
+parameters:
+  type: pd-ssd
+
+

--- a/tests/kubernetes/checks/test_ImagePullPolicyAlways.py
+++ b/tests/kubernetes/checks/test_ImagePullPolicyAlways.py
@@ -16,7 +16,7 @@ class TestImagePullPolicyAlways(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 5)
+        self.assertEqual(summary['passed'], 6)
         self.assertEqual(summary['failed'], 3)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/terraform/checks/resource/kubernetes/example_ImagePullPolicyAlways/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_ImagePullPolicyAlways/main.tf
@@ -1512,3 +1512,82 @@ resource "kubernetes_deployment_v1" "pass2" {
     }
   }
 }
+
+#happy path
+resource "kubernetes_deployment_v1" "pass3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image             = "nginx@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108"
+          name              = "example22"
+
+          security_context {
+            privileged = false
+          }
+
+          env {
+            name  = "environment"
+            value = "test"
+          }
+
+          port {
+            container_port = 8080
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+
+        dns_config {
+          nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+          searches    = ["example.com"]
+
+          option {
+            name  = "ndots"
+            value = 1
+          }
+
+          option {
+            name = "use-vc"
+          }
+        }
+
+        dns_policy = "None"
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/test_ImagePullPolicyAlways.py
+++ b/tests/terraform/checks/resource/kubernetes/test_ImagePullPolicyAlways.py
@@ -26,6 +26,7 @@ class TestImagePullPolicyAlways(unittest.TestCase):
             "kubernetes_deployment.pass2",
             "kubernetes_deployment_v1.pass",
             "kubernetes_deployment_v1.pass2",
+            "kubernetes_deployment_v1.pass3",
         }
 
         failing_resources = {
@@ -42,8 +43,8 @@ class TestImagePullPolicyAlways(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 4 * 2)
-        self.assertEqual(summary["failed"], 4 * 2)
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Don't report BC_K8S_14/CKV_K8S_15 "Image Pull Policy should be Always" when the image has a digest.

Fixes #4776

## New/Edited policies (Delete if not relevant)

[BC_K8S_14/CKV_K8S_15 "Image Pull Policy should be Always" should not be reported when using a digest](https://docs.bridgecrew.io/docs/bc_k8s_14)

### Description
Per the [documentation](https://docs.bridgecrew.io/docs/bc_k8s_14):
>  When the imagePullPolicy is set to Always, you ensure the latest version of the image is deployed every time the pod is started.

By specifying the digest, the same image is always used, so there is no concern about the latest version (since the the version cannot change), negating the need to always pull the image.

### Fix
*How does someone fix the issue in code and/or in runtime?*

As documented.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
