### PR TITLE
feat(kubernetes): support non-utf-8 encoded Kubernetes manifest files

### DIFF
--- a/checkov/kubernetes/parser/k8_json.py
+++ b/checkov/kubernetes/parser/k8_json.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Hashable
 from pathlib import Path
 from typing import Tuple, Dict, Any, List, TYPE_CHECKING
 
 import yaml
+from charset_normalizer import from_path
 from yaml.loader import SafeLoader
 
 if TYPE_CHECKING:
     from yaml import MappingNode
+
+logger = logging.getLogger(__name__)
 
 
 def loads(content: str) -> list[dict[str, Any]]:
@@ -35,7 +39,12 @@ def load(filename: Path) -> Tuple[List[Dict[str, Any]], List[Tuple[int, str]]]:
     """
 
     file_path = filename if isinstance(filename, Path) else Path(filename)
-    content = file_path.read_text()
+
+    try:
+        content = file_path.read_text()
+    except UnicodeDecodeError:
+        logger.debug(f"Encoding for file {file_path} is not UTF-8, trying to detect it")
+        content = str(from_path(file_path).best())
 
     if not all(key in content for key in ("apiVersion", "kind")):
         return [{}], []

--- a/tests/kubernetes/parser/examples/yaml/busybox_utf8_bom.yaml
+++ b/tests/kubernetes/parser/examples/yaml/busybox_utf8_bom.yaml
@@ -1,0 +1,28 @@
+﻿apiVersion: v1
+kind: Pod
+metadata:
+  labels: 
+    test: liveness
+  name: liveness-exec
+spec: 
+  containers: 
+  - name: liveness
+    image: k8s.gcr.io/busybox
+    args:
+    - /bin/sh
+    - -c 
+    - touch /tmp/healthy; sleep 30; rm -rf /tmp/healthy; sleep 600
+    livenessProbe: 
+      exec: 
+        command:
+        - cat
+        - /tmp/healthy
+      initialDelaySeconds: 5
+      periodSeconds: 5
+    readinessProbe:
+      exec:
+        command:
+        - cat 
+        - /tmp/healthy
+      initialDelaySeconds: 5
+      periodSeconds: 5

--- a/tests/kubernetes/parser/test_k8_yaml.py
+++ b/tests/kubernetes/parser/test_k8_yaml.py
@@ -3,10 +3,10 @@ from pathlib import Path
 
 from checkov.kubernetes.parser.k8_yaml import load
 
-
 EXAMPLES_DIR = Path(__file__).parent / "examples"
-class TestScannerRegistry(unittest.TestCase):
 
+
+class TestScannerRegistry(unittest.TestCase):
     def test_load_pod(self):
         # given
         file_path = EXAMPLES_DIR / "yaml/busybox.yaml"
@@ -54,6 +54,20 @@ class TestScannerRegistry(unittest.TestCase):
         # then
         assert template == [{}]
         assert file_lines == []
-        
+
+    def test_load_utf8_bom_file(self):
+        # given
+        file_path = EXAMPLES_DIR / "yaml/busybox_utf8_bom.yaml"
+
+        # when
+        template, file_lines = load(file_path)
+
+        # then
+        assert len(template) == 1
+        assert template[0]["apiVersion"] == "v1"
+        assert template[0]["kind"] == "Pod"
+        assert len(file_lines) == 28
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- adds support for non-utf-8 encoded Kubernetes manifest files (json + yaml)

Fixes #4809

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
