### PR TITLE
chore: disable checkov-secrets GHA job

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -10,7 +10,8 @@ on:
     branches:
       - main
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   bandit:
@@ -29,14 +30,14 @@ jobs:
         uses: edplato/trufflehog-actions-scan@0af17d9dd1410283f740eb76b0b8f6b696cadefc  # v0.9
         with:
           scanArguments: "--regex --entropy=False --exclude_paths .github/exclude-patterns.txt --max_depth=1"
-  checkov-secrets:
-    runs-on: [self-hosted, public, linux, x64]
-    steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}  # this is needed to use the API key in a PR
-      - name: Scan for secrets
-        uses: bridgecrewio/checkov-action@master  # use latest and greatest
-        with:
-          api-key: ${{ secrets.BC_API_KEY }}
-          config_file: .github/checkov.yaml
+#  checkov-secrets:
+#    runs-on: [self-hosted, public, linux, x64]
+#    steps:
+#      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3
+#        with:
+#          ref: ${{ github.event.pull_request.head.sha }}  # this is needed to use the API key in a PR
+#      - name: Scan for secrets
+#        uses: bridgecrewio/checkov-action@master  # use latest and greatest
+#        with:
+#          api-key: ${{ secrets.BC_API_KEY }}
+#          config_file: .github/checkov.yaml


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- disable checkov-secrets GHA job for now

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
