### PR TITLE
docs(graph): add jsonpath custom policy example

### DIFF
--- a/docs/3.Custom Policies/Examples.md
+++ b/docs/3.Custom Policies/Examples.md
@@ -463,3 +463,19 @@ definition:
     operator: "contains"
     value: "0.0.0.0/0"
 ```
+
+## Using a jsonpath operator to evaluate complex attributes
+
+The following policy looks for a CloudFormation S3 Bucket with a tag name `env` and it should have one of the values `prod` or `prod-eu`.
+
+```yaml
+definition:
+  cond_type: "attribute"
+  resource_types:
+    - "AWS::S3::Bucket"
+  attribute: "Tags[?(@.Key == env)].Value"
+  operator: "jsonpath_within"
+  value:
+    - prod
+    - prod-eu
+```


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added an example for our `jsonpath_` operator to make it easier for others to write their own policies

Relates to #5220 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
