### PR TITLE
fix(terraform): Length resolvers evaluate length of `dict` as 1.

### DIFF
--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_equals_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_equals_attribute_solver.py
@@ -14,6 +14,10 @@ class LengthEqualsAttributeSolver(BaseAttributeSolver):
 
         attr = vertex.get(attribute)  # type:ignore[arg-type]  # due to attribute can be None
         if isinstance(attr, Sized):
+            # this resolver assumes the attribute is a string or a list.
+            # if a dict is received, default the length to 1.
+            if isinstance(attr, dict):
+                return 1 == force_int(self.value)
             return len(attr) == force_int(self.value)
 
         return False

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_greater_than_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_greater_than_attribute_solver.py
@@ -18,6 +18,10 @@ class LengthGreaterThanAttributeSolver(BaseAttributeSolver):
         if value_int is None:
             return False
         if isinstance(attr, Sized):
+            # this resolver assumes the attribute is a string or a list.
+            # if a dict is received, default the length to 1.
+            if isinstance(attr, dict):
+                return 1 > value_int
             return len(attr) > value_int
 
         return False

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_greater_than_or_equal_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_greater_than_or_equal_attribute_solver.py
@@ -18,6 +18,10 @@ class LengthGreaterThanOrEqualAttributeSolver(LengthLessThanAttributeSolver):
         if value_int is None:
             return False
         if isinstance(attr, Sized):
+            # this resolver assumes the attribute is a string or a list.
+            # if a dict is received, default the length to 1.
+            if isinstance(attr, dict):
+                return 1 >= value_int
             return len(attr) >= value_int
 
         return False

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_less_than_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_less_than_attribute_solver.py
@@ -18,6 +18,10 @@ class LengthLessThanAttributeSolver(BaseAttributeSolver):
         if value_int is None:
             return False
         if isinstance(attr, Sized):
+            # this resolver assumes the attribute is a string or a list.
+            # if a dict is received, default the length to 1.
+            if isinstance(attr, dict):
+                return 1 < value_int
             return len(attr) < value_int
 
         return False

--- a/checkov/common/checks_infra/solvers/attribute_solvers/length_less_than_or_equal_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/length_less_than_or_equal_attribute_solver.py
@@ -18,6 +18,10 @@ class LengthLessThanOrEqualAttributeSolver(LengthGreaterThanAttributeSolver):
         if value_int is None:
             return False
         if isinstance(attr, Sized):
+            # this resolver assumes the attribute is a string or a list.
+            # if a dict is received, default the length to 1.
+            if isinstance(attr, dict):
+                return 1 <= value_int
             return len(attr) <= value_int
 
         return False

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/DictLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/DictLength.yaml
@@ -1,0 +1,11 @@
+metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
+  id: "DictLengthEquals"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - aws_security_group
+  attribute: ingress
+  operator: length_equals
+  value: "2"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_equals_solver/test_solver.py
@@ -37,3 +37,14 @@ class TestLengthEquals(TestBaseSolver):
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
         self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_dict_length_equals(self):
+        # this is just a basic check to make sure the operator works
+        # we'll check all the other combinations more directly (because coming up with all the policy combos is painful)
+        root_folder = '../../../resources/lengths'
+        check_id = "DictLengthEquals"
+        should_pass = ['aws_security_group.sg3']
+        should_fail = ['aws_security_group.sg2']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_or_equal_solver/DictLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_or_equal_solver/DictLength.yaml
@@ -1,0 +1,11 @@
+metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
+  id: "DictLengthGreaterThanOrEqual"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - aws_security_group
+  attribute: ingress
+  operator: length_greater_than_or_equal
+  value: "2"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_or_equal_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_or_equal_solver/test_solver.py
@@ -37,3 +37,14 @@ class TestLengthGreaterThanOrEqual(TestBaseSolver):
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
         self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_dict_length_greater_than_or_equal(self):
+        # this is just a basic check to make sure the operator works
+        # we'll check all the other combinations more directly (because coming up with all the policy combos is painful)
+        root_folder = '../../../resources/lengths'
+        check_id = "DictLengthGreaterThanOrEqual"
+        should_pass = ['aws_security_group.sg3']
+        should_fail = ['aws_security_group.sg2']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_solver/DictLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_solver/DictLength.yaml
@@ -1,0 +1,11 @@
+metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
+  id: "DictLengthGreaterThan"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - aws_security_group
+  attribute: ingress
+  operator: length_greater_than
+  value: "2"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_greater_than_solver/test_solver.py
@@ -37,3 +37,14 @@ class TestLengthGreaterThan(TestBaseSolver):
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
         self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_dict_length_greater_than(self):
