### PR TITLE
fix(terraform): exclude GCP asymmetric keys from key rotation

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleKMSRotationPeriod.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleKMSRotationPeriod.py
@@ -5,6 +5,7 @@ from checkov.common.util.type_forcers import force_int
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
+ASYMMETRIC_KEYS = {"ASYMMETRIC_DECRYPT", "ASYMMETRIC_SIGN"}
 # rotation_period time unit is seconds
 ONE_DAY = 24 * 60 * 60
 NINETY_DAYS = 90 * ONE_DAY
@@ -14,11 +15,17 @@ class GoogleKMSKeyRotationPeriod(BaseResourceCheck):
     def __init__(self) -> None:
         name = "Ensure KMS encryption keys are rotated within a period of 90 days"
         id = "CKV_GCP_43"
-        supported_resources = ["google_kms_crypto_key"]
-        categories = [CheckCategories.GENERAL_SECURITY]
+        supported_resources = ("google_kms_crypto_key",)
+        categories = (CheckCategories.GENERAL_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
+        purpose = conf.get("purpose")
+        if purpose and isinstance(purpose, list) and purpose[0] in ASYMMETRIC_KEYS:
+            # https://cloud.google.com/kms/docs/key-rotation#asymmetric
+            # automatic key rotation is not supported for asymmetric keys
+            return CheckResult.UNKNOWN
+
         self.evaluated_keys = ["rotation_period"]
         rotation = conf.get("rotation_period")
         if rotation and rotation[0]:

--- a/tests/terraform/checks/resource/gcp/example_GoogleKMSRotationPeriod/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleKMSRotationPeriod/main.tf
@@ -24,3 +24,11 @@ resource "google_kms_crypto_key" "default" {
   name     = "crypto-key-example"
   key_ring = "google_kms_key_ring.keyring.id"
 }
+
+# unknown
+
+resource "google_kms_crypto_key" "asymmetric" {
+  name     = "crypto-key-example"
+  key_ring = "google_kms_key_ring.keyring.id"
+  purpose  = "ASYMMETRIC_SIGN"
+}

--- a/tests/terraform/checks/resource/gcp/test_GoogleKMSKeyRotationPeriod.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleKMSKeyRotationPeriod.py
@@ -34,6 +34,7 @@ class TestGoogleKMSKeyRotationPeriod(unittest.TestCase):
         self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
+        self.assertEqual(summary["resource_count"], 5)  # 1 unknown
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- excluded GCP asymmetric keys from key rotation, because it is not supported

Fixes #4862

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
