### PR TITLE
docs(sca): Add more ways to skip CVEs

### DIFF
--- a/docs/2.Basics/Suppressing and Skipping Policies.md
+++ b/docs/2.Basics/Suppressing and Skipping Policies.md
@@ -184,8 +184,9 @@ Check: CKV_AWS_18: "Ensure the S3 bucket has access logging enabled"
 ```
 
 ### SCA
-Depending on the package manager there are different ways to suppress CVEs.
-You can either suppress a CVE for all packages, all CVEs for a package or specific CVE for a package. 
+CVEs can be suppressed using `--skip-check CKV_CVE_2022_1234` to suppress a specific CVE for that run or `--skip-cve-package package` to skip all CVEs for a specific package.
+
+For inline suppressions, depending on the package manager there are different ways to suppress CVEs. You can either suppress a CVE for all packages, all CVEs for a package or specific CVE for a package. Today, only requirements.txt is supported.
 
 #### Python - requirements.txt
 The skip comment can be anywhere


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Added more ways to skip CVEs for SCA scans.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
