### PR TITLE
fix(kustomize): Avoid index error when calculating file path

### DIFF
--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -189,7 +189,7 @@ class K8sKustomizeRunner(K8sRunner):
             # In case we don't have any relative paths, we need to remove the first directory parent
             # (as the first directory is the same one of the kustomization.yaml file)
             directory_prefix_path = k8s_file_dir.parent
-        elif amount_of_parents:
+        elif amount_of_parents and len(k8s_file_dir.parents) >= amount_of_parents:
             directory_prefix_path = k8s_file_dir.parents[amount_of_parents - 1]
 
         directory_prefix = str(directory_prefix_path)


### PR DESCRIPTION

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

 Avoid index error when calculating file path

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
