### PR TITLE
chore: make networkx import optional for graph upload

### DIFF
--- a/checkov/common/bridgecrew/wrapper.py
+++ b/checkov/common/bridgecrew/wrapper.py
@@ -11,8 +11,13 @@ from collections import defaultdict
 
 import dpath
 from igraph import Graph
-from networkx import DiGraph
-from networkx.readwrite import json_graph
+
+try:
+    from networkx import DiGraph, node_link_data
+except ImportError:
+    logging.info("Not able to import networkx")
+    DiGraph = str
+    node_link_data = lambda G : {}
 
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.models.consts import SUPPORTED_FILE_EXTENSIONS
@@ -145,7 +150,7 @@ def persist_graphs(graphs: dict[str, DiGraph | Graph], s3_client: S3Client, buck
                    timeout: int, absolute_root_folder: str = '') -> None:
     def _upload_graph(check_type: str, graph: DiGraph | Graph, _absolute_root_folder: str = '') -> None:
         if isinstance(graph, DiGraph):
-            json_obj = json_graph.node_link_data(graph)
+            json_obj = node_link_data(graph)
             graph_file_name = 'graph_networkx.json'
         elif isinstance(graph, Graph):
             json_obj = serialize_to_json(graph, _absolute_root_folder)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- somehow the MacOS integration tests became flaky, because they not always have `bz2` installed. Will remove `networkx` with the next bigger release

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
