### PR TITLE
platform(general): Fix local repo generated name if ends with /

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -940,7 +940,9 @@ class BcPlatformIntegration:
     def get_repository(self, args: argparse.Namespace) -> str:
         if CI_METADATA_EXTRACTOR.from_branch:
             return CI_METADATA_EXTRACTOR.from_branch
-        basename = 'unnamed_repo' if path.basename(args.directory[0]) == '.' else path.basename(args.directory[0])
+        arg_dir = args.directory[0]
+        arg_dir.rstrip(os.path.sep)  # If directory ends with /, remove it. Does not remove any other character!!
+        basename = 'unnamed_repo' if path.basename(arg_dir) == '.' else path.basename(arg_dir)
         repo_id = f"cli_repo/{basename}"
         return repo_id
 
@@ -1024,7 +1026,7 @@ class BcPlatformIntegration:
 
     def repo_matches(self, repo_name: str) -> bool:
         # matches xyz_org/repo or org/repo (where xyz is the BC org name and the CLI repo prefix from the platform)
-        return re.match(re.compile(f'^(\\w+_)?{self.repo_id}$'), repo_name) is not None
+        return re.match(re.compile(f'^(\\w+_)?{self.repo_id }$'), repo_name) is not None
 
     def get_default_headers(self, request_type: str) -> dict[str, Any]:
         if not self.bc_source:

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -1026,7 +1026,7 @@ class BcPlatformIntegration:
 
     def repo_matches(self, repo_name: str) -> bool:
         # matches xyz_org/repo or org/repo (where xyz is the BC org name and the CLI repo prefix from the platform)
-        return re.match(re.compile(f'^(\\w+_)?{self.repo_id }$'), repo_name) is not None
+        return re.match(re.compile(f'^(\\w+_)?{self.repo_id}$'), repo_name) is not None
 
     def get_default_headers(self, request_type: str) -> dict[str, Any]:
         if not self.bc_source:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
path.basepath() split by os.path.sep, i.e. `/` for linux and darwin. However, if the user runs checkov specifying the directory path ending with a `/`, it can turn the repo name to the empty string. This solves it


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
