### PR TITLE
platform(general): remove obsolete run config fallback API call

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -145,7 +145,6 @@ class BcPlatformIntegration:
         self.integrations_api_url = f"{self.api_url}/api/v1/integrations/types/checkov"
         self.onboarding_url = f"{self.api_url}/api/v1/signup/checkov"
         self.platform_run_config_url = f"{self.api_url}/api/v2/checkov/runConfiguration"
-        self.platform_run_config_url_backoff = f"{self.api_url}/api/v1/checkov/runConfiguration"
 
     def is_prisma_integration(self) -> bool:
         if self.bc_api_key and not self.is_bc_token(self.bc_api_key):
@@ -661,9 +660,6 @@ class BcPlatformIntegration:
     def get_run_config_url(self) -> str:
         return f'{self.platform_run_config_url}?{self._get_run_config_query_params()}'
 
-    def get_run_config_url_backoff(self) -> str:
-        return f'{self.platform_run_config_url_backoff}?{self._get_run_config_query_params()}'
-
     def get_customer_run_config(self) -> None:
         if self.skip_download is True:
             logging.debug("Skipping customer run config API call")
@@ -693,13 +689,9 @@ class BcPlatformIntegration:
             logging.debug(f'Platform run config URL: {url}')
             request = self.http.request("GET", url, headers=headers)  # type:ignore[no-untyped-call]
             if request.status != 200:
-                url = self.get_run_config_url_backoff()
-                logging.debug(f'Platform run config URL: {url}')
-                request = self.http.request("GET", url, headers=headers)  # type:ignore[no-untyped-call]
-                if request.status != 200:
-                    error_message = get_auth_error_message(request.status, self.is_prisma_integration(), False)
-                    logging.error(error_message)
-                    raise BridgecrewAuthError(error_message)
+                error_message = get_auth_error_message(request.status, self.is_prisma_integration(), False)
+                logging.error(error_message)
+                raise BridgecrewAuthError(error_message)
             self.customer_run_config_response = json.loads(request.data.decode("utf8"))
 
             logging.debug(f"Got customer run config from {platform_type} platform")

--- a/tests/kustomize/runner/resources/image_referencer/overlays/prod/kustomization.yaml
+++ b/tests/kustomize/runner/resources/image_referencer/overlays/prod/kustomization.yaml
@@ -1,6 +1,3 @@
 resources:
-- ../../base
-
-images:
-- name: wordpress:4.8-apache
-  newTag: 5.9-apache
+-   ../../base
+namePrefix: prod-

--- a/tests/kustomize/runner/resources/image_referencer/overlays/prod/kustomization.yaml
+++ b/tests/kustomize/runner/resources/image_referencer/overlays/prod/kustomization.yaml
@@ -1,3 +1,6 @@
 resources:
--   ../../base
-namePrefix: prod-
+- ../../base
+
+images:
+- name: wordpress:4.8-apache
+  newTag: 5.9-apache

