### PR TITLE
feat(general): Migrate loggers to use templates adapter

### DIFF
--- a/checkov/ansible/utils.py
+++ b/checkov/ansible/utils.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from checkov.ansible.graph_builder.graph_components.resource_types import ResourceType
 from checkov.common.parsers.yaml.parser import parse
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.consts import START_LINE, END_LINE
 from checkov.common.util.file_utils import read_file_with_any_encoding
 from checkov.common.util.suppression import collect_suppressions_for_context
@@ -59,6 +60,7 @@ TASK_RESERVED_KEYWORDS = {
 }
 
 logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logger)
 
 
 def get_scannable_file_paths(root_folder: str | Path) -> set[Path]:

--- a/checkov/ansible/utils.py
+++ b/checkov/ansible/utils.py
@@ -59,8 +59,7 @@ TASK_RESERVED_KEYWORDS = {
     "when",
 }
 
-logger = logging.getLogger(__name__)
-logger = get_logger_with_template_adapter(logger)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def get_scannable_file_paths(root_folder: str | Path) -> set[Path]:

--- a/checkov/arm/parser/parser.py
+++ b/checkov/arm/parser/parser.py
@@ -12,8 +12,8 @@ from checkov.common.parsers.yaml import loader
 from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.file_utils import read_file_with_any_encoding
 
-LOGGER = logging.getLogger(__name__)
-LOGGER = get_logger_with_template_adapter(LOGGER)
+LOGGER = get_logger_with_template_adapter(logging.getLogger(__name__))
+
 
 def parse(filename: str) -> tuple[dict[str, Any], list[tuple[int, str]]] | tuple[None, None]:
     """Decode filename into an object"""

--- a/checkov/arm/parser/parser.py
+++ b/checkov/arm/parser/parser.py
@@ -9,10 +9,11 @@ from yaml import YAMLError
 
 from checkov.common.parsers.json import parse as json_parse
 from checkov.common.parsers.yaml import loader
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.file_utils import read_file_with_any_encoding
 
 LOGGER = logging.getLogger(__name__)
-
+LOGGER = get_logger_with_template_adapter(LOGGER)
 
 def parse(filename: str) -> tuple[dict[str, Any], list[tuple[int, str]]] | tuple[None, None]:
     """Decode filename into an object"""

