### PR TITLE
feat(kubernetes): seperate service acoount builder to improve performance

### DIFF
--- a/checkov/kubernetes/graph_builder/graph_components/ResourceKeywordIdentifier.py
+++ b/checkov/kubernetes/graph_builder/graph_components/ResourceKeywordIdentifier.py
@@ -17,9 +17,9 @@ class ResourceKeywordIdentifier:
         # TODO: "ClusterRole": ["rules[].resources", "rules[].resourceNames"],
         # TODO: "Role": ["rules[].resources", "rules[].resourceNames"],
 
-        "ServiceAccount": [
-            {"spec.serviceAccountName": "metadata.name"}
-        ],
+        # "ServiceAccount": [
+        #     {"spec.serviceAccountName": "metadata.name"}
+        # ],
         "ClusterRoleBinding": [
             {"metadata.name": "roleRef.name", "kind": "roleRef.kind"},
             [{"subjects": {"metadata.name": "name", "kind": "kind"}}]

--- a/checkov/kubernetes/graph_builder/graph_components/ResourceKeywordIdentifier.py
+++ b/checkov/kubernetes/graph_builder/graph_components/ResourceKeywordIdentifier.py
@@ -17,9 +17,6 @@ class ResourceKeywordIdentifier:
         # TODO: "ClusterRole": ["rules[].resources", "rules[].resourceNames"],
         # TODO: "Role": ["rules[].resources", "rules[].resourceNames"],
 
-        # "ServiceAccount": [
-        #     {"spec.serviceAccountName": "metadata.name"}
-        # ],
         "ClusterRoleBinding": [
             {"metadata.name": "roleRef.name", "kind": "roleRef.kind"},
             [{"subjects": {"metadata.name": "name", "kind": "kind"}}]

--- a/checkov/kubernetes/graph_builder/graph_components/edge_builders/KeywordEdgeBuilder.py
+++ b/checkov/kubernetes/graph_builder/graph_components/edge_builders/KeywordEdgeBuilder.py
@@ -44,7 +44,7 @@ class KeywordEdgeBuilder(K8SEdgeBuilder):
                 elif isinstance(references_definition, list):
                     # not really a loop, just extracting the dict's key
                     for base_key_attribute, reference_definitions_items in references_definition[0].items():
-                        vertex_attribute_references_list: list[dict[str, str]] = vertex.attributes.get(base_key_attribute)  # type: ignore[assignment]
+                        vertex_attribute_references_list: list[dict[str, str]] = vertex.attributes.get(base_key_attribute)
                         if not vertex_attribute_references_list:
                             continue
                         # iterate every item on the list as a separate resource

--- a/checkov/kubernetes/graph_builder/graph_components/edge_builders/KeywordEdgeBuilder.py
+++ b/checkov/kubernetes/graph_builder/graph_components/edge_builders/KeywordEdgeBuilder.py
@@ -44,7 +44,7 @@ class KeywordEdgeBuilder(K8SEdgeBuilder):
                 elif isinstance(references_definition, list):
                     # not really a loop, just extracting the dict's key
                     for base_key_attribute, reference_definitions_items in references_definition[0].items():
-                        vertex_attribute_references_list: list[dict[str, str]] = vertex.attributes.get(base_key_attribute)
+                        vertex_attribute_references_list: list[dict[str, str]] = vertex.attributes.get(base_key_attribute)  # type: ignore[assignment]
                         if not vertex_attribute_references_list:
                             continue
                         # iterate every item on the list as a separate resource

--- a/checkov/kubernetes/graph_builder/graph_components/edge_builders/ServiceAccountEdgeBuilder.py
+++ b/checkov/kubernetes/graph_builder/graph_components/edge_builders/ServiceAccountEdgeBuilder.py
@@ -24,8 +24,14 @@ class ServiceAccountEdgeBuilder(K8SEdgeBuilder):
             if vertex.attributes.get('kind') != 'ServiceAccount' or service_account_name is None:
                 continue
             self._cache[service_account_name] = VertexConncetions(index)
+        return
 
-    def find_connections(self, vertex: KubernetesBlock, vertices: list[KubernetesBlock]) -> list[int]:
+    @staticmethod
+    def find_connections(vertex: KubernetesBlock, vertices: list[KubernetesBlock]) -> list[int]:
+        # DEPRECATED - this is just here for this builder to support the interface. Use `find_connections_for_instance`
+        raise NotImplementedError
+
+    def find_connections_for_instance(self, vertex: KubernetesBlock, vertices: list[KubernetesBlock]) -> list[int]:
         if not self._cache:
             self._find_all_service_accounts(vertices)
             for index, destination_vertex in enumerate(vertices):

--- a/checkov/kubernetes/graph_builder/graph_components/edge_builders/ServiceAccountEdgeBuilder.py
+++ b/checkov/kubernetes/graph_builder/graph_components/edge_builders/ServiceAccountEdgeBuilder.py
@@ -10,7 +10,6 @@ class VertexConncetions:
         self.destination_vertices_indices = destination_vertices_indices or []
 
 
-
 class ServiceAccountEdgeBuilder(K8SEdgeBuilder):
     def __init__(self) -> None:
         self._cache = {}

--- a/checkov/kubernetes/graph_builder/graph_components/edge_builders/ServiceAccountEdgeBuilder.py
+++ b/checkov/kubernetes/graph_builder/graph_components/edge_builders/ServiceAccountEdgeBuilder.py
@@ -12,7 +12,7 @@ class VertexConncetions:
 
 class ServiceAccountEdgeBuilder(K8SEdgeBuilder):
     def __init__(self) -> None:
-        self._cache = {}
+        self._cache: dict[str, VertexConncetions] = {}
 
     @staticmethod
     def should_search_for_edges(vertex: KubernetesBlock) -> bool:
@@ -26,7 +26,7 @@ class ServiceAccountEdgeBuilder(K8SEdgeBuilder):
             self._cache[service_account_name] = VertexConncetions(index)
 
     def find_connections(self, vertex: KubernetesBlock, vertices: list[KubernetesBlock]) -> list[int]:
-        if self._cache == {}:
+        if not self._cache:
             self._find_all_service_accounts(vertices)
             for index, destination_vertex in enumerate(vertices):
                 if destination_vertex.id == vertex.id:
@@ -37,5 +37,6 @@ class ServiceAccountEdgeBuilder(K8SEdgeBuilder):
                     self._cache[destination_vertex_ref].destination_vertices_indices.append(index)
 
         vertex_ref = vertex.attributes.get('metadata.name')
+        if vertex_ref is None:
+            return []
         return self._cache[vertex_ref].destination_vertices_indices
-

--- a/checkov/kubernetes/graph_builder/graph_components/edge_builders/ServiceAccountEdgeBuilder.py
+++ b/checkov/kubernetes/graph_builder/graph_components/edge_builders/ServiceAccountEdgeBuilder.py
@@ -16,7 +16,8 @@ class ServiceAccountEdgeBuilder(K8SEdgeBuilder):
 
     @staticmethod
     def should_search_for_edges(vertex: KubernetesBlock) -> bool:
-        return vertex.attributes.get('kind') == 'ServiceAccount'
+        kind: str | None = vertex.attributes.get('kind')
+        return kind == 'ServiceAccount'
 
     def _find_all_service_accounts(self, vertices: list[KubernetesBlock]) -> None:
         for index, vertex in enumerate(vertices):

--- a/checkov/kubernetes/graph_builder/graph_components/edge_builders/ServiceAccountEdgeBuilder.py
+++ b/checkov/kubernetes/graph_builder/graph_components/edge_builders/ServiceAccountEdgeBuilder.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from checkov.kubernetes.graph_builder.graph_components.blocks import KubernetesBlock
+from checkov.kubernetes.graph_builder.graph_components.edge_builders.K8SEdgeBuilder import K8SEdgeBuilder
+
+
+class VertexConncetions:
+    def __init__(self, origin_vertex_index: int, destination_vertices_indices: list[int] | None = None) -> None:
+        self.origin_vertex_index = origin_vertex_index
+        self.destination_vertices_indices = destination_vertices_indices or []
+
+
+
+class ServiceAccountEdgeBuilder(K8SEdgeBuilder):
+    def __init__(self) -> None:
+        self._cache = {}
+
+    @staticmethod
+    def should_search_for_edges(vertex: KubernetesBlock) -> bool:
+        return vertex.attributes.get('kind') == 'ServiceAccount'
+
+    def _find_all_service_accounts(self, vertices: list[KubernetesBlock]) -> None:
+        for index, vertex in enumerate(vertices):
+            service_account_name = vertex.attributes.get('metadata.name')
+            if vertex.attributes.get('kind') != 'ServiceAccount' or service_account_name is None:
+                continue
+            self._cache[service_account_name] = VertexConncetions(index)
+
+    def find_connections(self, vertex: KubernetesBlock, vertices: list[KubernetesBlock]) -> list[int]:
+        if self._cache == {}:
+            self._find_all_service_accounts(vertices)
+            for index, destination_vertex in enumerate(vertices):
+                if destination_vertex.id == vertex.id:
+                    continue
+
+                destination_vertex_ref = destination_vertex.attributes.get('spec.serviceAccountName')
+                if destination_vertex_ref in self._cache:
+                    self._cache[destination_vertex_ref].destination_vertices_indices.append(index)
+
+        vertex_ref = vertex.attributes.get('metadata.name')
+        return self._cache[vertex_ref].destination_vertices_indices
+

--- a/checkov/kubernetes/graph_builder/local_graph.py
+++ b/checkov/kubernetes/graph_builder/local_graph.py
@@ -9,6 +9,7 @@ from checkov.common.graph.graph_builder import Edge
 from checkov.common.graph.graph_builder.local_graph import LocalGraph
 from checkov.common.util.consts import START_LINE, END_LINE
 from checkov.kubernetes.graph_builder.graph_components.blocks import KubernetesBlock, KubernetesBlockMetadata, KubernetesSelector
+from checkov.kubernetes.graph_builder.graph_components.edge_builders.K8SEdgeBuilder import K8SEdgeBuilder
 from checkov.kubernetes.graph_builder.graph_components.edge_builders.ServiceAccountEdgeBuilder import ServiceAccountEdgeBuilder
 from checkov.kubernetes.kubernetes_utils import DEFAULT_NESTED_RESOURCE_TYPE, is_invalid_k8_definition, get_resource_id, is_invalid_k8_pod_definition, \
     remove_metadata_from_attribute, PARENT_RESOURCE_KEY_NAME, PARENT_RESOURCE_ID_KEY_NAME, SUPPORTED_POD_CONTAINERS_TYPES
@@ -21,8 +22,8 @@ from checkov.kubernetes.graph_builder.graph_components.edge_builders.NetworkPoli
 class KubernetesLocalGraph(LocalGraph[KubernetesBlock]):
     def __init__(self, definitions: dict[str, list[dict[str, Any]]]) -> None:
         self.definitions = definitions
-        self.edge_builders = (LabelSelectorEdgeBuilder, KeywordEdgeBuilder, NetworkPolicyEdgeBuilder,
-                              ServiceAccountEdgeBuilder())
+        self.edge_builders: list[type[K8SEdgeBuilder] | ServiceAccountEdgeBuilder] = \
+            [LabelSelectorEdgeBuilder, KeywordEdgeBuilder, NetworkPolicyEdgeBuilder, ServiceAccountEdgeBuilder()]
         super().__init__()
 
     def build_graph(self, render_variables: bool, graph_flags: K8sGraphFlags | None = None) -> None:

--- a/checkov/kubernetes/graph_builder/local_graph.py
+++ b/checkov/kubernetes/graph_builder/local_graph.py
@@ -9,6 +9,7 @@ from checkov.common.graph.graph_builder import Edge
 from checkov.common.graph.graph_builder.local_graph import LocalGraph
 from checkov.common.util.consts import START_LINE, END_LINE
 from checkov.kubernetes.graph_builder.graph_components.blocks import KubernetesBlock, KubernetesBlockMetadata, KubernetesSelector
+from checkov.kubernetes.graph_builder.graph_components.edge_builders.ServiceAccountEdgeBuilder import ServiceAccountEdgeBuilder
 from checkov.kubernetes.kubernetes_utils import DEFAULT_NESTED_RESOURCE_TYPE, is_invalid_k8_definition, get_resource_id, is_invalid_k8_pod_definition, \
     remove_metadata_from_attribute, PARENT_RESOURCE_KEY_NAME, PARENT_RESOURCE_ID_KEY_NAME, SUPPORTED_POD_CONTAINERS_TYPES
 from checkov.kubernetes.kubernetes_graph_flags import K8sGraphFlags
@@ -20,7 +21,8 @@ from checkov.kubernetes.graph_builder.graph_components.edge_builders.NetworkPoli
 class KubernetesLocalGraph(LocalGraph[KubernetesBlock]):
     def __init__(self, definitions: dict[str, list[dict[str, Any]]]) -> None:
         self.definitions = definitions
-        self.edge_builders = (LabelSelectorEdgeBuilder, KeywordEdgeBuilder, NetworkPolicyEdgeBuilder)
+        self.edge_builders = (LabelSelectorEdgeBuilder, KeywordEdgeBuilder, NetworkPolicyEdgeBuilder,
+                              ServiceAccountEdgeBuilder())
         super().__init__()
 
     def build_graph(self, render_variables: bool, graph_flags: K8sGraphFlags | None = None) -> None:

--- a/checkov/kubernetes/graph_builder/local_graph.py
+++ b/checkov/kubernetes/graph_builder/local_graph.py
@@ -89,7 +89,11 @@ class KubernetesLocalGraph(LocalGraph[KubernetesBlock]):
         for vertex_index, vertex in enumerate(self.vertices):
             for edge_builder in self.edge_builders:
                 if edge_builder.should_search_for_edges(vertex):
-                    current_vertex_connections = edge_builder.find_connections(vertex, self.vertices)
+                    # Needs to be handled separately as it requires an isntance rather than a static method
+                    if isinstance(edge_builder, ServiceAccountEdgeBuilder):
+                        current_vertex_connections = edge_builder.find_connections_for_instance(vertex, self.vertices)
+                    else:
+                        current_vertex_connections = edge_builder.find_connections(vertex, self.vertices)
                     if current_vertex_connections:
                         edges_to_create[vertex.name].extend(current_vertex_connections)
             for destination_vertex_index in edges_to_create[vertex.name]:

--- a/tests/kubernetes/graph/test_local_graph.py
+++ b/tests/kubernetes/graph/test_local_graph.py
@@ -1,5 +1,7 @@
 import os
 
+from checkov.kubernetes.graph_builder.graph_components.edge_builders.ServiceAccountEdgeBuilder import \
+    ServiceAccountEdgeBuilder
 from checkov.kubernetes.graph_builder.local_graph import KubernetesLocalGraph
 from checkov.kubernetes.parser.parser import parse
 from tests.kubernetes.graph.base_graph_tests import TestGraph
@@ -111,7 +113,7 @@ class TestKubernetesLocalGraph(TestGraph):
         self.assertEqual(local_graph.edges[1].origin, 0)
         self.assertEqual(local_graph.edges[1].dest, 4)
 
-    def test_KeywordEdgeBuilder_on_templates_with_pod_and_service_account(self) -> None:
+    def test_KeywordEdgeBuilder_and_ServiceAccountEdgeBuilder_on_templates_with_pod_and_service_account(self) -> None:
         relative_file_path = "resources/Keyword/pod_service_account.yaml"
         definitions = {}
         file = os.path.realpath(os.path.join(TEST_DIRNAME, relative_file_path))
@@ -119,8 +121,6 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        from checkov.kubernetes.graph_builder.graph_components.edge_builders.ServiceAccountEdgeBuilder import \
-            ServiceAccountEdgeBuilder
         local_graph.edge_builders = (KeywordEdgeBuilder, ServiceAccountEdgeBuilder())
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(4, len(local_graph.vertices))

--- a/tests/kubernetes/graph/test_local_graph.py
+++ b/tests/kubernetes/graph/test_local_graph.py
@@ -119,7 +119,9 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (KeywordEdgeBuilder, )
+        from checkov.kubernetes.graph_builder.graph_components.edge_builders.ServiceAccountEdgeBuilder import \
+            ServiceAccountEdgeBuilder
+        local_graph.edge_builders = (KeywordEdgeBuilder, ServiceAccountEdgeBuilder())
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(4, len(local_graph.vertices))
         self.assertEqual(3, len(local_graph.edges))

--- a/tests/kubernetes/graph/test_local_graph.py
+++ b/tests/kubernetes/graph/test_local_graph.py
@@ -65,7 +65,7 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (LabelSelectorEdgeBuilder, )
+        local_graph.edge_builders = [LabelSelectorEdgeBuilder, ]
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(2, len(local_graph.vertices))
         self.assertEqual(1, len(local_graph.edges))
@@ -78,7 +78,7 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (LabelSelectorEdgeBuilder, )
+        local_graph.edge_builders = [LabelSelectorEdgeBuilder, ]
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(2, len(local_graph.vertices))
         self.assertEqual(0, len(local_graph.edges))
@@ -91,7 +91,7 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (LabelSelectorEdgeBuilder, )
+        local_graph.edge_builders = [LabelSelectorEdgeBuilder, ]
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(3, len(local_graph.vertices))
         self.assertEqual(1, len(local_graph.edges))
@@ -104,7 +104,7 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (KeywordEdgeBuilder, )
+        local_graph.edge_builders = [KeywordEdgeBuilder, ]
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(6, len(local_graph.vertices))
         self.assertEqual(3, len(local_graph.edges))
@@ -121,7 +121,7 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (KeywordEdgeBuilder, ServiceAccountEdgeBuilder())
+        local_graph.edge_builders = [KeywordEdgeBuilder, ServiceAccountEdgeBuilder()]
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(4, len(local_graph.vertices))
         self.assertEqual(3, len(local_graph.edges))
@@ -140,7 +140,7 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (NetworkPolicyEdgeBuilder, LabelSelectorEdgeBuilder)
+        local_graph.edge_builders = [NetworkPolicyEdgeBuilder, LabelSelectorEdgeBuilder]
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(5, len(local_graph.vertices))
         self.assertEqual(4, len(local_graph.edges))
@@ -153,7 +153,7 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (NetworkPolicyEdgeBuilder, LabelSelectorEdgeBuilder)
+        local_graph.edge_builders = [NetworkPolicyEdgeBuilder, LabelSelectorEdgeBuilder]
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(2, len(local_graph.vertices))
         self.assertEqual(1, len(local_graph.edges))
@@ -166,7 +166,7 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (NetworkPolicyEdgeBuilder, LabelSelectorEdgeBuilder)
+        local_graph.edge_builders = [NetworkPolicyEdgeBuilder, LabelSelectorEdgeBuilder]
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(2, len(local_graph.vertices))
         self.assertEqual(0, len(local_graph.edges))
@@ -179,7 +179,7 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (KeywordEdgeBuilder, )
+        local_graph.edge_builders = [KeywordEdgeBuilder, ]
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(6, len(local_graph.vertices))
         self.assertEqual(1, len(local_graph.edges))
@@ -192,7 +192,7 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (NetworkPolicyEdgeBuilder, LabelSelectorEdgeBuilder)
+        local_graph.edge_builders = [NetworkPolicyEdgeBuilder, LabelSelectorEdgeBuilder]
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(0, len(local_graph.vertices))
         self.assertEqual(0, len(local_graph.edges))
@@ -205,7 +205,7 @@ class TestKubernetesLocalGraph(TestGraph):
         graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
 
         local_graph = KubernetesLocalGraph(definitions)
-        local_graph.edge_builders = (NetworkPolicyEdgeBuilder, LabelSelectorEdgeBuilder)
+        local_graph.edge_builders = [NetworkPolicyEdgeBuilder, LabelSelectorEdgeBuilder]
         local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
         self.assertEqual(1, len(local_graph.vertices))
         self.assertEqual(0, len(local_graph.edges))


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Separated handling of `ServiceAccount` edges while building the graph to implement a cache, thus improving performance of create_edges.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
