### PR TITLE
docs(sca): Add SCA skip comments to docs

### DIFF
--- a/docs/2.Basics/Suppressing and Skipping Policies.md
+++ b/docs/2.Basics/Suppressing and Skipping Policies.md
@@ -196,21 +196,87 @@ Check: CKV_AWS_18: "Ensure the S3 bucket has access logging enabled"
 
 ```
 
-### SCA
-CVEs can be suppressed using `--skip-check CKV_CVE_2022_1234` to suppress a specific CVE for that run or `--skip-cve-package package` to skip all CVEs for a specific package.
+### Software Composition Analysis (SCA)
+Suppressing SCA findings can be done a veriety of ways to fit your needs. CVEs can be suppressed using `--skip-check CKV_CVE_2022_1234` to suppress a specific CVE for that run or `--skip-cve-package package_name` to skip all CVEs for a specific package.
 
-For inline suppressions, depending on the package manager there are different ways to suppress CVEs. You can either suppress a CVE for all packages, all CVEs for a package or specific CVE for a package. Today, only requirements.txt is supported.
+For inline SCA suppressions, depending on the package manager, there are different ways to suppress CVEs and License violations. Adding a skip comment to any package manager file will suppress all findings for that CVE or package and License combination for that file.
 
-#### Python - requirements.txt
-The skip comment can be anywhere
+#### Python (requirements.txt), .NET (Paket), Java/Kotlin (gradle.properties), Ruby (Gemfile)
+The skip comment can be anywhere in the file.
+
+The example below is for requirements.txt
 
 ```requirements.txt
-# checkov:skip=CVE-2019-19844: ignore CVE for all packages
-# checkov:skip=jinja2: all CVEs for a package
-# checkov:skip=django[CVE-2019-19844,CVE-2019-19844]: specific CVEs for a package
+# checkov:skip=CVE-2019-19844: ignore CVE-2019-19844 for all packages in this file
+# checkov:skip=jinja2[BC_LIC_1]: ignore non-OSI license violations for jinja2
 django==1.2
 jinja2==3.1.0
 ```
+
+#### JavaScript (package.json and bower.json)
+The skip comment can be anywhere in the metadata. Add these skip comments to the non-lock file and ensure you scan the non-lock file with any lock file scan. For example, package.json and yarn.lock must be scanned together for the suppression from the package.json to apply tot he yarn.lock violations.
+
+The example below is for package.json
+
+```package.json
+{
+  "name": "my-package",
+  "version": "1.0.0",
+  "description": "A sample package.json file",
+  "//": "checkov:skip=CVE-2023-123: ignore this CVE for this file",
+  "//": "checkov:skip=express[BC_LIC_2]: ignore unknown license violations for express in this file",
+  "dependencies": {
+    "express": "4.17.1",
+    "lodash": "4.17.21"
+  },
+  "scripts": {
+    "start": "node server.js",
+    "test": "jest"
+  }
+}
+```
+
+### Java (pom.xml), .NET (*.csproj)
+The skip comment can be anywhere in the file.
+
+The example below is for pom.xml
+
+```pom.xml
+  <!--checkov:skip=CVE-2023-123: ignore this CVE for the file-->
+  <!--checkov:skip=junit[BC_LIC_1]: ignore non-compliant license findings for junit-->
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>5.3.9</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+```
+
+### Java/Kotlin (build.gradle), Go (go.mod)
+The skip comment can be anywhere in the file. Adding skips to the go.mod file will apply to the go.sum file.
+
+The example below is for go.mod
+
+```go.mod
+module example.com/myproject
+
+go 1.17
+
+require (
+    github.com/gin-gonic/gin v1.7.4
+    github.com/go-sql-driver/mysql v1.6.0
+    //checkov:skip=CVE-2023-123: ignore this CVE for this file
+    //checkov:skip=github.com/go-sql-driver/mysql[BC_LIC_2]: ignore unknown license violations for express in this file
+)
+```
+
 
 # Specifying or skipping checks for the entire run
 

--- a/docs/2.Basics/Suppressing and Skipping Policies.md
+++ b/docs/2.Basics/Suppressing and Skipping Policies.md
@@ -197,7 +197,7 @@ Check: CKV_AWS_18: "Ensure the S3 bucket has access logging enabled"
 ```
 
 ### Software Composition Analysis (SCA)
-Suppressing SCA findings can be done a veriety of ways to fit your needs. CVEs can be suppressed using `--skip-check CKV_CVE_2022_1234` to suppress a specific CVE for that run or `--skip-cve-package package_name` to skip all CVEs for a specific package.
+Suppressing SCA findings can be done in a variety of ways to fit your needs. CVEs can be suppressed using `--skip-check CKV_CVE_2022_1234` to suppress a specific CVE for that run or `--skip-cve-package package_name` to skip all CVEs for a specific package.
 
 For inline SCA suppressions, depending on the package manager, there are different ways to suppress CVEs and License violations. Adding a skip comment to any package manager file will suppress all findings for that CVE or package and License combination for that file.
 

--- a/docs/2.Basics/Suppressing and Skipping Policies.md
+++ b/docs/2.Basics/Suppressing and Skipping Policies.md
@@ -214,17 +214,17 @@ jinja2==3.1.0
 ```
 
 #### JavaScript (package.json and bower.json)
-The skip comment can be anywhere in the metadata. Add these skip comments to the non-lock file and ensure you scan the non-lock file with any lock file scan. For example, package.json and yarn.lock must be scanned together for the suppression from the package.json to apply tot he yarn.lock violations.
+The skip comment can be anywhere in the metadata. Add these skip comments to the non-lock file and ensure you scan the non-lock file with any lock file scan. For example, package.json and yarn.lock must be scanned together for the suppression from the package.json to apply to the yarn.lock violations.
 
-The example below is for package.json
+The example below is for multiple skip comments for package.json
 
 ```package.json
 {
   "name": "my-package",
   "version": "1.0.0",
   "description": "A sample package.json file",
-  "//": "checkov:skip=CVE-2023-123: ignore this CVE for this file",
-  "//": "checkov:skip=express[BC_LIC_2]: ignore unknown license violations for express in this file",
+  "//": ["checkov:skip=express[BC_LIC_2]: ignore unknown license violations for express in this file",
+         "checkov:skip=CVE-2023-123: ignore this CVE for this file"]
   "dependencies": {
     "express": "4.17.1",
     "lodash": "4.17.21"
@@ -234,6 +234,12 @@ The example below is for package.json
     "test": "jest"
   }
 }
+```
+
+Alternatively, you can add a single skip comment
+
+```
+"//": "checkov:skip=CVE-2023-123: ignore this CVE for this file"
 ```
 
 ### Java (pom.xml), .NET (*.csproj)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Adding the different ways to add skip comments for SCA violations
