### PR TITLE
chore: make networkx import truly optional

### DIFF
--- a/checkov/common/checks_infra/solvers/connections_solvers/connection_exists_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/connection_exists_solver.py
@@ -1,11 +1,17 @@
 import itertools
+import logging
 from typing import List, Optional, Dict, Any, Tuple
 
 from igraph import Graph
 
+try:
+    from networkx import edge_dfs
+except ImportError:
+    logging.info("Not able to import networkx")
+    edge_dfs = lambda G : []
+
 from checkov.common.graph.checks_infra.enums import Operators
 from checkov.common.checks_infra.solvers.connections_solvers.base_connection_solver import BaseConnectionSolver
-from networkx import edge_dfs
 from checkov.common.graph.graph_builder import CustomAttributes
 from checkov.common.typing import LibraryGraph
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType

--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -9,7 +9,6 @@ from collections.abc import Iterable
 from typing import List, Any, TYPE_CHECKING, TypeVar, Generic, Dict
 
 from checkov.common.graph.db_connectors.igraph.igraph_db_connector import IgraphConnector
-from checkov.common.graph.db_connectors.networkx.networkx_db_connector import NetworkxConnector
 from checkov.common.graph.graph_builder import CustomAttributes
 from checkov.common.util.tqdm_utils import ProgressBar
 
@@ -64,11 +63,12 @@ class BaseRunner(ABC, Generic[_GraphManager]):
         self.file_extensions = file_extensions or []
         self.file_names = file_names or []
         self.pbar = ProgressBar(self.check_type)
-        db_connector_class: "type[NetworkxConnector | IgraphConnector]" = NetworkxConnector
+        db_connector_class: "type[NetworkxConnector | IgraphConnector]" = IgraphConnector
         graph_framework = os.getenv("CHECKOV_GRAPH_FRAMEWORK", "IGRAPH")
         if graph_framework == "IGRAPH":
             db_connector_class = IgraphConnector
         elif graph_framework == "NETWORKX":
+            from checkov.common.graph.db_connectors.networkx.networkx_db_connector import NetworkxConnector
             db_connector_class = NetworkxConnector
 
         self.db_connector = db_connector_class()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- make `networkx` import truly optional, because it relies on `bz2`, which is not available on all linux distibutions 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
