### PR TITLE
fix(general): Dedup results contain multiple identical images if using template syntax

### DIFF
--- a/checkov/gitlab_ci/image_referencer/provider.py
+++ b/checkov/gitlab_ci/image_referencer/provider.py
@@ -57,4 +57,4 @@ class GitlabCiProvider(WorkflowImageReferencerProvider):
                                                                                     end_line=end_line)
                             )
                             images.append(image_obj)
-        return images
+        return list(set(images))


### PR DESCRIPTION
…(&run_create_badges_template and *run_create_badges_template)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
