### PR TITLE
fix(general): revert add composer files to supported package files

### DIFF
--- a/checkov/common/models/consts.py
+++ b/checkov/common/models/consts.py
@@ -12,9 +12,7 @@ SUPPORTED_PACKAGE_FILES = {
     "package.json",
     "package-lock.json",
     "pom.xml",
-    "requirements.txt",
-    "composer.json",
-    "composer.lock"
+    "requirements.txt"
 }
 SUPPORTED_FILES = SUPPORTED_PACKAGE_FILES.union({"Dockerfile"})
 


### PR DESCRIPTION
Reverts bridgecrewio/checkov#5263