### PR TITLE
feat(kustomize): Support inline skips for Kubernetes graph checks

### DIFF
--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -23,7 +23,7 @@ from checkov.common.output.report import Report
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.runners.base_runner import BaseRunner, filter_ignored_paths
 from checkov.common.typing import _CheckResult
-from checkov.kubernetes.kubernetes_utils import get_resource_id
+from checkov.kubernetes.kubernetes_utils import create_check_result, get_resource_id
 from checkov.kubernetes.runner import Runner as K8sRunner
 from checkov.kubernetes.runner import _get_entity_abs_path
 from checkov.kustomize.image_referencer.manager import KustomizeImageReferencerManager
@@ -178,10 +178,12 @@ class K8sKustomizeRunner(K8sRunner):
                 code_lines = entity_context["code_lines"]
                 file_line_range = self.line_range(code_lines)
 
+                clean_check_result = create_check_result(check_result=check_result, entity_context=entity_context, check_id=check.id)
+
                 record = Record(
                     check_id=check.id,
                     check_name=check.name,
-                    check_result=check_result,
+                    check_result=clean_check_result,
                     code_block=code_lines,
                     file_path=realKustomizeEnvMetadata['filePath'],
                     file_line_range=file_line_range,

--- a/tests/kustomize/graph/resources/example_checks/graph_check.yaml
+++ b/tests/kustomize/graph/resources/example_checks/graph_check.yaml
@@ -1,0 +1,139 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: internal-proxy-deployment
+  labels:
+    app: internal-proxy
+spec:
+  selector:
+    matchLabels:
+      app: internal-proxy
+  template:
+    metadata:
+      labels:
+        app: internal-proxy
+    spec:
+      containers:
+      - name: internal-api
+        image: madhuakula/k8s-goat-internal-api
+        resources:
+          limits:
+            cpu: 30m
+            memory: 40Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        ports:
+        - containerPort: 3000
+      - name: info-app
+        image: madhuakula/k8s-goat-info-app
+        resources:
+          limits:
+            cpu: 30m
+            memory: 40Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        ports:
+        - containerPort: 5000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-proxy-deployment
+  labels:
+    app: external-proxy
+spec:
+  selector:
+    matchLabels:
+      app: external-proxy
+  template:
+    metadata:
+      labels:
+        app: external-proxy
+    spec:
+      containers:
+      - name: internal-api
+        image: madhuakula/k8s-goat-internal-api
+        resources:
+          limits:
+            cpu: 30m
+            memory: 40Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        ports:
+        - containerPort: 3000
+      - name: info-app
+        image: madhuakula/k8s-goat-info-app
+        resources:
+          limits:
+            cpu: 30m
+            memory: 40Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        ports:
+        - containerPort: 5000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-network-policy
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: internal-proxy
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - podSelector:
+            matchLabels:
+              app: internal-proxy
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skipdeployment
+  annotations:
+    "checkov.io/skip": "CKV2_K8S_6=skip it"
+  labels:
+    app: skip
+spec:
+  selector:
+    matchLabels:
+      app: skip
+  template:
+    metadata:
+      labels:
+        app: skip
+    spec:
+      containers:
+      - name: info-app
+        image: madhuakula/k8s-goat-info-app
+        resources:
+          limits:
+            cpu: 30m
+            memory: 40Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        ports:
+        - containerPort: 5000

--- a/tests/kustomize/graph/resources/example_checks/kustomization.yaml
+++ b/tests/kustomize/graph/resources/example_checks/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - graph_check.yaml

--- a/tests/kustomize/graph/test_running_graph_checks.py
+++ b/tests/kustomize/graph/test_running_graph_checks.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+import os
+from checkov.kustomize.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+@pytest.mark.parametrize("graph_framework", ["NETWORKX", "IGRAPH"])
+def test_runner(mocker: MockerFixture, graph_framework):
+    scan_dir_path = Path(__file__).parent / "resources" / "example_checks"
+    dir_rel_path = os.path.realpath(scan_dir_path).replace('\\', '/')
+
+    runner_filter = RunnerFilter(framework=["kustomize"], checks=["CKV2_K8S_6"])
+
+    mocker.patch.dict("os.environ", {"CHECKOV_GRAPH_FRAMEWORK": graph_framework})
+
+    runner = Runner()
+    runner.templateRendererCommand = "kustomize"
+    runner.templateRendererCommandOptions = "build"
+
+    report = runner.run(root_folder=dir_rel_path, runner_filter=runner_filter, external_checks_dir=None)
+
+    summary = report.get_summary()
+
+    assert summary["passed"] == 1
+    assert summary["failed"] == 1
+    assert summary["skipped"] == 1
+    assert summary["parsing_errors"] == 0


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Applied the same fixes as https://github.com/bridgecrewio/checkov/pull/4412

Fixes #5069


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
