### PR TITLE
feat(terraform): don't fail CKV_AWS_2 on un-rendered value

### DIFF
--- a/checkov/terraform/checks/resource/aws/ALBListenerHTTPS.py
+++ b/checkov/terraform/checks/resource/aws/ALBListenerHTTPS.py
@@ -21,9 +21,12 @@ class ALBListenerHTTPS(BaseResourceCheck):
         self.evaluated_keys = ['protocol']
         key = 'protocol'
         if key in conf.keys():
-            if conf[key] in (["HTTPS"], ["TLS"], ["TCP"], ["UDP"], ["TCP_UDP"]):
+            protocol = conf.get(key, [None])[0]
+            if BaseResourceCheck._is_variable_dependant(protocol):
+                return CheckResult.UNKNOWN
+            if protocol in ("HTTPS", "TLS", "TCP", "UDP", "TCP_UDP"):
                 return CheckResult.PASSED
-            elif conf[key] == ["HTTP"]:
+            elif protocol == "HTTP":
                 if 'default_action' in conf.keys():
                     default_action = conf['default_action'][0]
                     action_type = default_action['type']

--- a/tests/terraform/checks/resource/aws/test_ALBListenerHTTPS.py
+++ b/tests/terraform/checks/resource/aws/test_ALBListenerHTTPS.py
@@ -75,6 +75,25 @@ resource "aws_lb_listener" "http_redirector" {
         result = check.scan_resource_conf(resource_conf)
         self.assertEqual(CheckResult.UNKNOWN, result)
 
+    def test_unknown_not_rendered(self):
+        hcl_res = hcl2.loads("""
+resource "aws_lb_listener" "http_redirector" {
+  load_balancer_arn = aws_lb.redirector.arn
+  port              = "80"
+  protocol          = var.lb_protocol
+  default_action {
+    type = "redirect"
+    redirect {
+      host        = "example.com"
+      status_code = "HTTP_302"
+    }
+  }
+}
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_lb_listener']['http_redirector']
+        result = check.scan_resource_conf(resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Currently, if the `protocol` field is unrendered by checkov, it fails the check. This makes it skip it as we don't know the answer.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
