### PR TITLE
feat(terraform): Add __address__ field on vertices even if render_variables is set to False

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -87,14 +87,20 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
             logging.info(f"Rendering variables, graph has {len(self.vertices)} vertices and {len(self.edges)} edges")
             renderer = TerraformVariableRenderer(self)
             renderer.render_variables_from_local_graph()
-            self.update_vertices_breadcrumbs_and_module_connections()
-            self.update_nested_modules_address()
+            self.update_vertices_fields()
             if strtobool(os.getenv("CHECKOV_EXPERIMENTAL_CROSS_VARIABLE_EDGES", "True")):
                 # experimental flag on building cross variable edges for terraform graph
                 logging.info("Building cross variable edges")
                 edges_count = len(self.edges)
                 self._build_cross_variable_edges()
                 logging.info(f"Found {len(self.edges) - edges_count} cross variable edges")
+        else:
+            self.update_vertices_fields()
+
+    def update_vertices_fields(self) -> None:
+        # Important to keep those 2 functions together, as the first affects the calculation of the second
+        self._update_vertices_breadcrumbs_and_module_connections()
+        self._update_nested_modules_address()
 
     def _create_vertices(self) -> None:
         logging.info("Creating vertices")
@@ -559,7 +565,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
     def get_resources_types_in_graph(self) -> List[str]:
         return self.module.get_resources_types()
 
-    def update_vertices_breadcrumbs_and_module_connections(self) -> None:
+    def _update_vertices_breadcrumbs_and_module_connections(self) -> None:
         """
         The function processes each vertex's breadcrumbs:
         1. Get more data to each vertex in breadcrumb (name, path, hash and type)
@@ -617,8 +623,11 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
             self.abspath_cache[path] = dir_name
         return dir_name
 
-    def update_nested_modules_address(self) -> None:
+    def _update_nested_modules_address(self) -> None:
         for vertex in self.vertices:
+            if vertex.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS) is not None:
+                # Can happen for example in `tf_plan` files as the address already exists
+                continue
             if vertex.block_type not in parser_registry.context_parsers:
                 continue
             source_module = vertex.breadcrumbs.get(CustomAttributes.SOURCE_MODULE)

--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -12,7 +12,7 @@ from checkov.common.util.type_forcers import force_list
 from checkov.terraform.context_parsers.tf_plan import parse
 
 SIMPLE_TYPES = (str, int, float, bool)
-TF_PLAN_RESOURCE_ADDRESS = "__address__"
+TF_PLAN_RESOURCE_ADDRESS = CustomAttributes.TF_RESOURCE_ADDRESS
 TF_PLAN_RESOURCE_CHANGE_ACTIONS = "__change_actions__"
 TF_PLAN_RESOURCE_CHANGE_KEYS = "__change_keys__"
 


### PR DESCRIPTION

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixed a bug in which the `__address__` field was only calculated on terraform vertices if `render_variables` is set to True.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
