### PR TITLE
feat(arm): add Storage accounts disallow public access check for ARM

### DIFF
--- a/checkov/arm/base_resource_negative_value_check.py
+++ b/checkov/arm/base_resource_negative_value_check.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import re
+from abc import abstractmethod
+from collections.abc import Iterable
+from typing import Any
+
+from checkov.arm.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.util.data_structures_utils import find_in_dict
+from checkov.common.util.type_forcers import force_list
+
+VARIABLE_DEPENDANT_REGEX = re.compile(r"(?:parameters|variables)\(")
+
+
+class BaseResourceNegativeValueCheck(BaseResourceCheck):
+    def __init__(
+        self,
+        name: str,
+        id: str,
+        categories: "Iterable[CheckCategories]",
+        supported_resources: "Iterable[str]",
+        missing_block_result: CheckResult = CheckResult.PASSED,
+        guideline: str | None = None,
+    ) -> None:
+        super().__init__(
+            name=name, id=id, categories=categories, supported_resources=supported_resources, guideline=guideline
+        )
+        self.missing_block_result = missing_block_result
+
+    @staticmethod
+    def _is_variable_dependant(value: Any) -> bool:
+        if isinstance(value, str) and re.match(VARIABLE_DEPENDANT_REGEX, value):
+            return True
+        return False
+
+    def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:  # type:ignore[override]  # issue with multi_signature annotation
+        inspected_key = self.get_inspected_key()
+        forbidden_values = self.get_forbidden_values()
+        value = find_in_dict(conf, inspected_key)
+        if value:
+            if isinstance(value, list) and len(value) == 1:
+                value = value[0]
+
+            if self._is_variable_dependant(value):
+                # If the tested attribute is variable-dependant, then result is PASSED
+                return CheckResult.UNKNOWN
+
+            if value in forbidden_values or ANY_VALUE in forbidden_values:
+                return CheckResult.FAILED
+            else:
+                return CheckResult.PASSED
+
+        return self.missing_block_result
+
+    @abstractmethod
+    def get_inspected_key(self) -> str:
+        """
+        :return: JSONPath syntax path of the checked attribute
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_forbidden_values(self) -> list[Any]:
+        """
+        Returns a list of vulnerable values for the inspected key, governed by provider best practices
+        """
+        raise NotImplementedError()
+
+    def get_evaluated_keys(self) -> list[str]:
+        return force_list(self.get_inspected_key())

--- a/checkov/arm/base_resource_negative_value_check.py
+++ b/checkov/arm/base_resource_negative_value_check.py
@@ -31,9 +31,7 @@ class BaseResourceNegativeValueCheck(BaseResourceCheck):
 
     @staticmethod
     def _is_variable_dependant(value: Any) -> bool:
-        if isinstance(value, str) and re.match(VARIABLE_DEPENDANT_REGEX, value):
-            return True
-        return False
+        return bool(isinstance(value, str) and re.match(VARIABLE_DEPENDANT_REGEX, value))
 
     def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:  # type:ignore[override]  # issue with multi_signature annotation
         inspected_key = self.get_inspected_key()

--- a/checkov/arm/checks/resource/StorageAccountDisablePublicAccess.py
+++ b/checkov/arm/checks/resource/StorageAccountDisablePublicAccess.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.arm.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class StorageAccountDisablePublicAccess(BaseResourceNegativeValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that Storage accounts disallow public access"
+        id = "CKV_AZURE_59"
+        supported_resources = ("Microsoft.Storage/storageAccounts",)
+        categories = (CheckCategories.NETWORKING,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "properties/publicNetworkAccess"
+
+    def get_forbidden_values(self) -> list[Any]:
+        return ["Enabled"]
+
+
+check = StorageAccountDisablePublicAccess()

--- a/tests/arm/checks/resource/example_StorageAccountDisablePublicAccess/FAILED.json
+++ b/tests/arm/checks/resource/example_StorageAccountDisablePublicAccess/FAILED.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_ZRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "Storage Account type"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    }
+  },
+  "variables": {
+    "storageAccountName": "[concat('store', uniquestring(resourceGroup().id))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2019-04-01",
+      "name": "enabled",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('storageAccountType')]"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "publicNetworkAccess": "Enabled"
+      }
+    }
+  ],
+  "outputs": {
+    "storageAccountName": {
+      "type": "string",
+      "value": "[variables('storageAccountName')]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/example_StorageAccountDisablePublicAccess/PASSED.json
+++ b/tests/arm/checks/resource/example_StorageAccountDisablePublicAccess/PASSED.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_ZRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "Storage Account type"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    }
+  },
+  "variables": {
+    "storageAccountName": "[concat('store', uniquestring(resourceGroup().id))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2019-04-01",
+      "name": "default",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('storageAccountType')]"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "supportsHttpsTrafficOnly": true
+      }
+    }
+  ],
+  "outputs": {
+    "storageAccountName": {
+      "type": "string",
+      "value": "[variables('storageAccountName')]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/example_StorageAccountDisablePublicAccess/PASSED_2.json
+++ b/tests/arm/checks/resource/example_StorageAccountDisablePublicAccess/PASSED_2.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_ZRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "Storage Account type"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    }
+  },
+  "variables": {
+    "storageAccountName": "[concat('store', uniquestring(resourceGroup().id))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2019-04-01",
+      "name": "disabled",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('storageAccountType')]"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "publicNetworkAccess": "Disabled"
+      }
+    }
+  ],
+  "outputs": {
+    "storageAccountName": {
+      "type": "string",
+      "value": "[variables('storageAccountName')]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/test_StorageAccountDisablePublicAccess.py
+++ b/tests/arm/checks/resource/test_StorageAccountDisablePublicAccess.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+from checkov.arm.checks.resource.StorageAccountDisablePublicAccess import check
+from checkov.arm.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestStorageAccountDisablePublicAccess(unittest.TestCase):
+    def test_summary(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_StorageAccountDisablePublicAccess"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "Microsoft.Storage/storageAccounts.default",
+            "Microsoft.Storage/storageAccounts.disabled",
+        }
+        failing_resources = {
+            "Microsoft.Storage/storageAccounts.enabled",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- adds the missing `CKV_AZURE_59` to ARM
- also added the negative value base check class to ARM

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
