### PR TITLE
fix(general): be more forgiving of skipped checks without comment

### DIFF
--- a/checkov/common/checks/object_registry.py
+++ b/checkov/common/checks/object_registry.py
@@ -195,7 +195,7 @@ class Registry(BaseCheckRegistry):
             results[result_key] = {
                 "check": check,
                 "result": result,
-                "suppress_comment": check_result["suppress_comment"],
+                "suppress_comment": check_result.get("suppress_comment", ""),
                 "results_configuration": None,
             }
             return result

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -401,7 +401,7 @@ class Report:
                 if self.check_type == CheckType.SCA_PACKAGE:
                     test_case.add_skipped_info(f"{check_id} skipped for {test_name_detail}")
                 else:
-                    test_case.add_skipped_info(record.check_result["suppress_comment"])
+                    test_case.add_skipped_info(record.check_result.get("suppress_comment", ""))
 
             test_cases.append(test_case)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- we already made skip comments in multiple areas optional, therefore I added the same behaviour in 2 other spots, this can happen by a misuse of the `SKIPPED` result status in a custom Python check 

Fixes #4835

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
