### PR TITLE
fix(terraform): support null values in list of dicts

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
@@ -335,7 +335,7 @@ def _handle_for_loop_in_list_of_dicts(object_to_run_on: list[Any], statement: st
                     if replace_value in val_to_assign:
                         if isinstance(obj_value, (list, dict)):
                             obj_value = json.dumps(obj_value)
-                        if isinstance(obj_value, (bool, int)):
+                        if isinstance(obj_value, (bool, int)) or obj_value is None:
                             # need to also remove the surrounding quotes
                             val_to_assign = val_to_assign.replace(f"'{replace_value}'", str(obj_value))
                         else:

--- a/tests/terraform/graph/variable_rendering/test_string_evaluation.py
+++ b/tests/terraform/graph/variable_rendering/test_string_evaluation.py
@@ -470,6 +470,10 @@ class TestTerraformEvaluation(TestCase):
         expected = [{'name': 'raw', 'type': 'container'}, {'name': 'masked', 'type': 'blob'}]
         self.assertEqual(expected, evaluate_terraform(input_str))
 
+        input_str = "[for val in [{'a': 123, 'b': True, 'c': None}] : {'a': '${val.a}', 'b': '${val.b}', 'c': '${val.c}'}]"
+        expected = [{'a': 123, 'b': True, 'c': None}]
+        self.assertEqual(expected, evaluate_terraform(input_str))
+
     def test_base64_value(self):
         input_str = "\"['dGVzdA==']\""
         expected = ["dGVzdA=="]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- adds support for `null` values in list of dicts, which otherwise resulted in a crash...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
