### PR TITLE
fix(general): properly encode non supported chars in SARIF uri field

### DIFF
--- a/checkov/common/output/sarif.py
+++ b/checkov/common/output/sarif.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 import json
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 from checkov.common.models.enums import CheckResult
 from checkov.common.output.cyclonedx_consts import SCA_CHECKTYPES
@@ -221,7 +222,7 @@ class Sarif:
                     "locations": [
                         {
                             "physicalLocation": {
-                                "artifactLocation": {"uri": record.repo_file_path.lstrip("/")},
+                                "artifactLocation": {"uri": quote(record.repo_file_path.lstrip("/"))},
                                 "region": {
                                     "startLine": int(record.file_line_range[0]) or 1,
                                     "endLine": int(record.file_line_range[1]) or 1,

--- a/tests/common/output/test_sarif_report.py
+++ b/tests/common/output/test_sarif_report.py
@@ -33,7 +33,7 @@ class TestSarifReport(unittest.TestCase):
             resource="aws_ebs_volume.web_host_storage",
             evaluations=None,
             check_class=None,
-            file_abs_path="./ec2.tf",
+            file_abs_path="/path to/ec2.tf",  # spaces should be handled correctly
             entity_tags={"tag1": "value1"},
         )
         record2.set_guideline("https://docs.bridgecrew.io/docs/general_7")
@@ -125,7 +125,7 @@ class TestSarifReport(unittest.TestCase):
                                 "locations": [
                                     {
                                         "physicalLocation": {
-                                            "artifactLocation": {"uri": "ec2.tf"},
+                                            "artifactLocation": {"uri": "path%20to/ec2.tf"},
                                             "region": {
                                                 "startLine": 5,
                                                 "endLine": 7,


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- leveraging the `quote()` function of `urllib` to properly handle unsupported chars

Fixes #5331

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
