### PR TITLE
fix(kustomize): support kubectl 1.28+

### DIFF
--- a/checkov/kustomize/utils.py
+++ b/checkov/kustomize/utils.py
@@ -20,6 +20,29 @@ def get_kustomize_version(kustomize_command: str) -> str | None:
 
         return kustomize_version
     except Exception:
-        logging.debug(f"An error occured testing the {kustomize_command} command:", exc_info=True)
+        logging.debug(f"An error occurred testing the {kustomize_command} command:", exc_info=True)
+
+    return None
+
+
+def get_kubectl_version(kubectl_command: str) -> float | None:
+    try:
+        proc = subprocess.run([kubectl_command, "version", "--client=true"], capture_output=True)  # nosec
+        version_output = proc.stdout.decode("utf-8")
+
+        if "Client Version:" in version_output:
+            if "Major:" in version_output and "Minor:" in version_output:
+                # version <= 1.27 output looks like 'Client Version: version.Info{Major:"1", Minor:"27", GitVersion:...}\n...'
+                kubectl_version_major = version_output.split("\n")[0].split('Major:"')[1].split('"')[0]
+                kubectl_version_minor = version_output.split("\n")[0].split('Minor:"')[1].split('"')[0]
+            else:
+                # version >= 1.28 output looks like 'Client Version: v1.28.0\n...'
+                kubectl_version_str = version_output.split("\n")[0].replace("Client Version: v", "")
+                kubectl_version_major, kubectl_version_minor, *_ = kubectl_version_str.split(".")
+            kubectl_version = float(f"{kubectl_version_major}.{kubectl_version_minor}")
+
+            return kubectl_version
+    except Exception:
+        logging.debug(f"An error occurred testing the {kubectl_command} command:", exc_info=True)
 
     return None

--- a/tests/kustomize/test_utils.py
+++ b/tests/kustomize/test_utils.py
@@ -2,7 +2,49 @@ from unittest.mock import MagicMock
 
 from pytest_mock import MockerFixture
 
-from checkov.kustomize.utils import get_kustomize_version
+from checkov.kustomize.utils import get_kustomize_version, get_kubectl_version
+
+
+def test_get_kubectl_version_v1_27(mocker: MockerFixture):
+    # given
+    subprocess_mock = MagicMock()
+    subprocess_mock.stdout = b'Client Version: version.Info{Major:"1", Minor:"27", GitVersion:"v1.27.2", GitCommit:"7f6f68fdabc4df88cfea2dcf9a19b2b830f1e647", GitTreeState:"clean", BuildDate:"2023-05-17T14:20:07Z", GoVersion:"go1.20.4", Compiler:"gc", Platform:"darwin/amd64"}\nKustomize Version: v5.0.1\n'
+
+    mocker.patch("checkov.kustomize.utils.subprocess.run", return_value=subprocess_mock)
+
+    # when
+    version = get_kubectl_version(kubectl_command="kubectl")
+
+    # then
+    assert version == 1.27
+
+
+def test_get_kubectl_version_v1_28(mocker: MockerFixture):
+    # given
+    subprocess_mock = MagicMock()
+    subprocess_mock.stdout = b"Client Version: v1.28.0\nKustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3\n"
+
+    mocker.patch("checkov.kustomize.utils.subprocess.run", return_value=subprocess_mock)
+
+    # when
+    version = get_kubectl_version(kubectl_command="kubectl")
+
+    # then
+    assert version == 1.28
+
+
+def test_get_kubectl_version_none(mocker: MockerFixture):
+    # given
+    subprocess_mock = MagicMock()
+    subprocess_mock.stdout = b"command not found: kubectl\n"
+
+    mocker.patch("checkov.kustomize.utils.subprocess.run", return_value=subprocess_mock)
+
+    # when
+    version = get_kubectl_version(kubectl_command="kubectl")
+
+    # then
+    assert version is None
 
 
 def test_get_kustomize_version_v4(mocker: MockerFixture):


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- looks like the output of the new kubectl v1.28.0 looks a bit different. Reminds me of the time I had to fix something similar for `kustomize` 😅 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
