### PR TITLE
fix(terraform): fix terraform variable rendering for provider alias

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -499,9 +499,13 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
             # skip, if there is no change
             return
 
+        vertex_name = vertex.name
         updated_config = deepcopy(vertex.config)
+        if vertex.block_type == BlockType.PROVIDER:
+            # provider blocks set the alias as a suffix to the name, ex. name: "aws.prod"
+            vertex_name = vertex_name.split(".")[0]
         if vertex.block_type != BlockType.LOCALS:
-            parts = vertex.name.split(".")
+            parts = vertex_name.split(".")
             start = 0
             end = 1
             while end <= len(parts):
@@ -510,17 +514,18 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
                     updated_config = updated_config[cur_key]
                     start = end
                 end += 1
+
         for changed_attribute in changed_attributes:
             new_value = vertex.attributes.get(changed_attribute, None)
             if new_value is not None:
                 if vertex.block_type == BlockType.LOCALS:
-                    changed_attribute = changed_attribute.replace(vertex.name + ".", "")
+                    changed_attribute = changed_attribute.replace(f"{vertex_name}.", "")
                 updated_config = update_dictionary_attribute(updated_config, changed_attribute, new_value, dynamic_blocks)
 
         if len(changed_attributes) > 0:
             if vertex.block_type == BlockType.LOCALS:
-                updated_config = updated_config.get(vertex.name)
-            update_dictionary_attribute(vertex.config, vertex.name, updated_config, dynamic_blocks)
+                updated_config = updated_config.get(vertex_name)
+            update_dictionary_attribute(vertex.config, vertex_name, updated_config, dynamic_blocks)
 
     def get_resources_types_in_graph(self) -> List[str]:
         return self.module.get_resources_types()

--- a/tests/terraform/graph/variable_rendering/expected_foreach_modules_tf_definitions.json
+++ b/tests/terraform/graph/variable_rendering/expected_foreach_modules_tf_definitions.json
@@ -90,7 +90,7 @@
             "us-west-2"
           ],
           "test_provider": [
-            "${True}"
+            true
           ],
           "__address__": "aws.test_provider"
         }

--- a/tests/terraform/graph/variable_rendering/test_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_renderer.py
@@ -457,3 +457,18 @@ class TestRenderer(TestCase):
             "ip_rules": [],
             "virtual_network_subnet_ids": []
         }
+
+    def test_provider_alias(self):
+        # given
+        resource_path = Path(TEST_DIRNAME) / "test_resources/provider_alias"
+
+        # when
+        graph_manager = TerraformGraphManager('m', ['m'])
+        local_graph, _ = graph_manager.build_graph_from_source_directory(str(resource_path), render_variables=True)
+
+        # then
+        provider = next(vertex for vertex in local_graph.vertices if vertex.block_type == BlockType.PROVIDER and vertex.name == "aws")
+        assert provider.config["aws"]["default_tags"] == [{"tags": [{"test": "Test"}]}]
+
+        provider_alias = next(vertex for vertex in local_graph.vertices if vertex.block_type == BlockType.PROVIDER and vertex.name == "aws.test")
+        assert provider_alias.config["aws"]["default_tags"] == [{"tags": [{"test": "Test"}]}]

--- a/tests/terraform/graph/variable_rendering/test_resources/provider_alias/main.tf
+++ b/tests/terraform/graph/variable_rendering/test_resources/provider_alias/main.tf
@@ -1,0 +1,19 @@
+locals {
+  tags = {
+    test = "Test"
+  }
+}
+
+provider "aws" {
+  default_tags {
+    tags = local.tags
+  }
+}
+
+
+provider "aws" {
+  alias = "test"
+  default_tags {
+    tags = local.tags
+  }
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- fixed a special case for provider alias, when we do variable rendering

Fixes #5118 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
