### PR TITLE
fix(terraform): fix foreach render value for lookup

### DIFF
--- a/checkov/terraform/graph_builder/foreach/abstract_handler.py
+++ b/checkov/terraform/graph_builder/foreach/abstract_handler.py
@@ -252,7 +252,7 @@ class ForeachAbstractHandler:
 
     @staticmethod
     def need_to_add_quotes(code, key) -> bool:
-        patterns = [r'lower\(' + key + r'\)']
+        patterns = [r'lower\(' + key + r'\)', r'upper\(' + key + r'\)']
         for pattern in patterns:
             if re.search(pattern, code):
                 return True

--- a/checkov/terraform/graph_builder/foreach/abstract_handler.py
+++ b/checkov/terraform/graph_builder/foreach/abstract_handler.py
@@ -140,7 +140,10 @@ class ForeachAbstractHandler:
                         v_changed = True
                     else:
                         attrs[k][0] = attrs[k][0].replace("${" + key_to_change + "}", str(val_to_change))
-                        attrs[k][0] = attrs[k][0].replace(key_to_change, str(val_to_change))
+                        if self.need_to_add_quotes(attrs[k][0], key_to_change):
+                            attrs[k][0] = attrs[k][0].replace(key_to_change, f'"{str(val_to_change)}"')
+                        else:
+                            attrs[k][0] = attrs[k][0].replace(key_to_change, str(val_to_change))
                         v_changed = True
                 elif isinstance(v, list) and len(v) == 1 and isinstance(v[0], list):
                     for i, item in enumerate(v):
@@ -246,3 +249,11 @@ class ForeachAbstractHandler:
     @staticmethod
     def extract_from_list(val: Any) -> Any:
         return val[0] if len(val) == 1 and isinstance(val[0], (str, int, list)) else val
+
+    @staticmethod
+    def need_to_add_quotes(code, key) -> bool:
+        patterns = [r'lower\(' + key + r'\)']
+        for pattern in patterns:
+            if re.search(pattern, code):
+                return True
+        return False

--- a/tests/terraform/graph/variable_rendering/resources/foreach_examples/foreach_lookup/main.tf
+++ b/tests/terraform/graph/variable_rendering/resources/foreach_examples/foreach_lookup/main.tf
@@ -1,0 +1,21 @@
+resource "google_storage_bucket" "buckets" {
+  for_each = var.names
+
+  uniform_bucket_level_access = lookup(
+    var.bucket_policy_only,
+    lower(each.value),
+    true,
+  )
+}
+
+variable "bucket_policy_only" {
+  description = "Disable ad-hoc ACLs on specified buckets. Defaults to true. Map of lowercase unprefixed name => boolean"
+  type        = map(bool)
+  default     = {}
+}
+
+variable "names" {
+  description = "Bucket name suffixes."
+  type        = list(string)
+  default = ["a"]
+}

--- a/tests/terraform/graph/variable_rendering/resources/foreach_examples/foreach_lookup/main.tf
+++ b/tests/terraform/graph/variable_rendering/resources/foreach_examples/foreach_lookup/main.tf
@@ -1,4 +1,14 @@
-resource "google_storage_bucket" "buckets" {
+resource "google_storage_bucket" "buckets_upper" {
+  for_each = var.names
+
+  uniform_bucket_level_access = lookup(
+    var.bucket_policy_only,
+    upper(each.value),
+    true,
+  )
+}
+
+resource "google_storage_bucket" "buckets_lower" {
   for_each = var.names
 
   uniform_bucket_level_access = lookup(

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -382,6 +382,7 @@ def test__is_static_foreach_statement(statement, expected):
     abstract_handler = ForeachAbstractHandler(None)
     assert abstract_handler._is_static_foreach_statement(statement) == expected
 
+
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})
 def test_foreach_with_lookup():
     dir_name = 'foreach_examples/foreach_lookup'

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -388,3 +388,4 @@ def test_foreach_with_lookup():
     dir_name = 'foreach_examples/foreach_lookup'
     graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
     assert graph.vertices[0].attributes.get('uniform_bucket_level_access') == [True]
+    assert graph.vertices[1].attributes.get('uniform_bucket_level_access') == [True]

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -381,3 +381,9 @@ def test_foreach_module_with_more_than_two_resources(checkov_source_path):
 def test__is_static_foreach_statement(statement, expected):
     abstract_handler = ForeachAbstractHandler(None)
     assert abstract_handler._is_static_foreach_statement(statement) == expected
+
+@mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})
+def test_foreach_with_lookup():
+    dir_name = 'foreach_examples/foreach_lookup'
+    graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
+    assert graph.vertices[0].attributes.get('uniform_bucket_level_access') == [True]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
This is the original lookup - `lookup(var.bucket_policy_only, lower(each.value), true,)`
After the foreach evaluation it looks like this - `lookup({}, lower(a), true,)` - invalid
After my fix - `lookup({}, lower("a"), true,)` - valid

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
