### PR TITLE
feat(arm): Handle another structure for SQL retention policy

### DIFF
--- a/checkov/arm/checks/resource/SQLServerAuditingRetention90Days.py
+++ b/checkov/arm/checks/resource/SQLServerAuditingRetention90Days.py
@@ -27,6 +27,7 @@ class SQLServerAuditingRetention90Days(BaseResourceCheck):
             ]
             if resource.get("type") in (
                 "Microsoft.Sql/servers/databases/auditingSettings",
+                'Microsoft.Sql/servers/auditingSettings',
                 "auditingSettings",
             ):
                 return self.check_resource(resource)

--- a/tests/arm/checks/resource/example_SQLServerAuditingRetention90Days/sqlServerAuditingRetention90Days-PASSED2.json
+++ b/tests/arm/checks/resource/example_SQLServerAuditingRetention90Days/sqlServerAuditingRetention90Days-PASSED2.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "sqlServerName": {
+      "type": "string",
+      "defaultValue": "[concat('sql-', uniqueString(resourceGroup().id))]",
+      "metadata": {
+        "description": "Name of the SQL server"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    },
+    "sqlAdministratorLogin": {
+      "type": "string",
+      "metadata": {
+        "description": "The administrator username of the SQL Server."
+      }
+    },
+    "sqlAdministratorLoginPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The administrator password of the SQL Server."
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "defaultValue": "[concat('sqlaudit', uniqueString(resourceGroup().id))]",
+      "metadata": {
+        "description": "The name of the auditing storage account."
+      }
+    },
+    "isStorageBehindVnet": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Enable Auditing to storage behind Virtual Network or firewall rules. The user deploying the template must have an administrator or owner permissions."
+      }
+    }
+  },
+  "variables": {
+    "StorageBlobContributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
+    "uniqueRoleGuid": "[guid(resourceId('Microsoft.Storage/storageAccounts',  parameters('storageAccountName')), variables('storageBlobContributor'), resourceId('Microsoft.Sql/servers', parameters('sqlServerName')))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('storageAccountName')]",
+      "apiVersion": "2019-06-01",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "networkAcls": {
+          "bypass": "AzureServices",
+          "defaultAction": "[if(parameters('isStorageBehindVnet'), 'Deny', 'Allow')]"
+        }
+      },
+      "resources": [
+        {
+          "condition": "[parameters('isStorageBehindVnet')]",
+          "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
+          "apiVersion": "2020-03-01-preview",
+          "name": "[concat(parameters('storageAccountName'), '/Microsoft.Authorization/', variables('uniqueRoleGuid'))]",
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', parameters('sqlServerName'))]",
+            "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+          ],
+          "properties": {
+            "roleDefinitionId": "[variables('StorageBlobContributor')]",
+            "principalId": "[reference(resourceId('Microsoft.Sql/servers', parameters('sqlServerName')), '2019-06-01-preview', 'Full').identity.principalId]",
+            "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+            "principalType": "ServicePrincipal"
+          }
+        }
+      ]
+    },
+    {
+      "apiVersion": "[variables('apiVSQLServer')]",
+      "type": "Microsoft.Sql/servers",
+      "location": "[parameters('locationFull')]",
+      "tags": {
+        "DisplayName": "[parameters('resourceNameFull')]",
+        "CreationDate": "[parameters('creationDate')]",
+        "ExpiryDate": "[parameters('expiryDate')]"
+      },
+      "name": "[parameters('resourceNameFull')]",
+      "properties": {
+        "administratorLogin": "[parameters('adminUsername')]",
+        "administratorLoginPassword": "[parameters('adminPassword')]",
+        "version":  "[variables('serverVersion')]",
+        "minimalTlsVersion":  "[variables('minimalTlsVersion')]",
+        "publicNetworkAccess":  "[variables('publicNetworkAccess')]"
+      },
+      "resources":[
+        {
+          "condition": "[equals(parameters('enableAudit'),'true')]",
+          "type": "Microsoft.Sql/servers/auditingSettings",
+          "apiVersion": "[variables('apiVsecurityPol')]",
+          "name": "[concat(parameters('resourceNameFull'), '/Default')]",
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', parameters('resourceNameFull'))]"
+          ],
+          "properties": {
+            "retentionDays": 91,
+            "auditActionsAndGroups": [
+              "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
+              "FAILED_DATABASE_AUTHENTICATION_GROUP",
+              "BATCH_COMPLETED_GROUP"
+            ],
+            "isAzureMonitorTargetEnabled": false,
+            "state": "Enabled",
+            "storageEndpoint": "[parameters('storageAccEndPoint')]",
+            "storageAccountSubscriptionId": "[parameters('subscriptionId')]"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/arm/checks/resource/test_SQLServerAuditingRetention90Days.py
+++ b/tests/arm/checks/resource/test_SQLServerAuditingRetention90Days.py
@@ -16,7 +16,7 @@ class TestSQLServerAuditingRetention90Days(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['passed'], 3)
         self.assertEqual(summary['failed'], 3)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Supports another way to configure retention policies in ARM


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
