### PR TITLE
fix(secrets): fix secrets omit crash when value is not string

### DIFF
--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -4,8 +4,6 @@ import itertools
 import json
 import logging
 import re
-
-# secret categories for use as constants
 from typing import Any, TYPE_CHECKING
 
 from checkov.common.models.enums import CheckCategories, CheckResult
@@ -17,7 +15,7 @@ if TYPE_CHECKING:
     from checkov.common.typing import _CheckResult, ResourceAttributesToOmit
     from pycep.typing import ParameterAttributes, ResourceAttributes
 
-
+# secret categories for use as constants
 AWS = 'aws'
 AZURE = 'azure'
 GCP = 'gcp'
@@ -163,6 +161,10 @@ def omit_secret_value_from_checks(
             if key not in resource_masks:
                 continue
             if isinstance(secret, list) and secret:
+                if not isinstance(secret[0], str):
+                    logging.debug(f"Secret value can't be masked, has type {type(secret)}")
+                    continue
+
                 secrets.add(secret[0])
 
     if not secrets:
@@ -207,6 +209,10 @@ def omit_secret_value_from_graph_checks(
             for attribute, secret in entity_config.items():
                 if attribute in resource_masks:
                     if isinstance(secret, list) and secret:
+                        if not isinstance(secret[0], str):
+                            logging.debug(f"Secret value can't be masked, has type {type(secret)}")
+                            continue
+
                         secrets.add(secret[0])
 
     if not secrets:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- non-string value are skipped and won't be omitted

Fixes #5258

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
