### PR TITLE
fix(secrets): handle regex error in custom secrets gracefully

### DIFF
--- a/checkov/secrets/plugins/custom_regex_detector.py
+++ b/checkov/secrets/plugins/custom_regex_detector.py
@@ -35,12 +35,18 @@ class CustomRegexDetector(RegexBasedDetector):
         detectors = load_detectors()
 
         for detector in detectors:
-            if detector.get("isMultiline"):
-                self.multiline_deny_list.add(re.compile('{}'.format(detector["Regex"])))
-                self.multiline_regex_to_metadata[detector["Regex"]] = detector
-                continue
-            self.denylist.add(re.compile('{}'.format(detector["Regex"])))
-            self.regex_to_metadata[detector["Regex"]] = detector
+            try:
+                if detector.get("isMultiline"):
+                    self.multiline_deny_list.add(re.compile('{}'.format(detector["Regex"])))
+                    self.multiline_regex_to_metadata[detector["Regex"]] = detector
+                    continue
+                self.denylist.add(re.compile('{}'.format(detector["Regex"])))
+                self.regex_to_metadata[detector["Regex"]] = detector
+            except Exception:
+                logging.error(
+                    f"Failed to load detector {detector.get('Name')} with regex {detector.get('Regex')}",
+                    exc_info=True,
+                )
 
     @property
     def multiline_regex_supported_file_types(self) -> Set[str]:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- till now it only happened for Python 3.11, but if one custom secret is invalid, none is used...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
