### PR TITLE
fix(graph): support string values for resource_types in graph checks properly

### DIFF
--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -228,6 +228,9 @@ class GraphCheckParser(BaseGraphCheckParser):
                     or (isinstance(resource_type, list) and resource_type[0].lower() == "all")
             ):
                 check.resource_types = resources_types or []
+            elif isinstance(resource_type, str):
+                #  for the case the "resource_types" value is a string, which can result in a silent exception
+                check.resource_types = [resource_type]
             else:
                 check.resource_types = resource_type
 

--- a/tests/terraform/graph/checks/custom_policies/CustomPolicy2.yaml
+++ b/tests/terraform/graph/checks/custom_policies/CustomPolicy2.yaml
@@ -1,0 +1,10 @@
+metadata:
+  name: "Tests resource_types value to be a string"
+  id: "CUSTOM_2"
+  category: "GENERAL_SECURITY"
+definition:
+  cond_type: "attribute"
+  resource_types: "aws_sqs_queue"
+  attribute: "delay_seconds"
+  operator: "equals"
+  value: 900

--- a/tests/terraform/graph/checks/resources/CustomPolicy2/expected.yaml
+++ b/tests/terraform/graph/checks/resources/CustomPolicy2/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "aws_sqs_queue.pass"
+fail:
+  - "aws_sqs_queue.fail"

--- a/tests/terraform/graph/checks/resources/CustomPolicy2/main.tf
+++ b/tests/terraform/graph/checks/resources/CustomPolicy2/main.tf
@@ -1,0 +1,12 @@
+# if there is a non-resource block, then the pre-fixed version failed with a silent exception
+variable "test" {}
+
+resource "aws_sqs_queue" "pass" {
+    name          = "pass"
+    delay_seconds = 900
+}
+
+resource "aws_sqs_queue" "fail" {
+    name          = "pass"
+    delay_seconds = 0
+}

--- a/tests/terraform/graph/checks/test_custom_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_custom_yaml_policies.py
@@ -20,6 +20,10 @@ class TestCustomYamlPolicies(unittest.TestCase):
     def test_CustomPolicy1(self):
         self.go("CustomPolicy1")
 
+    def test_CustomPolicy2(self):
+        # tests resource_types value to be a string
+        self.go("CustomPolicy2")
+
     def test_CustomAwsEMRSecurityConfiguration(self):
         self.go('CustomAwsEMRSecurityConfiguration')
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- this allows the `resource_types` value in a graph check to be a string, which in specific cases worked before, but not all the time

Fixes #4791

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
