### PR TITLE
fix(terraform): support condition in IAM policy data blocks

### DIFF
--- a/checkov/terraform/checks/utils/iam_terraform_document_to_policy_converter.py
+++ b/checkov/terraform/checks/utils/iam_terraform_document_to_policy_converter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, List, Any
 
 from checkov.common.util.data_structures_utils import pickle_deepcopy
@@ -23,4 +25,13 @@ def convert_terraform_conf_to_iam_policy(conf: Dict[str, List[Dict[str, Any]]]) 
                 statement["Effect"] = statement.pop("effect")[0]
             if "effect" not in statement and "Effect" not in statement:
                 statement["Effect"] = "Allow"
+            if "condition" in statement:
+                conditions = statement.pop("condition")
+                if conditions and isinstance(conditions, list):
+                    statement["Condition"] = {}
+                    for condition in conditions:
+                        cond_operator = condition["test"][0]
+                        cond_key = condition["variable"][0]
+                        cond_value = condition["values"][0]
+                        statement["Condition"].setdefault(cond_operator, {})[cond_key] = cond_value
     return result

--- a/tests/terraform/checks/data/aws/example_ResourcePolicyDocument/main.tf
+++ b/tests/terraform/checks/data/aws/example_ResourcePolicyDocument/main.tf
@@ -86,3 +86,23 @@ data "aws_iam_policy_document" "pass_unrestrictable" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "pass_condition" {
+  statement {
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
+    ]
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [
+        "arn"
+      ]
+    }
+  }
+}

--- a/tests/terraform/checks/data/aws/test_ResourcePolicyDocument.py
+++ b/tests/terraform/checks/data/aws/test_ResourcePolicyDocument.py
@@ -17,6 +17,7 @@ class TestResourcePolicyDocument(unittest.TestCase):
             "aws_iam_policy_document.pass",
             "aws_iam_policy_document.pass2",
             "aws_iam_policy_document.pass_unrestrictable",
+            "aws_iam_policy_document.pass_condition",
         }
         failing_resources = {
             "aws_iam_policy_document.fail",

--- a/tests/terraform/util/test_iam_converter.py
+++ b/tests/terraform/util/test_iam_converter.py
@@ -1,19 +1,79 @@
 import unittest
 
-from checkov.terraform.checks.utils.iam_terraform_document_to_policy_converter import \
-    convert_terraform_conf_to_iam_policy
+from checkov.terraform.checks.utils.iam_terraform_document_to_policy_converter import (
+    convert_terraform_conf_to_iam_policy,
+)
 
 
 class TestIAMConverter(unittest.TestCase):
-
     def test_iam_converter(self):
         conf = {'version': ['2012-10-17'], 'statement': [{'actions': [['*']], 'resources': [['*']]}]}
         expected_result = {'version': ['2012-10-17'], 'Statement': [{'Action': ['*'], 'Resource': ['*'], 'Effect': 'Allow'}]}
         result = convert_terraform_conf_to_iam_policy(conf)
-        self.assertDictEqual(result,expected_result)
-        self.assertNotEqual(result,conf)
+        self.assertDictEqual(result, expected_result)
+        self.assertNotEqual(result, conf)
+
+    def test_convert_condition(self):
+        # given
+        conf = {
+            "__end_line__": 77,
+            "__start_line__": 42,
+            "statement": [
+                {
+                    "actions": [["kms:Decrypt", "kms:GenerateDataKey"]],
+                    "condition": [
+                        {
+                            "test": ["ForAnyValue:StringEquals"],
+                            "values": [["pi"]],
+                            "variable": ["kms:EncryptionContext:service"],
+                        },
+                        {
+                            "test": ["ForAnyValue:StringEquals"],
+                            "values": [["rds"]],
+                            "variable": ["kms:EncryptionContext:aws:pi:service"],
+                        },
+                        {
+                            "test": ["ForAnyValue:StringEquals"],
+                            "values": [["db-AAAAABBBBBCCCCCDDDDDEEEEE", "db-EEEEEDDDDDCCCCCBBBBBAAAAA"]],
+                            "variable": ["kms:EncryptionContext:aws:rds:db-id"],
+                        },
+                        {"test": ["ArnEquals"], "values": [["arn"]], "variable": ["aws:SourceArn"]},
+                    ],
+                    "resources": [["*"]],
+                }
+            ],
+            "__address__": "aws_iam_policy_document.example_multiple_condition_keys_and_values",
+        }
+
+        result = convert_terraform_conf_to_iam_policy(conf)
+
+        self.assertDictEqual(
+            result,
+            {
+                "__end_line__": 77,
+                "__start_line__": 42,
+                "__address__": "aws_iam_policy_document.example_multiple_condition_keys_and_values",
+                "Statement": [
+                    {
+                        "Action": ["kms:Decrypt", "kms:GenerateDataKey"],
+                        "Resource": ["*"],
+                        "Effect": "Allow",
+                        "Condition": {
+                            "ForAnyValue:StringEquals": {
+                                "kms:EncryptionContext:service": ["pi"],
+                                "kms:EncryptionContext:aws:pi:service": ["rds"],
+                                "kms:EncryptionContext:aws:rds:db-id": [
+                                    "db-AAAAABBBBBCCCCCDDDDDEEEEE",
+                                    "db-EEEEEDDDDDCCCCCBBBBBAAAAA",
+                                ],
+                            },
+                            "ArnEquals": {"aws:SourceArn": ["arn"]},
+                        },
+                    }
+                ],
+            },
+        )
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- the `conidtion` argument of the IAM data block was not parsed and therefore `cloudsplaining` couldn't consider it

Fixes #5148

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
