### PR TITLE
docs(gha): Update setup-python version in GitHub Actions.md

### DIFF
--- a/docs/4.Integrations/GitHub Actions.md
+++ b/docs/4.Integrations/GitHub Actions.md
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Test with Checkov


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

We need to update the following action because not doing so will result on an error on certain architectures, see error below.

```
`Run actions/setup-python@v1
  with:
    python-version: 3.8
    architecture: x64
Error: Version 3.8 with arch x64 not found
Available versions: `

```
Version 4 of this action fixed the issue for me.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
