### PR TITLE
docs(terraform): make jq default

### DIFF
--- a/docs/7.Scan Examples/Terraform Plan Scanning.md
+++ b/docs/7.Scan Examples/Terraform Plan Scanning.md
@@ -15,19 +15,11 @@ Checkov supports the evaluation of policies on resources declared in `.tf` files
 ```json
 terraform init
 terraform plan --out tfplan.binary
-terraform show -json tfplan.binary > tfplan.json
+terraform show -json tfplan.binary | jq > tfplan.json
 
 checkov -f tfplan.json
 ```
 
-Note: The Terraform show output file `tf.json` will be a single line. For that reason Checkov will report all findings as line number 0.
-If you have installed jq, you can convert a JSON file into multiple lines making it easier to read the scan result.
-
-```json
-terraform show -json tfplan.binary | jq '.' > tfplan.json
-
-checkov -f tfplan.json
-```
 
 The output would look like:
 ```


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Make jq the default recommendation to help with secrets detection

## Checklist:

- [x] I have made corresponding changes to the documentation