--- a/checkov/cloudformation/parser/__init__.py
+++ b/checkov/cloudformation/parser/__init__.py
@@ -9,7 +9,10 @@ from checkov.cloudformation.parser.cfn_keywords import TemplateSections
 from yaml.scanner import ScannerError
 from yaml import YAMLError
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
+
 LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger_with_template_adapter(LOGGER)
 
 
 def parse(

--- a/checkov/cloudformation/parser/__init__.py
+++ b/checkov/cloudformation/parser/__init__.py
@@ -11,8 +11,7 @@ from yaml import YAMLError
 
 from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 
-LOGGER = logging.getLogger(__name__)
-LOGGER = get_logger_with_template_adapter(LOGGER)
+LOGGER = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def parse(

--- a/checkov/cloudformation/parser/cfn_yaml.py
+++ b/checkov/cloudformation/parser/cfn_yaml.py
@@ -44,8 +44,7 @@ if TYPE_CHECKING:
 UNCONVERTED_SUFFIXES = ['Ref', 'Condition']
 FN_PREFIX = 'Fn::'
 
-LOGGER = logging.getLogger(__name__)
-LOGGER = get_logger_with_template_adapter(LOGGER)
+LOGGER = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 class ContentType(str, Enum):

--- a/checkov/cloudformation/parser/cfn_yaml.py
+++ b/checkov/cloudformation/parser/cfn_yaml.py
@@ -25,6 +25,7 @@ from charset_normalizer import from_path
 
 from checkov.common.parsers.json.decoder import SimpleDecoder
 from checkov.common.parsers.node import StrNode, DictNode, ListNode
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.consts import MAX_IAC_FILE_SIZE
 from checkov.common.util.file_utils import read_file_with_any_encoding
 
@@ -44,6 +45,7 @@ UNCONVERTED_SUFFIXES = ['Ref', 'Condition']
 FN_PREFIX = 'Fn::'
 
 LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger_with_template_adapter(LOGGER)
 
 
 class ContentType(str, Enum):

--- a/checkov/common/checks/base_check.py
+++ b/checkov/common/checks/base_check.py
@@ -6,6 +6,7 @@ from abc import abstractmethod
 from collections.abc import Iterable
 from typing import List, Dict, Any, Callable, Optional
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.typing import _SkippedCheck, _CheckResult
 from checkov.common.util.type_forcers import force_list
 from checkov.common.models.enums import CheckResult, CheckCategories, CheckFailLevel
@@ -30,7 +31,7 @@ class BaseCheck(metaclass=MultiSignatureMeta):
         self.block_type = block_type
         self.path: str | None = None
         self.supported_entities = supported_entities
-        self.logger = logging.getLogger("{}".format(self.__module__))
+        self.logger = get_logger_with_template_adapter(logging.getLogger("{}".format(self.__module__)))
         self.evaluated_keys: List[str] = []
         self.entity_path = ""
         self.entity_type = ""

--- a/checkov/common/checks/base_check_registry.py
+++ b/checkov/common/checks/base_check_registry.py
@@ -12,6 +12,7 @@ from itertools import chain
 from typing import Generator, Tuple, Dict, List, Optional, Any, TYPE_CHECKING
 
 from checkov.common.models.enums import CheckResult
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.typing import _SkippedCheck, _CheckResult
 from checkov.runner_filter import RunnerFilter
 
@@ -26,7 +27,7 @@ class BaseCheckRegistry:
     __all_registered_checks: list[BaseCheck] = []  # noqa: CCE003
 
     def __init__(self, report_type: str) -> None:
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger_with_template_adapter(logging.getLogger(__name__))
         # IMPLEMENTATION NOTE: Checks is used to directly access checks based on an specific entity
         self.checks: Dict[str, List[BaseCheck]] = defaultdict(list)
         # IMPLEMENTATION NOTE: When using a wildcard, every pattern needs to be checked. To reduce the

--- a/checkov/common/checks_infra/registry.py
+++ b/checkov/common/checks_infra/registry.py
@@ -11,6 +11,7 @@ import yaml
 from checkov.common.checks_infra.checks_parser import GraphCheckParser
 from checkov.common.graph.checks_infra.base_parser import BaseGraphCheckParser
 from checkov.common.graph.checks_infra.registry import BaseRegistry
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.runner_filter import RunnerFilter
 from checkov.common.checks_infra.resources_types import resources_types
 
@@ -27,7 +28,7 @@ class Registry(BaseRegistry):
         super().__init__(parser)
         self.checks: list[BaseGraphCheck] = []
         self.checks_dir = checks_dir
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
     def load_checks(self) -> None:
         if self.checks:

--- a/checkov/common/checks_infra/solvers/attribute_solvers/contains_attribute_solver.py
+++ b/checkov/common/checks_infra/solvers/attribute_solvers/contains_attribute_solver.py
@@ -4,8 +4,9 @@ from typing import Optional, Any, Dict
 
 from checkov.common.graph.checks_infra.enums import Operators
 from checkov.common.checks_infra.solvers.attribute_solvers.base_attribute_solver import BaseAttributeSolver
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 class ContainsAttributeSolver(BaseAttributeSolver):

--- a/checkov/common/goget/github/get_git.py
+++ b/checkov/common/goget/github/get_git.py
@@ -5,6 +5,7 @@ import re
 import shutil
 
 from checkov.common.goget.base_getter import BaseGetter
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.contextmanagers import temp_environ
 
 try:
@@ -19,7 +20,7 @@ TAG_PATTERN = re.compile(r'\?(ref=)(?P<tag>(.*))')
 
 class GitGetter(BaseGetter):
     def __init__(self, url: str, create_clone_and_result_dirs: bool = True) -> None:
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger_with_template_adapter(logging.getLogger(__name__))
         self.create_clone_and_res_dirs = create_clone_and_result_dirs
         self.tag = ''
         self.commit_id: str | None = None

--- a/checkov/common/goget/registry/get_registry.py
+++ b/checkov/common/goget/registry/get_registry.py
@@ -3,6 +3,7 @@ import requests
 import os
 
 from checkov.common.goget.base_getter import BaseGetter
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.file_utils import extract_tar_archive
 from checkov.common.util.file_utils import extract_zip_archive
 from checkov.common.util.http_utils import DEFAULT_TIMEOUT
@@ -10,7 +11,7 @@ from checkov.common.util.http_utils import DEFAULT_TIMEOUT
 
 class RegistryGetter(BaseGetter):
     def __init__(self, url: str, extension: str, create_clone_and_result_dirs: bool = False) -> None:
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger_with_template_adapter(logging.getLogger(__name__))
         self.extension = extension
         self.create_clone_and_res_dirs = create_clone_and_result_dirs
         super().__init__(url)

--- a/checkov/common/graph/checks_infra/debug.py
+++ b/checkov/common/graph/checks_infra/debug.py
@@ -9,12 +9,13 @@ import yaml
 from termcolor import colored
 
 from checkov.common.graph.graph_builder import CustomAttributes
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.env_vars_config import env_vars_config
 
 if TYPE_CHECKING:
     from checkov.common.graph.checks_infra.solvers.base_solver import BaseSolver
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def graph_check(check_id: str, check_name: str) -> None:

--- a/checkov/common/parsers/json/__init__.py
+++ b/checkov/common/parsers/json/__init__.py
@@ -11,9 +11,10 @@ from typing import Any
 
 from checkov.common.parsers.json.decoder import Decoder
 from checkov.common.parsers.json.errors import DecodeError
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.file_utils import read_file_with_any_encoding
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def load(

--- a/checkov/common/parsers/node.py
+++ b/checkov/common/parsers/node.py
@@ -4,11 +4,13 @@ import logging
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Type, Generator
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
+
 if TYPE_CHECKING:
     from checkov.common.parsers.json.decoder import Mark
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 class TemplateAttributeError(AttributeError):

--- a/checkov/common/parsers/yaml/parser.py
+++ b/checkov/common/parsers/yaml/parser.py
@@ -6,8 +6,9 @@ from typing import Any
 from yaml import YAMLError
 
 import checkov.common.parsers.yaml.loader as loader
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def parse(

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -34,6 +34,7 @@ from checkov.common.output.report import Report, merge_reports
 from checkov.common.output.sarif import Sarif
 from checkov.common.output.spdx import SPDX
 from checkov.common.parallelizer.parallel_runner import parallel_runner
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.typing import _ExitCodeThresholds, _BaseRunner, _ScaExitCodeThresholds
 from checkov.common.util import data_structures_utils
 from checkov.common.util.banner import tool as tool_name
@@ -81,7 +82,7 @@ class RunnerRegistry:
         tool: str = tool_name,
         secrets_omitter_class: Type[SecretsOmitter] = SecretsOmitter,
     ) -> None:
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger_with_template_adapter(logging.getLogger(__name__))
         self.runner_filter = runner_filter
         self.runners = list(runners)
         self.banner = banner

--- a/checkov/common/util/file_utils.py
+++ b/checkov/common/util/file_utils.py
@@ -11,7 +11,9 @@ from zipfile import ZipFile
 
 from charset_normalizer import from_path
 
-logger = logging.getLogger(__name__)
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
+
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def convert_to_unix_path(path: str) -> str:

--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -14,6 +14,7 @@ from typing import Any, TYPE_CHECKING, cast, Optional, overload
 from urllib3.response import HTTPResponse
 from urllib3.util import parse_url
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.consts import DEV_API_GET_HEADERS, DEV_API_POST_HEADERS, PRISMA_API_GET_HEADERS, \
     PRISMA_PLATFORM, BRIDGECREW_PLATFORM
 from checkov.common.util.data_structures_utils import merge_dicts
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
 # https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
 DEFAULT_TIMEOUT = (3.1, 30)
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 @overload

--- a/checkov/common/util/runner_dependency_handler.py
+++ b/checkov/common/util/runner_dependency_handler.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
+
 if TYPE_CHECKING:
     from checkov.common.runners.runner_registry import RunnerRegistry
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 class RunnerDependencyHandler():

--- a/checkov/common/util/stopit/utils.py
+++ b/checkov/common/util/stopit/utils.py
@@ -27,7 +27,7 @@ P = ParamSpec("P")
 # Custom logger
 LOG = logging.getLogger(name='stopit')
 LOG.addHandler(NullHandler())
-LOG = get_logger_with_template_adapter(LOG)
+LOG = get_logger_with_template_adapter(LOG)  # type: ignore[assignment]
 
 
 class TimeoutException(Exception):

--- a/checkov/common/util/stopit/utils.py
+++ b/checkov/common/util/stopit/utils.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Any, TypeVar, Callable, cast
 
 from typing_extensions import ParamSpec, Self
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
+
 if TYPE_CHECKING:
     from types import TracebackType
 
@@ -25,6 +27,7 @@ P = ParamSpec("P")
 # Custom logger
 LOG = logging.getLogger(name='stopit')
 LOG.addHandler(NullHandler())
+LOG = get_logger_with_template_adapter(LOG)
 
 
 class TimeoutException(Exception):

--- a/checkov/kubernetes/parser/k8_json.py
+++ b/checkov/kubernetes/parser/k8_json.py
@@ -8,12 +8,13 @@ from typing import Tuple, Dict, Any, List, TYPE_CHECKING
 import yaml
 from yaml.loader import SafeLoader
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.file_utils import read_file_with_any_encoding
 
 if TYPE_CHECKING:
     from yaml import MappingNode
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def loads(content: str) -> list[dict[str, Any]]:

--- a/checkov/kubernetes/parser/k8_yaml.py
+++ b/checkov/kubernetes/parser/k8_yaml.py
@@ -8,12 +8,13 @@ from typing import List, Dict, Any, Tuple, TYPE_CHECKING
 import yaml
 from yaml.loader import SafeLoader
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.file_utils import read_file_with_any_encoding
 
 if TYPE_CHECKING:
     from yaml import MappingNode
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def loads(content: str) -> List[Dict[str, Any]]:

--- a/checkov/kubernetes/parser/parser.py
+++ b/checkov/kubernetes/parser/parser.py
@@ -6,10 +6,11 @@ from typing import Any
 
 from yaml import YAMLError
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.kubernetes.parser import k8_yaml, k8_json
 from checkov.kubernetes.parser.validatior import K8sValidator
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def parse(filename: str) -> tuple[list[dict[str, Any]], list[tuple[int, str]]] | None:

--- a/checkov/logging_init.py
+++ b/checkov/logging_init.py
@@ -23,4 +23,4 @@ stream_handler.setFormatter(log_formatter)
 stream_handler.setLevel(logging.DEBUG)
 root_logger.addHandler(stream_handler)
 
-root_logger = get_logger_with_template_adapter(root_logger)
+root_logger = get_logger_with_template_adapter(root_logger)  # type: ignore[assignment]

--- a/checkov/logging_init.py
+++ b/checkov/logging_init.py
@@ -2,6 +2,8 @@ import logging
 import os
 from io import StringIO
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
+
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'WARNING').upper()
 logging.basicConfig(level=LOG_LEVEL)
 log_formatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
@@ -20,3 +22,5 @@ stream_handler = logging.StreamHandler(stream=log_stream)
 stream_handler.setFormatter(log_formatter)
 stream_handler.setLevel(logging.DEBUG)
 root_logger.addHandler(stream_handler)
+
+root_logger = get_logger_with_template_adapter(root_logger)

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -44,6 +44,7 @@ from checkov.common.goget.github.get_git import GitGetter
 from checkov.common.output.baseline import Baseline
 from checkov.common.bridgecrew.check_type import checkov_runners, CheckType
 from checkov.common.runners.runner_registry import RunnerRegistry
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util import prompt
 from checkov.common.util.banner import banner as checkov_banner, tool as checkov_tool
 from checkov.common.util.config_utils import get_default_config_paths
@@ -89,7 +90,7 @@ signal.signal(signal.SIGINT, lambda x, y: sys.exit(''))
 
 outer_registry = None
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 # sca package runner added during the run method
 DEFAULT_RUNNERS = [

--- a/checkov/openapi/runner.py
+++ b/checkov/openapi/runner.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, TYPE_CHECKING  # noqa: F401  # Callable is use
 
 from checkov.common.checks.base_check_registry import BaseCheckRegistry
 from checkov.common.bridgecrew.check_type import CheckType
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.file_utils import read_file_with_any_encoding
 from checkov.yaml_doc.runner import Runner as YamlRunner
 from checkov.json_doc.runner import Runner as JsonRunner
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 _ParseFormatJsonCallable: TypeAlias = "Callable[[JsonRunner, str, str | None], tuple[dict[str, Any] | list[dict[str, Any]] | None, list[tuple[int, str]] | None] | None]"
 _ParseFormatYamlCallable: TypeAlias = "Callable[[YamlRunner, str, str | None], tuple[dict[str, Any] | list[dict[str, Any]] | None, list[tuple[int, str]] | None] | None]"
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 class Runner(YamlRunner, JsonRunner):

--- a/checkov/serverless/parsers/parser.py
+++ b/checkov/serverless/parsers/parser.py
@@ -17,8 +17,9 @@ from checkov.cloudformation.context_parser import ContextParser
 from checkov.cloudformation.parser.cfn_yaml import CfnParseError
 from checkov.common.models.consts import SLS_DEFAULT_VAR_PATTERN
 from checkov.common.parsers.node import DictNode, StrNode
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 IAM_ROLE_STATEMENTS_TOKEN = 'iamRoleStatements'  # nosec
 CFN_RESOURCES_TOKEN = 'resources'  # nosec

--- a/checkov/terraform/context_parsers/base_parser.py
+++ b/checkov/terraform/context_parsers/base_parser.py
@@ -13,6 +13,7 @@ import dpath
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import integration as metadata_integration
 from checkov.common.comment.enum import COMMENT_REGEX
 from checkov.common.models.enums import ContextCategories
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.parser_utils import get_abs_path
 from checkov.terraform.context_parsers.registry import parser_registry
 
@@ -23,7 +24,7 @@ CLOSE_CURLY = "}"
 class BaseContextParser(ABC):
     def __init__(self, definition_type: str) -> None:
         # bc_integration.setup_http_manager()
-        self.logger = logging.getLogger("{}".format(self.__module__))
+        self.logger = get_logger_with_template_adapter(logging.getLogger("{}".format(self.__module__)))
         if definition_type.upper() not in ContextCategories.__members__:
             self.logger.error("Terraform context parser type not supported yet")
             raise Exception()

--- a/checkov/terraform/context_parsers/registry.py
+++ b/checkov/terraform/context_parsers/registry.py
@@ -3,6 +3,7 @@ from typing import Dict, TYPE_CHECKING, Tuple, List, Any
 
 import dpath
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.terraform.modules.module_objects import TFDefinitionKey
 
 if TYPE_CHECKING:
@@ -14,7 +15,7 @@ class ParserRegistry:
     definitions_context: Dict[str, Dict[str, Dict[str, Any]]] = {}  # noqa: CCE003
 
     def __init__(self) -> None:
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
     def register(self, parser: "BaseContextParser") -> None:
         self.context_parsers[parser.definition_type] = parser

--- a/checkov/terraform/context_parsers/tf_plan/__init__.py
+++ b/checkov/terraform/context_parsers/tf_plan/__init__.py
@@ -5,8 +5,9 @@ from typing import Any
 
 from checkov.cloudformation.parser.cfn_yaml import ContentType
 from checkov.cloudformation.parser import cfn_yaml
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def parse(

--- a/checkov/terraform/evaluation/base_variable_evaluation.py
+++ b/checkov/terraform/evaluation/base_variable_evaluation.py
@@ -6,6 +6,8 @@ from typing import Tuple, Dict, Any, List
 
 import dpath
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
+
 TF_DEFINITIONS_STRIP_WORDS = re.compile(r"\b(?!\d)([^\/]+)")
 NON_PATH_WORDS_REGEX = re.compile(r"\b(?!output)[^ .]+")
 DEFINITION_TYPES_REGEX_MAPPING = {"variable": "var", "locals": "local"}
@@ -18,7 +20,7 @@ class BaseVariableEvaluation(ABC):
         tf_definitions: Dict[str, Dict[str, Any]],
         definitions_context: Dict[str, Dict[str, Any]],
     ) -> None:
-        self.logger = logging.getLogger("{}".format(self.__module__))
+        self.logger = get_logger_with_template_adapter(logging.getLogger("{}".format(self.__module__)))
         self.root_folder = root_folder
         self.tf_definitions = tf_definitions
         self.definitions_context = definitions_context

--- a/checkov/terraform/module_loading/loader.py
+++ b/checkov/terraform/module_loading/loader.py
@@ -3,6 +3,7 @@ import os
 from abc import ABC, abstractmethod
 from typing import Optional
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.terraform.module_loading.content import ModuleContent
 from checkov.terraform.module_loading.module_params import ModuleParams
 from checkov.terraform.module_loading.registry import module_loader_registry
@@ -16,7 +17,7 @@ from checkov.terraform.module_loading.registry import module_loader_registry
 class ModuleLoader(ABC):
     def __init__(self) -> None:
         module_loader_registry.register(self)
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger_with_template_adapter(logging.getLogger(__name__))
         self.module_source: str = ""
         self.current_dir: str = ""
         self.dest_dir: str = ""

--- a/checkov/terraform/module_loading/registry.py
+++ b/checkov/terraform/module_loading/registry.py
@@ -5,6 +5,7 @@ import os
 import hashlib
 from typing import Optional, List, TYPE_CHECKING, Set, Dict
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 from checkov.terraform.module_loading.content import ModuleContent
 from checkov.terraform.module_loading.module_params import ModuleParams
@@ -20,7 +21,7 @@ class ModuleLoaderRegistry:
     def __init__(
         self, download_external_modules: bool = False, external_modules_folder_name: str = DEFAULT_EXTERNAL_MODULES_DIR
     ) -> None:
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger_with_template_adapter(logging.getLogger(__name__))
         self.download_external_modules = download_external_modules
         self.external_modules_folder_name = external_modules_folder_name
         self.failed_urls_cache: Set[str] = set()

--- a/checkov/terraform_json/parser.py
+++ b/checkov/terraform_json/parser.py
@@ -10,6 +10,7 @@ from yaml import YAMLError
 
 from checkov.common.parsers.json import parse as json_parse
 from checkov.common.parsers.yaml import loader
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.consts import LINE_FIELD_NAMES
 from checkov.common.util.file_utils import read_file_with_any_encoding
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
@@ -18,7 +19,7 @@ COMMENT_FIELD_NAME = "//"
 IGNORE_FILED_NAMES = {COMMENT_FIELD_NAME} | LINE_FIELD_NAMES
 SIMPLE_TYPES = (str, int, float, bool)
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def parse(file_path: Path) -> tuple[dict[str, Any], list[tuple[int, str]]] | tuple[None, None]:

--- a/checkov/terraform_json/runner.py
+++ b/checkov/terraform_json/runner.py
@@ -12,6 +12,7 @@ from checkov.common.output.graph_record import GraphRecord
 from checkov.common.output.record import Record
 from checkov.common.output.report import Report
 from checkov.common.runners.base_runner import CHECKOV_CREATE_GRAPH
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.common.util.consts import START_LINE, END_LINE
 from checkov.common.util.secrets import omit_secret_value_from_checks
 from checkov.runner_filter import RunnerFilter
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
     from checkov.terraform.graph_manager import TerraformGraphManager
     from checkov.common.typing import LibraryGraphConnector, _CheckResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 class TerraformJsonRunner(TerraformRunner):

--- a/checkov/terraform_json/utils.py
+++ b/checkov/terraform_json/utils.py
@@ -6,11 +6,12 @@ from collections.abc import Collection
 from pathlib import Path
 from typing import Any
 
+from checkov.common.template_logger_adapter import get_logger_with_template_adapter
 from checkov.terraform_json.parser import parse
 
 TF_JSON_POSSIBLE_FILE_ENDINGS = (".tf.json",)
 
-logger = logging.getLogger(__name__)
+logger = get_logger_with_template_adapter(logging.getLogger(__name__))
 
 
 def get_scannable_file_paths(


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Migrate all `logging.getLogger` locations to use the new template adapter

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
