### PR TITLE
feat(secrets): Add new pre-commit hook for secrets

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,7 +16,7 @@
 -   id: checkov_secrets
     name: Checkov Secrets
     description: This hook looks for secrets with checkov.
-    entry: checkov -d . --framework secrets
+    entry: checkov -d . --framework secrets --enable-secret-scan-all-files
     language: python
     pass_filenames: false
     always_run: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,3 +13,11 @@
     files: \.tf$
     exclude: \.+.terraform\/.*$
     require_serial: true
+-   id: checkov_secrets
+    name: Checkov Secrets
+    description: This hook looks for secrets with checkov.
+    entry: checkov -d . --framework secrets
+    language: python
+    pass_filenames: false
+    always_run: true
+    require_serial: true


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Add a new [pre-commit](https://pre-commit.com/) hook plugin. Note that this is not used in this repository, but is meant to be used from other repositories. Post-merge, this could be used by other repositories in their `.pre-commit-config.yaml` as follows:

```yaml
repos:
  - repo: https://github.com/bridgecrewio/checkov
    rev: 2.3.24X
    hooks:
      - id: checkov_secrets
```

This can currently be tested as follows:
```
pre-commit try-repo --ref new_hook https://github.com/james-otten-pan/checkov checkov_secrets
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
