### PR TITLE
chore: leverage GHA reusable workflow to build container images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,94 +266,22 @@ jobs:
       version: ${{ steps.calculateVersion.outputs.version }}
       major_version: ${{ steps.calculateVersion.outputs.major_version }}
   publish-checkov-dockerhub:
-    runs-on: [self-hosted, public, linux, x64]
     needs: bump-version
-    environment: release
+    uses: bridgecrewio/gha-reusable-workflows/.github/workflows/publish-image.yaml@main
     permissions:
-      packages: write
+      contents: read
       id-token: write  # Enable OIDC
-    env:
-      DH_IMAGE_NAME: bridgecrew/checkov
-      GHCR_IMAGE_NAME: ghcr.io/${{ github.repository }}
-      FULL_IMAGE_TAG: ${{ needs.bump-version.outputs.version }}
-      SHORT_IMAGE_TAG: ${{ needs.bump-version.outputs.major_version }}
-    steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3
-      - uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b  # v2
-      - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18  # v2
-        with:
-          platforms: 'arm64,arm'
-      - uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c  # v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a  # v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a  # v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker meta
-        id: docker_meta
-        uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e  # v4
-        with:
-          images: ${{ env.DH_IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.authors=Bridgecrew
-            org.opencontainers.image.version=${{ needs.bump-version.outputs.version }}
-      - name: Build and export image to Docker
-        # buildx changes the driver to 'docker-container' which doesn't expose the image to the host,
-        # so it is built and loaded to Docker and in the next step pushed to the registry
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671  # v4
-        with:
-          context: .
-          no-cache: true
-          load: true
-          labels: ${{ steps.docker_meta.outputs.labels }}
-          tags: ${{ env.DH_IMAGE_NAME }}:${{ env.FULL_IMAGE_TAG }}
-      - name: Push Docker image
-        id: docker_push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671  # v4
-        with:
-          context: .
-          platforms: 'linux/amd64,linux/arm64'
-          push: true
-          labels: ${{ steps.docker_meta.outputs.labels }}
-          tags: |
-            ${{ env.DH_IMAGE_NAME }}:latest
-            ${{ env.DH_IMAGE_NAME }}:${{ env.SHORT_IMAGE_TAG }}
-            ${{ env.DH_IMAGE_NAME }}:${{ env.FULL_IMAGE_TAG }}
-            ${{ env.GHCR_IMAGE_NAME }}:latest
-            ${{ env.GHCR_IMAGE_NAME }}:${{ env.SHORT_IMAGE_TAG }}
-            ${{ env.GHCR_IMAGE_NAME }}:${{ env.FULL_IMAGE_TAG }}
-      - name: Generate SBOM
-        continue-on-error: true
-        uses: bridgecrewio/checkov-action@master  # use latest and greatest
-        with:
-          api-key: ${{ secrets.BC_API_KEY }}
-          docker_image: ${{ env.DH_IMAGE_NAME }}:${{ env.FULL_IMAGE_TAG }}
-          dockerfile_path: Dockerfile
-          output_format: cyclonedx_json
-          output_file_path: cyclonedx.json,
-      - name: Sign and attest image
-        run: |
-          # sign image
-          cosign sign ${{ env.DH_IMAGE_NAME }}@${{ steps.docker_push.outputs.digest }}
-          cosign sign -f ${{ env.GHCR_IMAGE_NAME }}@${{ steps.docker_push.outputs.digest }}
-          
-          # attest SBOM
-          cosign attest \
-            --type cyclonedx \
-            --predicate cyclonedx.json \
-            ${{ env.DH_IMAGE_NAME }}@${{ steps.docker_push.outputs.digest }}
-          cosign attest -f \
-            --type cyclonedx \
-            --predicate cyclonedx.json \
-            ${{ env.GHCR_IMAGE_NAME }}@${{ steps.docker_push.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: 1  # needed for keyless signing
+      packages: write
+    with:
+      image_name_dockerhub: bridgecrew/checkov
+      image_name_ghcr: ghcr.io/${{ github.repository }}
+      image_tag_full: ${{ needs.bump-version.outputs.version }}
+      image_tag_short: ${{ needs.bump-version.outputs.major_version }}
+      runner: "['self-hosted', 'public', 'linux', 'x64']"
+    secrets:
+      BC_API_KEY: ${{ secrets.BC_API_KEY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
   publish-checkov-k8s-dockerhub:
     runs-on: [self-hosted, public, linux, x64]
     needs: bump-version


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- finally using the previously created reusable workflow to build/push container images, if this works, then the others will also be changed

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
