### PR TITLE
fix(terraform): add module prefix to the resource ID of a module

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -603,6 +603,11 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
             context_parser = parser_registry.context_parsers[vertex.block_type]
             entity_context_path = context_parser.get_entity_context_path(vertex.config)
             resource_id = '.'.join(entity_context_path) if entity_context_path else vertex.name
+
+            if vertex.block_type == BlockType.MODULE:
+                # prefix modules with 'module' to properly identify them
+                resource_id = f"{BlockType.MODULE}.{resource_id}"
+
             address = f'{address_prefix}{resource_id}'
             vertex.attributes[CustomAttributes.TF_RESOURCE_ADDRESS] = address
 

--- a/tests/terraform/checks/module/generic/test_RevisionHash.py
+++ b/tests/terraform/checks/module/generic/test_RevisionHash.py
@@ -18,12 +18,12 @@ class TestRevisionHash(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            "hash",
-            "sub_dir_hash",
+            "module.hash",
+            "module.sub_dir_hash",
         }
         failing_resources = {
-            "tag",
-            "tf_registry",
+            "module.tag",
+            "module.tf_registry",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}

--- a/tests/terraform/graph/graph_builder/test_graph_builder.py
+++ b/tests/terraform/graph/graph_builder/test_graph_builder.py
@@ -316,9 +316,9 @@ class TestGraphBuilder(TestCase):
         graph_manager = TerraformGraphManager(NetworkxConnector())
         local_graph, _ = graph_manager.build_graph_from_source_directory(resources_dir, render_variables=True)
         module_1 = self.get_vertex_by_name_and_type(local_graph, BlockType.MODULE, 'inner_s3_module')
-        assert module_1.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS) == 'module.s3_module.inner_s3_module'
+        assert module_1.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS) == 'module.s3_module.module.inner_s3_module'
         module_2 = self.get_vertex_by_name_and_type(local_graph, BlockType.MODULE, 's3_module')
-        assert module_2.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS) == 's3_module'
+        assert module_2.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS) == 'module.s3_module'
         resource_1 = self.get_vertex_by_name_and_type(local_graph, BlockType.RESOURCE, 'aws_s3_bucket_public_access_block.var_bucket')
         assert resource_1.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS) == 'module.s3_module.module.inner_s3_module.aws_s3_bucket_public_access_block.var_bucket'
         resource_2 = self.get_vertex_by_name_and_type(local_graph, BlockType.RESOURCE, 'aws_s3_bucket.example')

--- a/tests/terraform/graph/resources/modules/nested_modules_instances/expected_local_graph.json
+++ b/tests/terraform/graph/resources/modules/nested_modules_instances/expected_local_graph.json
@@ -10,7 +10,7 @@
         "source": [
           "../module3"
         ],
-        "__address__": "another_s3_module"
+        "__address__": "module.another_s3_module"
       },
       "block_type": "module",
       "breadcrumbs": {},
@@ -28,7 +28,7 @@
           "source": [
             "../module3"
           ],
-          "__address__": "another_s3_module"
+          "__address__": "module.another_s3_module"
         }
       },
       "id": "",
@@ -154,7 +154,7 @@
         "source": [
           "./module"
         ],
-        "__address__": "s3_module"
+        "__address__": "module.s3_module"
       },
       "block_type": "module",
       "breadcrumbs": {},
@@ -172,7 +172,7 @@
           "source": [
             "./module"
           ],
-          "__address__": "s3_module"
+          "__address__": "module.s3_module"
         }
       },
       "id": "",
@@ -194,7 +194,7 @@
         "source": [
           "./module"
         ],
-        "__address__": "s3_module2"
+        "__address__": "module.s3_module2"
       },
       "block_type": "module",
       "breadcrumbs": {},
@@ -212,7 +212,7 @@
           "source": [
             "./module"
           ],
-          "__address__": "s3_module2"
+          "__address__": "module.s3_module2"
         }
       },
       "id": "",
@@ -338,7 +338,7 @@
         "source": [
           "../module2"
         ],
