### PR TITLE
fix(secrets): fix missing history results when history store is used

### DIFF
--- a/checkov/secrets/scan_git_history.py
+++ b/checkov/secrets/scan_git_history.py
@@ -58,6 +58,7 @@ class GitHistoryScanner:
         # mark the scan to finish within the timeout
         with timeout_class(self.timeout) as to_ctx_mgr:
             scanned = self._scan_history(last_commit_scanned)
+            self._create_secret_collection()
         if to_ctx_mgr.state == to_ctx_mgr.TIMED_OUT:
             logging.info(f"timeout reached ({self.timeout}), stopping scan.")
             return False
@@ -81,8 +82,8 @@ class GitHistoryScanner:
 
         if not self.raw_store:  # scanned nothing
             return False
+
         self._process_raw_store()
-        self._create_secret_collection()
         return True
 
     def _process_raw_store(self) -> None:

--- a/tests/secrets/git_history/test_utils.py
+++ b/tests/secrets/git_history/test_utils.py
@@ -423,7 +423,7 @@ def mock_git_repo_commits_too_much(self, last_commit_sha: str) -> List[Commit]:
                 committer='Cherry🍒moi-moi-lots-of-commits',
                 committed_datetime='2022-12-14T16:10:21+00:00'),
             files=mock_case()
-        ) for _i in range(50000)
+        ) for _i in range(40000)
     ]
 
 

--- a/tests/secrets/git_history/test_utils.py
+++ b/tests/secrets/git_history/test_utils.py
@@ -423,7 +423,7 @@ def mock_git_repo_commits_too_much(self, last_commit_sha: str) -> List[Commit]:
                 committer='Cherry🍒moi-moi-lots-of-commits',
                 committed_datetime='2022-12-14T16:10:21+00:00'),
             files=mock_case()
-        ) for _i in range(40000)
+        ) for _i in range(20000)
     ]
 
 

--- a/tests/secrets/test_secret_git_history.py
+++ b/tests/secrets/test_secret_git_history.py
@@ -457,7 +457,7 @@ def test_scan_history_secrets_with_history_store_and_no_new_commit() -> None:
         metadata=CommitMetadata(
             commit_hash="8a21fa691e17907afee57e93b7820c5943b12746",
             committer="Momo",
-            committed_datetime="'2022-12-24T01:02:03+00:00'",
+            committed_datetime="2022-12-24T01:02:03+00:00",
         ),
         files={
             "Dockerfile": 'diff --git a/Dockerfile b/Dockerfile\nindex 0000..0000 0000\n--- a/Dockerfile\n+++ b/Dockerfile\n@@ -4,6 +4,8 @@ FROM public.ecr.aws/lambda/python:3.9\n \n ENV PIP_ENV_VERSION="2022.1.8"\n \n+ENV AWS_ACCESS_KEY_ID="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"\n+\n COPY Pipfile Pipfile.lock ./\n \n RUN pip install pipenv==${PIP_ENV_VERSION} \\\n'

--- a/tests/secrets/test_secret_git_history.py
+++ b/tests/secrets/test_secret_git_history.py
@@ -4,13 +4,17 @@ from unittest import mock
 from pathlib import Path
 import shutil
 from copy import deepcopy
+
+import pytest
+from detect_secrets import SecretsCollection
+from detect_secrets.core.potential_secret import PotentialSecret
+from detect_secrets.settings import transient_settings
 from pytest_mock import MockerFixture
 
-from detect_secrets import SecretsCollection
-
+from checkov.secrets.git_history_store import GitHistorySecretStore
+from checkov.secrets.git_types import Commit, CommitMetadata
 from checkov.secrets.runner import Runner
 from checkov.runner_filter import RunnerFilter
-from detect_secrets.settings import transient_settings
 from checkov.common.output.secrets_record import COMMIT_REMOVED_STR, COMMIT_ADDED_STR
 
 from tests.secrets.git_history.test_utils import mock_git_repo_commits1, mock_git_repo_commits2, mock_git_repo_commits3, \
@@ -143,6 +147,7 @@ def test_scan_git_history_merge_added_removed2() -> None:
                           commit_hash='900b1e8f6f336a92e8f5fca3babca764e32c3b3d')
 
 
+@pytest.mark.filterwarnings("error")  # otherwise pytest sometimes suppresses the raised Timeout Exception
 @mock.patch('checkov.secrets.scan_git_history.GitHistoryScanner._get_commits_diff', mock_git_repo_commits_too_much)
 @mock.patch('checkov.secrets.scan_git_history.GitHistoryScanner.set_repo', mock_set_repo)
 @mock.patch('checkov.secrets.scan_git_history.GitHistoryScanner._get_first_commit', mock_get_first_commit)
@@ -424,3 +429,55 @@ def test_git_history_plugin(mocker: MockerFixture) -> None:
     check = report.failed_checks[0]
     assert check.added_commit_hash
     assert check.check_name == 'Base64 High Entropy String'
+
+
+@mock.patch("checkov.secrets.scan_git_history.GitHistoryScanner._get_commits_diff", lambda self, last_commit_sha: [])
+@mock.patch("checkov.secrets.scan_git_history.GitHistoryScanner.set_repo", mock_set_repo)
+@mock.patch("checkov.secrets.scan_git_history.GitHistoryScanner._get_first_commit", mock_get_first_commit)
+def test_scan_history_secrets_with_history_store_and_no_new_commit() -> None:
+    # given
+    root_folder = "test"
+    secrets = SecretsCollection()
+    plugins_used = [
+        {"name": "AWSKeyDetector"},
+    ]
+
+    file_name = "Dockerfile"
+    file_results = [
+        PotentialSecret(
+            type="AWS Access Key",
+            filename=file_name,
+            secret="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            line_number=7,
+            is_added=True,
+            is_removed=False,
+        )
+    ]
+    commit = Commit(
+        metadata=CommitMetadata(
+            commit_hash="8a21fa691e17907afee57e93b7820c5943b12746",
+            committer="Momo",
+            committed_datetime="'2022-12-24T01:02:03+00:00'",
+        ),
+        files={
+            "Dockerfile": 'diff --git a/Dockerfile b/Dockerfile\nindex 0000..0000 0000\n--- a/Dockerfile\n+++ b/Dockerfile\n@@ -4,6 +4,8 @@ FROM public.ecr.aws/lambda/python:3.9\n \n ENV PIP_ENV_VERSION="2022.1.8"\n \n+ENV AWS_ACCESS_KEY_ID="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"\n+\n COPY Pipfile Pipfile.lock ./\n \n RUN pip install pipenv==${PIP_ENV_VERSION} \\\n'
+        },
+    )
+
+    history_store = GitHistorySecretStore()
+    history_store.set_secret_map(file_results=file_results, file_name=file_name, commit=commit)
+
+    # when
+    from checkov.secrets.scan_git_history import GitHistoryScanner
+
+    with transient_settings(
+        {
+            # Only run scans with only these plugins.
+            "plugins_used": plugins_used
+        }
+    ) as settings:
+        settings.disable_filters(*["detect_secrets.filters.common.is_invalid_file"])
+        GitHistoryScanner(root_folder=root_folder, secrets=secrets, history_store=history_store).scan_history()
+
+    # then
+    assert len(secrets.data) == 1


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- when the history store is used and no new commit was found, then the scan result became empty

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
