### PR TITLE
chore: move the jsonpath cache to class level

### DIFF
--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -20,6 +20,7 @@ from checkov.common.util.var_utils import is_terraform_variable_dependent
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType as TerraformBlockType
 
 if TYPE_CHECKING:
+    from bc_jsonpath_ng import JSONPath
     from checkov.common.typing import LibraryGraph
 
 SUPPORTED_BLOCK_TYPES = {BlockType.RESOURCE, TerraformBlockType.DATA, TerraformBlockType.MODULE}
@@ -28,7 +29,8 @@ WILDCARD_PATTERN = re.compile(r"(\S+[.][*][.]*)+")
 
 class BaseAttributeSolver(BaseSolver):
     operator = ""  # noqa: CCE003  # a static attribute
-    is_value_attribute_check = True    # noqa: CCE003  # a static attribute
+    is_value_attribute_check = True  # noqa: CCE003  # a static attribute
+    jsonpath_parsed_statement_cache: "dict[str, JSONPath]" = {}  # noqa: CCE003  # global cache
 
     def __init__(
         self, resource_types: List[str], attribute: Optional[str], value: Any, is_jsonpath_check: bool = False
@@ -38,7 +40,6 @@ class BaseAttributeSolver(BaseSolver):
         self.attribute = attribute
         self.value = value
         self.is_jsonpath_check = is_jsonpath_check
-        self.parsed_attributes: Dict[Optional[str], Any] = {}
 
     def run(self, graph_connector: LibraryGraph) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         executer = ThreadPoolExecutor()
@@ -141,11 +142,8 @@ class BaseAttributeSolver(BaseSolver):
     def get_attribute_matches(self, vertex: Dict[str, Any]) -> List[str]:
         try:
             attribute_matches: List[str] = []
-            if self.is_jsonpath_check:
-                parsed_attr = self.parsed_attributes.get(self.attribute)
-                if parsed_attr is None:
-                    parsed_attr = parse(self.attribute)  # type:ignore[arg-type]  # self.attribute is no longer going to be Optional here
-                    self.parsed_attributes[self.attribute] = parsed_attr
+            if self.is_jsonpath_check and self.attribute:
+                parsed_attr = self._get_cached_jsonpath_statement(statement=self.attribute)
 
                 for match in parsed_attr.find(vertex):
                     full_path = str(match.full_path)
@@ -225,3 +223,13 @@ class BaseAttributeSolver(BaseSolver):
         except Exception as e:
             logging.info(f'cant parse policy str to object, {str(e)}')
         return value_to_check
+
+    def _get_cached_jsonpath_statement(self, statement: str) -> JSONPath:
+        """Returns the parsed jsonpath statement from the cache or adds it"""
+
+        if statement not in BaseAttributeSolver.jsonpath_parsed_statement_cache:
+            parsed_attr = parse(statement)
+            BaseAttributeSolver.jsonpath_parsed_statement_cache[statement] = parsed_attr
+            return parsed_attr
+
+        return BaseAttributeSolver.jsonpath_parsed_statement_cache[statement]

--- a/tests/terraform/graph/checks_infra/test_base.py
+++ b/tests/terraform/graph/checks_infra/test_base.py
@@ -1,6 +1,7 @@
 import os
 from unittest import TestCase
 from unittest import mock
+from unittest.mock import MagicMock
 
 from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.checks_infra.registry import Registry
@@ -30,6 +31,37 @@ class TestBaseSolver(TestCase):
     def test_unrendered_variable_source(self):
         self.assertTrue(BaseAttributeSolver._is_variable_dependant("var.location", "Terraform"))
         self.assertTrue(BaseAttributeSolver._is_variable_dependant("var.location", "terraform"))
+
+    def test_get_cached_jsonpath_statement(self):
+        # given
+        statement = "policy.Statement[?(@.Effect == Allow)].Action[*]"
+        solver_1 = BaseAttributeSolver(
+            resource_types=["aws_iam_policy"],
+            attribute=statement,
+            value="iam:*",
+            is_jsonpath_check=True,
+        )
+        solver_2 = BaseAttributeSolver(
+            resource_types=["aws_iam_policy"],
+            attribute=statement,
+            value="iam:*",
+            is_jsonpath_check=True,
+        )
+        jsonpath_parse_mock = MagicMock()
+
+        self.assertEqual(len(BaseAttributeSolver.jsonpath_parsed_statement_cache), 0)
+
+        # when
+        solver_1._get_cached_jsonpath_statement(statement=statement)
+        self.assertEqual(len(BaseAttributeSolver.jsonpath_parsed_statement_cache), 1)
+
+        # patch jsonpath_ng.parse to be able to check it was really not called again and the cache was properly used
+        with mock.patch("checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver.parse", side_effect=jsonpath_parse_mock):
+            solver_2._get_cached_jsonpath_statement(statement=statement)
+
+        # then
+        self.assertEqual(len(BaseAttributeSolver.jsonpath_parsed_statement_cache), 1)
+        jsonpath_parse_mock.assert_not_called()  # jsonpath_ng.parse shouldn't have been called again
 
 
 def verify_report(report, expected_results):

--- a/tests/terraform/graph/checks_infra/test_base.py
+++ b/tests/terraform/graph/checks_infra/test_base.py
@@ -1,7 +1,6 @@
 import os
 from unittest import TestCase
 from unittest import mock
-from unittest.mock import MagicMock
 
 from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.checks_infra.registry import Registry
@@ -31,37 +30,6 @@ class TestBaseSolver(TestCase):
     def test_unrendered_variable_source(self):
         self.assertTrue(BaseAttributeSolver._is_variable_dependant("var.location", "Terraform"))
         self.assertTrue(BaseAttributeSolver._is_variable_dependant("var.location", "terraform"))
-
-    def test_get_cached_jsonpath_statement(self):
-        # given
-        statement = "policy.Statement[?(@.Effect == Allow)].Action[*]"
-        solver_1 = BaseAttributeSolver(
-            resource_types=["aws_iam_policy"],
-            attribute=statement,
-            value="iam:*",
-            is_jsonpath_check=True,
-        )
-        solver_2 = BaseAttributeSolver(
-            resource_types=["aws_iam_policy"],
-            attribute=statement,
-            value="iam:*",
-            is_jsonpath_check=True,
-        )
-        jsonpath_parse_mock = MagicMock()
-
-        self.assertEqual(len(BaseAttributeSolver.jsonpath_parsed_statement_cache), 0)
-
-        # when
-        solver_1._get_cached_jsonpath_statement(statement=statement)
-        self.assertEqual(len(BaseAttributeSolver.jsonpath_parsed_statement_cache), 1)
-
-        # patch jsonpath_ng.parse to be able to check it was really not called again and the cache was properly used
-        with mock.patch("checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver.parse", side_effect=jsonpath_parse_mock):
-            solver_2._get_cached_jsonpath_statement(statement=statement)
-
-        # then
-        self.assertEqual(len(BaseAttributeSolver.jsonpath_parsed_statement_cache), 1)
-        jsonpath_parse_mock.assert_not_called()  # jsonpath_ng.parse shouldn't have been called again
 
 
 def verify_report(report, expected_results):

--- a/tests/terraform/graph/checks_infra/test_base_attribute_solver.py
+++ b/tests/terraform/graph/checks_infra/test_base_attribute_solver.py
@@ -1,0 +1,36 @@
+from mock.mock import MagicMock
+from pytest_mock import MockerFixture
+
+from checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver import BaseAttributeSolver
+
+
+def test_get_cached_jsonpath_statement(mocker: MockerFixture):
+    # given
+    statement = "policy.Statement[?(@.Effect == Allow)].Action[*]"
+    solver_1 = BaseAttributeSolver(
+        resource_types=["aws_iam_policy"],
+        attribute=statement,
+        value="iam:*",
+        is_jsonpath_check=True,
+    )
+    solver_2 = BaseAttributeSolver(
+        resource_types=["aws_iam_policy"],
+        attribute=statement,
+        value="iam:*",
+        is_jsonpath_check=True,
+    )
+    jsonpath_parse_mock = MagicMock()
+
+    assert len(BaseAttributeSolver.jsonpath_parsed_statement_cache) == 0
+
+    # when
+    solver_1._get_cached_jsonpath_statement(statement=statement)
+    assert len(BaseAttributeSolver.jsonpath_parsed_statement_cache) == 1
+
+    # patch jsonpath_ng.parse to be able to check it was really not called again and the cache was properly used
+    with mocker.patch("checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver.parse", side_effect=jsonpath_parse_mock):
+        solver_2._get_cached_jsonpath_statement(statement=statement)
+
+    # then
+    assert len(BaseAttributeSolver.jsonpath_parsed_statement_cache) == 1
+    jsonpath_parse_mock.assert_not_called()  # jsonpath_ng.parse shouldn't have been called again

--- a/tests/terraform/graph/checks_infra/test_base_attribute_solver.py
+++ b/tests/terraform/graph/checks_infra/test_base_attribute_solver.py
@@ -6,6 +6,7 @@ from checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver
 
 def test_get_cached_jsonpath_statement(mocker: MockerFixture):
     # given
+    BaseAttributeSolver.jsonpath_parsed_statement_cache = {}  # reset cache
     statement = "policy.Statement[?(@.Effect == Allow)].Action[*]"
     solver_1 = BaseAttributeSolver(
         resource_types=["aws_iam_policy"],


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- moved the `jsonpath` parsed statement cache to the class level, so it can be leveraged by other policies, which use the same statement

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
