### PR TITLE
fix(terraform): fix false positive CKV2_GCP_20 (fails for any non-MySQL instance)

### DIFF
--- a/checkov/terraform/checks/graph_checks/gcp/GCPMySQLdbInstancePoint_In_TimeRecoveryBackupIsEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPMySQLdbInstancePoint_In_TimeRecoveryBackupIsEnabled.yaml
@@ -4,23 +4,16 @@ metadata:
   category: "BACKUP_AND_RECOVERY"
 
 definition:
-  and:
+  or:
     - cond_type: "attribute"
-      resource_types: "google_sql_database_instance"
+      resource_types: 
+        - "google_sql_database_instance"
+      attribute: "database_version"
+      operator: "not_contains"
+      value: "MYSQL"
+    - cond_type: "attribute"
+      resource_types:
+        - "google_sql_database_instance"
       attribute: "settings.backup_configuration.binary_log_enabled"
       operator: "equals_ignore_case"
       value: "true"
-
-    - or:
-
-      - cond_type: "attribute"
-        resource_types: "google_sql_database_instance"
-        attribute: "database_version"
-        operator: "starting_with"
-        value: "MYSQL_"
-
-      - cond_type: "attribute"
-        resource_types: "google_sql_database_instance"
-        attribute: "database_version"
-        operator: "starting_with"
-        value: "mysql_"

--- a/tests/terraform/graph/checks/resources/GCPMySQLdbInstancePoint_In_TimeRecoveryBackupIsEnabled/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPMySQLdbInstancePoint_In_TimeRecoveryBackupIsEnabled/expected.yaml
@@ -1,5 +1,5 @@
 pass:
-  - "google_sql_database_instance.pass"
+  - "google_sql_database_instance.pass_1"
+  - "google_sql_database_instance.pass_2"
 fail:
-  - "google_sql_database_instance.fail_1"
-  - "google_sql_database_instance.fail_2"
+  - "google_sql_database_instance.fail"

--- a/tests/terraform/graph/checks/resources/GCPMySQLdbInstancePoint_In_TimeRecoveryBackupIsEnabled/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPMySQLdbInstancePoint_In_TimeRecoveryBackupIsEnabled/main.tf
@@ -1,44 +1,44 @@
 #PASS case 1: 
-resource "google_sql_database_instance" "pass" {
+resource "google_sql_database_instance" "pass_1" {
   name             = "pud_pass_sqldb"
   database_version = "MYSQL_5_7"
- 
+
   deletion_protection = false
   settings {
     tier = "db-f1-micro"
-    
+
     backup_configuration {
-        binary_log_enabled = "true"
+      binary_log_enabled = "true"
     }
   }
 }
 
-#FAIL case 2: database_version is not starting with "MYSQL_"
-resource "google_sql_database_instance" "fail_1" {
+#PASS case 2: database_version is not starting with "MYSQL_"
+resource "google_sql_database_instance" "pass_2" {
   name             = "pud_sqldb"
   database_version = "POSTGRES_14"
 
   deletion_protection = false
   settings {
     tier = "db-f1-micro"
-    
+
     backup_configuration {
-        binary_log_enabled = "true"
+      binary_log_enabled = "true"
     }
   }
 }
 
 #FAIL case 3: binary_log_enabled is not True
-resource "google_sql_database_instance" "fail_2" {
+resource "google_sql_database_instance" "fail" {
   name             = "pud_sqldb"
   database_version = "MYSQL_5_7"
 
   deletion_protection = false
   settings {
     tier = "db-f1-micro"
-    
+
     backup_configuration {
-        binary_log_enabled = "false"
+      binary_log_enabled = "false"
     }
   }
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

CKV2_GCP_20 fails for any non-MySQL instance because of how the conditions are set up. This PR fixes this issue and brings it more in line with conditions used in similar checks.

## New/Edited policies
```
id: "CKV2_GCP_20"
name: "Ensure MySQL DB instance has point-in-time recovery backup configured"
category: "BACKUP_AND_RECOVERY"
```

### Description
Name suggests this policy should only apply to MySQL instances, but because of how the conditions are set up, it also fails for any PostgreSQL instance (even if it has point-in-time recovery enabled).

### Fix
Changed the condition from failing if the instance is not of type MYSQL, to succeeding if it is not. This seems to be more consistent with how it is implemented in other checks, e.g. [CKV2_GCP_13](https://github.com/bridgecrewio/checkov/blob/main/checkov/terraform/checks/graph_checks/gcp/GCPPostgreSQLDatabaseFlaglog_durationIsSetToON.yaml), [CKV2_GCP_14](https://github.com/bridgecrewio/checkov/blob/main/checkov/terraform/checks/graph_checks/gcp/GCPPostgreSQLDatabaseFlaglog_executor_statsIsSetToOFF.yaml).

The original check also checked whether the instance type started with "MYSQL_" or "mysql_", but instance types should always be in full caps, and the aforementioned checks do not check for both of these cases.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
