### PR TITLE
fix(dockerfile): negative `is_dockerfile()` lookup on `.dockerignore` suffix

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -39,7 +39,7 @@ from checkov.common.runners.base_runner import filter_ignored_paths
 from checkov.common.typing import _CicdDetails
 from checkov.common.util.consts import PRISMA_PLATFORM, BRIDGECREW_PLATFORM, CHECKOV_RUN_SCA_PACKAGE_SCAN_V2
 from checkov.common.util.data_structures_utils import merge_dicts
-from checkov.common.util.dockerfile import is_docker_file
+from checkov.common.util.dockerfile import is_dockerfile
 from checkov.common.util.http_utils import normalize_prisma_url, get_auth_header, get_default_get_headers, \
     get_user_agent_header, get_default_post_headers, get_prisma_get_headers, get_prisma_auth_header, \
     get_auth_error_message, normalize_bc_url
@@ -406,7 +406,7 @@ class BcPlatformIntegration:
                     _, file_extension = os.path.splitext(file_path)
                     if CHECKOV_RUN_SCA_PACKAGE_SCAN_V2 and file_extension in SCANNABLE_PACKAGE_FILES:
                         continue
-                    if file_extension in SUPPORTED_FILE_EXTENSIONS or file_path in SUPPORTED_FILES or is_docker_file(file_path):
+                    if file_extension in SUPPORTED_FILE_EXTENSIONS or file_path in SUPPORTED_FILES or is_dockerfile(file_path):
                         full_file_path = os.path.join(root_path, file_path)
                         relative_file_path = os.path.relpath(full_file_path, root_dir)
                         files_to_persist.append(FileToPersist(full_file_path, relative_file_path))

--- a/checkov/common/util/dockerfile.py
+++ b/checkov/common/util/dockerfile.py
@@ -1,6 +1,6 @@
 import re
 
-DOCKER_FILE_MASK = re.compile(r"^(?:.+\.)?[Dd]ockerfile(?:\..+)?$")
+DOCKER_FILE_MASK = re.compile(r"^(?:.+\.)?[Dd]ockerfile(?:\..+)?$(?<!\.dockerignore)")
 
 
 def is_docker_file(file: str) -> bool:

--- a/checkov/common/util/dockerfile.py
+++ b/checkov/common/util/dockerfile.py
@@ -1,6 +1,6 @@
 import re
 
-DOCKER_FILE_MASK = re.compile(r"^(?:.+\.)?[Dd]ockerfile(?:\..+)?$(?<!\.dockerignore)")
+DOCKER_FILE_MASK = re.compile(r"^(?:.+\.)?[Dd]ockerfile(?:\..+)?$(?<!\.[Dd]ockerignore)")
 
 
 def is_dockerfile(file: str) -> bool:

--- a/checkov/common/util/dockerfile.py
+++ b/checkov/common/util/dockerfile.py
@@ -1,7 +1,13 @@
 import re
+import warnings
 
 DOCKERFILE_MASK = re.compile(r"^(?:.+\.)?[Dd]ockerfile(?:\..+)?$(?<!\.[Dd]ockerignore)")
 
 
 def is_dockerfile(file: str) -> bool:
     return re.fullmatch(DOCKERFILE_MASK, file) is not None
+
+
+def is_docker_file(file: str) -> bool:
+    warnings.warn("Please use is_dockerfile()", DeprecationWarning)
+    return is_dockerfile(file)

--- a/checkov/common/util/dockerfile.py
+++ b/checkov/common/util/dockerfile.py
@@ -1,7 +1,7 @@
 import re
 
-DOCKER_FILE_MASK = re.compile(r"^(?:.+\.)?[Dd]ockerfile(?:\..+)?$(?<!\.[Dd]ockerignore)")
+DOCKERFILE_MASK = re.compile(r"^(?:.+\.)?[Dd]ockerfile(?:\..+)?$(?<!\.[Dd]ockerignore)")
 
 
 def is_dockerfile(file: str) -> bool:
-    return re.fullmatch(DOCKER_FILE_MASK, file) is not None
+    return re.fullmatch(DOCKERFILE_MASK, file) is not None

--- a/checkov/common/util/dockerfile.py
+++ b/checkov/common/util/dockerfile.py
@@ -3,5 +3,5 @@ import re
 DOCKER_FILE_MASK = re.compile(r"^(?:.+\.)?[Dd]ockerfile(?:\..+)?$(?<!\.dockerignore)")
 
 
-def is_docker_file(file: str) -> bool:
+def is_dockerfile(file: str) -> bool:
     return re.fullmatch(DOCKER_FILE_MASK, file) is not None

