### PR TITLE
feat(secrets): support scanning of secrets in hidden paths

### DIFF
--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -32,9 +32,7 @@ from checkov.common.models.enums import CheckResult
 from checkov.common.output.report import Report
 from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.runners.base_runner import BaseRunner, filter_ignored_paths
-from checkov.common.runners.base_runner import ignored_directories
 from checkov.common.typing import _CheckResult
-from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 from checkov.common.util.dockerfile import is_docker_file
 from checkov.common.util.secrets import omit_secret_value_from_line
 from checkov.runner_filter import RunnerFilter
@@ -44,6 +42,7 @@ from checkov.secrets.plugins.load_detectors import get_runnable_plugins
 from checkov.secrets.git_history_store import GitHistorySecretStore
 from checkov.secrets.git_types import EnrichedPotentialSecret
 from checkov.secrets.scan_git_history import GitHistoryScanner
+from checkov.secrets.utils import filter_excluded_paths, EXCLUDED_PATHS
 
 if TYPE_CHECKING:
     from checkov.common.util.tqdm_utils import ProgressBar
@@ -159,7 +158,7 @@ class Runner(BaseRunner[None]):
 
             # Implement non IaC files (including .terraform dir)
             files_to_scan = files or []
-            excluded_paths = (runner_filter.excluded_paths or []) + ignored_directories + [DEFAULT_EXTERNAL_MODULES_DIR]
+            excluded_paths = (runner_filter.excluded_paths or []) + EXCLUDED_PATHS
             self._add_custom_detectors_to_metadata_integration()
             if root_folder:
                 if runner_filter.enable_git_history_secret_scan:
@@ -173,8 +172,14 @@ class Runner(BaseRunner[None]):
                     block_list_secret_scan = runner_filter.block_list_secret_scan or []
                     block_list_secret_scan_lower = [file_type.lower() for file_type in block_list_secret_scan]
                     for root, d_names, f_names in os.walk(root_folder):
-                        filter_ignored_paths(root, d_names, excluded_paths)
-                        filter_ignored_paths(root, f_names, excluded_paths)
+                        if enable_secret_scan_all_files:
+                            # 'excluded_paths' shouldn't include the static paths from 'EXCLUDED_PATHS'
+                            # they are separately referenced inside the 'filter_excluded_paths' function
+                            filter_excluded_paths(root_dir=root, names=d_names, excluded_paths=runner_filter.excluded_paths)
+                            filter_excluded_paths(root_dir=root, names=f_names, excluded_paths=runner_filter.excluded_paths)
+                        else:
+                            filter_ignored_paths(root, d_names, excluded_paths)
+                            filter_ignored_paths(root, f_names, excluded_paths)
                         for file in f_names:
                             if enable_secret_scan_all_files:
                                 if is_docker_file(file):

--- a/checkov/secrets/utils.py
+++ b/checkov/secrets/utils.py
@@ -17,7 +17,7 @@ def filter_excluded_paths(
 ) -> None:
     """Special build of checkov.common.runners.base_runner.filter_ignored_paths for Secrets scanning"""
 
-    # old logic
+    # support for the --skip-path flag
     if excluded_paths:
         compiled = []
         for p in excluded_paths:
@@ -32,7 +32,7 @@ def filter_excluded_paths(
             if any(pattern.search(full_path) for pattern in compiled) or any(p in full_path for p in excluded_paths):
                 safe_remove(names, entry)
 
-    # new logic
+    # support for our own excluded paths list
     for entry in list(names):
         path = entry.name if isinstance(entry, os.DirEntry) else entry
         if path in EXCLUDED_PATHS:

--- a/checkov/secrets/utils.py
+++ b/checkov/secrets/utils.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Iterable
+
+from checkov.common.runners.base_runner import ignored_directories, safe_remove
+from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
+
+EXCLUDED_PATHS = [*ignored_directories, DEFAULT_EXTERNAL_MODULES_DIR, ".idea", ".git", "venv"]
+
+
+def filter_excluded_paths(
+    root_dir: str,
+    names: list[str] | list[os.DirEntry[str]],
+    excluded_paths: Iterable[str] | None,
+) -> None:
+    """Special build of checkov.common.runners.base_runner.filter_ignored_paths for Secrets scanning"""
+
+    # old logic
+    if excluded_paths:
+        compiled = []
+        for p in excluded_paths:
+            try:
+                compiled.append(re.compile(p.replace(".terraform", r"\.terraform")))
+            except re.error:
+                # do not add compiled paths that aren't regexes
+                continue
+        for entry in list(names):
+            path = entry.name if isinstance(entry, os.DirEntry) else entry
+            full_path = os.path.join(root_dir, path)
+            if any(pattern.search(full_path) for pattern in compiled) or any(p in full_path for p in excluded_paths):
+                safe_remove(names, entry)
+
+    # new logic
+    for entry in list(names):
+        path = entry.name if isinstance(entry, os.DirEntry) else entry
+        if path in EXCLUDED_PATHS:
+            safe_remove(names, entry)

--- a/tests/secrets/test_utils.py
+++ b/tests/secrets/test_utils.py
@@ -1,0 +1,26 @@
+from checkov.secrets.utils import filter_excluded_paths
+
+
+def test_filter_excluded_paths():
+    # given
+    root_dir = "path/to"
+    names = ["test", "node_modules", ".github", ".projen", ".git", "coverage", ".idea", "src"]
+
+    # when
+    filter_excluded_paths(root_dir=root_dir, names=names, excluded_paths=[])
+
+    # then
+    assert names.sort() == ["test", ".github", ".projen", "coverage", "src"].sort()
+
+
+def test_filter_excluded_paths_with_extra_paths():
+    # given
+    root_dir = "path/to"
+    names = ["test", "node_modules", ".github", ".projen", ".git", "coverage", ".idea", "src"]
+    excluded_paths = [".projen'"]
+
+    # when
+    filter_excluded_paths(root_dir=root_dir, names=names, excluded_paths=excluded_paths)
+
+    # then
+    assert names.sort() == ["test", ".github", "coverage", "src"].sort()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- created a new method to do the filtering, when the user decides to scan all files, because the logic in the old function didn't play nice with the `excluded_paths` parameter
- also excluded `.idea`, `.git` and `venv` from scanning

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
