### PR TITLE
feat(terraform): Update CKV_AZURE_43 StorageAccountName.py VARIABLE_REFS

### DIFF
--- a/checkov/terraform/checks/resource/azure/StorageAccountName.py
+++ b/checkov/terraform/checks/resource/azure/StorageAccountName.py
@@ -6,7 +6,7 @@ from checkov.common.models.enums import CheckResult, CheckCategories
 
 STO_NAME_REGEX = re.compile(r"^[a-z0-9]{3,24}$")
 VARIABLE_REFS = ("local.", "module.", "var.", "random_string.", "random_id.", "random_integer.", "random_pet.",
-                 "azurecaf_name")
+                 "azurecaf_name", "each.")
 
 
 class StorageAccountName(BaseResourceCheck):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Update VARIABLE_REFS list within StorageAccountName.py to also include `each.` value . This is useful when using for_each with a certain resource/module and can reference variables from within the map instead of directly a global `var.` variable .

Fixes #5042 

## New/Edited policies (Delete if not relevant)

### Description
Modify the VARIABLE_REFS list to contain `each.` for CKV_AWS_123 check.

### Fix
Add the `each.` to the VARIABLE_REFS list in order to match the for_each meta-argument scenario in terraform.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
