### PR TITLE
fix(terraform): adjust CKV_AZURE_6 to comply with new provider version

### DIFF
--- a/checkov/terraform/checks/resource/azure/AKSApiServerAuthorizedIpRanges.py
+++ b/checkov/terraform/checks/resource/azure/AKSApiServerAuthorizedIpRanges.py
@@ -16,7 +16,7 @@ class AKSApiServerAuthorizedIpRanges(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self) -> str:
-        return "api_server_authorized_ip_ranges/[0]"
+        return "api_server_access_profile/[0]/authorized_ip_ranges/[0]"
 
     def get_expected_value(self) -> Any:
         return ANY_VALUE
@@ -26,6 +26,12 @@ class AKSApiServerAuthorizedIpRanges(BaseResourceValueCheck):
         private_cluster_enabled = conf.get("private_cluster_enabled", [False])[0]
         if private_cluster_enabled:
             return CheckResult.PASSED
+
+        # provider version <=3.38.0
+        api_server = conf.get("api_server_authorized_ip_ranges")
+        if api_server and isinstance(api_server, list) and api_server[0]:
+            return CheckResult.PASSED
+
         return super().scan_resource_conf(conf)
 
 

--- a/tests/terraform/checks/resource/azure/example_AKSApiServerAuthorizedIpRanges/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AKSApiServerAuthorizedIpRanges/main.tf
@@ -38,6 +38,17 @@ resource "azurerm_kubernetes_cluster" "private" {
   private_cluster_enabled = true
 }
 
+resource "azurerm_kubernetes_cluster" "version_3_39" {
+  name                = "example"
+  location            = "azurerm_resource_group.example.location"
+  resource_group_name = "azurerm_resource_group.example.name"
+  dns_prefix          = "example"
+
+  api_server_access_profile {
+    authorized_ip_ranges = ["192.168.0.0/16"]
+  }
+}
+
 # fail
 
 resource "azurerm_kubernetes_cluster" "default" {

--- a/tests/terraform/checks/resource/azure/test_AKSApiServerAuthorizedIpRanges.py
+++ b/tests/terraform/checks/resource/azure/test_AKSApiServerAuthorizedIpRanges.py
@@ -19,7 +19,8 @@ class TestAKSApiServerAuthorizedIpRanges(unittest.TestCase):
 
         passing_resources = {
             "azurerm_kubernetes_cluster.enabled",
-            "azurerm_kubernetes_cluster.private"
+            "azurerm_kubernetes_cluster.private",
+            "azurerm_kubernetes_cluster.version_3_39",
         }
 
         failing_resources = {
@@ -30,8 +31,8 @@ class TestAKSApiServerAuthorizedIpRanges(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- updated the check to comply with the new provider version and made it the default recommendation

Fixes #5168 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