-        "__address__": "module.s3_module.inner_s3_module"
+        "__address__": "module.s3_module.module.inner_s3_module"
       },
       "block_type": "module",
       "breadcrumbs": {
@@ -379,7 +379,7 @@
           "source": [
             "../module2"
           ],
-          "__address__": "module.s3_module.inner_s3_module"
+          "__address__": "module.s3_module.module.inner_s3_module"
         }
       },
       "id": "",
@@ -403,7 +403,7 @@
         "source": [
           "../module2"
         ],
-        "__address__": "module.s3_module.inner_s3_module_2"
+        "__address__": "module.s3_module.module.inner_s3_module_2"
       },
       "block_type": "module",
       "breadcrumbs": {
@@ -444,7 +444,7 @@
           "source": [
             "../module2"
           ],
-          "__address__": "module.s3_module.inner_s3_module_2"
+          "__address__": "module.s3_module.module.inner_s3_module_2"
         }
       },
       "id": "",
@@ -468,7 +468,7 @@
         "source": [
           "../module2"
         ],
-        "__address__": "module.s3_module2.inner_s3_module"
+        "__address__": "module.s3_module2.module.inner_s3_module"
       },
       "block_type": "module",
       "breadcrumbs": {
@@ -509,7 +509,7 @@
           "source": [
             "../module2"
           ],
-          "__address__": "module.s3_module2.inner_s3_module"
+          "__address__": "module.s3_module2.module.inner_s3_module"
         }
       },
       "id": "",
@@ -533,7 +533,7 @@
         "source": [
           "../module2"
         ],
-        "__address__": "module.s3_module2.inner_s3_module_2"
+        "__address__": "module.s3_module2.module.inner_s3_module_2"
       },
       "block_type": "module",
       "breadcrumbs": {
@@ -574,7 +574,7 @@
           "source": [
             "../module2"
           ],
-          "__address__": "module.s3_module2.inner_s3_module_2"
+          "__address__": "module.s3_module2.module.inner_s3_module_2"
         }
       },
       "id": "",
@@ -714,7 +714,7 @@
         "source": [
           "../module3"
         ],
-        "__address__": "module.s3_module.module.inner_s3_module.inner_s3_module2"
+        "__address__": "module.s3_module.module.inner_s3_module.module.inner_s3_module2"
       },
       "block_type": "module",
       "breadcrumbs": {
@@ -761,7 +761,7 @@
           "source": [
             "../module3"
           ],
-          "__address__": "module.s3_module.module.inner_s3_module.inner_s3_module2"
+          "__address__": "module.s3_module.module.inner_s3_module.module.inner_s3_module2"
         }
       },
       "id": "",
@@ -785,7 +785,7 @@
         "source": [
           "../module3"
         ],
-        "__address__": "module.s3_module2.module.inner_s3_module.inner_s3_module2"
+        "__address__": "module.s3_module2.module.inner_s3_module.module.inner_s3_module2"
       },
       "block_type": "module",
       "breadcrumbs": {
@@ -832,7 +832,7 @@
           "source": [
             "../module3"
           ],
-          "__address__": "module.s3_module2.module.inner_s3_module.inner_s3_module2"
+          "__address__": "module.s3_module2.module.inner_s3_module.module.inner_s3_module2"
         }
       },
       "id": "",
@@ -856,7 +856,7 @@
         "source": [
           "../module3"
         ],
-        "__address__": "module.s3_module.module.inner_s3_module_2.inner_s3_module2"
+        "__address__": "module.s3_module.module.inner_s3_module_2.module.inner_s3_module2"
       },
       "block_type": "module",
       "breadcrumbs": {
@@ -903,7 +903,7 @@
           "source": [
             "../module3"
           ],
-          "__address__": "module.s3_module.module.inner_s3_module_2.inner_s3_module2"
+          "__address__": "module.s3_module.module.inner_s3_module_2.module.inner_s3_module2"
         }
       },
       "id": "",
@@ -927,7 +927,7 @@
         "source": [
           "../module3"
         ],
