### PR TITLE
fix(general): remove invalid URLs in GitLab SAST output

### DIFF
--- a/checkov/common/output/gitlab_sast.py
+++ b/checkov/common/output/gitlab_sast.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from checkov.common.output.cyclonedx_consts import SCA_CHECKTYPES
+from checkov.common.util.http_utils import valid_url
 from checkov.version import version
 
 if TYPE_CHECKING:
@@ -99,12 +100,13 @@ class GitLabSast:
             "solution": f"Further info can be found {record.guideline}",
         }
 
-        if record.guideline:
+        link = record.guideline
+        if valid_url(link):
             # url can't be None
-            vulnerability["identifiers"][0]["url"] = record.guideline
+            vulnerability["identifiers"][0]["url"] = link
             vulnerability["links"] = [
                 {
-                    "url": record.guideline,
+                    "url": link,
                 }
             ]
 
@@ -137,7 +139,7 @@ class GitLabSast:
         }
 
         link = details.get("link")
-        if link:
+        if valid_url(link):
             # url can't be None
             vulnerability["identifiers"][0]["url"] = link
             vulnerability["links"] = [

--- a/tests/common/output/test_gitlab_sast_report.py
+++ b/tests/common/output/test_gitlab_sast_report.py
@@ -2,8 +2,10 @@ from operator import itemgetter
 from pathlib import Path
 
 from checkov.common.bridgecrew.check_type import CheckType
+from checkov.common.models.enums import CheckResult
 from checkov.common.output.extra_resource import ExtraResource
 from checkov.common.output.gitlab_sast import GitLabSast
+from checkov.common.output.record import Record
 from checkov.common.output.report import Report
 from checkov.common.sca.output import create_report_cve_record, _add_to_report_licenses_statuses
 from checkov.runner_filter import RunnerFilter
@@ -106,7 +108,7 @@ def test_sca_package_output():
         check_class=check_class,
         vulnerability_details=vulnerability_details,
         licenses="OSI_BDS",
-        package={'package_registry': "https://registry.npmjs.org/", 'is_private_registry': False},
+        package={"package_registry": "https://registry.npmjs.org/", "is_private_registry": False},
     )
     # also add a BC_VUL_2 record
     bc_record = create_report_cve_record(
@@ -115,7 +117,7 @@ def test_sca_package_output():
         check_class=check_class,
         vulnerability_details=vulnerability_details,
         licenses="OSI_BDS",
-        package={'package_registry': "https://registry.npmjs.org/", 'is_private_registry': False},
+        package={"package_registry": "https://registry.npmjs.org/", "is_private_registry": False},
     )
     bc_record.check_id = "BC_VUL_2"
 
@@ -231,3 +233,32 @@ def test_sca_license_output():
             "description": "Package docutils@0.15.2 has license GPL",
         }
     ]
+
+
+def test_create_iac_vulnerability_with_non_url_guideline():
+    # given
+    # the report doesn't matter for this test, because we pass the record to method directly
+    gitlab_sast = GitLabSast(reports=[])
+    record = Record(
+        check_id="CKV_AWS_5",
+        check_name="Ensure all data stored in the Elasticsearch is securely encrypted at rest",
+        check_result={"result": CheckResult.FAILED},
+        code_block=[],
+        file_path="./main.tf",
+        file_line_range=[7, 10],
+        resource="aws_elasticsearch_domain.enabled",
+        evaluations=None,
+        check_class="",
+        file_abs_path=".",
+        bc_check_id="BC_AWS_ELASTICSEARCH_3",
+    )
+    record.guideline = "Some guideline text"
+
+    # when
+    vulnerability = gitlab_sast._create_iac_vulnerability(record=record)
+
+    # then
+    # vulnerability["identifiers"][0]["url"] shouldn't exist
+    assert vulnerability["identifiers"] == [{"name": "CKV_AWS_5", "type": "checkov", "value": "CKV_AWS_5"}]
+    # vulnerability["links"] shouldn't exist
+    assert "links" not in vulnerability


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- add URL validation check before trying to add a possibly invalid URL to specific GitLab SAST output fields

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
