### PR TITLE
fix(terraform): Fix CKV_AWS_104 to support new values

### DIFF
--- a/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
+++ b/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
@@ -12,18 +12,18 @@ class DocDBAuditLogs(BaseResourceCheck):
     def __init__(self):
         name = "Ensure DocDB has audit logs enabled"
         id = "CKV_AWS_104"
-        supported_resources = ('aws_docdb_cluster_parameter_group',)
+        supported_resources = ("aws_docdb_cluster_parameter_group",)
         categories = (CheckCategories.LOGGING,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        self.evaluated_keys = ['parameter']
-        
-        if 'parameter' in conf:
+        self.evaluated_keys = ["parameter"]
+
+        if "parameter" in conf:
             for idx, elem in enumerate(conf["parameter"]):
                 if isinstance(elem, dict) and elem["name"][0] == "audit_logs":
-                    if elem["value"][0] in ACCEPTED_VALUES:
-                        self.evaluated_keys = [f'parameter/[{idx}]/name', f'parameter/[{idx}]/value']
+                    if any(v in elem["value"][0] for v in ACCEPTED_VALUES):
+                        self.evaluated_keys = [f"parameter/[{idx}]/name", f"parameter/[{idx}]/value"]
                         return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
+++ b/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
@@ -1,26 +1,28 @@
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceCheck
 
+ACCEPTED_VALUES = (
+    "enabled",  # Legacy value, but still valid
+    "ddl",  # Equivalent to the legacy value enabled
+    "all",
+)
+
 
 class DocDBAuditLogs(BaseResourceCheck):
     def __init__(self):
         name = "Ensure DocDB has audit logs enabled"
         id = "CKV_AWS_104"
-        supported_resources = ['aws_docdb_cluster_parameter_group']
-        categories = [CheckCategories.LOGGING]
+        supported_resources = ('aws_docdb_cluster_parameter_group',)
+        categories = (CheckCategories.LOGGING,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
         self.evaluated_keys = ['parameter']
-        accepted_values = [
-            "enabled",  # Legacy value, but still valid
-            "ddl",  # Equivalent to the legacy value enabled
-            "all",
-        ]
+        
         if 'parameter' in conf:
             for idx, elem in enumerate(conf["parameter"]):
                 if isinstance(elem, dict) and elem["name"][0] == "audit_logs":
-                    if any([v for v in accepted_values if elem["value"][0] in v]):
+                    if elem["value"][0] in ACCEPTED_VALUES:
                         self.evaluated_keys = [f'parameter/[{idx}]/name', f'parameter/[{idx}]/value']
                         return CheckResult.PASSED
         return CheckResult.FAILED

--- a/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
+++ b/checkov/terraform/checks/resource/aws/DocDBAuditLogs.py
@@ -12,11 +12,17 @@ class DocDBAuditLogs(BaseResourceCheck):
 
     def scan_resource_conf(self, conf):
         self.evaluated_keys = ['parameter']
+        accepted_values = [
+            "enabled",  # Legacy value, but still valid
+            "ddl",  # Equivalent to the legacy value enabled
+            "all",
+        ]
         if 'parameter' in conf:
             for idx, elem in enumerate(conf["parameter"]):
-                if isinstance(elem, dict) and elem["name"][0] == "audit_logs" and elem["value"][0] == "enabled":
-                    self.evaluated_keys = [f'parameter/[{idx}]/name', f'parameter/[{idx}]/value']
-                    return CheckResult.PASSED
+                if isinstance(elem, dict) and elem["name"][0] == "audit_logs":
+                    if any([v for v in accepted_values if elem["value"][0] in v]):
+                        self.evaluated_keys = [f'parameter/[{idx}]/name', f'parameter/[{idx}]/value']
+                        return CheckResult.PASSED
         return CheckResult.FAILED
 
 

--- a/tests/terraform/checks/resource/aws/test_DocDBAuditLogs.py
+++ b/tests/terraform/checks/resource/aws/test_DocDBAuditLogs.py
@@ -42,21 +42,22 @@ class TestDocDBAuditLogs(unittest.TestCase):
         self.assertEqual(CheckResult.FAILED, scan_result)
 
     def test_success_with_parameters(self):
-        hcl_res = hcl2.loads("""
-                resource "aws_docdb_cluster_parameter_group" "test" {
-                  family      = "docdb3.6"
-                  name        = "test"
-                  description = "docdb cluster parameter group"
+        for accepted_value in ["enabled", "ddl", "all", "ddl, dml_write"]:
+            hcl_res = hcl2.loads(f"""
+                    resource "aws_docdb_cluster_parameter_group" "test" {{
+                      family      = "docdb3.6"
+                      name        = "test"
+                      description = "docdb cluster parameter group"
 
-                  parameter {
-                    name  = "audit_logs"
-                    value = "enabled"
-                  }
-                }
-        """)
-        resource_conf = hcl_res['resource'][0]['aws_docdb_cluster_parameter_group']['test']
-        scan_result = check.scan_resource_conf(conf=resource_conf)
-        self.assertEqual(CheckResult.PASSED, scan_result)
+                      parameter {{
+                        name  = "audit_logs"
+                        value = "{accepted_value}"
+                      }}
+                    }}
+            """)
+            resource_conf = hcl_res['resource'][0]['aws_docdb_cluster_parameter_group']['test']
+            scan_result = check.scan_resource_conf(conf=resource_conf)
+            self.assertEqual(CheckResult.PASSED, scan_result)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Based on the documentation, the value enabled for audit_logs is legacy and not recommended, https://docs.aws.amazon.com/documentdb/latest/developerguide/event-auditing.html#event-auditing-enabling-auditing. 

New valid values are : `ddl` and `all`, but can also accepted any combinaison like `ddl, dml_read`. The important is to activate the `ddl` audit logs.

Fixes # (issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