-        "__address__": "module.s3_module2.module.inner_s3_module_2.inner_s3_module2"
+        "__address__": "module.s3_module2.module.inner_s3_module_2.module.inner_s3_module2"
       },
       "block_type": "module",
       "breadcrumbs": {
@@ -974,7 +974,7 @@
           "source": [
             "../module3"
           ],
-          "__address__": "module.s3_module2.module.inner_s3_module_2.inner_s3_module2"
+          "__address__": "module.s3_module2.module.inner_s3_module_2.module.inner_s3_module2"
         }
       },
       "id": "",

--- a/tests/terraform/graph/variable_rendering/expected_foreach_modules_tf_definitions.json
+++ b/tests/terraform/graph/variable_rendering/expected_foreach_modules_tf_definitions.json
@@ -17,7 +17,7 @@
           "source": [
             "./module"
           ],
-          "__address__": "s3_module[\"a\"]"
+          "__address__": "module.s3_module[\"a\"]"
         }
       },
       {
@@ -36,7 +36,7 @@
           "source": [
             "./module"
           ],
-          "__address__": "s3_module2[0]"
+          "__address__": "module.s3_module2[0]"
         }
       },
       {
@@ -55,7 +55,7 @@
           "source": [
             "./module"
           ],
-          "__address__": "s3_module[\"b\"]"
+          "__address__": "module.s3_module[\"b\"]"
         }
       },
       {
@@ -74,7 +74,7 @@
           "source": [
             "./module"
           ],
-          "__address__": "s3_module2[1]"
+          "__address__": "module.s3_module2[1]"
         }
       }
     ],
@@ -112,7 +112,7 @@
           "source": [
             "./module2"
           ],
-          "__address__": "module.s3_module[\"a\"].inner_s3_module"
+          "__address__": "module.s3_module[\"a\"].module.inner_s3_module"
         }
       },
       {
@@ -128,7 +128,7 @@
           "source": [
             "./module2"
           ],
-          "__address__": "module.s3_module[\"a\"].inner_s3_module2"
+          "__address__": "module.s3_module[\"a\"].module.inner_s3_module2"
         }
       }
     ],
@@ -170,7 +170,7 @@
           "source": [
             "./module2"
           ],
-          "__address__": "module.s3_module2[0].inner_s3_module"
+          "__address__": "module.s3_module2[0].module.inner_s3_module"
         }
       },
       {
@@ -186,7 +186,7 @@
           "source": [
             "./module2"
           ],
-          "__address__": "module.s3_module2[0].inner_s3_module2"
+          "__address__": "module.s3_module2[0].module.inner_s3_module2"
         }
       }
     ],
@@ -447,7 +447,7 @@
           "source": [
             "./module2"
           ],
-          "__address__": "module.s3_module[\"b\"].inner_s3_module"
+          "__address__": "module.s3_module[\"b\"].module.inner_s3_module"
         }
       },
       {
@@ -463,7 +463,7 @@
           "source": [
             "./module2"
           ],
-          "__address__": "module.s3_module[\"b\"].inner_s3_module2"
+          "__address__": "module.s3_module[\"b\"].module.inner_s3_module2"
         }
       }
     ],
@@ -601,7 +601,7 @@
           "source": [
             "./module2"
           ],
-          "__address__": "module.s3_module2[1].inner_s3_module"
+          "__address__": "module.s3_module2[1].module.inner_s3_module"
         }
       },
       {
@@ -617,7 +617,7 @@
           "source": [
             "./module2"
           ],
-          "__address__": "module.s3_module2[1].inner_s3_module2"
+          "__address__": "module.s3_module2[1].module.inner_s3_module2"
         }
       }
     ],

--- a/tests/terraform/parser/resources/parser_scenarios/account_dirs_and_modules/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/account_dirs_and_modules/expected.json
@@ -13,7 +13,7 @@
           ],
           "__start_line__": 1,
           "__end_line__": 6,
-          "__address__": "mydb"
+          "__address__": "module.mydb"
         }
       }
     ]
@@ -112,7 +112,7 @@
           ],
           "__start_line__": 1,
           "__end_line__": 6,
-          "__address__": "mydb"
+          "__address__": "module.mydb"
         }
       }
     ]

