### PR TITLE
fix(terraform): Unable to download Terraform modules from JFrog Artifactory

### DIFF
--- a/checkov/common/goget/registry/get_registry.py
+++ b/checkov/common/goget/registry/get_registry.py
@@ -4,18 +4,20 @@ import os
 
 from checkov.common.goget.base_getter import BaseGetter
 from checkov.common.util.file_utils import extract_tar_archive
+from checkov.common.util.file_utils import extract_zip_archive
 from checkov.common.util.http_utils import DEFAULT_TIMEOUT
 
 
 class RegistryGetter(BaseGetter):
-    def __init__(self, url: str, create_clone_and_result_dirs: bool = False) -> None:
+    def __init__(self, url: str, extension: str, create_clone_and_result_dirs: bool = False) -> None:
         self.logger = logging.getLogger(__name__)
+        self.extension = extension
         self.create_clone_and_res_dirs = create_clone_and_result_dirs
         super().__init__(url)
 
     def do_get(self) -> str:
         # get dest dir
-        download_path = os.path.join(self.temp_dir, 'module_source.tar.gz')
+        download_path = os.path.join(self.temp_dir, f'module_source.{self.extension}')
         # download zip
         dest_path = os.path.dirname(download_path)
         with requests.get(self.url, stream=True, timeout=DEFAULT_TIMEOUT) as r:
@@ -25,7 +27,10 @@ class RegistryGetter(BaseGetter):
                 for chunk in r.iter_content(chunk_size=8192):
                     f.write(chunk)
         # extract
-        extract_tar_archive(source_path=download_path, dest_path=dest_path)
+        if self.extension == 'zip':
+            extract_zip_archive(source_path=download_path, dest_path=dest_path)
+        else:
+            extract_tar_archive(source_path=download_path, dest_path=dest_path)
         os.remove(download_path)
 
         return dest_path

--- a/checkov/common/util/file_utils.py
+++ b/checkov/common/util/file_utils.py
@@ -5,6 +5,8 @@ import gzip
 import io
 import logging
 
+from zipfile import ZipFile
+
 
 def convert_to_unix_path(path: str) -> str:
     return path.replace('\\', '/')
@@ -13,6 +15,11 @@ def convert_to_unix_path(path: str) -> str:
 def extract_tar_archive(source_path: str, dest_path: str) -> None:
     with tarfile.open(source_path) as tar:
         tar.extractall(path=dest_path)  # nosec  # only trusted source
+
+
+def extract_zip_archive(source_path: str, dest_path: str) -> None:
+    with ZipFile(source_path) as zip:
+        zip.extractall(path=dest_path)  # nosec  # only trusted source
 
 
 def compress_file_gzip_base64(input_path: str) -> str:

--- a/checkov/terraform/module_loading/loaders/registry_loader.py
+++ b/checkov/terraform/module_loading/loaders/registry_loader.py
@@ -43,7 +43,7 @@ class RegistryLoader(ModuleLoader):
 
     def _is_matching_loader(self, module_params: ModuleParams) -> bool:
         # https://developer.hashicorp.com/terraform/language/modules/sources#github
-        if module_params.module_source.startswith(("github.com", "bitbucket.org", "git::", "git@github.com")):
+        if module_params.module_source.startswith(("/", "github.com", "bitbucket.org", "git::", "git@github.com")):
             return False
         self._process_inner_registry_module(module_params)
         # determine tf api endpoints

--- a/checkov/terraform/module_loading/loaders/registry_loader.py
+++ b/checkov/terraform/module_loading/loaders/registry_loader.py
@@ -210,8 +210,9 @@ class RegistryLoader(ModuleLoader):
 
     @staticmethod
     def _is_download_url_archive(module_download_url: str) -> bool:
+        module_download_path = urlparse(module_download_url).path
         for extension in MODULE_ARCHIVE_EXTENSIONS:
-            if module_download_url.endswith(extension):
+            if module_download_path.endswith(extension):
                 return True
         query_params_str = urlparse(module_download_url).query
         if query_params_str:

--- a/checkov/terraform/module_loading/loaders/registry_loader.py
+++ b/checkov/terraform/module_loading/loaders/registry_loader.py
@@ -193,7 +193,7 @@ class RegistryLoader(ModuleLoader):
                     return None
 
             self.logger.debug(f"Service discovery response: {response.json()}")
-            module_params.tf_modules_endpoint = f"https://{module_params.tf_host_name}{response.json().get('modules.v1')}"
+            module_params.tf_modules_endpoint = self._normalize_module_download_url(module_params, response.json().get('modules.v1'))
         else:
             # use terraform cloud host name and url for the public registry
             module_params.tf_host_name = TFC_HOST_NAME

--- a/checkov/terraform/module_loading/loaders/registry_loader.py
+++ b/checkov/terraform/module_loading/loaders/registry_loader.py
@@ -98,9 +98,10 @@ class RegistryLoader(ModuleLoader):
         self.logger.debug(f"X-Terraform-Get: {module_download_url}")
         module_download_url = self._normalize_module_download_url(module_params, module_download_url)
         self.logger.debug(f"Cloning module from normalized url {module_download_url}")
-        if self._is_download_url_archive(module_download_url):
+        archive_extension = self._get_archive_extension(module_download_url)
+        if archive_extension:
             try:
-                registry_getter = RegistryGetter(module_download_url)
+                registry_getter = RegistryGetter(module_download_url, archive_extension)
                 registry_getter.temp_dir = module_params.dest_dir
                 registry_getter.do_get()
                 return_dir = module_params.dest_dir
@@ -209,18 +210,18 @@ class RegistryLoader(ModuleLoader):
         return module_download_url
 
     @staticmethod
