### PR TITLE
fix(terraform): Update CKV_AWS_338 message and retention check for 0

### DIFF
--- a/checkov/terraform/checks/resource/aws/CloudWatchLogGroupRetentionYear.py
+++ b/checkov/terraform/checks/resource/aws/CloudWatchLogGroupRetentionYear.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import Any
 
 from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+from checkov.terraform.checks.resource.base_resource_check import \
+    BaseResourceCheck
 
 
 class CloudWatchLogGroupRetentionYear(BaseResourceCheck):
@@ -13,7 +14,7 @@ class CloudWatchLogGroupRetentionYear(BaseResourceCheck):
         NIST.800-53.r5 CA-7, NIST.800-53.r5 SI-12
         CloudWatch log groups should be retained for at least 1 year
         """
-        name = "Ensure that CloudWatch Log Group specifies retention days"
+        name = "Ensure CloudWatch log groups retains logs for at least 1 year"
         id = "CKV_AWS_338"
         supported_resource = ("aws_cloudwatch_log_group",)
         categories = (CheckCategories.LOGGING,)
@@ -26,8 +27,8 @@ class CloudWatchLogGroupRetentionYear(BaseResourceCheck):
             if not isinstance(retention, int):
                 # probably a dependent variable
                 return CheckResult.UNKNOWN
-
-            if retention >= 365:
+            # If you select 0, the events in the log group are always retained and never expire.
+            if retention == 0 or retention >= 365:
                 return CheckResult.PASSED
 
         return CheckResult.FAILED

--- a/tests/terraform/checks/resource/aws/example_CloudWatchLogGroupRetentionYear/main.tf
+++ b/tests/terraform/checks/resource/aws/example_CloudWatchLogGroupRetentionYear/main.tf
@@ -1,5 +1,9 @@
-resource "aws_cloudwatch_log_group" "pass" {
+resource "aws_cloudwatch_log_group" "pass_365" {
   retention_in_days = 365
+}
+
+resource "aws_cloudwatch_log_group" "pass_0" {
+  retention_in_days = 0
 }
 
 resource "aws_cloudwatch_log_group" "fail" {

--- a/tests/terraform/checks/resource/aws/test_CloudWatchLogGroupRetentionYear.py
+++ b/tests/terraform/checks/resource/aws/test_CloudWatchLogGroupRetentionYear.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from pathlib import Path
 
@@ -19,7 +18,8 @@ class TestCloudWatchLogGroupRetentionYear(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            "aws_cloudwatch_log_group.pass",
+            "aws_cloudwatch_log_group.pass_365",
+            "aws_cloudwatch_log_group.pass_0",
         }
         failing_resources = {
             "aws_cloudwatch_log_group.fail",
@@ -32,7 +32,7 @@ class TestCloudWatchLogGroupRetentionYear(unittest.TestCase):
         self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
-        self.assertEqual(summary["resource_count"], 3)  # 1 unknown
+        self.assertEqual(summary["resource_count"], 4)  # 1 unknown
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

This PR addresses the correction of message displayed to users in the issue listed below. 
The current message matches CKV_AWS_66 which doesn't reflect the length of time.

Fixes #5009

## New/Edited policies 

### Description
- AWS Security Hub controls update : https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-16
- Related requirements: NIST.800-53.r5 AU-10, NIST.800-53.r5 AU-11, NIST.800-53.r5 AU-6(3), NIST.800-53.r5 AU-6(4), NIST.800-53.r5 CA-7, NIST.800-53.r5 SI-12

### Fix
Updated the message displayed for the rule and included a check for retention of 0 which is allowed per Terraform documentation.
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days

## Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
