### PR TITLE
fix(gitlab): Skipping image blocks without name attribute

### DIFF
--- a/checkov/gitlab_ci/image_referencer/provider.py
+++ b/checkov/gitlab_ci/image_referencer/provider.py
@@ -22,6 +22,8 @@ class GitlabCiProvider(WorkflowImageReferencerProvider):
                     if key in self.supported_keys:
                         image_name = ""
                         if isinstance(subjob, dict):
+                            if 'name' not in subjob:
+                                continue
                             start_line, end_line = GitlabCiProvider._get_start_end_lines(subjob)
                             image_name = subjob['name']
                         elif isinstance(subjob, str):

--- a/tests/gitlab_ci/image_referencer/resources/single_image/image_without_name.gitlab-ci.yml
+++ b/tests/gitlab_ci/image_referencer/resources/single_image/image_without_name.gitlab-ci.yml
@@ -1,0 +1,8 @@
+unit tests:
+  image:
+    entrypoint:
+      - "/opt/bin/entry_point_unit_tests.sh"
+
+  services:
+    - name: "postgres:13.2"
+      alias: postgres

--- a/tests/gitlab_ci/image_referencer/test_gitlab_ci_provider.py
+++ b/tests/gitlab_ci/image_referencer/test_gitlab_ci_provider.py
@@ -104,3 +104,36 @@ def test_extract_images_from_workflow_no_images():
     images = gitlab_ci_provider.extract_images_from_workflow()
 
     assert not images
+
+
+def test_extract_images_from_workflow_image_without_name():
+    file_path = 'tests/gitlab_ci/resources/rules/image_without_name.gitlab-ci.yml'
+    workflow_config = {
+          "unit tests": {
+            "image": {
+              "entrypoint": [
+                "/opt/bin/entry_point_unit_tests.sh"
+              ],
+              "__startline__": 3,
+              "__endline__": 6
+            },
+            "services": [
+              {
+                "name": "postgres:13.2",
+                "alias": "postgres",
+                "__startline__": 7,
+                "__endline__": 8
+              }
+            ],
+            "__startline__": 2,
+            "__endline__": 8
+          },
+          "__startline__": 1,
+          "__endline__": 8
+        }
+
+    gitlab_ci_provider = GitlabCiProvider(workflow_config=workflow_config, file_path=file_path)
+    images = gitlab_ci_provider.extract_images_from_workflow()
+
+    assert len(images) == 1
+    assert images[0] == Image(name='postgres:13.2', file_path=file_path, start_line=7, end_line=8, related_resource_id='unit tests.services.1')


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
