### PR TITLE
fix(terraform): secret- also check user data in launch config and template

### DIFF
--- a/checkov/terraform/checks/resource/aws/EC2Credentials.py
+++ b/checkov/terraform/checks/resource/aws/EC2Credentials.py
@@ -9,7 +9,7 @@ class EC2Credentials(BaseResourceCheck):
     def __init__(self):
         name = "Ensure no hard-coded secrets exist in EC2 user data"
         id = "CKV_AWS_46"
-        supported_resources = ['aws_instance']
+        supported_resources = ['aws_instance', 'aws_launch_template', 'aws_launch_configuration']
         categories = [CheckCategories.SECRETS]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/tests/terraform/checks/resource/aws/example_EC2Credentials/main.tf
+++ b/tests/terraform/checks/resource/aws/example_EC2Credentials/main.tf
@@ -1,0 +1,82 @@
+resource "aws_instance" "pass" {
+  ami           = "ami-04169656fea786776"
+  instance_type = "t2.nano"
+  user_data     = <<EOF
+#! /bin/bash
+sudo apt-get update
+sudo apt-get install -y apache2
+sudo systemctl start apache2
+sudo systemctl enable apache2
+export AWS_ACCESS_KEY_ID
+export AWS_ACCESS_KEY_ID=FOO
+export AWS_SECRET_ACCESS_KEY=bar
+export AWS_DEFAULT_REGION=us-west-2
+echo "<h1>Deployed via Terraform</h1>" | sudo tee /var/www/html/index.html
+EOF
+  tags = {
+    Name = "${local.resource_prefix.value}-ec2"
+  }
+
+}
+resource "aws_instance" "fail" {
+  ami           = "ami-04169656fea786776"
+  instance_type = "t2.nano"
+  user_data     = <<EOF
+#! /bin/bash
+sudo apt-get update
+sudo apt-get install -y apache2
+sudo systemctl start apache2
+sudo systemctl enable apache2
+export AWS_ACCESS_KEY_ID
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+export AWS_DEFAULT_REGION=us-west-2
+echo "<h1>Deployed via Terraform</h1>" | sudo tee /var/www/html/index.html
+EOF
+  tags = {
+    Name = "${local.resource_prefix.value}-ec2"
+  }
+}
+
+#resource "aws_launch_configuration" "fail" {
+#   name          = "web_config"
+#   image_id      = data.aws_ami.ubuntu.id
+#   instance_type = "t2.micro"
+#   user_data     = <<EOF
+# export DATABASE_PASSWORD=\"SomeSortOfPassword\"
+# EOF
+# }
+
+resource "aws_launch_template" "fail" {
+
+  image_id      = "ami-12345667"
+  instance_type = "t2.small"
+
+  user_data = <<EOF
+ export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+ export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+ export AWS_DEFAULT_REGION=us-west-2
+EOF
+}
+
+resource "aws_launch_template" "pass" {
+     image_id      = "ami-12345667"
+     instance_type = "t2.small"
+}
+
+resource "aws_launch_configuration" "fail" {
+   name          = "web_config"
+   image_id      = data.aws_ami.ubuntu.id
+   instance_type = "t2.micro"
+   user_data = <<EOF
+ export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+ export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+ export AWS_DEFAULT_REGION=us-west-2
+EOF
+ }
+
+resource "aws_launch_configuration" "pass" {
+   name          = "web_config"
+   image_id      = data.aws_ami.ubuntu.id
+   instance_type = "t2.micro"
+ }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
