### PR TITLE
feat(terraform): Ensure that cloudwatch alarms are set on

### DIFF
--- a/checkov/terraform/checks/resource/aws/CloudWatchAlarmsEnabled.py
+++ b/checkov/terraform/checks/resource/aws/CloudWatchAlarmsEnabled.py
@@ -1,0 +1,25 @@
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class CloudWatchAlarmsEnabled(BaseResourceNegativeValueCheck):
+    def __init__(self):
+        """
+        NIST.800-53.r5 AU-6(1), NIST.800-53.r5 AU-6(5), NIST.800-53.r5 CA-7,
+        NIST.800-53.r5 SI-2, NIST.800-53.r5 SI-4(12)
+        CloudWatch alarm actions should be activated
+        """
+        name = "Ensure that CloudWatch alarm actions are enabled"
+        id = "CKV_AWS_319"
+        supported_resources = ['aws_cloudwatch_metric_alarm']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "actions_enabled"
+
+    def get_forbidden_values(self):
+        return [False]
+
+
+check = CloudWatchAlarmsEnabled()

--- a/tests/terraform/checks/resource/aws/example_CloudWatchAlarmsEnabled/main.tf
+++ b/tests/terraform/checks/resource/aws/example_CloudWatchAlarmsEnabled/main.tf
@@ -1,0 +1,55 @@
+resource "aws_cloudwatch_metric_alarm" "pass" {
+  alarm_name          = "alarmname"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/NetworkELB"
+  period              = 60
+  statistic           = "Average"
+  threshold           = var.logstash_servers_count
+  alarm_description   = "Number of healthy nodes in Target Group"
+  alarm_actions       = [aws_sns_topic.sns.arn]
+  ok_actions          = [aws_sns_topic.sns.arn]
+  dimensions = {
+    TargetGroup  = aws_lb_target_group.lb-tg.arn_suffix
+    LoadBalancer = aws_lb.lb.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "pass2" {
+  alarm_name          = "alarmname"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/NetworkELB"
+  period              = 60
+  statistic           = "Average"
+  threshold           = var.logstash_servers_count
+  alarm_description   = "Number of healthy nodes in Target Group"
+  actions_enabled     = true
+  alarm_actions       = [aws_sns_topic.sns.arn]
+  ok_actions          = [aws_sns_topic.sns.arn]
+  dimensions = {
+    TargetGroup  = aws_lb_target_group.lb-tg.arn_suffix
+    LoadBalancer = aws_lb.lb.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "fail" {
+  alarm_name          = "alarmname"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/NetworkELB"
+  period              = 60
+  statistic           = "Average"
+  threshold           = var.logstash_servers_count
+  alarm_description   = "Number of healthy nodes in Target Group"
+  actions_enabled     = false
+  alarm_actions       = [aws_sns_topic.sns.arn]
+  ok_actions          = [aws_sns_topic.sns.arn]
+  dimensions = {
+    TargetGroup  = aws_lb_target_group.lb-tg.arn_suffix
+    LoadBalancer = aws_lb.lb.arn_suffix
+  }
+}

--- a/tests/terraform/checks/resource/aws/test_CloudWatchAlarmsEnabled.py
+++ b/tests/terraform/checks/resource/aws/test_CloudWatchAlarmsEnabled.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.CloudWatchAlarmsEnabled import check
+from checkov.terraform.runner import Runner
+
+
+class TestCloudWatchAlarmsEnabled(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_CloudWatchAlarmsEnabled"
+        report = runner.run(
+            root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
+        )
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_cloudwatch_metric_alarm.pass",
+            "aws_cloudwatch_metric_alarm.pass2",
+
+        }
+        failing_resources = {
+            "aws_cloudwatch_metric_alarm.fail",
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
