### PR TITLE
feat(kustomize): Support child k8s resources inside kustomize origin annotations

### DIFF
--- a/checkov/kubernetes/graph_builder/local_graph.py
+++ b/checkov/kubernetes/graph_builder/local_graph.py
@@ -162,11 +162,20 @@ class KubernetesLocalGraph(LocalGraph[KubernetesBlock]):
                 # resource does not contain all required fields and can not be associated with the pod
                 all_resources.append(conf)
                 return
-            template[PARENT_RESOURCE_KEY_NAME] = metadata.get('name', "")
+
+            parent_name = metadata.get('name', "")
+            template[PARENT_RESOURCE_KEY_NAME] = parent_name
             if not template.get('kind'):
                 template['kind'] = DEFAULT_NESTED_RESOURCE_TYPE
             if not template.get('apiVersion'):
                 template['apiVersion'] = conf.get('apiVersion')
+
+            template_metadata = template.get('metadata')
+            template_metadata[PARENT_RESOURCE_ID_KEY_NAME] = parent_name
+            annotations = metadata.get('annotations')
+            if annotations is not None and template_metadata is not None and 'annotations' not in template_metadata:
+                # Updates annotations to template as well to handle metadata added to the parent resource
+                template_metadata['annotations'] = annotations
             spec.pop('template', None)
         else:
             template = {}

--- a/checkov/kubernetes/graph_builder/local_graph.py
+++ b/checkov/kubernetes/graph_builder/local_graph.py
@@ -171,11 +171,11 @@ class KubernetesLocalGraph(LocalGraph[KubernetesBlock]):
                 template['apiVersion'] = conf.get('apiVersion')
 
             template_metadata = template.get('metadata')
-            template_metadata[PARENT_RESOURCE_ID_KEY_NAME] = parent_name
             annotations = metadata.get('annotations')
             if annotations is not None and template_metadata is not None and 'annotations' not in template_metadata:
                 # Updates annotations to template as well to handle metadata added to the parent resource
                 template_metadata['annotations'] = annotations
+                template_metadata[PARENT_RESOURCE_ID_KEY_NAME] = parent_name
             spec.pop('template', None)
         else:
             template = {}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

In case we have a child resource created from a k8s configuration (for example - a `Pod` inside a `Deployment` resource), correctly pass the configuration to identify it inside the resource's template. After it we use this info to also get the correct information about the origin annotations of this inner resource based on the parent's origin annotations. 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