-    def _is_download_url_archive(module_download_url: str) -> bool:
+    def _get_archive_extension(module_download_url: str) -> str:
         module_download_path = urlparse(module_download_url).path
         for extension in MODULE_ARCHIVE_EXTENSIONS:
             if module_download_path.endswith(extension):
-                return True
+                return extension
         query_params_str = urlparse(module_download_url).query
         if query_params_str:
             query_params = query_params_str.split("&")
             for query_param in query_params:
                 if query_param.startswith("archive="):
-                    return True
-        return False
+                    return query_params_str.split("=")[1]
+        return None
 
 
 loader = RegistryLoader()

--- a/checkov/terraform/module_loading/loaders/registry_loader.py
+++ b/checkov/terraform/module_loading/loaders/registry_loader.py
@@ -210,7 +210,7 @@ class RegistryLoader(ModuleLoader):
         return module_download_url
 
     @staticmethod
-    def _get_archive_extension(module_download_url: str) -> str:
+    def _get_archive_extension(module_download_url: str) -> str | None:
         module_download_path = urlparse(module_download_url).path
         for extension in MODULE_ARCHIVE_EXTENSIONS:
             if module_download_path.endswith(extension):

--- a/tests/terraform/module_loading/loaders/test_registry_loader.py
+++ b/tests/terraform/module_loading/loaders/test_registry_loader.py
@@ -43,8 +43,31 @@ def test_determine_tf_api_endpoints_tfc():
     assert module_params.tf_modules_endpoint == "https://registry.terraform.io/v1/modules"
     assert module_params.tf_modules_versions_endpoint == "https://registry.terraform.io/v1/modules/terraform-aws-modules/example/versions"
 
+@pytest.mark.parametrize(
+    "discovery_response",
+    [
+        ({
+        "modules.v1": "/api/registry/v1/modules/",
+        "providers.v1": "/api/registry/v1/providers/",
+        "state.v2": "/api/v2/",
+        "tfe.v2": "/api/v2/",
+        "tfe.v2.1": "/api/v2/",
+        "tfe.v2.2": "/api/v2/",
+        "versions.v1": "https://checkpoint-api.hashicorp.com/v1/versions/"
+        }),
+        ({
+        "modules.v1": "https://example.registry.com/api/registry/v1/modules/",
+        "providers.v1": "https://example.registry.com/api/registry/v1/providers/",
+        "state.v2": "https://example.registry.com/api/v2/",
+        "tfe.v2": "https://example.registry.com/api/v2/",
+        "tfe.v2.1": "https://example.registry.com/api/v2/",
+        "tfe.v2.2": "https://example.registry.com/api/v2/",
+        "versions.v1": "https://checkpoint-api.hashicorp.com/v1/versions/"
+        }),
+    ]
+)
 @responses.activate
-def test_determine_tf_api_endpoints_tfe():
+def test_determine_tf_api_endpoints_tfe(discovery_response):
     # given
     loader = RegistryLoader()
     module_params = ModuleParams("", "", "example.registry.com/terraform-aws-modules/example", "", "", "")
@@ -53,15 +76,7 @@ def test_determine_tf_api_endpoints_tfe():
     responses.add(
         method=responses.GET,
         url=f"https://{module_params.tf_host_name}/.well-known/terraform.json",
-        json={
-        "modules.v1": "/api/registry/v1/modules/",
-        "providers.v1": "/api/registry/v1/providers/",
-        "state.v2": "/api/v2/",
-        "tfe.v2": "/api/v2/",
-        "tfe.v2.1": "/api/v2/",
-        "tfe.v2.2": "/api/v2/",
-        "versions.v1": "https://checkpoint-api.hashicorp.com/v1/versions/"
-        },
+        json=discovery_response,
         status=200,
     )
 

--- a/tests/terraform/module_loading/loaders/test_registry_loader.py
+++ b/tests/terraform/module_loading/loaders/test_registry_loader.py
@@ -113,16 +113,16 @@ def test_load_module():
 @pytest.mark.parametrize(
     "download_url, expected_result",
     [
-        ("https://example.com/download?archive=tgz", True),
-        ("https://example.com/download?archive=zip", True),
-        ("https://example.com/download/module.zip", True),
-        ("https://example.com/download/module.zip?sig=foo", True),
-        ("https://example.com/download/module/archive", False),
+        ("https://example.com/download?archive=tgz", "tgz"),
+        ("https://example.com/download?archive=zip", "zip"),
+        ("https://example.com/download/module.zip", "zip"),
+        ("https://example.com/download/module.zip?sig=foo", "zip"),
+        ("https://example.com/download/module/archive", None),
     ]
 )
-def test_is_download_url_archive(download_url, expected_result):
-    is_archive = RegistryLoader._is_download_url_archive(download_url)
-    assert is_archive == expected_result
+def test_get_archive_extension(download_url, expected_result):
+    archive_extension = RegistryLoader._get_archive_extension(download_url)
+    assert archive_extension == expected_result
 
 @pytest.mark.parametrize(
     "tf_host_name, module_download_url, expected_result",

--- a/tests/terraform/module_loading/loaders/test_registry_loader.py
+++ b/tests/terraform/module_loading/loaders/test_registry_loader.py
@@ -116,6 +116,7 @@ def test_load_module():
         ("https://example.com/download?archive=tgz", True),
         ("https://example.com/download?archive=zip", True),
         ("https://example.com/download/module.zip", True),
+        ("https://example.com/download/module.zip?sig=foo", True),
         ("https://example.com/download/module/archive", False),
     ]
 )


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

This change fixes a number of problems that prevent Checkov successfully downloading Terraform modules from JFrog Artifactory. Each problem fixed is described in the commit history.

Fixes #5154

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