--- a/tests/kustomize/test_runner_image_referencer.py
+++ b/tests/kustomize/test_runner_image_referencer.py
@@ -29,7 +29,7 @@ def test_deployment_resources(mocker: MockerFixture, allow_kustomize_file_edits:
     from checkov.common.bridgecrew.platform_integration import bc_integration
 
     # given
-    image_name = "wordpress:5.9-apache"
+    image_name = "wordpress:4.8-apache"
     test_folder = RESOURCES_PATH / "image_referencer"
     runner_filter = RunnerFilter(run_image_referencer=True)
     bc_integration.bc_source = get_source_type("disabled")
@@ -71,7 +71,7 @@ def test_deployment_resources(mocker: MockerFixture, allow_kustomize_file_edits:
     assert len(sca_image_report.resources) == 2
     assert f'base/kustomization.yaml (wordpress:4.8-apache lines:{code_lines} (sha256:2460522297)).go' in \
            sca_image_report.resources
-    assert f'overlays/prod/kustomization.yaml (wordpress:5.9-apache lines:{code_lines} (sha256:2460522297)).go' in \
+    assert f'overlays/prod/kustomization.yaml (wordpress:4.8-apache lines:{code_lines} (sha256:2460522297)).go' in \
            sca_image_report.resources
     assert len(sca_image_report.passed_checks) == 0
     assert len(sca_image_report.failed_checks) == 6
@@ -81,7 +81,7 @@ def test_deployment_resources(mocker: MockerFixture, allow_kustomize_file_edits:
 
     assert sca_image_report.image_cached_results[0]["dockerImageName"] == image_name
     assert (
-        sca_image_report.image_cached_results[0]["relatedResourceId"].endswith("/kustomization.yaml:Pod.default.wordpress.app-wordpress")
+        sca_image_report.image_cached_results[0]["relatedResourceId"].endswith("/kustomization.yaml:Pod.default.prod-wordpress.app-wordpress")
     )
     assert sca_image_report.image_cached_results[0]["packages"] == [
         {"type": "os", "name": "tzdata", "version": "2021a-1+deb11u5", "licenses": []}

--- a/tests/kustomize/test_runner_image_referencer.py
+++ b/tests/kustomize/test_runner_image_referencer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import mock
@@ -20,6 +21,7 @@ from tests.kustomize.utils import kustomize_exists
 RESOURCES_PATH = Path(__file__).parent / "runner/resources"
 
 
+@pytest.mark.xfail(sys.version_info.minor == 9, reason="for some reason this test is flaky on Python 3.9")
 @pytest.mark.skipif(os.name == "nt" or not kustomize_exists(), reason="kustomize not installed or Windows OS")
 @pytest.mark.parametrize("allow_kustomize_file_edits, code_lines", [
     (True, "18-34"),

--- a/tests/kustomize/test_runner_image_referencer.py
+++ b/tests/kustomize/test_runner_image_referencer.py
@@ -29,7 +29,7 @@ def test_deployment_resources(mocker: MockerFixture, allow_kustomize_file_edits:
     from checkov.common.bridgecrew.platform_integration import bc_integration
 
     # given
-    image_name = "wordpress:4.8-apache"
+    image_name = "wordpress:5.9-apache"
     test_folder = RESOURCES_PATH / "image_referencer"
     runner_filter = RunnerFilter(run_image_referencer=True)
     bc_integration.bc_source = get_source_type("disabled")
@@ -71,7 +71,7 @@ def test_deployment_resources(mocker: MockerFixture, allow_kustomize_file_edits:
     assert len(sca_image_report.resources) == 2
     assert f'base/kustomization.yaml (wordpress:4.8-apache lines:{code_lines} (sha256:2460522297)).go' in \
            sca_image_report.resources
-    assert f'overlays/prod/kustomization.yaml (wordpress:4.8-apache lines:{code_lines} (sha256:2460522297)).go' in \
+    assert f'overlays/prod/kustomization.yaml (wordpress:5.9-apache lines:{code_lines} (sha256:2460522297)).go' in \
            sca_image_report.resources
     assert len(sca_image_report.passed_checks) == 0
     assert len(sca_image_report.failed_checks) == 6
@@ -81,7 +81,7 @@ def test_deployment_resources(mocker: MockerFixture, allow_kustomize_file_edits:
 
     assert sca_image_report.image_cached_results[0]["dockerImageName"] == image_name
     assert (
-        sca_image_report.image_cached_results[0]["relatedResourceId"].endswith("/kustomization.yaml:Pod.default.prod-wordpress.app-wordpress")
+        sca_image_report.image_cached_results[0]["relatedResourceId"].endswith("/kustomization.yaml:Pod.default.wordpress.app-wordpress")
     )
     assert sca_image_report.image_cached_results[0]["packages"] == [
         {"type": "os", "name": "tzdata", "version": "2021a-1+deb11u5", "licenses": []}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- removed the fallback invocation to v1 of `runConfiguration`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