--- a/checkov/dockerfile/runner.py
+++ b/checkov/dockerfile/runner.py
@@ -17,7 +17,7 @@ from checkov.common.output.extra_resource import ExtraResource
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.runners.base_runner import BaseRunner, CHECKOV_CREATE_GRAPH
 from checkov.common.util.consts import START_LINE, END_LINE
-from checkov.common.util.dockerfile import is_docker_file
+from checkov.common.util.dockerfile import is_dockerfile
 from checkov.common.typing import _CheckResult
 from checkov.dockerfile.graph_builder.local_graph import DockerfileLocalGraph
 from checkov.dockerfile.graph_manager import DockerfileGraphManager
@@ -67,7 +67,7 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, list[_Instruction]]]"], B
         self.root_folder: str | None = None
 
     def should_scan_file(self, filename: str) -> bool:
-        return is_docker_file(os.path.basename(filename))
+        return is_dockerfile(os.path.basename(filename))
 
     def run(
         self,
@@ -94,7 +94,7 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, list[_Instruction]]]"], B
                         self.graph_registry.load_external_checks(directory)
 
             if files:
-                files_list = [file for file in files if is_docker_file(os.path.basename(file))]
+                files_list = [file for file in files if is_dockerfile(os.path.basename(file))]
 
             if root_folder:
                 filepath_fn = lambda f: f"/{os.path.relpath(f, os.path.commonprefix((root_folder, f)))}"

--- a/checkov/dockerfile/utils.py
+++ b/checkov/dockerfile/utils.py
@@ -70,7 +70,7 @@ def get_abs_path(root_folder: str | None, file_path: str) -> str:
     There are a few cases here. If -f was used, there could be a leading / because it's an absolute path,
     or there will be no leading slash; root_folder will always be none.
     If -d is used, root_folder will be the value given, and -f will start with a / (hardcoded above).
