### PR TITLE
chore: update bc-detect-secrets version to 1.4.26

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -44,7 +44,7 @@ boto3-stubs-lite = {extras = ["s3"], version = "*"}
 # REMINDER: Update "install_requires" deps on setup.py when changing
 #
 bc-python-hcl2 = "==0.3.51"
-bc-detect-secrets = "==1.4.24"
+bc-detect-secrets = "==1.4.26"
 bc-jsonpath-ng = "==1.5.9"
 deep-merge = "*"
 tabulate = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a1d84228f13280a33fe3e8c107a33088b6b100dfee4dd59876f81b2cf37811f8"
+            "sha256": "8835d3746500f665bdb821915c564658caae5573166e308a455451da08afa82f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -167,11 +167,11 @@
         },
         "bc-detect-secrets": {
             "hashes": [
-                "sha256:8df551cf5c77c854ee325330b0a72bd88e509dab05413bea3724d5a5ccd32252",
-                "sha256:adad3e365ad19d911984f8f85f0b6e571fd6d94b7821ffdd691787f2d4b5f440"
+                "sha256:ade5e85478e2d052d0dee1250cf869638c170500827f3cebe1fdeccebc299855",
+                "sha256:d5027443bb87c9ab5733a192b12fce4c9bc58a10f1bd19a91605eedf280d8385"
             ],
             "index": "pypi",
-            "version": "==1.4.24"
+            "version": "==1.4.26"
         },
         "bc-jsonpath-ng": {
             "hashes": [
@@ -199,19 +199,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:2ccb1827dc9d654970375b9bbe1bd77eb6a50ec6fa76cf227a34b4bff144814f",
-                "sha256:51722a3a791108236c8ce05e0ced030b13c08276001132d4153d29353038f8cc"
+                "sha256:4847855cfa4ff272eb66cf1fc9542068ada6d4816d56573cc9cafde51962d0ef",
+                "sha256:ec53175eaf818dfe1eec33f7e165eca957744c1d8a82047a9efbcce9547e5cc9"
             ],
             "index": "pypi",
-            "version": "==1.26.123"
+            "version": "==1.26.124"
         },
         "botocore": {
             "hashes": [
-                "sha256:88f743e1db5bb65e3770af674400642f1d09fca159a1508bdbb8f8cc691589ca",
-                "sha256:b69cdf1c6f451ab1314a363bf97753dfbfe1da93d33853ed241edbdcb806867d"
+                "sha256:cbcbd5b084952d332d7b8170577f10509e3e7b3b6abbc2920b1c27e93ad2ab25",
+                "sha256:ebe8a83dd1db18180774ce45b1911959c60bb1843ea0db610231495527a3518a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.123"
+            "version": "==1.29.124"
         },
         "cached-property": {
             "hashes": [
@@ -846,11 +846,11 @@
         },
         "openai": {
             "hashes": [
-                "sha256:5b2121d8c0a4350626096fa482306d12e246a83b992530d54fd474f309f2882c",
-                "sha256:75778ca05759c77dde704985ee16976ba58804212f10e61f44356e68ffb8390e"
+                "sha256:1f07ed06f1cfc6c25126107193726fe4cf476edcc4e1485cd9eb708f068f2606",
+                "sha256:63ca9f6ac619daef8c1ddec6d987fe6aa1c87a9bfdce31ff253204d077222375"
             ],
             "index": "pypi",
-            "version": "==0.27.5"
+            "version": "==0.27.6"
         },
         "packageurl-python": {
             "hashes": [
@@ -1596,19 +1596,19 @@
                 "s3"
             ],
             "hashes": [
-                "sha256:1e1b2cb3c3863e42a8ab26deccc82077ba64450205842d516a5547434ee462fd",
-                "sha256:c179b91d2a1860b13bd596f93b95be7356de825e43119763eb1ee8736d73e4fa"
+                "sha256:6a0639162fd43fe9c9ee29888fd28c3906f667c200fdd6076e6c8efa792b61a9",
+                "sha256:f274f50074f0fed25074d095d71e0085185703f0879c9c519f0b16237b50a3cf"
             ],
             "index": "pypi",
-            "version": "==1.26.123"
+            "version": "==1.26.124"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:5e7873cfc07c705efb546683f5914fece0e5845dd83e62657b3ae034cc73740b",
-                "sha256:c23e5202cf3580e7d349ac37618ac9d119bf26884413751d20f70aa4664e4c62"
+                "sha256:01671dd064c49638d10c54f7fe8431b681b0e83f717e3d397a7dcabfdd154a23",
+                "sha256:52331b0ba854d27d418d1ed498298c9e16a8b3f100212e343f398cb6b4338f67"
             ],
             "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==1.29.123"
+            "version": "==1.29.124"
         },
         "certifi": {
             "hashes": [
@@ -2537,11 +2537,11 @@
         },
         "types-urllib3": {
             "hashes": [
-                "sha256:04235e792139cf3624b25d38faab593456738fbdb7439634046172e3b1339400",
-                "sha256:697102ddf4f781eed6f692353f40cee1098643526f5a8b99f49d2ede90fd3754"
+                "sha256:3ba3d3a8ee46e0d5512c6bd0594da4f10b2584b47a470f8422044a2ab462f1df",
+                "sha256:a1557355ce8d350a555d142589f3001903757d2d36c18a66f588d9659bbc917d"
             ],
             "index": "pypi",
-            "version": "==1.26.25.11"
+            "version": "==1.26.25.12"
         },
         "typing-extensions": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     },
     install_requires=[
         "bc-python-hcl2==0.3.51",
-        "bc-detect-secrets==1.4.24",
+        "bc-detect-secrets==1.4.26",
         "bc-jsonpath-ng==1.5.9",
         "deep-merge",
         "tabulate",
@@ -99,7 +99,7 @@ setup(
         "aiohttp",
         "aiodns",
         "aiomultiprocess",
-        "jsonschema<5.0.0,>=4.6.0",
+        "jsonschema>=4.6.0,<5.0.0",
         "prettytable>=3.0.0",
         "pycep-parser==0.4.0",
         "charset-normalizer",


### PR DESCRIPTION
- Automatic update of bc-detect-secrets

powered by [create-pull-request](https://github.com/peter-evans/create-pull-request) GHA