### PR TITLE
fix(terraform): add missing AWS RDS CA certificate identifiers for aws_db_instance resource

### DIFF
--- a/checkov/terraform/checks/resource/aws/RDSCACertIsRecent.py
+++ b/checkov/terraform/checks/resource/aws/RDSCACertIsRecent.py
@@ -21,7 +21,7 @@ class RDSCACertIsRecent(BaseResourceValueCheck):
         return "ca_cert_identifier"
 
     def get_expected_values(self) -> List[Any]:
-        return ["rds-ca-2019"]
+        return ["rds-ca-2019", "rds-ca-rsa2048-g1", "rds-ca-rsa4096-g1", "rds-ca-ecc384-g1"]
 
 
 check = RDSCACertIsRecent()

--- a/checkov/terraform/checks/resource/aws/RDSCACertIsRecent.py
+++ b/checkov/terraform/checks/resource/aws/RDSCACertIsRecent.py
@@ -21,7 +21,7 @@ class RDSCACertIsRecent(BaseResourceValueCheck):
         return "ca_cert_identifier"
 
     def get_expected_values(self) -> List[Any]:
-        return ["rds-ca-2019", "rds-ca-rsa2048-g1", "rds-ca-rsa4096-g1", "rds-ca-ecc384-g1"]
+        return ["rds-ca-rsa2048-g1", "rds-ca-rsa4096-g1", "rds-ca-ecc384-g1"]
 
 
 check = RDSCACertIsRecent()

--- a/tests/terraform/checks/resource/aws/example_RDSCACertIsRecent/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSCACertIsRecent/main.tf
@@ -5,7 +5,7 @@ resource "aws_db_instance" "fail" {
   engine                              = "mysql"
   engine_version                      = "5.7"
   instance_class                      = "db.t2.micro"
-  name                                = "mydb"
+  db_name                             = "mydb"
   username                            = "foo"
   password                            = "foobarbaz"
   iam_database_authentication_enabled = true
@@ -13,29 +13,26 @@ resource "aws_db_instance" "fail" {
   ca_cert_identifier                  = "rds-ca-2015"
 }
 
-resource "aws_db_instance" "pass" {
-  allocated_storage                   = 20
-  storage_type                        = "gp2"
-  engine                              = "mysql"
-  engine_version                      = "5.7"
-  instance_class                      = "db.t2.micro"
-  name                                = "mydb"
-  username                            = "foo"
-  password                            = "foobarbaz"
-  iam_database_authentication_enabled = true
-  storage_encrypted                   = true
-  ca_cert_identifier                  = "rds-ca-2019"
+locals {
+  passing_ca_cert_identifiers = [
+    "rds-ca-2019",
+    "rds-ca-rsa2048-g1",
+    "rds-ca-rsa4096-g1",
+    "rds-ca-ecc384-g1",
+  ]
 }
 
-resource "aws_db_instance" "pass2" {
+resource "aws_db_instance" "pass" {
+  for_each                            = local.passing_ca_cert_identifiers
   allocated_storage                   = 20
   storage_type                        = "gp2"
   engine                              = "mysql"
   engine_version                      = "5.7"
   instance_class                      = "db.t2.micro"
-  name                                = "mydb"
+  db_name                             = "mydb"
   username                            = "foo"
   password                            = "foobarbaz"
   iam_database_authentication_enabled = true
   storage_encrypted                   = true
+  ca_cert_identifier                  = each.key
 }

--- a/tests/terraform/checks/resource/aws/example_RDSCACertIsRecent/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSCACertIsRecent/main.tf
@@ -15,7 +15,6 @@ resource "aws_db_instance" "fail" {
 
 locals {
   passing_ca_cert_identifiers = [
-    "rds-ca-2019",
     "rds-ca-rsa2048-g1",
     "rds-ca-rsa4096-g1",
     "rds-ca-ecc384-g1",

--- a/tests/terraform/checks/resource/aws/test_RDSCACertIsRecent.py
+++ b/tests/terraform/checks/resource/aws/test_RDSCACertIsRecent.py
@@ -14,7 +14,6 @@ class TestRDSCACertIsRecent(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            "aws_db_instance.pass[\"rds-ca-2019\"]",
             "aws_db_instance.pass[\"rds-ca-rsa2048-g1\"]",
             "aws_db_instance.pass[\"rds-ca-rsa4096-g1\"]",
             "aws_db_instance.pass[\"rds-ca-ecc384-g1\"]",
@@ -26,7 +25,7 @@ class TestRDSCACertIsRecent(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 4)
+        self.assertEqual(summary["passed"], 3)
         self.assertEqual(summary["failed"], 1)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)

--- a/tests/terraform/checks/resource/aws/test_RDSCACertIsRecent.py
+++ b/tests/terraform/checks/resource/aws/test_RDSCACertIsRecent.py
@@ -14,8 +14,10 @@ class TestRDSCACertIsRecent(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            "aws_db_instance.pass",
-            "aws_db_instance.pass2",
+            "aws_db_instance.pass[\"rds-ca-2019\"]",
+            "aws_db_instance.pass[\"rds-ca-rsa2048-g1\"]",
+            "aws_db_instance.pass[\"rds-ca-rsa4096-g1\"]",
+            "aws_db_instance.pass[\"rds-ca-ecc384-g1\"]",
         }
         failing_resources = {
             "aws_db_instance.fail",
@@ -24,7 +26,7 @@ class TestRDSCACertIsRecent(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["passed"], 4)
         self.assertEqual(summary["failed"], 1)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

AWS RDS supports several recent Certificate Authorities (CA) as explained in the [AWS official documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.RegionCertificateAuthorities). I have added the 3 missing RDS CA in check CKV_AWS_211.

Fixes #5246

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