--- a/tests/terraform/parser/resources/parser_scenarios/bad_tf/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/bad_tf/expected.json
@@ -7,7 +7,7 @@
           "source": ["baz"],
           "__start_line__": 11,
           "__end_line__": 14,
-          "__address__": "bar"
+          "__address__": "module.bar"
         }
       },
       {
@@ -15,7 +15,7 @@
           "source": ["./okay", "baz2"],
           "__start_line__": 16,
           "__end_line__": 19,
-          "__address__": "okay"
+          "__address__": "module.okay"
         }
       }
     ],

--- a/tests/terraform/parser/resources/parser_scenarios/bad_tf_nested_modules_enable/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/bad_tf_nested_modules_enable/expected.json
@@ -8,7 +8,7 @@
           "__start_line__": 11,
           "__end_line__": 14,
           "__resolved__": [],
-          "__address__": "bar"
+          "__address__": "module.bar"
         }
       },
       {
@@ -17,7 +17,7 @@
           "__start_line__": 16,
           "__end_line__": 19,
           "__resolved__": [],
-          "__address__": "okay"
+          "__address__": "module.okay"
         }
       }
     ],

--- a/tests/terraform/parser/resources/parser_scenarios/maze_of_variables/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/maze_of_variables/expected.json
@@ -44,7 +44,7 @@
           "__resolved__": ["{\"file_path\": \"bucket/bucket.tf\", \"tf_source_modules\": {\"path\": \"maze.tf\", \"name\": \"bucket\", \"foreach_idx\": null, \"nested_tf_module\": null}}"],
           "__start_line__": 20,
           "__end_line__": 23,
-          "__address__": "bucket"
+          "__address__": "module.bucket"
         }
       }
     ],

--- a/tests/terraform/parser/resources/parser_scenarios/module_matryoshka/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/module_matryoshka/expected.json
@@ -7,7 +7,7 @@
           "__resolved__": ["bucket1/bucket.tf([{buckets.tf#*#0}])"],
           "__start_line__": 1,
           "__end_line__": 3,
-          "__address__": "bucket1"
+          "__address__": "module.bucket1"
         }
       }
     ],
@@ -47,7 +47,7 @@
           "__resolved__": ["bucket1/bucket2/bucket3/bucket.tf([{bucket1/bucket2/bucket.tf#*#0}])"],
           "__start_line__": 1,
           "__end_line__": 3,
-          "__address__": "module.bucket1.module.bucket2.bucket3"
+          "__address__": "module.bucket1.module.bucket2.module.bucket3"
         }
       }
     ],
@@ -74,7 +74,7 @@
           "__resolved__": ["bucket1/bucket2/bucket.tf([{bucket1/bucket.tf#*#0}])"],
           "__start_line__": 1,
           "__end_line__": 3,
-          "__address__": "module.bucket1.bucket2"
+          "__address__": "module.bucket1.module.bucket2"
         }
       }
     ],

--- a/tests/terraform/parser/resources/parser_scenarios/module_matryoshka_nested_module_enable/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/module_matryoshka_nested_module_enable/expected.json
@@ -9,7 +9,7 @@
                     ],
                     "__start_line__": 1,
                     "__end_line__": 3,
-                    "__address__": "bucket1"
+                    "__address__": "module.bucket1"
                 }
             }
         ],
@@ -36,7 +36,7 @@
                     ],
                     "__start_line__": 1,
                     "__end_line__": 3,
-                    "__address__": "module.bucket1.bucket2"
+                    "__address__": "module.bucket1.module.bucket2"
                 }
             }
         ],
@@ -63,7 +63,7 @@
                     ],
                     "__start_line__": 1,
                     "__end_line__": 3,
-                    "__address__": "module.bucket1.module.bucket2.bucket3"
+                    "__address__": "module.bucket1.module.bucket2.module.bucket3"
                 }
             }
         ],

--- a/tests/terraform/parser/resources/parser_scenarios/module_output_reference/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/module_output_reference/expected.json
@@ -7,7 +7,7 @@
           "__resolved__": ["{\"file_path\": \"common/common.tf\", \"tf_source_modules\": {\"path\": \"main.tf\", \"name\": \"common\", \"foreach_idx\": null, \"nested_tf_module\": null}}"],
           "__start_line__": 1,
           "__end_line__": 3,