-    The goal here is simply to get a valid path to the file (which docker_file_path does not always give).
+    The goal here is simply to get a valid path to the file (which dockerfile_path does not always give).
     """
 
     if root_folder and file_path.startswith("/"):

--- a/checkov/dockerfile/utils.py
+++ b/checkov/dockerfile/utils.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Callable, Any
 from dockerfile_parse.constants import COMMENT_INSTRUCTION
 
 from checkov.common.runners.base_runner import filter_ignored_paths
-from checkov.common.util.dockerfile import is_docker_file
+from checkov.common.util.dockerfile import is_dockerfile
 from checkov.common.util.suppression import collect_suppressions_for_context
 from checkov.dockerfile.parser import parse
 
@@ -35,7 +35,7 @@ def get_scannable_file_paths(
         filter_ignored_paths(root, d_names, excluded_paths)
         filter_ignored_paths(root, f_names, excluded_paths)
         for file in f_names:
-            if is_docker_file(file):
+            if is_dockerfile(file):
                 file_path = os.path.join(root, file)
                 file_paths.add(file_path)
 

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -22,7 +22,7 @@ from checkov.common.runners.base_runner import filter_ignored_paths, strtobool
 from checkov.common.sca.commons import should_run_scan
 from checkov.common.sca.output import add_to_report_sca_data, get_license_statuses
 from checkov.common.util.file_utils import compress_file_gzip_base64
-from checkov.common.util.dockerfile import is_docker_file
+from checkov.common.util.dockerfile import is_dockerfile
 from checkov.common.util.http_utils import request_wrapper
 from checkov.runner_filter import RunnerFilter
 from checkov.sca_package.runner import Runner as PackageRunner
@@ -41,7 +41,7 @@ class Runner(PackageRunner):
         self.image_referencers: set[ImageReferencer] | None = None
 
     def should_scan_file(self, filename: str) -> bool:
-        return is_docker_file(os.path.basename(filename))
+        return is_dockerfile(os.path.basename(filename))
 
     def scan(
             self,

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -34,7 +34,7 @@ from checkov.common.output.report import Report
 from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.runners.base_runner import BaseRunner, filter_ignored_paths
 from checkov.common.typing import _CheckResult
-from checkov.common.util.dockerfile import is_docker_file
+from checkov.common.util.dockerfile import is_dockerfile
 from checkov.common.util.secrets import omit_secret_value_from_line
 from checkov.runner_filter import RunnerFilter
 from checkov.secrets.consts import ValidationStatus, VerifySecretsResult
@@ -192,12 +192,12 @@ class Runner(BaseRunner[None]):
                             filter_ignored_paths(root, f_names, excluded_paths)
                         for file in f_names:
                             if enable_secret_scan_all_files:
-                                if is_docker_file(file):
+                                if is_dockerfile(file):
                                     if 'dockerfile' not in block_list_secret_scan_lower:
                                         files_to_scan.append(os.path.join(root, file))
                                 elif f".{file.split('.')[-1]}" not in block_list_secret_scan_lower:
                                     files_to_scan.append(os.path.join(root, file))
-                            elif file not in PROHIBITED_FILES and f".{file.split('.')[-1]}" in SUPPORTED_FILE_EXTENSIONS or is_docker_file(
+                            elif file not in PROHIBITED_FILES and f".{file.split('.')[-1]}" in SUPPORTED_FILE_EXTENSIONS or is_dockerfile(
                                     file):
                                 files_to_scan.append(os.path.join(root, file))
                     logging.info(f'Secrets scanning will scan {len(files_to_scan)} files')

--- a/tests/dockerfile/test_utils.py
+++ b/tests/dockerfile/test_utils.py
@@ -22,6 +22,8 @@ INVALID_DOCKER_FILE_NAMES = [
     "ockerfile",
     "docker-file",
     "dockerfile1",
+    "Dockerfile.env.dockerignore",
+    "dockerfile.dockerignore",
 ]
 
 

--- a/tests/dockerfile/test_utils.py
+++ b/tests/dockerfile/test_utils.py
@@ -1,7 +1,7 @@
 from operator import itemgetter
 from pathlib import Path
 
-from checkov.common.util.dockerfile import is_docker_file
+from checkov.common.util.dockerfile import is_dockerfile
 from checkov.dockerfile.graph_builder.graph_components.resource_types import ResourceType
 from checkov.dockerfile.utils import get_files_definitions, build_definitions_context
 
@@ -25,9 +25,9 @@ INVALID_DOCKER_FILE_NAMES = [
 ]
 
 
-def test_is_docker_file():
-    assert all(is_docker_file(curr_name) for curr_name in VALID_DOCKER_FILE_NAMES)
-    assert all(not is_docker_file(curr_name) for curr_name in INVALID_DOCKER_FILE_NAMES)
+def test_is_dockerfile():
+    assert all(is_dockerfile(curr_name) for curr_name in VALID_DOCKER_FILE_NAMES)
+    assert all(not is_dockerfile(curr_name) for curr_name in INVALID_DOCKER_FILE_NAMES)
 
 
 def test_build_definitions_context():

--- a/tests/dockerfile/test_utils.py
+++ b/tests/dockerfile/test_utils.py
@@ -5,7 +5,7 @@ from checkov.common.util.dockerfile import is_dockerfile
 from checkov.dockerfile.graph_builder.graph_components.resource_types import ResourceType
 from checkov.dockerfile.utils import get_files_definitions, build_definitions_context
 
-VALID_DOCKER_FILE_NAMES = [
+VALID_DOCKERFILE_NAMES = [
     "Dockerfile",
     "dockerfile",
     "Dockerfile.prod",
@@ -13,7 +13,7 @@ VALID_DOCKER_FILE_NAMES = [
     "dev.Dockerfile",
     "team1.product.dockerfile",
 ]
-INVALID_DOCKER_FILE_NAMES = [
+INVALID_DOCKERFILE_NAMES = [
     "package.json",
     "dockerfil",
     "dockerfilee",
@@ -29,8 +29,8 @@ INVALID_DOCKER_FILE_NAMES = [
 
 
 def test_is_dockerfile():
-    assert all(is_dockerfile(curr_name) for curr_name in VALID_DOCKER_FILE_NAMES)
-    assert all(not is_dockerfile(curr_name) for curr_name in INVALID_DOCKER_FILE_NAMES)
+    assert all(is_dockerfile(curr_name) for curr_name in VALID_DOCKERFILE_NAMES)
+    assert all(not is_dockerfile(curr_name) for curr_name in INVALID_DOCKERFILE_NAMES)
 
 
 def test_build_definitions_context():

--- a/tests/dockerfile/test_utils.py
+++ b/tests/dockerfile/test_utils.py
@@ -23,6 +23,7 @@ INVALID_DOCKER_FILE_NAMES = [
     "docker-file",
     "dockerfile1",
     "Dockerfile.env.dockerignore",
+    "Dockerfile.env.Dockerignore",
     "dockerfile.dockerignore",
 ]
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

This updated regex pattern includes a negative lookbehind assertion (?<!\.dockerignore) at the end.

Fixes #5218 

Also refactors the term `docker_file` to the more conventional `dockerfile`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
  * Not altered, as it would add noise
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
  * Please help me verify.
  * Update: Github search `org:bridgecrewio is_docker_file` suggests indeed only used by `checkov3` which uses self-reference.