### PR TITLE
chore: scan repo with own secrets runner

### DIFF
--- a/.github/checkov.yaml
+++ b/.github/checkov.yaml
@@ -2,5 +2,15 @@ enable-secret-scan-all-files: true
 framework:
 - secrets
 skip-path:
+- docs
+- tests/arm/checks/resource/example_StorageAccountAzureServicesAccessEnabled/storageAccountAzureServicesAccessEnabled-FAILED2.json
+- tests/arm/checks/resource/example_StorageAccountDefaultNetworkAccessDeny/storageAccountDefaultNetworkAccessDeny-FAILED2.json
 - tests/secrets
+- tests/terraform/parser/resources/plan_tags/tfplan.json
+- tests/terraform/runner/resources/plan/tfplan.json
+- tests/terraform/runner/tf_plan_skip_check_regex/resource/skip_directory/tfplan2.json
+- tests/terraform/runner/tf_plan_skip_check_regex/resource/tfplan1.json
+- tests/terraform/runner/tfplan2.json
+- tests/unit/test_secrets.py
+- anton
 summary-position: bottom

--- a/.github/checkov.yaml
+++ b/.github/checkov.yaml
@@ -1,0 +1,6 @@
+enable-secret-scan-all-files: true
+framework:
+- secrets
+skip-path:
+- tests/secrets
+summary-position: bottom

--- a/.github/checkov.yaml
+++ b/.github/checkov.yaml
@@ -1,6 +1,7 @@
 enable-secret-scan-all-files: true
 framework:
 - secrets
+quiet: true
 skip-path:
 - docs
 - tests/arm/checks/resource/example_StorageAccountAzureServicesAccessEnabled/storageAccountAzureServicesAccessEnabled-FAILED2.json
@@ -12,5 +13,4 @@ skip-path:
 - tests/terraform/runner/tf_plan_skip_check_regex/resource/tfplan1.json
 - tests/terraform/runner/tfplan2.json
 - tests/unit/test_secrets.py
-- anton
 summary-position: bottom

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           bash -c './integration_tests/prepare_data.sh "${{ matrix.os }}" "${{ matrix.python }}"'
         env:
           LOG_LEVEL: INFO
-          BC_KEY: ${{ secrets.BC_API_KEY }}
+          BC_KEY: ${{ secrets.BC_API_KEY_NEW }}
           TF_REGISTRY_TOKEN: ${{ secrets.TFC_TOKEN }}
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
@@ -317,7 +317,7 @@ jobs:
         continue-on-error: true
         uses: bridgecrewio/checkov-action@master  # use latest and greatest
         with:
-          api-key: ${{ secrets.BC_API_KEY }}
+          api-key: ${{ secrets.BC_API_KEY_NEW }}
           docker_image: ${{ env.DH_IMAGE_NAME }}:${{ env.FULL_IMAGE_TAG }}
           dockerfile_path: Dockerfile
           output_format: cyclonedx_json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           bash -c './integration_tests/prepare_data.sh "${{ matrix.os }}" "${{ matrix.python }}"'
         env:
           LOG_LEVEL: INFO
-          BC_KEY: ${{ secrets.BC_API_KEY_NEW }}
+          BC_KEY: ${{ secrets.BC_API_KEY }}
           TF_REGISTRY_TOKEN: ${{ secrets.TFC_TOKEN }}
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
@@ -317,7 +317,7 @@ jobs:
         continue-on-error: true
         uses: bridgecrewio/checkov-action@master  # use latest and greatest
         with:
-          api-key: ${{ secrets.BC_API_KEY_NEW }}
+          api-key: ${{ secrets.BC_API_KEY }}
           docker_image: ${{ env.DH_IMAGE_NAME }}:${{ env.FULL_IMAGE_TAG }}
           dockerfile_path: Dockerfile
           output_format: cyclonedx_json

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Create checkov reports
         env:
           LOG_LEVEL: INFO
-          BC_KEY: ${{ secrets.BC_API_KEY }}
+          BC_KEY: ${{ secrets.BC_API_KEY_NEW }}
         run: |
           # Just making sure the API key tests don't run on PRs
           bash -c './integration_tests/prepare_data.sh ${{ matrix.os }} 3.8'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Create checkov reports
         env:
           LOG_LEVEL: INFO
-          BC_KEY: ${{ secrets.BC_API_KEY_NEW }}
+          BC_KEY: ${{ secrets.BC_API_KEY }}
         run: |
           # Just making sure the API key tests don't run on PRs
           bash -c './integration_tests/prepare_data.sh ${{ matrix.os }} 3.8'

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -32,6 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3
       - name: Scan for secrets
