### PR TITLE
fix(kustomize): Checked for existence of caller_file_path in definitions_raw 

### DIFF
--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -216,6 +216,12 @@ class K8sKustomizeRunner(K8sRunner):
         if caller_file_path not in self.definitions:
             return None
         caller_resource = self.definitions[caller_file_path][0]
+
+        if caller_file_path not in self.definitions_raw:
+            # As we cannot calculate better lines with the `calculate_code_lines` without the raw code,
+            # we can use the existing info in the resource
+            return caller_resource[START_LINE], caller_resource[END_LINE]
+
         raw_caller_resource = self.definitions_raw[caller_file_path]
 
         caller_raw_start_line = caller_resource[START_LINE]
@@ -223,7 +229,7 @@ class K8sKustomizeRunner(K8sRunner):
 
         _, caller_start_line, caller_end_line = calculate_code_lines(raw_caller_resource, caller_raw_start_line,
                                                                      caller_raw_end_line)
-        return (caller_start_line, caller_end_line)
+        return caller_start_line, caller_end_line
 
     def line_range(self, code_lines: list[tuple[int, str]]) -> list[int]:
         num_of_lines = len(code_lines)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

If `self.definitions_raw` does not include the calculated `caller_file_path`, use the saved lines on the resource instead of trying to better calculate them from the raw code


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
