### PR TITLE
fix(general): don't add an invalid URL to helpUri field in SARIF output

### DIFF
--- a/checkov/common/output/ai.py
+++ b/checkov/common/output/ai.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 OPENAI_API_KEY = os.getenv("CKV_OPENAI_API_KEY")
-OPENAI_MAX_FINDINGS = int(os.getenv("CKV_OPENAI_MAX_FINDINGS", 2))
+OPENAI_MAX_FINDINGS = int(os.getenv("CKV_OPENAI_MAX_FINDINGS", 5))
 OPENAI_MAX_TOKENS = int(os.getenv("CKV_OPENAI_MAX_TOKENS", 512))
 OPENAI_MODEL = os.getenv("CKV_OPENAI_MODEL", "gpt-3.5-turbo")
 

--- a/checkov/common/output/sarif.py
+++ b/checkov/common/output/sarif.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from checkov.common.models.enums import CheckResult
 from checkov.common.output.cyclonedx_consts import SCA_CHECKTYPES
+from checkov.common.util.http_utils import valid_url
 from checkov.version import version
 
 if TYPE_CHECKING:
@@ -100,7 +101,7 @@ class Sarif:
         }
 
         help_uri = record.guideline
-        if help_uri:
+        if valid_url(help_uri):
             rule["helpUri"] = help_uri
 
         return rule
@@ -127,7 +128,7 @@ class Sarif:
         }
 
         help_uri = details.get("link")
-        if help_uri:
+        if valid_url(help_uri):
             rule["helpUri"] = help_uri
 
         return rule
@@ -154,7 +155,7 @@ class Sarif:
         }
 
         help_uri = record.guideline
-        if help_uri:
+        if valid_url(help_uri):
             rule["helpUri"] = help_uri
 
         return rule

--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -12,6 +12,7 @@ import asyncio
 from typing import Any, TYPE_CHECKING, cast, Optional, overload
 
 from urllib3.response import HTTPResponse
+from urllib3.util import parse_url
 
 from checkov.common.util.consts import DEV_API_GET_HEADERS, DEV_API_POST_HEADERS, PRISMA_API_GET_HEADERS, \
     PRISMA_PLATFORM, BRIDGECREW_PLATFORM
@@ -113,6 +114,19 @@ def get_default_post_headers(client: SourceType, client_version: str | None) -> 
 
 def get_prisma_get_headers() -> dict[str, str]:
     return merge_dicts(PRISMA_API_GET_HEADERS, get_user_agent_header())
+
+
+def valid_url(url: str | None) -> bool:
+    """Checks for a valid URL, otherwise returns False"""
+
+    if not url:
+        return False
+
+    try:
+        result = parse_url(url)
+        return all([result.scheme, result.netloc])
+    except Exception:
+        return False
 
 
 def request_wrapper(

--- a/tests/common/output/test_sarif_report.py
+++ b/tests/common/output/test_sarif_report.py
@@ -16,23 +16,7 @@ from checkov.common.output.sarif import Sarif
 class TestSarifReport(unittest.TestCase):
     def test_valid_passing_valid_testcases(self):
         # given
-        record1 = Record(
-            check_id="CKV_AWS_21",
-            check_name="Some Check",
-            check_result={"result": CheckResult.FAILED},
-            code_block=[
-                (1, 'resource aws_s3_bucket "operations" {\n'),
-                (2, '  bucket = "example"\n'),
-                (3, "}\n"),
-            ],
-            file_path="./s3.tf",
-            file_line_range=[1, 3],
-            resource="aws_s3_bucket.operations",
-            evaluations=None,
-            check_class=None,
-            file_abs_path="./s3.tf",
-            entity_tags={"tag1": "value1"},
-        )
+        record1 = get_ckv_aws_21_record()
         record1.set_guideline("https://docs.bridgecrew.io/docs/s3_16-enable-versioning")
 
         record2 = Record(
@@ -160,19 +144,7 @@ class TestSarifReport(unittest.TestCase):
         )
 
     def test_multiple_instances_of_same_rule_do_not_break_schema(self):
-        record1 = Record(
-            check_id="CKV_AWS_21",
-            check_name="Some Check",
-            check_result={"result": CheckResult.FAILED},
-            code_block=[(1, "some code")],
-            file_path="./s3.tf",
-            file_line_range=[1, 3],
-            resource="aws_s3_bucket.operations",
-            evaluations=None,
-            check_class=None,
-            file_abs_path=",.",
-            entity_tags={"tag1": "value1"},
-        )
+        record1 = get_ckv_aws_21_record()
         record1.set_guideline("")
 
         record2 = Record(
@@ -352,23 +324,7 @@ class TestSarifReport(unittest.TestCase):
 
     def test_non_url_guideline_link(self):
         # given
-        record1 = Record(
-            check_id="CKV_AWS_21",
-            check_name="Some Check",
-            check_result={"result": CheckResult.FAILED},
-            code_block=[
-                (1, 'resource aws_s3_bucket "operations" {\n'),
-                (2, '  bucket = "example"\n'),
-                (3, "}\n"),
-            ],
-            file_path="./s3.tf",
-            file_line_range=[1, 3],
-            resource="aws_s3_bucket.operations",
-            evaluations=None,
-            check_class=None,
-            file_abs_path="./s3.tf",
-            entity_tags={"tag1": "value1"},
-        )
+        record1 = get_ckv_aws_21_record()
         record1.set_guideline("some random text")
 
         r = Report("terraform")
@@ -448,6 +404,25 @@ def get_sarif_schema() -> dict[str, Any]:
         schema = json.load(file)
     return schema
 
+
+def get_ckv_aws_21_record() -> Record:
+    return Record(
+        check_id="CKV_AWS_21",
+        check_name="Some Check",
+        check_result={"result": CheckResult.FAILED},
+        code_block=[
+            (1, 'resource aws_s3_bucket "operations" {\n'),
+            (2, '  bucket = "example"\n'),
+            (3, "}\n"),
+        ],
+        file_path="./s3.tf",
+        file_line_range=[1, 3],
+        resource="aws_s3_bucket.operations",
+        evaluations=None,
+        check_class=None,
+        file_abs_path="./s3.tf",
+        entity_tags={"tag1": "value1"},
+    )
 
 def are_duplicates_in_sarif_rules(sarif_json) -> bool:
     rules = sarif_json["runs"][0]["tool"]["driver"]["rules"]

--- a/tests/common/utils/test_http_utils.py
+++ b/tests/common/utils/test_http_utils.py
@@ -7,7 +7,7 @@ from pytest_mock import MockerFixture
 from aioresponses import aioresponses
 import aiohttp
 
-from checkov.common.util.http_utils import request_wrapper, aiohttp_client_session_wrapper
+from checkov.common.util.http_utils import request_wrapper, aiohttp_client_session_wrapper, valid_url
 
 
 def get_report_url() -> str:
@@ -187,3 +187,19 @@ async def test_raiohttp_client_session_wrapper_with_one_not_handled_exception(mo
         except aiohttp.ServerTimeoutError:
             # case the specific error was raised
             assert True
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (None, False),
+        ("", False),
+        ("/path/to", False),
+        ("some random text", False),
+        ("https://www.checkov.io", True),
+        ("https://docs.bridgecrew.io/docs/bc_aws_iam_45", True),
+    ],
+    ids=["None", "empty", "local path", "text", "url", "url with subdirectory"],
+)
+def test_valid_url(input, expected):
+    assert valid_url(input) == expected


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added an URL validation for the `helpUri` field in the SARIF output, because it can also be just text
- also adjusted the default for max findings to 5, which I accidentally set to 2 🙈  

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
