### PR TITLE
feat(graph): add experimental debug output for graph check evaluation

### DIFF
--- a/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/base_attribute_solver.py
@@ -9,6 +9,7 @@ from typing import List, Tuple, Dict, Any, Optional, Pattern, TYPE_CHECKING
 from igraph import Graph
 from bc_jsonpath_ng.ext import parse
 
+from checkov.common.graph.checks_infra import debug
 from checkov.common.graph.checks_infra.enums import SolverType
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
 
@@ -106,20 +107,38 @@ class BaseAttributeSolver(BaseSolver):
                     if not resource_variable_dependant or resource_variable_dependant and policy_variable_dependant:
                         filtered_attribute_matches.append(attribute)
             if attribute_matches:
-                if self.is_jsonpath_check:
-                    if self.resource_type_pred(vertex, self.resource_types) and all(
-                            self._get_operation(vertex=vertex, attribute=attr) for attr in filtered_attribute_matches):
-                        return True if len(attribute_matches) == len(filtered_attribute_matches) else None
-                    return False
+                result = self._evaluate_attribute_matches(
+                    vertex=vertex,
+                    attribute_matches=attribute_matches,
+                    filtered_attribute_matches=filtered_attribute_matches,
+                )
+                if result is not None:
+                    # skip unknown
+                    debug.attribute_block(
+                        resource_types=self.resource_types,
+                        attribute=self.attribute,
+                        operator=self.operator,
+                        value=self.value,
+                        resource=vertex,
+                        status="passed" if result is True else "failed",
+                    )
 
-                if self.resource_type_pred(vertex, self.resource_types) and any(
-                        self._get_operation(vertex=vertex, attribute=attr) for attr in filtered_attribute_matches):
-                    return True
-                return False if len(attribute_matches) == len(filtered_attribute_matches) else None
+                return result
 
