### PR TITLE
feat(terraform): add support for list of dicts in for loop

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
@@ -5,7 +5,6 @@ import json
 import logging
 import os
 import re
-from json import JSONDecodeError
 from typing import Any, Union, Optional, List, Dict, Callable, TypeVar, Tuple
 
 from checkov.common.util.type_forcers import force_int
@@ -24,7 +23,7 @@ CHECKOV_RENDER_MAX_LEN = force_int(os.getenv("CHECKOV_RENDER_MAX_LEN", "10000"))
 
 
 def evaluate_terraform(input_str: Any, keep_interpolations: bool = True) -> Any:
-    if input_str is None:
+    if input_str is None or isinstance(input_str, int):
         # no need for further evaluation
         return input_str
 

--- a/tests/terraform/checks/resource/aws/example_EC2PublicIP/main.tf
+++ b/tests/terraform/checks/resource/aws/example_EC2PublicIP/main.tf
@@ -95,3 +95,31 @@ resource "aws_instance" "public_foreach_loop_list" {
   associate_public_ip_address = each.value
 }
 
+variable "loop_list_of_dicts" {
+  default = [
+    {
+      "name": "public",
+      "public_ip": true
+    },
+    {
+      "name": "private",
+      "public_ip": false
+    }
+  ]
+}
+
+locals {
+  loop_list_of_dicts = [
+    for val in var.loop_list_of_dicts : {
+      name = val.name
+      public_ip = val.public_ip
+    }
+  ]
+}
+
+resource "aws_instance" "public_foreach_loop_list_of_dicts" {
+  for_each = { for val in local.loop_list_of_dicts : val.name => val }
+
+  name                        = each.value.name
+  associate_public_ip_address = each.value.public_ip
+}

--- a/tests/terraform/checks/resource/aws/test_EC2PublicIP.py
+++ b/tests/terraform/checks/resource/aws/test_EC2PublicIP.py
@@ -23,6 +23,7 @@ class TestEC2PublicIP(unittest.TestCase):
             "aws_instance.public_foreach[\"key2\"]",
             "aws_instance.public_foreach_loop_list[\"k\"]",
             "aws_instance.public_foreach_loop_list[\"v\"]",
+            "aws_instance.public_foreach_loop_list_of_dicts[\"private\"]",
         }
         failing_resources = {
             "aws_instance.public",
@@ -30,6 +31,7 @@ class TestEC2PublicIP(unittest.TestCase):
             "aws_instance.public_foreach[\"key1\"]",
             "aws_instance.public_foreach_loop[\"key3\"]",
             "aws_instance.public_foreach_loop[\"key4\"]",
+            "aws_instance.public_foreach_loop_list_of_dicts[\"public\"]",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}

--- a/tests/terraform/graph/variable_rendering/test_string_evaluation.py
+++ b/tests/terraform/graph/variable_rendering/test_string_evaluation.py
@@ -451,17 +451,23 @@ class TestTerraformEvaluation(TestCase):
         expected = "11 Hours and 1 Minute(s)"
         self.assertEqual(expected, evaluate_terraform(input_str))
 
-    def test_handle_for_loop(self):
+    def test_handle_for_loop_in_dict(self):
         input_str = "{for val in [{'name': 'key3'},{'name': 'key4'}] : val.name => true}"
         expected = {'key3': 'true', 'key4': 'true'}
         self.assertEqual(expected, evaluate_terraform(input_str))
 
+    def test_handle_for_loop_in_list(self):
         input_str = "[for val in ['k', 'v'] : val]"
         expected = ['k', 'v']
         self.assertEqual(expected, evaluate_terraform(input_str))
 
         input_str = "{for val in ['k', 'v'] : val.name => true}"
         expected = "{for val in ['k', 'v'] : val.name :> true}"
+        self.assertEqual(expected, evaluate_terraform(input_str))
+
+    def test_handle_for_loop_in_list_of_dicts(self):
+        input_str = "[for val in [{'name': 'raw', 'type': 'container'}, {'name': 'masked', 'type': 'blob'}] : {'name': '${val.name}', 'type': '${val.type}'}]"
+        expected = [{'name': 'raw', 'type': 'container'}, {'name': 'masked', 'type': 'blob'}]
         self.assertEqual(expected, evaluate_terraform(input_str))
 
     def test_base64_value(self):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- extend `for` loop support for list of dicts

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
