### PR TITLE
fix(terraform): make sure K8s volume is a dict

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/DockerSocketVolume.py
+++ b/checkov/terraform/checks/resource/kubernetes/DockerSocketVolume.py
@@ -33,7 +33,7 @@ class DockerSocketVolume(BaseResourceCheck):
         if "volume" in spec and spec.get("volume"):
             volumes = spec.get("volume")
             for idx, v in enumerate(volumes):
-                if v.get("host_path"):
+                if isinstance(v, dict) and v.get("host_path"):
                     if "path" in v["host_path"][0]:
                         if v["host_path"][0]["path"] == ["/var/run/docker.sock"]:
                             self.evaluated_keys = [f"spec/volume/{idx}/host_path/[0]/path"]
@@ -47,8 +47,7 @@ class DockerSocketVolume(BaseResourceCheck):
                     for idx, v in enumerate(volumes):
                         if isinstance(v, dict) and v.get("host_path"):
                             if "path" in v["host_path"][0]:
-                                path = v["host_path"][0]["path"]
-                                if path == ["/var/run/docker.sock"]:
+                                if v["host_path"][0]["path"] == ["/var/run/docker.sock"]:
                                     self.evaluated_keys = [f"spec/template/spec/volume/{idx}/host_path/[0]/path"]
                                     return CheckResult.FAILED
 

--- a/tests/terraform/checks/resource/kubernetes/example_DockerSocketVolume/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_DockerSocketVolume/main.tf
@@ -75,12 +75,7 @@ resource "kubernetes_pod_v1" "fail" {
 
   spec {
 
-    volume {
-      host_path {
-        path = "/var/run/docker.sock"
-        type = "Directory"
-      }
-    }
+    volume = "invalid"
 
     volume {
       host_path {


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixes #4916

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
