### PR TITLE
fix(general): fix SARIF output related to security-severity field

### DIFF
--- a/checkov/common/output/sarif.py
+++ b/checkov/common/output/sarif.py
@@ -147,7 +147,7 @@ class Sarif:
         if cvss:
             # use CVSS, if exists
             rule["properties"] = {
-                "security-severity": cvss,
+                "security-severity": str(cvss),
             }
         elif record.severity:
             # otherwise severity, if exists

--- a/tests/sca_image/test_output_reports.py
+++ b/tests/sca_image/test_output_reports.py
@@ -182,7 +182,7 @@ def test_sarif_output(sca_image_report_scope_function):
                                     "text": "SCA package scan\nResource: path/to/Dockerfile (sha256:123456).perl\nStatus: needed"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 7.8},
+                                "properties": {"security-severity": "7.8"},
                                 "helpUri": "https://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-16156",
                             },
                             {
@@ -196,7 +196,7 @@ def test_sarif_output(sca_image_report_scope_function):
                                     "text": "SCA package scan\nResource: path/to/Dockerfile (sha256:123456).pcre2\nStatus: needed"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 9.1},
+                                "properties": {"security-severity": "9.1"},
                                 "helpUri": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-1587",
                             },
                             {
@@ -210,7 +210,7 @@ def test_sarif_output(sca_image_report_scope_function):
                                     "text": "SCA package scan\nResource: path/to/Dockerfile (sha256:123456).pcre2\nStatus: needed"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 9.1},
+                                "properties": {"security-severity": "9.1"},
                                 "helpUri": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-1586",
                             },
                         ],

--- a/tests/sca_package/test_output_reports.py
+++ b/tests/sca_package/test_output_reports.py
@@ -341,7 +341,7 @@ def test_sarif_output(sca_package_report_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: path/to/requirements.txt.django\nStatus: fixed in 3.0.1, 2.2.9, 1.11.27"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 9.8},
+                                "properties": {"security-severity": "9.8"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2019-19844",
                             },
                             {
@@ -355,7 +355,7 @@ def test_sarif_output(sca_package_report_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: path/to/requirements.txt.django\nStatus: fixed in 1.9.8, 1.8.14"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 6.1},
+                                "properties": {"security-severity": "6.1"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2016-6186",
                             },
                             {
@@ -369,7 +369,7 @@ def test_sarif_output(sca_package_report_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: path/to/requirements.txt.django\nStatus: fixed in 1.9.10, 1.8.15"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 7.5},
+                                "properties": {"security-severity": "7.5"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2016-7401",
                             },
                             {
@@ -383,7 +383,7 @@ def test_sarif_output(sca_package_report_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: path/to/requirements.txt.django\nStatus: fixed in 3.2.4, 3.1.12, 2.2.24"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 4.9},
+                                "properties": {"security-severity": "4.9"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2021-33203",
                             },
                             {
@@ -397,7 +397,7 @@ def test_sarif_output(sca_package_report_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: path/to/requirements.txt.flask\nStatus: fixed in 1.0"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 7.5},
+                                "properties": {"security-severity": "7.5"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010083",
                             },
                             {
@@ -411,7 +411,7 @@ def test_sarif_output(sca_package_report_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: path/to/requirements.txt.flask\nStatus: fixed in 0.12.3"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 7.5},
+                                "properties": {"security-severity": "7.5"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000656",
                             },
                             {
@@ -425,7 +425,7 @@ def test_sarif_output(sca_package_report_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: path/to/go.sum.github.com/dgrijalva/jwt-go\nStatus: fixed in v4.0.0-preview1"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 7.7},
+                                "properties": {"security-severity": "7.7"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
                             },
                             {
@@ -439,7 +439,7 @@ def test_sarif_output(sca_package_report_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: path/to/go.sum.golang.org/x/crypto\nStatus: fixed in v0.0.2"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 7.5},
+                                "properties": {"security-severity": "7.5"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
                             },
                         ],

--- a/tests/sca_package_2/test_output_reports.py
+++ b/tests/sca_package_2/test_output_reports.py
@@ -350,7 +350,7 @@ def test_sarif_output(sca_package_report_2_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: requirements.txt.django\nStatus: fixed in 3.0.1, 2.2.9, 1.11.27"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 9.8},
+                                "properties": {"security-severity": "9.8"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2019-19844",
                             },
                             {
@@ -364,7 +364,7 @@ def test_sarif_output(sca_package_report_2_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: requirements.txt.django\nStatus: fixed in 1.9.10, 1.8.15"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 7.5},
+                                "properties": {"security-severity": "7.5"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2016-7401",
                             },
                             {
@@ -378,7 +378,7 @@ def test_sarif_output(sca_package_report_2_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: requirements.txt.django\nStatus: fixed in 3.2.4, 3.1.12, 2.2.24"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 4.9},
+                                "properties": {"security-severity": "4.9"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2021-33203",
                             },
                             {
@@ -392,7 +392,7 @@ def test_sarif_output(sca_package_report_2_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: requirements.txt.flask\nStatus: fixed in 1.0"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 7.5},
+                                "properties": {"security-severity": "7.5"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010083",
                             },
                             {
@@ -406,7 +406,7 @@ def test_sarif_output(sca_package_report_2_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: requirements.txt.flask\nStatus: fixed in 0.12.3"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 7.5},
+                                "properties": {"security-severity": "7.5"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000656",
                             },
                             {
@@ -420,7 +420,7 @@ def test_sarif_output(sca_package_report_2_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: path/to/go.sum.github.com/dgrijalva/jwt-go\nStatus: fixed in v4.0.0-preview1"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 7.7},
+                                "properties": {"security-severity": "7.7"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
                             },
                             {
@@ -434,7 +434,7 @@ def test_sarif_output(sca_package_report_2_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: requirements.txt.django\nStatus: fixed in 1.9.8, 1.8.14"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 6.1},
+                                "properties": {"security-severity": "6.1"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2016-6186",
                             },
                             {
@@ -448,7 +448,7 @@ def test_sarif_output(sca_package_report_2_with_skip_scope_function):
                                     "text": "SCA package scan\nResource: path/to/go.sum.golang.org/x/crypto\nStatus: fixed in v0.0.2"
                                 },
                                 "defaultConfiguration": {"level": "error"},
-                                "properties": {"security-severity": 7.5},
+                                "properties": {"security-severity": "7.5"},
                                 "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
                             },
                         ],


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

 - fixes an issue with SARIF output, where the field `security-severity` is not a string (it was a float)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
