### PR TITLE
fix(terraform): fix invalid value in CKV_AWS_304

### DIFF
--- a/checkov/terraform/checks/resource/aws/SecretManagerSecret90days.py
+++ b/checkov/terraform/checks/resource/aws/SecretManagerSecret90days.py
@@ -1,23 +1,27 @@
+from __future__ import annotations
 
+from typing import Any
+
+from checkov.common.util.type_forcers import force_int
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class SecretManagerSecret90days(BaseResourceCheck):
-
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure Secrets Manager secrets should be rotated within 90 days"
         id = "CKV_AWS_304"
-        supported_resources = ["aws_secretsmanager_secret_rotation"]
-        categories = [CheckCategories.GENERAL_SECURITY]
+        supported_resources = ("aws_secretsmanager_secret_rotation",)
+        categories = (CheckCategories.GENERAL_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def scan_resource_conf(self, conf) -> CheckResult:
-        if conf.get("rotation_rules") and isinstance(conf.get("rotation_rules"), list):
-            rule = conf.get("rotation_rules")[0]
-            if rule.get('automatically_after_days') and isinstance(rule.get('automatically_after_days'), list):
-                days = rule.get('automatically_after_days')[0]
-                if days < 90:
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        rules = conf.get("rotation_rules")
+        if rules and isinstance(rules, list):
+            days = rules[0].get('automatically_after_days')
+            if days and isinstance(days, list):
+                days = force_int(days[0])
+                if days is not None and days < 90:
                     return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/tests/terraform/checks/resource/aws/example_SecretManagerSecret90days/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SecretManagerSecret90days/main.tf
@@ -15,3 +15,12 @@ resource "aws_secretsmanager_secret_rotation" "fail" {
     automatically_after_days = 90
   }
 }
+
+resource "aws_secretsmanager_secret_rotation" "fail_2" {
+  secret_id           = aws_secretsmanager_secret.example.id
+  rotation_lambda_arn = aws_lambda_function.example.arn
+
+  rotation_rules {
+    automatically_after_days = var.days
+  }
+}

--- a/tests/terraform/checks/resource/aws/test_SecretManagerSecret90days.py
+++ b/tests/terraform/checks/resource/aws/test_SecretManagerSecret90days.py
@@ -20,10 +20,11 @@ class TestSecretManagerSecret90days(unittest.TestCase):
         }
         failing_resources = {
             "aws_secretsmanager_secret_rotation.fail",
+            "aws_secretsmanager_secret_rotation.fail_2",
         }
 
-        passed_check_resources = set([c.resource for c in report.passed_checks])
-        failed_check_resources = set([c.resource for c in report.failed_checks])
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
 
         self.assertEqual(summary["passed"], len(passing_resources))
         self.assertEqual(summary["failed"], len(failing_resources))


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- now it will fail if the value can't transformed to an `int`

Fixes #5297

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
