### PR TITLE
fix(terraform): Fix for-each/count updating inner for each index for every child resource

### DIFF
--- a/checkov/terraform/graph_builder/foreach/module_handler.py
+++ b/checkov/terraform/graph_builder/foreach/module_handler.py
@@ -150,7 +150,7 @@ class ForeachModuleHandler(ForeachAbstractHandler):
                 # Important to copy to avoid changing the object by reference
                 child_source_module_object_copy = pickle_deepcopy(child.source_module_object)
                 if should_override_foreach_key and child_source_module_object_copy is not None:
-                    tf_module = child_source_module_object_copy
+                    tf_module: TFModule | None = child_source_module_object_copy
                     while tf_module is not None:
                         tf_module.foreach_idx = None
                         tf_module = tf_module.nested_tf_module

--- a/checkov/terraform/graph_builder/foreach/module_handler.py
+++ b/checkov/terraform/graph_builder/foreach/module_handler.py
@@ -150,7 +150,10 @@ class ForeachModuleHandler(ForeachAbstractHandler):
                 # Important to copy to avoid changing the object by reference
                 child_source_module_object_copy = pickle_deepcopy(child.source_module_object)
                 if should_override_foreach_key and child_source_module_object_copy is not None:
-                    child_source_module_object_copy.foreach_idx = None
+                    tf_module = child_source_module_object_copy
+                    while tf_module is not None:
+                        tf_module.foreach_idx = None
+                        tf_module = tf_module.nested_tf_module
 
                 child_module_key = TFModule(path=child.path, name=child.name,
                                             nested_tf_module=child_source_module_object_copy,


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

There was a bug that not all child vertices will be updated with the proper foreach index.
This PR fixes this issue by exhausting all nested module options for each child.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