-          "__address__": "common"
+          "__address__": "module.common"
         }
       },
       {
@@ -22,7 +22,7 @@
           "__resolved__": ["{\"file_path\": \"bucket/bucket.tf\", \"tf_source_modules\": {\"path\": \"main.tf\", \"name\": \"bucket\", \"foreach_idx\": null, \"nested_tf_module\": null}}"],
           "__start_line__": 4,
           "__end_line__": 7,
-          "__address__": "bucket"
+          "__address__": "module.bucket"
         }
       }
     ]

--- a/tests/terraform/parser/resources/parser_scenarios/module_reference/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/module_reference/expected.json
@@ -7,7 +7,7 @@
           "__resolved__": ["{\"file_path\": \"bucket/bucket.tf\", \"tf_source_modules\": {\"path\": \"main.tf\", \"name\": \"bucket\", \"foreach_idx\": null, \"nested_tf_module\": null}}"],
           "__start_line__": 1,
           "__end_line__": 3,
-          "__address__": "bucket"
+          "__address__": "module.bucket"
         }
       }
     ],

--- a/tests/terraform/parser/resources/parser_scenarios/module_simple/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/module_simple/expected.json
@@ -7,7 +7,7 @@
           "__resolved__": ["{\"file_path\": \"bucket/bucket.tf\", \"tf_source_modules\": {\"path\": \"main.tf\", \"name\": \"bucket\", \"foreach_idx\": null, \"nested_tf_module\": null}}"],
           "__start_line__": 1,
           "__end_line__": 3,
-          "__address__": "bucket"
+          "__address__": "module.bucket"
         }
       }
     ]

--- a/tests/terraform/parser/resources/parser_scenarios/module_simple_up_dir_ref/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/module_simple_up_dir_ref/expected.json
@@ -7,7 +7,7 @@
           "__resolved__": ["{\"file_path\": \"bucket/bucket.tf\", \"tf_source_modules\": {\"path\": \"tf/main.tf\", \"name\": \"bucket\", \"foreach_idx\": null, \"nested_tf_module\": null}}"],
           "__start_line__": 1,
           "__end_line__": 3,
-          "__address__": "bucket"
+          "__address__": "module.bucket"
         }
       }
     ]

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -244,8 +244,8 @@ class TestRunnerValid(unittest.TestCase):
         # then
         summary = report.get_summary()
 
-        passing_resources = {"pass"}
-        failing_resources = {"fail"}
+        passing_resources = {"module.pass"}
+        failing_resources = {"module.fail"}
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
@@ -465,7 +465,7 @@ class TestRunnerValid(unittest.TestCase):
             module_registry.checks[resource].remove(check)
 
         self.assertEqual(len(result.passed_checks), 1)
-        self.assertIn('some-module', map(lambda record: record.resource, result.passed_checks))
+        self.assertIn('module.some-module', map(lambda record: record.resource, result.passed_checks))
 
     def test_terraform_module_checks_are_performed_even_if_supported_resources_is_omitted(self):
         check_name = "TF_M_2"
@@ -498,7 +498,7 @@ class TestRunnerValid(unittest.TestCase):
             module_registry.checks[resource].remove(check)
 
         self.assertEqual(len(result.passed_checks), 1)
-        self.assertIn('some-module', map(lambda record: record.resource, result.passed_checks))
+        self.assertIn('module.some-module', map(lambda record: record.resource, result.passed_checks))
 
     @mock.patch.dict(os.environ, {"CHECKOV_NEW_TF_PARSER": "False"})
     @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_FOREACH_HANDLING": "False"})
@@ -511,7 +511,7 @@ class TestRunnerValid(unittest.TestCase):
             root_folder=str(root_dir),
             runner_filter=RunnerFilter(
                 checks=["CKV_AWS_88"],
-                framework="terraform",
+                framework=["terraform"],
                 download_external_modules=True
             )
         )


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added `module.` prefix to the resoruce ID of the module resources, now they are also more aligned to the address of normal resources

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