-        return self.resource_type_pred(vertex, self.resource_types) and self._get_operation(
+        result = self.resource_type_pred(vertex, self.resource_types) and self._get_operation(
             vertex=vertex, attribute=self.attribute
         )
+
+        debug.attribute_block(
+            resource_types=self.resource_types,
+            attribute=self.attribute,
+            operator=self.operator,
+            value=self.value,
+            resource=vertex,
+            status="passed" if result is True else "failed",
+        )
+
+        return result
 
     def _get_operation(self, vertex: Dict[str, Any], attribute: Optional[str]) -> bool:
         raise NotImplementedError
@@ -138,6 +157,22 @@ class BaseAttributeSolver(BaseSolver):
             passed_vartices.append(data)
         else:
             failed_vertices.append(data)
+
+    def _evaluate_attribute_matches(
+        self, vertex: dict[str, Any], attribute_matches: list[str], filtered_attribute_matches: list[str]
+    ) -> bool | None:
+        if self.is_jsonpath_check:
+            if self.resource_type_pred(vertex, self.resource_types) and all(
+                self._get_operation(vertex=vertex, attribute=attr) for attr in filtered_attribute_matches
+            ):
+                return True if len(attribute_matches) == len(filtered_attribute_matches) else None
+            return False
+
+        if self.resource_type_pred(vertex, self.resource_types) and any(
+            self._get_operation(vertex=vertex, attribute=attr) for attr in filtered_attribute_matches
+        ):
+            return True
+        return False if len(attribute_matches) == len(filtered_attribute_matches) else None
 
     def get_attribute_matches(self, vertex: Dict[str, Any]) -> List[str]:
         try:

--- a/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
+++ b/checkov/common/checks_infra/solvers/complex_solvers/base_complex_solver.py
@@ -5,6 +5,7 @@ from typing import List, Any, Tuple, Dict, TYPE_CHECKING, Optional
 
 from igraph import Graph
 
+from checkov.common.graph.checks_infra import debug
 from checkov.common.graph.checks_infra.enums import SolverType
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
 
@@ -49,6 +50,14 @@ class BaseComplexSolver(BaseSolver):
                     passed_vertices.append(data)
                 else:
                     failed_vertices.append(data)
+
+            debug.complex_connection_block(
+                solvers=self.solvers,
+                operator=self.operator,
+                passed_resources=passed_vertices,
+                failed_resources=failed_vertices,
+            )
+
             return passed_vertices, failed_vertices, unknown_vertices
 
         for _, data in graph_connector.nodes(data=True):

--- a/checkov/common/checks_infra/solvers/connections_solvers/complex_connection_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/complex_connection_solver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 from typing import List, Optional, Dict, Any, Tuple, TYPE_CHECKING
 
+from checkov.common.graph.checks_infra import debug
 from checkov.common.graph.checks_infra.enums import SolverType
 from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
 from checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver import BaseAttributeSolver
@@ -52,6 +53,9 @@ class ComplexConnectionSolver(BaseConnectionSolver):
         passed = self.filter_duplicates(passed)
         failed = self.filter_duplicates(failed)
         unknown = self.filter_duplicates(unknown)
+
+        debug.complex_connection_block(solvers=self.solvers, operator=self.operator, passed_resources=passed, failed_resources=failed)
+
         return passed, failed, unknown
 
     def get_sorted_connection_solvers(self) -> List[BaseConnectionSolver]:

--- a/checkov/common/checks_infra/solvers/connections_solvers/connection_not_exists_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/connection_not_exists_solver.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import List, Optional, Dict, Any, Tuple, TYPE_CHECKING
 
+from checkov.common.graph.checks_infra import debug
 from checkov.common.graph.checks_infra.enums import Operators
 from checkov.common.checks_infra.solvers.connections_solvers.connection_exists_solver import ConnectionExistsSolver
 
@@ -28,5 +29,14 @@ class ConnectionNotExistsSolver(ConnectionExistsSolver):
 
     def get_operation(self, graph_connector: LibraryGraph) -> \
             Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
-        passed, failed, unknown = super().get_operation(graph_connector)
+        passed, failed, unknown = super()._get_operation(graph_connector)
+
+        debug.connection_block(
+            resource_types=self.resource_types,
+            connected_resource_types=self.connected_resources_types,
+            operator=self.operator,
+            passed_resources=failed,  # it has to be switched here, like the output
+            failed_resources=passed,
+        )
+
         return failed, passed, unknown

--- a/checkov/common/checks_infra/solvers/connections_solvers/connection_one_exists_solver.py
+++ b/checkov/common/checks_infra/solvers/connections_solvers/connection_one_exists_solver.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import List, Optional, Dict, Any, Tuple, TYPE_CHECKING
 from checkov.common.checks_infra.solvers import ConnectionExistsSolver
+from checkov.common.graph.checks_infra import debug
 from checkov.common.graph.checks_infra.enums import Operators
 
 if TYPE_CHECKING:
@@ -27,7 +28,16 @@ class ConnectionOneExistsSolver(ConnectionExistsSolver):
 
     def get_operation(self, graph_connector: LibraryGraph) -> \
             Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
-        passed, failed, unknown = super().get_operation(graph_connector)
+        passed, failed, unknown = super()._get_operation(graph_connector)
         failed = [f for f in failed if f not in passed]
         unknown = [u for u in unknown if u not in passed]
+
+        debug.connection_block(
+            resource_types=self.resource_types,
+            connected_resource_types=self.connected_resources_types,
+            operator=self.operator,
+            passed_resources=passed,
+            failed_resources=failed,
+        )
+
         return passed, failed, unknown

--- a/checkov/common/graph/checks_infra/debug.py
+++ b/checkov/common/graph/checks_infra/debug.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from typing import Any, TYPE_CHECKING
+
+import yaml
+from termcolor import colored
+
+from checkov.common.graph.graph_builder import CustomAttributes
+from checkov.common.util.env_vars_config import env_vars_config
+
+if TYPE_CHECKING:
+    from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
+
+logger = logging.getLogger(__name__)
+
+
+def graph_check(check_id: str, check_name: str) -> None:
+    if not env_vars_config.EXPERIMENTAL_GRAPH_DEBUG:
+        return
+
+    print(f'\nEvaluating graph policy: "{check_id}" - "{check_name}"')
+
+
+def resource_types(resource_types: Iterable[str], resource_count: int, operator: str) -> None:
+    if not env_vars_config.EXPERIMENTAL_GRAPH_DEBUG:
+        return
+
+    resource_types_str = '", "'.join(resource_types)
+    print(
+        f'\nFound {resource_count} resources with resource types: "{resource_types_str}" to check against operator: "{operator}"'
+    )
+
+
+def attribute_block(
+    resource_types: Iterable[str],
+    attribute: str | None,
+    operator: str,
+    value: str | list[str] | None,
+    resource: dict[str, Any],
+    status: str,
+) -> None:
+    if not env_vars_config.EXPERIMENTAL_GRAPH_DEBUG:
+        return
+
+    attribute_block_conf = _create_attribute_block(
+        resource_types=resource_types, attribute=attribute, operator=operator, value=value
+    )
+    color = "green" if status == "passed" else "red"
+
+    print(f"\nEvaluated block:\n")
+    print(colored(yaml.dump([attribute_block_conf], sort_keys=False), "blue"))
+    print(f"and got:")
+    print(colored(f'\nResource "{resource[CustomAttributes.ID]}" {status}:', color))
+    print(colored(json.dumps(resource[CustomAttributes.CONFIG], indent=2), "yellow"))
+
+
+def connection_block(
+    resource_types: Iterable[str],
+    connected_resource_types: Iterable[str],
+    operator: str,
+    passed_resources: list[dict[str, Any]],
+    failed_resources: list[dict[str, Any]],
+) -> None:
+    if not env_vars_config.EXPERIMENTAL_GRAPH_DEBUG:
+        return
+
+    connection_block_conf = _create_connection_block(
+        resource_types=resource_types,
+        connected_resource_types=connected_resource_types,
+        operator=operator,
+    )
+
+    passed_resources_str = '", "'.join(resource[CustomAttributes.ID] for resource in passed_resources)
+    failed_resources_str = '", "'.join(resource[CustomAttributes.ID] for resource in failed_resources)
+
+    print(f"\nEvaluated blocks:\n")
+    print(colored(yaml.dump([connection_block_conf], sort_keys=False), "blue"))
+    print(f"and got:\n")
+    print(colored(f'Passed resources: "{passed_resources_str}"', "green"))
+    print(colored(f'Failed resources: "{failed_resources_str}"', "red"))
+
+
+def complex_connection_block(
+    solvers: list[BaseSolver],
+    operator: str,
+    passed_resources: list[dict[str, Any]],
+    failed_resources: list[dict[str, Any]],
+) -> None:
+    if not env_vars_config.EXPERIMENTAL_GRAPH_DEBUG:
+        return
+
+    # to prevent circular dependencies
+    from checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver import BaseAttributeSolver
+    from checkov.common.checks_infra.solvers.complex_solvers.base_complex_solver import BaseComplexSolver
+    from checkov.common.checks_infra.solvers.connections_solvers.base_connection_solver import BaseConnectionSolver
+    from checkov.common.checks_infra.solvers.connections_solvers.complex_connection_solver import (
+        ComplexConnectionSolver,
+    )
+    from checkov.common.checks_infra.solvers.filter_solvers.base_filter_solver import BaseFilterSolver
+
+    complex_connection_block = []
+
+    for solver in solvers:
+        if isinstance(solver, BaseAttributeSolver):
+            block = _create_attribute_block(
+                resource_types=solver.resource_types,
+                attribute=solver.attribute,
+                operator=solver.operator,
+                value=solver.value,
+            )
+        elif isinstance(solver, BaseFilterSolver):
+            block = _create_filter_block(attribute=solver.attribute, operator=solver.operator, value=solver.value)
+        elif isinstance(solver, (ComplexConnectionSolver, BaseComplexSolver)):
+            # ComplexConnectionSolver check needs to be before BaseConnectionSolver, because it is a subclass
+            block = {solver.operator: ["..." for _ in solver.solvers]}
+        elif isinstance(solver, BaseConnectionSolver):
+            block = _create_connection_block(
+                resource_types=solver.resource_types,
+                connected_resource_types=solver.connected_resources_types,
+                operator=solver.operator,
+            )
+        else:
+            logger.info(f"Unsupported solver type {type(solver)} found")
+            continue
+
+        complex_connection_block.append(block)
+
+    passed_resources_str = '", "'.join(resource[CustomAttributes.ID] for resource in passed_resources)
+    failed_resources_str = '", "'.join(resource[CustomAttributes.ID] for resource in failed_resources)
+
+    print(f"\nEvaluated blocks:\n")
+    print(colored(yaml.dump([{operator: complex_connection_block}], sort_keys=False), "blue"))
+    print(f"and got:\n")
+    print(colored(f'Passed resources: "{passed_resources_str}"', "green"))
+    print(colored(f'Failed resources: "{failed_resources_str}"', "red"))
+
+
+def _create_attribute_block(
+    resource_types: Iterable[str], attribute: str | None, operator: str, value: str | list[str] | None
+) -> dict[str, Any]:
+    attribute_block_conf = {
+        "cond_type": "attribute",
+        "resource_types": resource_types,
+        "attribute": attribute,
+        "operator": operator,
+    }
+    if value is not None:
+        attribute_block_conf["value"] = value
+
+    return attribute_block_conf
+
+
+def _create_connection_block(
+    resource_types: Iterable[str], connected_resource_types: Iterable[str], operator: str
+) -> dict[str, Any]:
+    attribute_block_conf = {
+        "cond_type": "connection",
+        "resource_types": resource_types,
+        "connected_resource_types": connected_resource_types,
+        "operator": operator,
+    }
+    return attribute_block_conf
+
+
+def _create_filter_block(attribute: str | None, operator: str, value: str | list[str]) -> dict[str, Any]:
+    attribute_block_conf = {
+        "cond_type": "filter",
+        "attribute": attribute,
+        "operator": operator,
+        "value": value,
+    }
+    return attribute_block_conf

--- a/checkov/common/graph/checks_infra/debug.py
+++ b/checkov/common/graph/checks_infra/debug.py
@@ -50,9 +50,9 @@ def attribute_block(
     )
     color = "green" if status == "passed" else "red"
 
-    print(f"\nEvaluated block:\n")
+    print("\nEvaluated block:\n")
     print(colored(yaml.dump([attribute_block_conf], sort_keys=False), "blue"))
-    print(f"and got:")
+    print("and got:")
     print(colored(f'\nResource "{resource[CustomAttributes.ID]}" {status}:', color))
     print(colored(json.dumps(resource[CustomAttributes.CONFIG], indent=2), "yellow"))
 
@@ -76,9 +76,9 @@ def connection_block(
     passed_resources_str = '", "'.join(resource[CustomAttributes.ID] for resource in passed_resources)
     failed_resources_str = '", "'.join(resource[CustomAttributes.ID] for resource in failed_resources)
 
-    print(f"\nEvaluated blocks:\n")
+    print("\nEvaluated blocks:\n")
     print(colored(yaml.dump([connection_block_conf], sort_keys=False), "blue"))
-    print(f"and got:\n")
+    print("and got:\n")
     print(colored(f'Passed resources: "{passed_resources_str}"', "green"))
     print(colored(f'Failed resources: "{failed_resources_str}"', "red"))
 
@@ -131,9 +131,9 @@ def complex_connection_block(
     passed_resources_str = '", "'.join(resource[CustomAttributes.ID] for resource in passed_resources)
     failed_resources_str = '", "'.join(resource[CustomAttributes.ID] for resource in failed_resources)
 
-    print(f"\nEvaluated blocks:\n")
+    print("\nEvaluated blocks:\n")
     print(colored(yaml.dump([{operator: complex_connection_block}], sort_keys=False), "blue"))
-    print(f"and got:\n")
+    print("and got:\n")
     print(colored(f'Passed resources: "{passed_resources_str}"', "green"))
     print(colored(f'Failed resources: "{failed_resources_str}"', "red"))
 

--- a/checkov/common/graph/checks_infra/registry.py
+++ b/checkov/common/graph/checks_infra/registry.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 import concurrent.futures
 import logging
 from typing import Any, TYPE_CHECKING
+
+from checkov.common.graph.checks_infra import debug
 from checkov.common.models.enums import CheckResult
 from checkov.runner_filter import RunnerFilter
 
@@ -37,6 +39,8 @@ class BaseRegistry:
             graph_connector: LibraryGraph
     ) -> None:
         logging.debug(f'Running graph check: {check.id}')
+        debug.graph_check(check_id=check.id, check_name=check.name)
+
         passed, failed, unknown = check.run(graph_connector)
         evaluated_keys = check.get_evaluated_keys()
         check_result = self._process_check_result(passed, [], CheckResult.PASSED, evaluated_keys)

--- a/checkov/common/util/env_vars_config.py
+++ b/checkov/common/util/env_vars_config.py
@@ -35,9 +35,7 @@ class EnvVarsConfig:
             os.getenv("CHECKOV_ENABLE_MODULES_FOREACH_HANDLING", True)
         )
         self.ENABLE_NESTED_MODULES = convert_str_to_bool(os.getenv("CHECKOV_ENABLE_NESTED_MODULES", True))
-        self.EXPERIMENTAL_CROSS_VARIABLE_EDGES = convert_str_to_bool(
-            os.getenv("CHECKOV_EXPERIMENTAL_CROSS_VARIABLE_EDGES", True)
-        )
+        self.EXPERIMENTAL_GRAPH_DEBUG = convert_str_to_bool(os.getenv("CHECKOV_EXPERIMENTAL_GRAPH_DEBUG", False))
         self.EXPIRATION_TIME_IN_SEC = force_int(os.getenv("CHECKOV_EXPIRATION_TIME_IN_SEC", 604800))
         self.GITHUB_CONF_DIR_NAME = os.getenv("CKV_GITHUB_CONF_DIR_NAME", "github_conf")
         self.GITHUB_CONFIG_FETCH_DATA = convert_str_to_bool(os.getenv("CKV_GITHUB_CONFIG_FETCH_DATA", True))
@@ -56,7 +54,6 @@ class EnvVarsConfig:
         self.OUTPUT_CODE_LINE_LIMIT = force_int(os.getenv("CHECKOV_OUTPUT_CODE_LINE_LIMIT", 50))
         self.PARSE_ERROR_FAIL = convert_str_to_bool(os.getenv("CKV_PARSE_ERROR_FAIL", False))
         self.RENDER_ASYNC_MAX_WORKERS = force_int(os.getenv("RENDER_ASYNC_MAX_WORKERS", 50))
-        self.RENDER_DYNAMIC_MODULES = convert_str_to_bool(os.getenv("CHECKOV_RENDER_DYNAMIC_MODULES", True))
         self.RENDER_EDGES_DUPLICATE_ITER_COUNT = force_int(os.getenv("RENDER_EDGES_DUPLICATE_ITER_COUNT", 4))
         self.RENDER_EDGES_DUPLICATE_PERCENT = force_int(os.getenv("RENDER_EDGES_DUPLICATE_PERCENT", 90))
         self.RENDER_MAX_LEN = force_int(os.getenv("CHECKOV_RENDER_MAX_LEN", 10000))

--- a/tests/common/checks_infra/test_debug.py
+++ b/tests/common/checks_infra/test_debug.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+from _pytest.capture import CaptureFixture
+
+from checkov.common.graph.checks_infra.debug import attribute_block, graph_check, connection_block
+from checkov.common.graph.checks_infra.enums import Operators
+from checkov.common.graph.graph_builder import CustomAttributes
+from checkov.common.util.env_vars_config import env_vars_config
+
+
+@pytest.fixture
+def enable_graph_debug():
+    env_vars_config.EXPERIMENTAL_GRAPH_DEBUG = True
+    yield
+    env_vars_config.EXPERIMENTAL_GRAPH_DEBUG = False
+
+
+def test_no_output_on_default(capfd: CaptureFixture[str]):
+    # given/when
+    graph_check(check_id="CKV_EXAMPLE_1", check_name="Example")
+
+    # then
+    assert not capfd.readouterr().out
+
+
+def test_attribute_block(capfd: CaptureFixture[str], enable_graph_debug):
+    # given
+    resource_types = ["aws_s3_bucket"]
+    attribute = "lifecycle_rule"
+    operator = Operators.EXISTS
+    value = None
+    resource = {
+        CustomAttributes.ID: "aws_s3_bucket.example",
+        CustomAttributes.CONFIG: {
+            "aws_s3_bucket": {
+                "example": {
+                    "__end_line__": 3,
+                    "__start_line__": 1,
+                    "bucket": ["example"],
+                    "__address__": "aws_s3_bucket.example",
+                }
+            }
+        },
+    }
+    status = "failed"
+
+    # when
+    attribute_block(
+        resource_types=resource_types,
+        attribute=attribute,
+        operator=operator,
+        value=value,
+        resource=resource,
+        status=status,
+    )
+
+    # then
+    assert capfd.readouterr().out == dedent(
+        """
+        Evaluated block:
+        
+        - cond_type: attribute
+          resource_types:
+          - aws_s3_bucket
+          attribute: lifecycle_rule
+          operator: exists
+        
+        and got:
+        
+        Resource "aws_s3_bucket.example" failed:
+        {
+          "aws_s3_bucket": {
+            "example": {
+              "__end_line__": 3,
+              "__start_line__": 1,
+              "bucket": [
+                "example"
+              ],
+              "__address__": "aws_s3_bucket.example"
+            }
+          }
+        }
+        """
+    )
+
+
+def test_connection_block(capfd: CaptureFixture[str], enable_graph_debug):
+    # given
+    resource_types = ["aws_s3_bucket"]
+    connected_resource_types = ["aws_s3_bucket_lifecycle_configuration"]
+    operator = Operators.EXISTS
+    value = None
+    passed_resources = [
+        {
+            CustomAttributes.ID: "aws_s3_bucket.good",
+        },
+        {
+            CustomAttributes.ID: "aws_s3_bucket_lifecycle_configuration.good",
+        },
+    ]
+    failed_resources = [
+        {
+            CustomAttributes.ID: "aws_s3_bucket.bad",
+        }
+    ]
+
+    # when
+    connection_block(
+        resource_types=resource_types,
+        connected_resource_types=connected_resource_types,
+        operator=operator,
+        passed_resources=passed_resources,
+        failed_resources=failed_resources,
+    )
+
+    # then
+    assert capfd.readouterr().out == dedent(
+        """
+        Evaluated blocks:
+        
+        - cond_type: connection
+          resource_types:
+          - aws_s3_bucket
+          connected_resource_types:
+          - aws_s3_bucket_lifecycle_configuration
+          operator: exists
+        
+        and got:
+        
+        Passed resources: "aws_s3_bucket.good", "aws_s3_bucket_lifecycle_configuration.good"
+        Failed resources: "aws_s3_bucket.bad"
+        """
+    )


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- this is experimental and could be removed again after some internal testing

This is how an output would look like, but with color 😄 

```shell
$ CHECKOV_EXPERIMENTAL_GRAPH_DEBUG=True checkov -f main.tf -c CKV2_AWS_61

Evaluating graph policy: "CKV2_AWS_61" - "Ensure that an S3 bucket has a lifecycle configuration"

Evaluated block:

- cond_type: attribute
  resource_types:
  - aws_s3_bucket
  attribute: lifecycle_rule
  operator: exists

and got:

Resource "aws_s3_bucket.pass" failed:
{
  "aws_s3_bucket": {
    "pass": {
      "__end_line__": 3,
      "__start_line__": 1,
      "bucket": [
        "bucket_good"
      ],
      "__address__": "aws_s3_bucket.pass"
    }
  }
}

Evaluated blocks:

- cond_type: connection
  resource_types:
  - aws_s3_bucket
  connected_resource_types:
  - aws_s3_bucket_lifecycle_configuration
  operator: exists

and got:

Passed resources: "aws_s3_bucket_lifecycle_configuration.pass", "aws_s3_bucket.pass"
Failed resources: ""

Evaluated blocks:

- and:
  - cond_type: filter
    attribute: resource_type
    operator: within
    value:
    - aws_s3_bucket
  - cond_type: connection
    resource_types:
    - aws_s3_bucket
    connected_resource_types:
    - aws_s3_bucket_lifecycle_configuration
    operator: exists

and got:

Passed resources: "aws_s3_bucket.pass"
Failed resources: ""

Evaluated blocks:

- or:
  - and:
    - '...'
    - '...'
  - cond_type: attribute
    resource_types:
    - aws_s3_bucket
    attribute: lifecycle_rule
    operator: exists

and got:

Passed resources: "aws_s3_bucket.pass"
Failed resources: ""


       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By bridgecrew.io | version: 2.3.302 


terraform scan results:
Check: CKV2_AWS_61: "Ensure that an S3 bucket has a lifecycle configuration"
	PASSED for resource: aws_s3_bucket.pass
	File: /main.tf:1-3

Passed checks: 1, Failed checks: 0, Skipped checks: 0
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