+        continue-on-error: true  # should be removed after checking all findings
         uses: bridgecrewio/checkov-action@master  # use latest and greatest
         with:
           api-key: ${{ secrets.BC_API_KEY }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,7 +1,7 @@
 name: security
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - '*'
   push:
@@ -35,7 +35,6 @@ jobs:
         continue-on-error: true  # should be removed after checking all findings
         uses: bridgecrewio/checkov-action@master  # use latest and greatest
         with:
+          api-key: ${{ secrets.BC_API_KEY }}
           config_file: .github/checkov.yaml
           log_level: DEBUG
-        env:
-          BC_API_KEY: ${{ secrets.BC_API_KEY }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -35,5 +35,4 @@ jobs:
         uses: bridgecrewio/checkov-action@master  # use latest and greatest
         with:
           api-key: ${{ secrets.BC_API_KEY }}
-          framework: secrets
-          enable_secrets_scan_all_files: true
+          config_file: .github/checkov.yaml

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -35,5 +35,5 @@ jobs:
         continue-on-error: true  # should be removed after checking all findings
         uses: bridgecrewio/checkov-action@master  # use latest and greatest
         with:
-          api-key: ${{ secrets.BC_API_KEY }}
+          api-key: ${{ secrets.BC_API_KEY_NEW }}
           config_file: .github/checkov.yaml

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -2,8 +2,7 @@ name: security
 
 on:
   pull_request_target:
-    branches:
-      - '*'
+    types: [opened, synchronize, reopened, edited]
   push:
     branches:
       - main

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -35,5 +35,7 @@ jobs:
         continue-on-error: true  # should be removed after checking all findings
         uses: bridgecrewio/checkov-action@master  # use latest and greatest
         with:
-          api-key: ${{ secrets.BC_API_KEY_NEW }}
           config_file: .github/checkov.yaml
+          log_level: DEBUG
+        env:
+          BC_API_KEY: ${{ secrets.BC_API_KEY }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -27,3 +27,13 @@ jobs:
         uses: edplato/trufflehog-actions-scan@0af17d9dd1410283f740eb76b0b8f6b696cadefc  # v0.9
         with:
           scanArguments: "--regex --entropy=False --exclude_paths .github/exclude-patterns.txt --max_depth=1"
+  checkov-secrets:
+    runs-on: [self-hosted, public, linux, x64]
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3
+      - name: Scan for secrets
+        uses: bridgecrewio/checkov-action@master  # use latest and greatest
+        with:
+          api-key: ${{ secrets.BC_API_KEY }}
+          framework: secrets
+          enable_secrets_scan_all_files: true

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -2,7 +2,6 @@ name: security
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, edited]
   push:
     branches:
       - main
@@ -30,10 +29,11 @@ jobs:
     runs-on: [self-hosted, public, linux, x64]
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}  # this is needed to use the API key in a PR
       - name: Scan for secrets
         continue-on-error: true  # should be removed after checking all findings
         uses: bridgecrewio/checkov-action@master  # use latest and greatest
         with:
           api-key: ${{ secrets.BC_API_KEY }}
           config_file: .github/checkov.yaml
-          log_level: DEBUG

--- a/tests/terraform/checks/resource/aws/test_RDSClusterActivityStreamEncryptedWithCMK.py
+++ b/tests/terraform/checks/resource/aws/test_RDSClusterActivityStreamEncryptedWithCMK.py
@@ -11,7 +11,7 @@ class TestRDSClusterActivityStreamEncryptedWithCMK(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_RDSClusterActivityStreamEncryptedWithCMK"
+        test_files_dir = current_dir + "/example_RDSClusterActivityStreamEncryptedWithCMK"  # checkov:skip=CKV_SECRET_6 false positive
         report = runner.run(
             root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
         )

--- a/tests/terraform/checks/resource/aws/test_RDSInstanceAutoBackupEncryptionWithCMK.py
+++ b/tests/terraform/checks/resource/aws/test_RDSInstanceAutoBackupEncryptionWithCMK.py
@@ -9,7 +9,7 @@ from checkov.terraform.runner import Runner
 class TestRDSInstanceAutoBackupEncryptionWithCMK(unittest.TestCase):
     def test(self):
         # given
-        test_files_dir = Path(__file__).parent / "example_RDSInstanceAutoBackupEncryptionWithCMK"
+        test_files_dir = Path(__file__).parent / "example_RDSInstanceAutoBackupEncryptionWithCMK"  # checkov:skip=CKV_SECRET_6 false positive
 
         # when
         report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))

--- a/tests/terraform/checks/resource/aws/test_RedshiftClusterAllowVersionUpgrade.py
+++ b/tests/terraform/checks/resource/aws/test_RedshiftClusterAllowVersionUpgrade.py
@@ -14,7 +14,7 @@ class TestRedshiftClusterAllowVersionUpgrade(unittest.TestCase):
                   cluster_identifier = "tf-redshift-cluster"
                   database_name      = "mydb"
                   master_username    = "foo"
-                  master_password    = "Mustbe8characters"
+                  master_password    = "Mustbe8characters"  # checkov:skip=CKV_SECRET_6 test secret
                   node_type          = "dc1.large"
                   cluster_type       = "single-node"
                   allow_version_upgrade = false

--- a/tests/terraform/checks/resource/aws/test_RedshiftClusterKMSKey.py
+++ b/tests/terraform/checks/resource/aws/test_RedshiftClusterKMSKey.py
@@ -13,7 +13,7 @@ class TestRedshiftClusterKMSKey(unittest.TestCase):
                   cluster_identifier = "tf-redshift-cluster"
                   database_name      = "mydb"
                   master_username    = "foo"
-                  master_password    = "Mustbe8characters"
+                  master_password    = "Mustbe8characters"  # checkov:skip=CKV_SECRET_6 test secret
                   node_type          = "dc1.large"
                   cluster_type       = "single-node"
                 }

--- a/tests/terraform/checks/resource/aws/test_RedshiftClusterLogging.py
+++ b/tests/terraform/checks/resource/aws/test_RedshiftClusterLogging.py
@@ -14,7 +14,7 @@ class TestRedshiftClusterLogging(unittest.TestCase):
           cluster_identifier = "tf-redshift-cluster"
           database_name      = "mydb"
           master_username    = "foo"
-          master_password    = "Mustbe8characters"
+          master_password    = "Mustbe8characters"  # checkov:skip=CKV_SECRET_6 test secret
           node_type          = "dc1.large"
           cluster_type       = "single-node"
         }

