### PR TITLE
fix(terraform): support new field in CKV2_AWS_3

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/GuardDutyIsEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/GuardDutyIsEnabled.yaml
@@ -4,6 +4,11 @@ metadata:
   category: "GENERAL_SECURITY"
 definition:
   and:
+    - cond_type: filter
+      attribute: resource_type
+      value:
+        - aws_guardduty_detector
+      operator: within
     - resource_types:
         - aws_guardduty_detector
       connected_resource_types:
@@ -12,19 +17,22 @@ definition:
       cond_type: connection
     - cond_type: "attribute"
       resource_types: 
-        - aws_guardduty_organization_configuration
-      attribute: auto_enable
-      operator: equals
-      value: true
-    - cond_type: "attribute"
-      resource_types: 
         - aws_guardduty_detector
       attribute: enable
       operator: equals
       value: true
-    - cond_type: filter
-      attribute: resource_type
-      value:
-        - aws_guardduty_detector
-      operator: within
-
+    - or:
+        - cond_type: "attribute"
+          resource_types:
+            - aws_guardduty_organization_configuration
+          attribute: auto_enable
+          operator: equals
+          value: true
+        - cond_type: "attribute"
+          resource_types:
+            - aws_guardduty_organization_configuration
+          attribute: auto_enable_organization_members
+          operator: within
+          value:
+            - "ALL"
+            - "NEW"

--- a/tests/terraform/graph/checks/resources/GuardDutyIsEnabled/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GuardDutyIsEnabled/expected.yaml
@@ -1,5 +1,7 @@
 pass:
-  - "aws_guardduty_detector.ok"
+  - "aws_guardduty_detector.all"
+  - "aws_guardduty_detector.ok_old"
 fail:
   - "aws_guardduty_detector.not_ok"
-  - "aws_guardduty_detector.not_ok_false"
+  - "aws_guardduty_detector.not_ok_false_old"
+  - "aws_guardduty_detector.none"

--- a/tests/terraform/graph/checks/resources/GuardDutyIsEnabled/main.tf
+++ b/tests/terraform/graph/checks/resources/GuardDutyIsEnabled/main.tf
@@ -1,21 +1,43 @@
-resource "aws_guardduty_detector" "ok" {
+# pass
+
+resource "aws_guardduty_detector" "ok_old" {
   enable = true
 }
+
+resource "aws_guardduty_organization_configuration" "ok_old" {
+  auto_enable = true
+  detector_id = aws_guardduty_detector.ok_old.id
+}
+
+resource "aws_guardduty_detector" "all" {
+  enable = true
+}
+
+resource "aws_guardduty_organization_configuration" "all" {
+  auto_enable_organization_members = "ALL"
+  detector_id                      = aws_guardduty_detector.all.id
+}
+
+# fail
 
 resource "aws_guardduty_detector" "not_ok" {
   enable = true
 }
 
-resource "aws_guardduty_organization_configuration" "example" {
-  auto_enable = true
-  detector_id = aws_guardduty_detector.ok.id
-}
-
-resource "aws_guardduty_detector" "not_ok_false" {
+resource "aws_guardduty_detector" "not_ok_false_old" {
   enable = true
 }
 
-resource "aws_guardduty_organization_configuration" "example" {
+resource "aws_guardduty_organization_configuration" "not_ok_false_old" {
   auto_enable = false
-  detector_id = aws_guardduty_detector.not_ok_false.id
+  detector_id = aws_guardduty_detector.not_ok_false_old.id
+}
+
+resource "aws_guardduty_detector" "none" {
+  enable = true
+}
+
+resource "aws_guardduty_organization_configuration" "none" {
+  auto_enable_organization_members = "NONE"
+  detector_id                      = aws_guardduty_detector.none.id
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added support for the new field `auto_enable_organization_members` which seems to be better than the old one 😄 

Fixes #5291 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
