### PR TITLE
fix(terraform): make the ECS cluster logging check more resilient

### DIFF
--- a/checkov/terraform/checks/resource/aws/ECSClusterLoggingEncryptedWithCMK.py
+++ b/checkov/terraform/checks/resource/aws/ECSClusterLoggingEncryptedWithCMK.py
@@ -1,28 +1,36 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
 
 class ECSClusterLoggingEncryptedWithCMK(BaseResourceCheck):
-    def __init__(self):
-        name = "Ensure Cluster logging with CMK"
+    def __init__(self) -> None:
+        name = "Ensure ECS Cluster logging uses CMK"
         id = "CKV_AWS_224"
-        supported_resources = ['aws_ecs_cluster']
-        categories = [CheckCategories.ENCRYPTION]
+        supported_resources = ("aws_ecs_cluster",)
+        categories = (CheckCategories.ENCRYPTION,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf):
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
         configuration = conf.get("configuration")
-        if configuration and isinstance(configuration[0], dict) and configuration[0].get('execute_command_configuration'):
-            command_conf = configuration[0].get('execute_command_configuration')[0]
-            if not command_conf.get('logging') == ['NONE']:
-                if command_conf.get('kms_key_id'):
-                    if command_conf.get('log_configuration'):
-                        log_conf = command_conf.get('log_configuration')[0]
-                        if log_conf.get('cloud_watch_encryption_enabled') == [True] or \
-                                log_conf.get('s3_bucket_encryption_enabled') == [True]:
-                            return CheckResult.PASSED
-                    return CheckResult.FAILED
-                else:
+        if configuration and isinstance(configuration, list) and isinstance(configuration[0], dict):
+            execute_command = configuration[0].get("execute_command_configuration")
+            if execute_command and isinstance(execute_command, list):
+                execute_command = execute_command[0]
+                if isinstance(execute_command, dict) and not execute_command.get("logging") == ["NONE"]:
+                    if execute_command.get("kms_key_id"):
+                        log_conf = execute_command.get("log_configuration")
+                        if log_conf and isinstance(log_conf, list):
+                            log_conf = log_conf[0]
+                            if isinstance(log_conf, dict) and (
+                                log_conf.get("cloud_watch_encryption_enabled") == [True]
+                                or log_conf.get("s3_bucket_encryption_enabled") == [True]
+                            ):
+                                return CheckResult.PASSED
+
                     return CheckResult.FAILED
 
         return CheckResult.UNKNOWN

--- a/tests/terraform/checks/resource/aws/example_ECSClusterLoggingEncryptedWithCMK/main.tf
+++ b/tests/terraform/checks/resource/aws/example_ECSClusterLoggingEncryptedWithCMK/main.tf
@@ -13,7 +13,7 @@ resource "aws_ecs_cluster" "unknown" {
   tags = { test = "fail" }
 }
 
-resource "aws_ecs_cluster" "unknown" {
+resource "aws_ecs_cluster" "unknown2" {
   name = "white-hart"
   configuration {
     execute_command_configuration {
@@ -87,6 +87,18 @@ resource "aws_ecs_cluster" "fail3" {
         # s3_bucket_name=   and
         # s3_bucket_encryption_enabled =true
       }
+    }
+  }
+  tags = { test = "fail" }
+}
+
+resource "aws_ecs_cluster" "fail5" {
+  name = "white-hart"
+  configuration {
+    execute_command_configuration {
+      kms_key_id = aws_kms_key.example.arn
+
+      log_configuration = [null]
     }
   }
   tags = { test = "fail" }

--- a/tests/terraform/checks/resource/aws/test_ECSClusterLoggingEncryptedWithCMK.py
+++ b/tests/terraform/checks/resource/aws/test_ECSClusterLoggingEncryptedWithCMK.py
@@ -26,13 +26,14 @@ class TestECSClusterLoggingEncryptedWithCMK(unittest.TestCase):
             "aws_ecs_cluster.fail2",
             "aws_ecs_cluster.fail3",
             "aws_ecs_cluster.fail4",
+            "aws_ecs_cluster.fail5",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 4)
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added multiple type checks to be sure it doesn't through an error

Fixes #4921 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
