### PR TITLE
fix(dockerfile): support platform flag in CKV_DOCKER_11

### DIFF
--- a/checkov/dockerfile/checks/AliasIsUnique.py
+++ b/checkov/dockerfile/checks/AliasIsUnique.py
@@ -24,13 +24,12 @@ class AliasIsUnique(BaseDockerfileCheck):
         alias = []
         for instruction in conf:
             if " as " in instruction["value"]:
-                temp = instruction["value"].split()
-                alias += [temp[2]]
+                alias.append(instruction["value"].rsplit(maxsplit=1)[-1])
 
         if len(alias) == len(set(alias)):
             return CheckResult.PASSED, None
-        else:
-            return CheckResult.FAILED, [conf[0]]
+
+        return CheckResult.FAILED, [conf[0]]
 
 
 check = AliasIsUnique()

--- a/tests/dockerfile/checks/example_AliasIsUnique/success_platform/Dockerfile
+++ b/tests/dockerfile/checks/example_AliasIsUnique/success_platform/Dockerfile
@@ -1,0 +1,10 @@
+FROM --platform=linux/amd64 node:16 as FOO
+RUN npm install
+
+FROM --platform=linux/amd64 node:16 as BAR
+RUN npm run
+
+USER nobody
+HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1
+
+CMD mycommand.sh

--- a/tests/dockerfile/checks/test_AliasIsUnique.py
+++ b/tests/dockerfile/checks/test_AliasIsUnique.py
@@ -15,14 +15,17 @@ class TestAliasIsUnique(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        passing_resources = {"/success/Dockerfile."}
+        passing_resources = {
+            "/success/Dockerfile.",
+            "/success_platform/Dockerfile.",
+        }
         failing_resources = {"/failure/Dockerfile.FROM"}
 
-        passed_check_resources = set([c.resource for c in report.passed_checks])
-        failed_check_resources = set([c.resource for c in report.failed_checks])
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- fixed the check to grab the alias from the right side of the split list

Fixes #5161

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
