### PR TITLE
feat(kubernetes): support suppressing custom K8s policies

### DIFF
--- a/checkov/kubernetes/kubernetes_utils.py
+++ b/checkov/kubernetes/kubernetes_utils.py
@@ -84,23 +84,19 @@ def get_skipped_checks(entity_conf: dict[str, Any]) -> list[_SkippedCheck]:
             for key in annotation:
                 skipped_item: "_SkippedCheck" = {}
                 if "checkov.io/skip" in key or "bridgecrew.io/skip" in key:
-                    if "CKV_K8S" in annotation[key] or "BC_K8S" in annotation[key] or "CKV2_K8S" in annotation[key]:
-                        if "=" in annotation[key]:
-                            (skipped_item["id"], skipped_item["suppress_comment"]) = annotation[key].split("=")
-                        else:
-                            skipped_item["id"] = annotation[key]
-                            skipped_item["suppress_comment"] = "No comment provided"
-
-                        # No matter which ID was used to skip, save the pair of IDs in the appropriate fields
-                        if bc_id_mapping and skipped_item["id"] in bc_id_mapping:
-                            skipped_item["bc_id"] = skipped_item["id"]
-                            skipped_item["id"] = bc_id_mapping[skipped_item["id"]]
-                        elif metadata_integration.check_metadata:
-                            skipped_item["bc_id"] = metadata_integration.get_bc_id(skipped_item["id"])
-                        skipped.append(skipped_item)
+                    if "=" in annotation[key]:
+                        (skipped_item["id"], skipped_item["suppress_comment"]) = annotation[key].split("=")
                     else:
-                        logging.debug(f"Parse of Annotation Failed for {metadata['annotations'][key]}: {entity_conf}")
-                        continue
+                        skipped_item["id"] = annotation[key]
+                        skipped_item["suppress_comment"] = "No comment provided"
+
+                    # No matter which ID was used to skip, save the pair of IDs in the appropriate fields
+                    if bc_id_mapping and skipped_item["id"] in bc_id_mapping:
+                        skipped_item["bc_id"] = skipped_item["id"]
+                        skipped_item["id"] = bc_id_mapping[skipped_item["id"]]
+                    elif metadata_integration.check_metadata:
+                        skipped_item["bc_id"] = metadata_integration.get_bc_id(skipped_item["id"])
+                    skipped.append(skipped_item)
     return skipped
 
 

--- a/tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/kubernetes/test_kubernetes_utils.py
@@ -43,6 +43,10 @@ def test_get_skipped_checks():
     skipped = get_skipped_checks(entity_conf=manifest)
 
     # then
+    # remove 'bc_id' if present
+    for skip in skipped:
+        skip.pop("bc_id", None)
+
     assert sorted(skipped, key=itemgetter("id")) == sorted(
         [
             {"id": "CKV_K8S_11", "suppress_comment": "I have not set CPU limits as I want BestEffort QoS"},

--- a/tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/kubernetes/test_kubernetes_utils.py
@@ -1,0 +1,54 @@
+from operator import itemgetter
+
+from checkov.kubernetes.kubernetes_utils import get_skipped_checks
+
+
+def test_get_skipped_checks():
+    # given
+    manifest = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": "nginx",
+            "labels": {"test": "test", "__startline__": 6, "__endline__": 7},
+            "annotations": {
+                "checkov.io/skip1": "CKV_K8S_11=I have not set CPU limits as I want BestEffort QoS",
+                "checkov.io/skip2": "CKV2_CUSTOM_1=I have not set CPU limits as I want BestEffort QoS",
+                "checkov.io/skip3": "CKV_K8S_14",
+                "checkov.io/skip4": "CUSTOM_1",
+                "__startline__": 8,
+                "__endline__": 12,
+            },
+            "__startline__": 4,
+            "__endline__": 12,
+        },
+        "spec": {
+            "containers": [
+                {
+                    "name": "nginx",
+                    "image": "nginx:1.14.2",
+                    "ports": [{"containerPort": 80, "__startline__": 17, "__endline__": 17}],
+                    "__startline__": 14,
+                    "__endline__": 17,
+                }
+            ],
+            "__startline__": 13,
+            "__endline__": 17,
+        },
+        "__startline__": 1,
+        "__endline__": 17,
+    }
+
+    # when
+    skipped = get_skipped_checks(entity_conf=manifest)
+
+    # then
+    assert sorted(skipped, key=itemgetter("id")) == sorted(
+        [
+            {"id": "CKV_K8S_11", "suppress_comment": "I have not set CPU limits as I want BestEffort QoS"},
+            {"id": "CKV2_CUSTOM_1", "suppress_comment": "I have not set CPU limits as I want BestEffort QoS"},
+            {"id": "CKV_K8S_14", "suppress_comment": "No comment provided"},
+            {"id": "CUSTOM_1", "suppress_comment": "No comment provided"},
+        ],
+        key=itemgetter("id"),
+    )


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- support suppressing custom K8s policies, which was before limited to our default IDs

Fixes #4977 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
