### PR TITLE
fix(terraform): remove invalid Terraform module reference support

### DIFF
--- a/checkov/common/images/graph/image_referencer_provider.py
+++ b/checkov/common/images/graph/image_referencer_provider.py
@@ -24,7 +24,7 @@ class GraphImageReferencerProvider:
                      str, _ExtractImagesCallableAlias]):
         self.graph_connector = graph_connector
         self.supported_resource_types = supported_resource_types
-        self.graph_framework = os.environ.get('CHECKOV_GRAPH_FRAMEWORK', 'NETWORKX')
+        self.graph_framework = os.environ.get('CHECKOV_GRAPH_FRAMEWORK', 'IGRAPH')
 
     @abstractmethod
     def extract_images_from_resources(self) -> list[Image]:

--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -65,7 +65,7 @@ class BaseRunner(ABC, Generic[_GraphManager]):
         self.file_names = file_names or []
         self.pbar = ProgressBar(self.check_type)
         db_connector_class: "type[NetworkxConnector | IgraphConnector]" = NetworkxConnector
-        graph_framework = os.getenv("CHECKOV_GRAPH_FRAMEWORK", "NETWORKX")
+        graph_framework = os.getenv("CHECKOV_GRAPH_FRAMEWORK", "IGRAPH")
         if graph_framework == "IGRAPH":
             db_connector_class = IgraphConnector
         elif graph_framework == "NETWORKX":

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -50,7 +50,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         self.vertices: list[TerraformBlock] = []
         self.module = module
         self.map_path_to_module: Dict[str, List[int]] = {}
-        self.relative_paths_cache: dict[str, str] = {}
+        self.relative_paths_cache: dict[tuple[str, str], str] = {}
         self.abspath_cache: Dict[str, str] = {}
         self.dirname_cache: Dict[str, str] = {}
         self.vertices_by_module_dependency_by_name: Dict[Tuple[str, str], Dict[BlockType, Dict[str, List[int]]]] = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
@@ -383,12 +383,12 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         :param dest_module_source: the value of module.source
         :return: the real path in the local file system of the dest module
         """
-
-        if dest_module_source in self.relative_paths_cache:
-            return self.relative_paths_cache[dest_module_source]
+        relative_path_key = (curr_module_dir, dest_module_source)
+        if relative_path_key in self.relative_paths_cache:
+            return self.relative_paths_cache[relative_path_key]
         elif is_local_path(curr_module_dir, dest_module_source):
-            self.relative_paths_cache[dest_module_source] = os.path.abspath(Path(curr_module_dir) / dest_module_source)
-            return self.relative_paths_cache[dest_module_source]
+            self.relative_paths_cache[relative_path_key] = os.path.abspath(Path(curr_module_dir) / dest_module_source)
+            return self.relative_paths_cache[relative_path_key]
         elif (dest_module_source, dest_module_version) in self.module.external_modules_source_map:
             return self.module.external_modules_source_map[(dest_module_source, dest_module_version)]
 

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -55,7 +55,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         self.dirname_cache: Dict[str, str] = {}
         self.vertices_by_module_dependency_by_name: Dict[Tuple[str, str], Dict[BlockType, Dict[str, List[int]]]] = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         self.vertices_by_module_dependency: Dict[Tuple[str, str], Dict[BlockType, List[int]]] = defaultdict(lambda: defaultdict(list))
-        self.enable_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_FOREACH_HANDLING', 'True'))
+        self.enable_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_FOREACH_HANDLING', 'False'))
         self.enable_modules_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_MODULES_FOREACH_HANDLING', 'False'))
         self.use_new_tf_parser = strtobool(os.getenv('CHECKOV_NEW_TF_PARSER', 'False'))
         self.foreach_blocks: Dict[str, List[int]] = {BlockType.RESOURCE: [], BlockType.MODULE: []}

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -55,7 +55,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         self.dirname_cache: Dict[str, str] = {}
         self.vertices_by_module_dependency_by_name: Dict[Tuple[str, str], Dict[BlockType, Dict[str, List[int]]]] = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         self.vertices_by_module_dependency: Dict[Tuple[str, str], Dict[BlockType, List[int]]] = defaultdict(lambda: defaultdict(list))
-        self.enable_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_FOREACH_HANDLING', 'False'))
+        self.enable_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_FOREACH_HANDLING', 'True'))
         self.enable_modules_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_MODULES_FOREACH_HANDLING', 'False'))
         self.use_new_tf_parser = strtobool(os.getenv('CHECKOV_NEW_TF_PARSER', 'False'))
         self.foreach_blocks: Dict[str, List[int]] = {BlockType.RESOURCE: [], BlockType.MODULE: []}

--- a/checkov/terraform/graph_builder/utils.py
+++ b/checkov/terraform/graph_builder/utils.py
@@ -29,7 +29,6 @@ def is_local_path(root_dir: str, source: str) -> bool:
         source.startswith("./")
         or source.startswith("/./")
         or source.startswith("../")
-        or source in os.listdir(root_dir)
     )
 
 

--- a/tests/terraform/graph/checks/test_yaml_connected_nodes.py
+++ b/tests/terraform/graph/checks/test_yaml_connected_nodes.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 import warnings
+from unittest import mock
+
 from checkov.terraform import checks
 from .test_yaml_policies import load_yaml_data, get_policy_results
 
@@ -58,4 +60,6 @@ class TestYamlConnectedNodes(unittest.TestCase):
                     continue
                 policy = load_yaml_data(f_name, root)
                 assert policy is not None
-                return get_policy_results(dir_path, policy)
+                with mock.patch.dict('os.environ', {'CHECKOV_GRAPH_FRAMEWORK': 'NETWORKX'}):
+                    # connected nodes don't exist in igraph, because they are not needed
+                    return get_policy_results(dir_path, policy)

--- a/tests/terraform/graph/checks_infra/connection_solvers/connection_exist_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/connection_solvers/connection_exist_solver/test_solver.py
@@ -30,7 +30,7 @@ class ConnectionSolver(TestBaseSolver):
     def test_output_connection(self):
         root_folder = '../../../resources/output_example'
         check_id = "VPCForSubnet"
-        should_pass = ['aws_vpc.my_vpc','aws_subnet.my_subnet']
+        should_pass = ['module.submodule.aws_vpc.my_vpc','aws_subnet.my_subnet']
         should_fail = []
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 

--- a/tests/terraform/graph/resources/modules/linked_modules/external_modules/terraform-aws-modules/s3-bucket/examples/notification/main.tf
+++ b/tests/terraform/graph/resources/modules/linked_modules/external_modules/terraform-aws-modules/s3-bucket/examples/notification/main.tf
@@ -40,7 +40,7 @@ data "null_data_source" "downloaded_package" {
 }
 
 module "lambda_function1" {
-  source  = "terraform-aws-modules/lambda/"
+  source  = "terraform-aws-modules/lambda/aws"
   version = "~> 1.0"
 
   function_name = "${random_pet.this.id}-lambda1"

--- a/tests/terraform/graph/resources/output_example/main.tf
+++ b/tests/terraform/graph/resources/output_example/main.tf
@@ -1,5 +1,5 @@
 module "submodule" {
-  source = "submodule"
+  source = "./submodule"
 }
 
 resource "aws_subnet" "my_subnet" {


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- removed an old mechanism to find the module by relative path, which was not relative and actually searched for an "absolute" path, which you can't use in Terraform
- also switch the default graph connector to `igraph` 🍻   

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
