### PR TITLE
fix(terraform): limit RDS cluster audit logging to MySQL engine

### DIFF
--- a/tests/terraform/checks/resource/aws/example_RDSClusterAuditLogging/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSClusterAuditLogging/main.tf
@@ -12,6 +12,7 @@ resource "aws_rds_cluster" "pass2" {
   master_password = "password"
   enabled_cloudwatch_logs_exports = ["general", "audit"]
   iam_database_authentication_enabled = true
+  engine = "aurora-mysql"
 }
 
 resource "aws_rds_cluster" "fail" {
@@ -24,4 +25,13 @@ resource "aws_rds_cluster" "fail2" {
   master_password = "password"
   enabled_cloudwatch_logs_exports = ["error", "general", "slowquery"]
   iam_database_authentication_enabled = false
+}
+
+# unknown
+
+resource "aws_rds_cluster" "unknown" {
+  master_username = "username"
+  master_password = "password"
+
+  engine = "aurora-postgresql"
 }

--- a/tests/terraform/checks/resource/aws/test_RDSClusterAuditLogging.py
+++ b/tests/terraform/checks/resource/aws/test_RDSClusterAuditLogging.py
@@ -10,7 +10,7 @@ class TestRDSClusterAuditLogging(unittest.TestCase):
     def test(self):
         test_files_dir = Path(__file__).parent / "example_RDSClusterAuditLogging"
 
-        report = Runner().run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
         passing_resources = {
@@ -29,6 +29,7 @@ class TestRDSClusterAuditLogging(unittest.TestCase):
         self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
+        self.assertEqual(summary["resource_count"], 5)
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- audit logging through the CW export can only be enabled for MySQL DB egines

Fixes #4887 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
