### PR TITLE
fix(kustomize): Added support for case where no parents are found for the relative fie path

### DIFF
--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -185,7 +185,11 @@ class K8sKustomizeRunner(K8sRunner):
         """
         amount_of_parents = str.count(origin_relative_path, '..')
         directory_prefix_path = k8s_file_dir
-        if amount_of_parents:
+        if amount_of_parents == 0:
+            # In case we don't have any relative paths, we need to remove the first directory parent
+            # (as the first directory is the same one of the kustomization.yaml file)
+            directory_prefix_path = k8s_file_dir.parent
+        elif amount_of_parents:
             directory_prefix_path = k8s_file_dir.parents[amount_of_parents - 1]
 
         directory_prefix = str(directory_prefix_path)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Added support for case where no parents are found for the relative fie path

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
