### PR TITLE
fix(terraform): fix empty value issue for CKV_GIT_4

### DIFF
--- a/checkov/terraform/checks/resource/github/SecretsEncrypted.py
+++ b/checkov/terraform/checks/resource/github/SecretsEncrypted.py
@@ -25,6 +25,10 @@ class SecretsEncrypted(BaseResourceNegativeValueCheck):
         if plaintext and self._is_variable_dependant(plaintext[0]):
             return CheckResult.UNKNOWN
 
+        if isinstance(plaintext, list) and not plaintext[0]:
+            # this happens mainly in TF plan files, because the value is just an empty string
+            return CheckResult.PASSED
+
         return super().scan_resource_conf(conf)
 
     def get_inspected_key(self) -> str:

--- a/tests/terraform/checks/resource/github/example_SecretsEncrypted/main.tf
+++ b/tests/terraform/checks/resource/github/example_SecretsEncrypted/main.tf
@@ -40,6 +40,13 @@ resource "github_actions_secret" "pass" {
   encrypted_value   = "WOULDBEENCRYPTED"
 }
 
+resource "github_actions_organization_secret" "pass_empty_value" {
+  environment       = "example_environment"
+  secret_name       = "example_secret_name"
+  encrypted_value   = "WOULDBEENCRYPTED"
+  plaintext_value   = ""
+}
+
 # value ref
 
 resource "azuread_service_principal_password" "gh_actions" {

--- a/tests/terraform/checks/resource/github/test_SecretsEncrypted.py
+++ b/tests/terraform/checks/resource/github/test_SecretsEncrypted.py
@@ -20,6 +20,7 @@ class TestSecretsEncrypted(unittest.TestCase):
         passing_resources = {
             "github_actions_environment_secret.pass",
             "github_actions_organization_secret.pass",
+            "github_actions_organization_secret.pass_empty_value",
             "github_actions_secret.pass",
         }
         failing_resources = {
@@ -36,7 +37,7 @@ class TestSecretsEncrypted(unittest.TestCase):
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
         # github_actions_secret.value_ref is dependent on azuread_service_principal_password.gh_actions
-        self.assertEqual(summary["resource_count"], 8)  # 2 extra
+        self.assertEqual(summary["resource_count"], 9)  # 2 extra
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- interestingly the value is empty in a TF plan file

Fixes #5099 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