+        # this is just a basic check to make sure the operator works
+        # we'll check all the other combinations more directly (because coming up with all the policy combos is painful)
+        root_folder = '../../../resources/lengths'
+        check_id = "DictLengthGreaterThan"
+        should_pass = ['aws_security_group.sg4']
+        should_fail = ['aws_security_group.sg3']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_or_equal_solver/DictLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_or_equal_solver/DictLength.yaml
@@ -1,0 +1,11 @@
+metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
+  id: "DictLengthLessThanOrEqual"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - aws_security_group
+  attribute: ingress
+  operator: length_less_than_or_equal
+  value: "2"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_or_equal_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_or_equal_solver/test_solver.py
@@ -37,3 +37,14 @@ class TestLengthLessThanOrEqual(TestBaseSolver):
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
         self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_dict_length_less_than_or_equal(self):
+        # this is just a basic check to make sure the operator works
+        # we'll check all the other combinations more directly (because coming up with all the policy combos is painful)
+        root_folder = '../../../resources/lengths'
+        check_id = "DictLengthLessThanOrEqual"
+        should_pass = ['aws_security_group.sg3']
+        should_fail = ['aws_security_group.sg4']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_solver/DictLength.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_solver/DictLength.yaml
@@ -1,0 +1,11 @@
+metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
+  id: "DictLengthLessThan"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - aws_security_group
+  attribute: ingress
+  operator: length_less_than
+  value: "2"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_less_than_solver/test_solver.py
@@ -37,3 +37,14 @@ class TestLengthLessThan(TestBaseSolver):
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
         self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_dict_length_less_than(self):
+        # this is just a basic check to make sure the operator works
+        # we'll check all the other combinations more directly (because coming up with all the policy combos is painful)
+        root_folder = '../../../resources/lengths'
+        check_id = "DictLengthLessThan"
+        should_pass = ['aws_security_group.sg2']
+        should_fail = ['aws_security_group.sg3']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/DictLengthNotEquals.yaml
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/DictLengthNotEquals.yaml
@@ -1,0 +1,11 @@
+metadata:
+  name: "example"
+  category: "GENERAL_SECURITY"
+  id: "DictLengthNotEquals"
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - aws_security_group
+  attribute: ingress
+  operator: length_not_equals
+  value: "2"

--- a/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/length_not_equals_solver/test_solver.py
@@ -37,3 +37,14 @@ class TestLengthNotEquals(TestBaseSolver):
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
         self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_dict_length_not_equals(self):
+        # this is just a basic check to make sure the operator works
+        # we'll check all the other combinations more directly (because coming up with all the policy combos is painful)
+        root_folder = '../../../resources/lengths'
+        check_id = "DictLengthNotEquals"
+        should_pass = ['aws_security_group.sg2']
+        should_fail = ['aws_security_group.sg3']
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)

--- a/tests/terraform/graph/resources/lengths/main.tf
+++ b/tests/terraform/graph/resources/lengths/main.tf
@@ -41,3 +41,74 @@ resource "aws_security_group" "sg2" {
     to_port         = "1234"
   }
 }
+
+resource "aws_security_group" "sg3" {
+  description = "security_group_3"
+
+  egress {
+    description = "Self Reference"
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = "0"
+    protocol    = "-1"
+    self        = "false"
+    to_port     = "0"
+  }
+
+  ingress {
+    description     = "Access to Bastion Host Security Group"
+    from_port       = "5432"
+    protocol        = "tcp"
+    security_groups = ["sg-id-0"]
+    self            = "false"
+    to_port         = "1234"
+  }
+
+  ingress {
+    description     = "Access to Bastion Host Security Group"
+    from_port       = "5432"
+    protocol        = "tcp"
+    security_groups = ["sg-id-0"]
+    self            = "false"
+    to_port         = "1234"
+  }
+}
+
+resource "aws_security_group" "sg4" {
+  description = "security_group_4"
+
+  egress {
+    description = "Self Reference"
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = "0"
+    protocol    = "-1"
+    self        = "false"
+    to_port     = "0"
+  }
+
+  ingress {
+    description     = "Access to Bastion Host Security Group"
+    from_port       = "5432"
+    protocol        = "tcp"
+    security_groups = ["sg-id-0"]
+    self            = "false"
+    to_port         = "1234"
+  }
+
+  ingress {
+    description     = "Access to Bastion Host Security Group"
+    from_port       = "5432"
+    protocol        = "tcp"
+    security_groups = ["sg-id-0"]
+    self            = "false"
+    to_port         = "1234"
+  }
+
+  ingress {
+    description     = "Access to Bastion Host Security Group"
+    from_port       = "5432"
+    protocol        = "tcp"
+    security_groups = ["sg-id-0"]
+    self            = "false"
+    to_port         = "1234"
+  }
+}


### PR DESCRIPTION
See https://github.com/bridgecrewio/checkov/issues/4751

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes #4751

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I have made corresponding changes to the documentation
- [ X ] I have added tests that prove my feature, policy, or fix is effective and works
- [ X ] New and existing tests pass locally with my changes
- [ X ] Any dependent changes have been merged and published in downstream modules