--- a/tests/terraform/checks/resource/aws/test_RedshiftClusterPubliclyAccessible.py
+++ b/tests/terraform/checks/resource/aws/test_RedshiftClusterPubliclyAccessible.py
@@ -13,7 +13,7 @@ class TestRedshitClusterPubliclyAccessible(unittest.TestCase):
             cluster_identifier  = "tf-redshift-cluster"
             database_name       = "mydb"
             master_username     = "foo"
-            master_password     = "Mustbe8characters"
+            master_password     = "Mustbe8characters"  # checkov:skip=CKV_SECRET_6 test secret
             node_type           = "dc1.large"
             publicly_accessible = true
           }

--- a/tests/terraform/checks/resource/aws/test_RedshiftSnapshotCopyGrantEncryptedWithCMK.py
+++ b/tests/terraform/checks/resource/aws/test_RedshiftSnapshotCopyGrantEncryptedWithCMK.py
@@ -11,7 +11,7 @@ class TestRedshiftClusterSnapshotCopyGrantEncryptedWithCMK(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_RedshiftSnapshotCopyGrantEncryptedWithCMK"
+        test_files_dir = current_dir + "/example_RedshiftSnapshotCopyGrantEncryptedWithCMK"  # checkov:skip=CKV_SECRET_6 false positive
         report = runner.run(
             root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
         )

--- a/tests/terraform/checks/resource/aws/test_S3BucketObjectEncryptedWithCMK.py
+++ b/tests/terraform/checks/resource/aws/test_S3BucketObjectEncryptedWithCMK.py
@@ -11,7 +11,7 @@ class TestS3BucketObjectEncryptedWithCMK(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_S3BucketObjectEncryptedWithCMK"
+        test_files_dir = current_dir + "/example_S3BucketObjectEncryptedWithCMK"  # checkov:skip=CKV_SECRET_6 false positive
         report = runner.run(
             root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
         )

--- a/tests/terraform/checks/resource/aws/test_S3ObjectCopyEncryptedWithCMK.py
+++ b/tests/terraform/checks/resource/aws/test_S3ObjectCopyEncryptedWithCMK.py
@@ -11,7 +11,7 @@ class TestS3ObjectCopyEncryptedWithCMK(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_S3ObjectCopyEncryptedWithCMK"
+        test_files_dir = current_dir + "/example_S3ObjectCopyEncryptedWithCMK"  # checkov:skip=CKV_SECRET_6 false positive
         report = runner.run(
             root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
         )

--- a/tests/terraform/checks/resource/azure/test_PostgreSQLEncryptionEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_PostgreSQLEncryptionEnabled.py
@@ -16,7 +16,7 @@ class TestPostgreSQLEncryptionEnabled(unittest.TestCase):
               resource_group_name = azurerm_resource_group.example.name
             
               administrator_login          = "psqladminun"
-              administrator_login_password = "H@Sh1CoR3!"
+              administrator_login_password = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
             
               sku_name   = "GP_Gen5_4"
               version    = "9.6"

--- a/tests/terraform/checks/resource/azure/test_PostgreSQLServerPublicAccessDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_PostgreSQLServerPublicAccessDisabled.py
@@ -16,7 +16,7 @@ class TestPostgreSQLServerPublicAccessDisabled(unittest.TestCase):
               resource_group_name = azurerm_resource_group.example.name
             
               administrator_login          = "psqladminun"
-              administrator_login_password = "H@Sh1CoR3!"
+              administrator_login_password = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
             
               sku_name   = "GP_Gen5_4"
               version    = "9.6"

--- a/tests/terraform/checks/resource/azure/test_PostgreSQLServerSSLEnforcementEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_PostgreSQLServerSSLEnforcementEnabled.py
@@ -16,7 +16,7 @@ class TestPostgreSQLServerSSLEnforcementEnabled(unittest.TestCase):
               resource_group_name = azurerm_resource_group.example.name
             
               administrator_login          = "psqladminun"
-              administrator_login_password = "H@Sh1CoR3!"
+              administrator_login_password = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
             
               sku_name   = "GP_Gen5_4"
               version    = "9.6"

--- a/tests/terraform/checks/resource/azure/test_PostgresSQLGeoBackupEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_PostgresSQLGeoBackupEnabled.py
@@ -16,7 +16,7 @@ class TestPostgressSQLGeoBackupEnabled(unittest.TestCase):
               resource_group_name = azurerm_resource_group.example.name
             
               administrator_login          = "psqladminun"
-              administrator_login_password = "H@Sh1CoR3!"
+              administrator_login_password = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
             
               sku_name   = "GP_Gen5_4"
               version    = "9.6"

--- a/tests/terraform/checks/resource/azure/test_PostgresSQLTreatDetectionEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_PostgresSQLTreatDetectionEnabled.py
@@ -16,7 +16,7 @@ class TestPostgresSQLTreatDetectionEnabled(unittest.TestCase):
               resource_group_name = azurerm_resource_group.example.name
             
               administrator_login          = "mysqladminun"
-              administrator_login_password = "H@Sh1CoR3!"
+              administrator_login_password = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
             
               sku_name   = "B_Gen5_2"
               storage_mb = 5120

--- a/tests/terraform/checks/resource/azure/test_SynapseWorkspaceEnablesManagedVirtualNetworks.py
+++ b/tests/terraform/checks/resource/azure/test_SynapseWorkspaceEnablesManagedVirtualNetworks.py
@@ -16,7 +16,7 @@ class TestSynapseWorkspaceEnablesManagedVirtualNetworks(unittest.TestCase):
               location                             = azurerm_resource_group.example.location
               storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.example.id
               sql_administrator_login              = "sqladminuser"
-              sql_administrator_login_password     = "H@Sh1CoR3!"
+              sql_administrator_login_password     = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
               managed_virtual_network_enabled      = false
               aad_admin {
                 login     = "AzureAD Admin"
@@ -41,7 +41,7 @@ class TestSynapseWorkspaceEnablesManagedVirtualNetworks(unittest.TestCase):
               location                             = azurerm_resource_group.example.location
               storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.example.id
               sql_administrator_login              = "sqladminuser"
-              sql_administrator_login_password     = "H@Sh1CoR3!"
+              sql_administrator_login_password     = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
               aad_admin {
                 login     = "AzureAD Admin"
                 object_id = "00000000-0000-0000-0000-000000000000"

--- a/tests/terraform/checks/resource/azure/test_VMEncryptionAtHostEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_VMEncryptionAtHostEnabled.py
@@ -16,7 +16,7 @@ class TestVMEncryptionAtHostEnabled(unittest.TestCase):
                   location            = azurerm_resource_group.example.location
                   sku                 = "Standard_F2"
                   instances           = 1
-                  admin_password      = "P@55w0rd1234!"
+                  admin_password      = "P@55w0rd1234!"  # checkov:skip=CKV_SECRET_80 test secret
                   admin_username      = "adminuser"
                 
                   source_image_reference {

--- a/tests/terraform/checks/resource/gcp/test_BigQueryTableEncryptedWithCMK.py
+++ b/tests/terraform/checks/resource/gcp/test_BigQueryTableEncryptedWithCMK.py
@@ -9,7 +9,7 @@ from checkov.terraform.runner import Runner
 class TestBigQueryTableEncryptedWithCMK(unittest.TestCase):
     def test(self):
         # given
-        test_files_dir = Path(__file__).parent / "example_BigQueryTableEncryptedWithCMK"
+        test_files_dir = Path(__file__).parent / "example_BigQueryTableEncryptedWithCMK"  # checkov:skip=CKV_SECRET_6 false positive
 
         # when
         report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))

--- a/tests/terraform/checks/resource/gcp/test_CloudPubSubEncryptedWithCMK.py
+++ b/tests/terraform/checks/resource/gcp/test_CloudPubSubEncryptedWithCMK.py
@@ -9,7 +9,7 @@ from checkov.terraform.runner import Runner
 class TestCloudPubSubEncryptedWithCMK(unittest.TestCase):
     def test(self):
         # given
-        test_files_dir = Path(__file__).parent / "example_CloudPubSubEncryptedWithCMK"
+        test_files_dir = Path(__file__).parent / "example_CloudPubSubEncryptedWithCMK"  # checkov:skip=CKV_SECRET_6 false positive
 
         # when
         report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))

--- a/tests/terraform/checks/resource/gcp/test_DataflowJobEncryptedWithCMK.py
+++ b/tests/terraform/checks/resource/gcp/test_DataflowJobEncryptedWithCMK.py
@@ -9,7 +9,7 @@ from checkov.terraform.runner import Runner
 class TestDataflowJobEncryptedWithCMK(unittest.TestCase):
     def test(self):
         # given
-        test_files_dir = Path(__file__).parent / "example_DataflowJobEncryptedWithCMK"
+        test_files_dir = Path(__file__).parent / "example_DataflowJobEncryptedWithCMK"  # checkov:skip=CKV_SECRET_6 false positive
 
         # when
         report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeBootDiskEncryption.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeBootDiskEncryption.py
@@ -28,7 +28,7 @@ class TestGoogleComputeBootDiskEncryption(unittest.TestCase):
               machine_type = "n1-standard-1"
               zone         = "us-central1-a"
               boot_disk {
-                disk_encryption_key_raw = "acXTX3rxrKAFTF0tYVLvydU1riRZTvUNC4g5I11NY-c="
+                disk_encryption_key_raw = "acXTX3rxrKAFTF0tYVLvydU1riRZTvUNC4g5I11NY-c="  # checkov:skip=CKV_SECRET_6 test secret
                 }
             }
                 """)

--- a/tests/terraform/checks/resource/gcp/test_GoogleComputeDiskEncryption.py
+++ b/tests/terraform/checks/resource/gcp/test_GoogleComputeDiskEncryption.py
@@ -31,7 +31,7 @@ class TestGoogleComputeDiskEncryption(unittest.TestCase):
               image = "debian-8-jessie-v20170523"
               physical_block_size_bytes = 4096
               disk_encryption_key {
-                raw_key = "acXTX3rxrKAFTF0tYVLvydU1riRZTvUNC4g5I11NY-c="
+                raw_key = "acXTX3rxrKAFTF0tYVLvydU1riRZTvUNC4g5I11NY-c="  # checkov:skip=CKV_SECRET_6 test secret
                 }
             }
                 """)

