### PR TITLE
fix(terraform): remove duplicate call to convert graph vertices

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -55,7 +55,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         self.dirname_cache: Dict[str, str] = {}
         self.vertices_by_module_dependency_by_name: Dict[Tuple[str, str], Dict[BlockType, Dict[str, List[int]]]] = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         self.vertices_by_module_dependency: Dict[Tuple[str, str], Dict[BlockType, List[int]]] = defaultdict(lambda: defaultdict(list))
-        self.enable_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_FOREACH_HANDLING', 'True'))
+        self.enable_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_FOREACH_HANDLING', 'False'))
         self.enable_modules_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_MODULES_FOREACH_HANDLING', 'False'))
         self.use_new_tf_parser = strtobool(os.getenv('CHECKOV_NEW_TF_PARSER', 'False'))
         self.foreach_blocks: Dict[str, List[int]] = {BlockType.RESOURCE: [], BlockType.MODULE: []}

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -55,7 +55,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         self.dirname_cache: Dict[str, str] = {}
         self.vertices_by_module_dependency_by_name: Dict[Tuple[str, str], Dict[BlockType, Dict[str, List[int]]]] = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         self.vertices_by_module_dependency: Dict[Tuple[str, str], Dict[BlockType, List[int]]] = defaultdict(lambda: defaultdict(list))
-        self.enable_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_FOREACH_HANDLING', 'False'))
+        self.enable_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_FOREACH_HANDLING', 'True'))
         self.enable_modules_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_MODULES_FOREACH_HANDLING', 'False'))
         self.use_new_tf_parser = strtobool(os.getenv('CHECKOV_NEW_TF_PARSER', 'False'))
         self.foreach_blocks: Dict[str, List[int]] = {BlockType.RESOURCE: [], BlockType.MODULE: []}

--- a/checkov/terraform/graph_manager.py
+++ b/checkov/terraform/graph_manager.py
@@ -6,7 +6,6 @@ from typing import Type, Any, TYPE_CHECKING
 
 from checkov.common.runners.base_runner import strtobool
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
-from checkov.terraform.graph_builder.graph_to_tf_definitions import convert_graph_vertices_to_tf_definitions
 from checkov.terraform.graph_builder.local_graph import TerraformLocalGraph
 from checkov.terraform.parser import Parser
 
@@ -52,7 +51,6 @@ class TerraformGraphManager(GraphManager[TerraformLocalGraph, "dict[str, dict[st
             local_graph = local_graph_class(module)
             local_graph.build_graph(render_variables=render_variables)
 
-        tf_definitions, _ = convert_graph_vertices_to_tf_definitions(local_graph.vertices, source_dir)
         return local_graph, tf_definitions
 
     def build_graph_from_definitions(

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -8,6 +8,7 @@ from checkov.common.util.json_utils import object_hook, CustomJSONEncoder
 from checkov.terraform.graph_builder.foreach.abstract_handler import ForeachAbstractHandler
 from checkov.terraform.graph_builder.foreach.builder import ForeachBuilder
 from checkov.terraform.graph_builder.foreach.resource_handler import ForeachResourceHandler
+from checkov.terraform.graph_builder.graph_to_tf_definitions import convert_graph_vertices_to_tf_definitions
 
 TEST_DIRNAME = os.path.dirname(os.path.realpath(__file__))
 
@@ -245,7 +246,9 @@ def test_update_attrs(attrs, k_v_to_change, expected_attrs, expected_res):
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})
 def test_new_tf_parser_with_foreach_modules(checkov_source_path):
     dir_name = 'parser_dup_nested'
-    local_graph, tf_definitions = build_and_get_graph_by_path(dir_name, render_var=True)
+    local_graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
+    tf_definitions, _ = convert_graph_vertices_to_tf_definitions(vertices=local_graph.vertices, root_folder=dir_name)
+
     assert len(tf_definitions.keys()) == 14
     assert len([block for block in local_graph.vertices if block.block_type == 'resource']) == 8
     assert len([block for block in local_graph.vertices if block.block_type == 'module']) == 12
@@ -310,7 +313,8 @@ def test_new_tf_parser_with_foreach_modules(checkov_source_path):
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})
 def test_tf_definitions_for_foreach_on_modules(checkov_source_path):
     dir_name = 'parser_dup_nested'
-    _, tf_definitions = build_and_get_graph_by_path(dir_name, render_var=True)
+    local_graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
+    tf_definitions, _ = convert_graph_vertices_to_tf_definitions(vertices=local_graph.vertices, root_folder=dir_name)
 
     file_path = os.path.join(os.path.dirname(__file__), 'expected_foreach_modules_tf_definitions.json')
     with open(file_path, 'r') as f:
@@ -327,7 +331,8 @@ def test_tf_definitions_for_foreach_on_modules(checkov_source_path):
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})
 def test_foreach_module_in_second_level_module(checkov_source_path):
     dir_name = 'foreach_module'
-    graph, tf_definitions = build_and_get_graph_by_path(dir_name, render_var=True)
+    graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
+    tf_definitions, _ = convert_graph_vertices_to_tf_definitions(vertices=graph.vertices, root_folder=dir_name)
 
     assert len([block for block in graph.vertices if block.block_type == 'module']) == 10
     assert len([block for block in graph.vertices if block.block_type == 'resource']) == 8
@@ -339,7 +344,8 @@ def test_foreach_module_in_second_level_module(checkov_source_path):
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})
 def test_foreach_module_in_both_levels_module(checkov_source_path):
     dir_name = 'foreach_module_dup_foreach'
-    graph, tf_definitions = build_and_get_graph_by_path(dir_name, render_var=True)
+    graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
+    tf_definitions, _ = convert_graph_vertices_to_tf_definitions(vertices=graph.vertices, root_folder=dir_name)
 
     assert len([block for block in graph.vertices if block.block_type == 'module']) == 20
     assert len([block for block in graph.vertices if block.block_type == 'resource']) == 16
@@ -351,7 +357,8 @@ def test_foreach_module_in_both_levels_module(checkov_source_path):
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})
 def test_foreach_module_and_resource(checkov_source_path):
     dir_name = 'foreach_module_and_resource'
-    graph, tf_definitions = build_and_get_graph_by_path(dir_name, render_var=True)
+    graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
+    tf_definitions, _ = convert_graph_vertices_to_tf_definitions(vertices=graph.vertices, root_folder=dir_name)
 
     assert len([block for block in graph.vertices if block.block_type == 'module']) == 2
     assert len([block for block in graph.vertices if block.block_type == 'resource']) == 4
@@ -368,7 +375,8 @@ def test_foreach_module_and_resource(checkov_source_path):
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})
 def test_foreach_module_with_more_than_two_resources(checkov_source_path):
     dir_name = 'foreach_module_with_more_than_two_resources'
-    graph, tf_definitions = build_and_get_graph_by_path(dir_name, render_var=True)
+    graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
+    tf_definitions, _ = convert_graph_vertices_to_tf_definitions(vertices=graph.vertices, root_folder=dir_name)
 
     assert len([block for block in graph.vertices if block.block_type == 'module']) == 16
     assert len([block for block in graph.vertices if block.block_type == 'resource']) == 14


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- removed the unneeded call of `convert_graph_vertices_to_tf_definitions` in the graph manager, because it is done anyway in the `run` method of the TF runner

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