--- a/tests/terraform/checks/resource/github/example_SecretsEncrypted/main.tf
+++ b/tests/terraform/checks/resource/github/example_SecretsEncrypted/main.tf
@@ -1,7 +1,7 @@
 
 resource "github_actions_environment_secret" "fail" {
   environment       = "example_environment"
-  secret_name       = "example_secret_name"
+  secret_name       = "example_secret_name"  # checkov:skip=CKV_SECRET_6 false positive
   plaintext_value   = "INTHECLEAR"
 }
 

--- a/tests/terraform/checks/resource/openstack/example_ComputeInstanceAdminPassword/main.tf
+++ b/tests/terraform/checks/resource/openstack/example_ComputeInstanceAdminPassword/main.tf
@@ -3,7 +3,7 @@ resource "openstack_compute_instance_v2" "fail" {
   name            = "basic"
   image_id        = "ad091b52-742f-469e-8f3c-fd81cadf0743"
   flavor_id       = "3"
-  admin_pass      = "N0tSoS3cretP4ssw0rd"
+  admin_pass      = "N0tSoS3cretP4ssw0rd"  # checkov:skip=CKV_SECRET_6 test secret
   security_groups = ["default"]
   user_data       = "#cloud-config\nhostname: instance_1.example.com\nfqdn: instance_1.example.com"
 

--- a/tests/terraform/graph/checks/resources/AccessToPostgreSQLFromAzureServicesIsDisabled/main.tf
+++ b/tests/terraform/graph/checks/resources/AccessToPostgreSQLFromAzureServicesIsDisabled/main.tf
@@ -9,7 +9,7 @@ resource "azurerm_sql_server" "sql_server_good" {
   location                     = "West US"
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
-  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"  # checkov:skip=CKV_SECRET_6 test secret
 }
 
 resource "azurerm_sql_server" "sql_server_bad" {

--- a/tests/terraform/graph/checks/resources/AzureActiveDirectoryAdminIsConfigured/main.tf
+++ b/tests/terraform/graph/checks/resources/AzureActiveDirectoryAdminIsConfigured/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_sql_server" "sql_server_good" {
   location                     = azurerm_resource_group.example.location
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
-  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"  # checkov:skip=CKV_SECRET_6 test secret
 }
 
 resource "azurerm_sql_server" "sql_server_bad" {

--- a/tests/terraform/graph/checks/resources/AzureConfigMSSQLwithAD/main.tf
+++ b/tests/terraform/graph/checks/resources/AzureConfigMSSQLwithAD/main.tf
@@ -27,7 +27,7 @@ resource "azurerm_mssql_server" "fail_1" {
   location                     = azurerm_resource_group.dep-rg-j1-1-rlp-77266.location
   version                      = "12.0"
   administrator_login          = "pudadministrator1"
-  administrator_login_password = "thisIspudfortest2"
+  administrator_login_password = "thisIspudfortest2"  # checkov:skip=CKV_SECRET_6 test secret
 }
 
 # FAIL case 2: "azuread_administrator.login_username" exists

--- a/tests/terraform/graph/checks/resources/AzureMSSQLServerHasSecurityAlertPolicy/main.tf
+++ b/tests/terraform/graph/checks/resources/AzureMSSQLServerHasSecurityAlertPolicy/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_sql_server" "sql_server_good_1" {
   location                     = "location"
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
-  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"  # checkov:skip=CKV_SECRET_6 test secret
 }
 
 resource "azurerm_sql_server" "sql_server_good_2" {

--- a/tests/terraform/graph/checks/resources/AzureSynapseWorkspacesHaveNoIPFirewallRulesAttached/main.tf
+++ b/tests/terraform/graph/checks/resources/AzureSynapseWorkspacesHaveNoIPFirewallRulesAttached/main.tf
@@ -6,7 +6,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_synapse_workspace" "workspace_good" {
   name                                 = "example"
   sql_administrator_login              = "sqladminuser"
-  sql_administrator_login_password     = "H@Sh1CoR3!"
+  sql_administrator_login_password     = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
   managed_virtual_network_enabled      = true
   tags = {
     Env = "production"
@@ -16,7 +16,7 @@ resource "azurerm_synapse_workspace" "workspace_good" {
 resource "azurerm_synapse_workspace" "workspace_bad" {
   name                                 = "example"
   sql_administrator_login              = "sqladminuser"
-  sql_administrator_login_password     = "H@Sh1CoR3!"
+  sql_administrator_login_password     = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
   tags = {
     Env = "production"
   }

--- a/tests/terraform/graph/checks/resources/EFSAddedBackup/main.tf
+++ b/tests/terraform/graph/checks/resources/EFSAddedBackup/main.tf
@@ -28,7 +28,7 @@ resource "aws_backup_selection" "ok_backup" {
 }
 
 resource "aws_efs_file_system" "ok_efs" {
-  creation_token = "my-product"
+  creation_token = "my-product"  # checkov:skip=CKV_SECRET_6 false positive
 
   tags = {
     Name = "MyProduct"

--- a/tests/terraform/graph/checks/resources/EFSAddedBackupSuppress/main.tf
+++ b/tests/terraform/graph/checks/resources/EFSAddedBackupSuppress/main.tf
@@ -39,7 +39,7 @@ resource "aws_backup_selection" "not_ok_backup" {
 }
 
 resource "aws_efs_file_system" "ok_efs" {
-  creation_token = "my-product"
+  creation_token = "my-product"  # checkov:skip=CKV_SECRET_6 false positive
 
   tags = {
     Name = "MyProduct"

--- a/tests/terraform/graph/checks/resources/MSQLenablesCustomerManagedKey/main.tf
+++ b/tests/terraform/graph/checks/resources/MSQLenablesCustomerManagedKey/main.tf
@@ -46,7 +46,7 @@ resource "azurerm_mysql_server" "ok" {
   resource_group_name              = azurerm_resource_group.ok.name
   sku_name                         = "GP_Gen5_2"
   administrator_login              = "acctestun"
-  administrator_login_password     = "H@Sh1CoR3!"
+  administrator_login_password     = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
   ssl_enforcement_enabled          = true
   ssl_minimal_tls_version_enforced = "TLS1_1"
   storage_mb                       = 51200

--- a/tests/terraform/graph/checks/resources/PGSQLenablesCustomerManagedKey/main.tf
+++ b/tests/terraform/graph/checks/resources/PGSQLenablesCustomerManagedKey/main.tf
@@ -46,7 +46,7 @@ resource "azurerm_postgresql_server" "ok" {
   resource_group_name              = azurerm_resource_group.ok.name
   sku_name                         = "GP_Gen5_2"
   administrator_login              = "acctestun"
-  administrator_login_password     = "H@Sh1CoR3!"
+  administrator_login_password     = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
   ssl_enforcement_enabled          = true
   ssl_minimal_tls_version_enforced = "TLS1_1"
   storage_mb                       = 51200

--- a/tests/terraform/graph/checks/resources/SQLServerAuditingEnabled/main.tf
+++ b/tests/terraform/graph/checks/resources/SQLServerAuditingEnabled/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_sql_server" "failure" {
   location                     = azurerm_resource_group.example.location
   version                      = "12.0"
   administrator_login          = "mradministrator"
-  administrator_login_password = "thisIsDog11"
+  administrator_login_password = "thisIsDog11"  # checkov:skip=CKV_SECRET_6 test secret
 }
 
 resource "azurerm_sql_server" "success" {

--- a/tests/terraform/graph/checks/resources/SQLServerAuditingRetention90Days/main.tf
+++ b/tests/terraform/graph/checks/resources/SQLServerAuditingRetention90Days/main.tf
@@ -6,7 +6,7 @@ resource "azurerm_sql_server" "deprecated" {
   location                     = azurerm_resource_group.example.location
   version                      = "12.0"
   administrator_login          = "mradministrator"
-  administrator_login_password = "thisIsDog11"
+  administrator_login_password = "thisIsDog11"  # checkov:skip=CKV_SECRET_6 test secret
 
   extended_auditing_policy {
     storage_endpoint                        = azurerm_storage_account.example.primary_blob_endpoint

--- a/tests/terraform/graph/checks/resources/VAconfiguredToSendReports/main.tf
+++ b/tests/terraform/graph/checks/resources/VAconfiguredToSendReports/main.tf
@@ -9,7 +9,7 @@ resource "azurerm_sql_server" "okLegacyExample" {
   location                     = azurerm_resource_group.okLegacyExample.location
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
-  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"  # checkov:skip=CKV_SECRET_6 test secret
 }
 
 resource "azurerm_storage_account" "okLegacyExample" {
@@ -130,7 +130,7 @@ resource "azurerm_sql_server" "badExample" {
   location                     = azurerm_resource_group.badExample.location
   version                      = "12.0"
   administrator_login          = "mradministrator"
-  administrator_login_password = "thisIsDog11"
+  administrator_login_password = "thisIsDog11"  # checkov:skip=CKV_SECRET_6 test secret
 
   extended_auditing_policy {
     storage_endpoint                        = azurerm_storage_account.badExample.primary_blob_endpoint

--- a/tests/terraform/graph/checks/resources/VAconfiguredToSendReportsToAdmins/main.tf
+++ b/tests/terraform/graph/checks/resources/VAconfiguredToSendReportsToAdmins/main.tf
@@ -9,7 +9,7 @@ resource "azurerm_sql_server" "okLegacyExample" {
   location                     = azurerm_resource_group.okLegacyExample.location
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
-  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"  # checkov:skip=CKV_SECRET_6 test secret
 }
 
 resource "azurerm_storage_account" "okLegacyExample" {
@@ -130,7 +130,7 @@ resource "azurerm_sql_server" "badExample" {
   location                     = azurerm_resource_group.badExample.location
   version                      = "12.0"
   administrator_login          = "mradministrator"
-  administrator_login_password = "thisIsDog11"
+  administrator_login_password = "thisIsDog11"  # checkov:skip=CKV_SECRET_6 test secret
 
   extended_auditing_policy {
     storage_endpoint                        = azurerm_storage_account.badExample.primary_blob_endpoint

--- a/tests/terraform/graph/checks/resources/VAisEnabledInStorageAccount/main.tf
+++ b/tests/terraform/graph/checks/resources/VAisEnabledInStorageAccount/main.tf
@@ -9,7 +9,7 @@ resource "azurerm_sql_server" "okExample" {
   location                     = azurerm_resource_group.okExample.location
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
-  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"  # checkov:skip=CKV_SECRET_6 test secret
 }
 
 resource "azurerm_storage_account" "okExample" {
@@ -66,7 +66,7 @@ resource "azurerm_sql_server" "badExample" {
   location                     = azurerm_resource_group.badExample.location
   version                      = "12.0"
   administrator_login          = "mradministrator"
-  administrator_login_password = "thisIsDog11"
+  administrator_login_password = "thisIsDog11"  # checkov:skip=CKV_SECRET_6 test secret
 
   extended_auditing_policy {
     storage_endpoint                        = azurerm_storage_account.badExample.primary_blob_endpoint

--- a/tests/terraform/graph/checks/resources/VAsetPeriodicScansOnSQL/main.tf
+++ b/tests/terraform/graph/checks/resources/VAsetPeriodicScansOnSQL/main.tf
@@ -9,7 +9,7 @@ resource "azurerm_sql_server" "okLegacyExample" {
   location                     = azurerm_resource_group.okLegacyExample.location
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
-  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"  # checkov:skip=CKV_SECRET_6 test secret
 }
 
 resource "azurerm_storage_account" "okLegacyExample" {
@@ -130,7 +130,7 @@ resource "azurerm_sql_server" "badExample" {
   location                     = azurerm_resource_group.badExample.location
   version                      = "12.0"
   administrator_login          = "mradministrator"
-  administrator_login_password = "thisIsDog11"
+  administrator_login_password = "thisIsDog11"  # checkov:skip=CKV_SECRET_6 test secret
 
   extended_auditing_policy {
     storage_endpoint                        = azurerm_storage_account.badExample.primary_blob_endpoint

--- a/tests/terraform/graph/checks/resources/VirtualMachinesUtilizingManagedDisks/main.tf
+++ b/tests/terraform/graph/checks/resources/VirtualMachinesUtilizingManagedDisks/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_virtual_machine" "virtual_machine_good" {
   os_profile {
     computer_name  = "hostname"
     admin_username = "testadmin"
-    admin_password = "Password1234!"
+    admin_password = "Password1234!"  # checkov:skip=CKV_SECRET_80 test secret
   }
   os_profile_linux_config {
     disable_password_authentication = false

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -359,7 +359,7 @@ class TestYamlPolicies(unittest.TestCase):
         self.go("AzurePostgreSQLFlexServerNotOverlyPermissive")
 
     def test_GCPMySQLdbInstancePoint_In_TimeRecoveryBackupIsEnabled(self):
-        self.go("GCPMySQLdbInstancePoint_In_TimeRecoveryBackupIsEnabled")
+        self.go("GCPMySQLdbInstancePoint_In_TimeRecoveryBackupIsEnabled")  # checkov:skip=CKV_SECRET_6 false positive
 
     def test_GCPdisableAlphaClusterFeatureInKubernetesEngineClusters(self):
         self.go("GCPdisableAlphaClusterFeatureInKubernetesEngineClusters")

--- a/tests/terraform/image_referencer/provider/test_azure.py
+++ b/tests/terraform/image_referencer/provider/test_azure.py
@@ -19,7 +19,7 @@ def test_extract_images_from_resources(graph_framework):
         "container_configuration": {
             "container_image_names": ["nginx", "python:3.9-alpine"],
             "container_registries": {
-                "password": "myPassword",
+                "password": "myPassword",  # checkov:skip=CKV_SECRET_6 test secret
                 "registry_server": "myContainerRegistry.azurecr.io",
                 "user_name": "myUserName",
             },

--- a/tests/terraform/image_referencer/resources/azure/batch.tf
+++ b/tests/terraform/image_referencer/resources/azure/batch.tf
@@ -19,7 +19,7 @@ resource "azurerm_batch_pool" "test" {
     container_registries {
       registry_server = "myContainerRegistry.azurecr.io"
       user_name       = "myUserName"
-      password        = "myPassword"
+      password        = "myPassword"  # checkov:skip=CKV_SECRET_6 test secret
     }
   }
 }

--- a/tests/terraform/image_referencer/resources/gcp/cloudbuild.tf
+++ b/tests/terraform/image_referencer/resources/gcp/cloudbuild.tf
@@ -35,7 +35,7 @@ resource "google_cloudbuild_trigger" "build-trigger" {
     secret {
       kms_key_name = "projects/myProject/locations/global/keyRings/keyring-name/cryptoKeys/key-name"
       secret_env = {
-        PASSWORD = "ZW5jcnlwdGVkLXBhc3N3b3JkCg=="
+        PASSWORD = "ZW5jcnlwdGVkLXBhc3N3b3JkCg=="  # checkov:skip=CKV_SECRET_6 test secret
       }
     }
     available_secrets {

--- a/tests/terraform/image_referencer/test_manager.py
+++ b/tests/terraform/image_referencer/test_manager.py
@@ -35,7 +35,7 @@ def test_extract_images_from_resources(graph_framework):
         "container_configuration": {
             "container_image_names": ["python:3.9-alpine"],
             "container_registries": {
-                "password": "myPassword",
+                "password": "myPassword",  # checkov:skip=CKV_SECRET_6 test secret
                 "registry_server": "myContainerRegistry.azurecr.io",
                 "user_name": "myUserName",
             },

--- a/tests/terraform/module_loading/test_registry.py
+++ b/tests/terraform/module_loading/test_registry.py
@@ -341,7 +341,7 @@ def test_load_local_path(git_getter, tmp_path: Path, source, expected_content_pa
         (
             "github.com/kartikp10/terraform-aws-s3-bucket1",
             "github.com/kartikp10/terraform-aws-s3-bucket1/HEAD",
-            "https://x-access-token:ghp_xxxxxxxxxxxxxxxxx@github.com/kartikp10/terraform-aws-s3-bucket1",
+            "https://x-access-token:ghp_xxxxxxxxxxxxxxxxx@github.com/kartikp10/terraform-aws-s3-bucket1",  # checkov:skip=CKV_SECRET_4 test secret
             "github.com/kartikp10/terraform-aws-s3-bucket1/HEAD",
             "git::https://x-access-token:ghp_xxxxxxxxxxxxxxxxx@github.com/kartikp10/terraform-aws-s3-bucket1",
             "",
@@ -429,7 +429,7 @@ def test_load_github_private(
         (
             "bitbucket.org/kartikp10/terraform-aws-s3-bucket1",
             "bitbucket.org/kartikp10/terraform-aws-s3-bucket1/HEAD",
-            "https://x-token-auth:xxxxxxxxxxxxxxxxx@bitbucket.org/kartikp10/terraform-aws-s3-bucket1",
+            "https://x-token-auth:xxxxxxxxxxxxxxxxx@bitbucket.org/kartikp10/terraform-aws-s3-bucket1",  # checkov:skip=CKV_SECRET_4 test secret
             "bitbucket.org/kartikp10/terraform-aws-s3-bucket1/HEAD",
             "git::https://x-token-auth:xxxxxxxxxxxxxxxxx@bitbucket.org/kartikp10/terraform-aws-s3-bucket1",
             "",
@@ -437,7 +437,7 @@ def test_load_github_private(
     ],
     ids=["module"],
 )
-@mock.patch.dict(os.environ, {"BITBUCKET_TOKEN": "xxxxxxxxxxxxxxxxx"})
+@mock.patch.dict(os.environ, {"BITBUCKET_TOKEN": "xxxxxxxxxxxxxxxxx"})  # checkov:skip=CKV_SECRET_6 test secret
 @mock.patch("checkov.terraform.module_loading.loaders.git_loader.GitGetter", autospec=True)
 def test_load_bitbucket_private(
     git_getter,

--- a/tests/terraform/runner/resources/example/example.tf
+++ b/tests/terraform/runner/resources/example/example.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   region     = "us-west-2"
-  access_key = "AKIAIOSFODNN7EXAMPLE"
-  secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  access_key = "AKIAIOSFODNN7EXAMPLE"  # checkov:skip=CKV_SECRET_2 test secret
+  secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"  # checkov:skip=CKV_SECRET_6 test secret
 }
 resource "azurerm_virtual_machine" "main" {
   name                = "${var.prefix}-vm"
@@ -33,7 +33,7 @@ resource "azurerm_virtual_machine" "main" {
   os_profile {
     computer_name  = "hostname"
     admin_username = "testadmin"
-    admin_password = "Password1234!"
+    admin_password = "Password1234!"  # checkov:skip=CKV_SECRET_80 test secret
   }
   os_profile_linux_config {
     disable_password_authentication = false
@@ -646,7 +646,7 @@ resource "aws_s3_bucket" "sse_block_and_rule_block_as_map" {
 }
 
 resource "aws_efs_file_system" "sharedstore" {
-  creation_token                  = "my-product"
+  creation_token                  = "my-product"  # checkov:skip=CKV_SECRET_6 false positive
 
   lifecycle_policy {
     transition_to_ia = "AFTER_30_DAYS"
@@ -773,7 +773,7 @@ resource aws_lambda_function "bad-function" {
   environment {
     variables = {
       AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
-      secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+      secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"  # checkov:skip=CKV_SECRET_80 test secret
     }
   }
 }
@@ -1426,7 +1426,7 @@ resource "azurerm_sql_server" "example" {
   location                     = azurerm_resource_group.example.location
   version                      = "12.0"
   administrator_login          = "mradministrator"
-  administrator_login_password = "thisIsDog11"
+  administrator_login_password = "thisIsDog11"  # checkov:skip=CKV_SECRET_6 test secret
 
   extended_auditing_policy {
     storage_endpoint                        = azurerm_storage_account.example.primary_blob_endpoint
@@ -1454,7 +1454,7 @@ resource "azurerm_mysql_server" "example" {
   resource_group_name = azurerm_resource_group.example.name
 
   administrator_login          = "mysqladminun"
-  administrator_login_password = "H@Sh1CoR3!"
+  administrator_login_password = "H@Sh1CoR3!"  # checkov:skip=CKV_SECRET_80 test secret
 
   sku_name   = "B_Gen5_2"
   storage_mb = 5120

--- a/tests/terraform/runner/resources/get_graph_resource_entity_config/main.tf
+++ b/tests/terraform/runner/resources/get_graph_resource_entity_config/main.tf
@@ -1,8 +1,8 @@
 provider "aws" {
   alias      = "plain_text_access_keys_provider"
   region     = "us-west-1"
-  access_key = "AKIAIOSFODNN7EXAMPLE"
-  secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  access_key = "AKIAIOSFODNN7EXAMPLE"  # checkov:skip=CKV_SECRET_2 test secret
+  secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"  # checkov:skip=CKV_SECRET_6 test secret
 }
 
 locals {

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -8,9 +8,9 @@ class TestSecrets(unittest.TestCase):
 
     def test_secrets(self):
         test_strings = [
-            'AKIAIOSFODNN7EXAMPLE',
-            'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-            '-----BEGIN RSA PRIVATE KEY-----\n',
+            'AKIAIOSFODNN7EXAMPLE',  # checkov:skip=CKV_SECRET_2 test secret
+            'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',  # checkov:skip=CKV_SECRET_6 test secret
+            '-----BEGIN RSA PRIVATE KEY-----\n',  # checkov:skip=CKV_SECRET_13 test secret
             'Hello from Bridgecrew'
         ]
 
@@ -38,7 +38,7 @@ class TestSecrets(unittest.TestCase):
         self.assertFalse(string_has_secrets("d9de48cf0676e9edb99bd8ee1ed44a21"))
 
     def test_omit_secret_value_from_line(self):
-        secret = 'AKIAIOSFODNN7EXAMPLE'
+        secret = 'AKIAIOSFODNN7EXAMPLE'  # checkov:skip=CKV_SECRET_6 test secret
         line = 'access_key: "AKIAIOSFODNN7EXAMPLE"'
 
         censored_line = omit_secret_value_from_line(secret, line)
@@ -56,7 +56,7 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(line, omit_secret_value_from_line(secret, line))
 
     def test_omit_long_secret_value_from_line(self):
-        secret = '123456AKIAIOSFODNN7EXAMPLEAKIAIOSFODNN7EXAMPLEAKIAIOSFODNN7EXAM'
+        secret = '123456AKIAIOSFODNN7EXAMPLEAKIAIOSFODNN7EXAMPLEAKIAIOSFODNN7EXAM'  # checkov:skip=CKV_SECRET_6 test secret
         line = 'access_key: "123456AKIAIOSFODNN7EXAMPLEAKIAIOSFODNN7EXAMPLEAKIAIOSFODNN7EXAM"'
 
         censored_line = omit_secret_value_from_line(secret, line)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- add `checkov` GHA to scan its own repo for secrets
- adjust security workflow trigger

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
