### PR TITLE
feat(secrets): fix resource in git history scan

### DIFF
--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -286,7 +286,7 @@ class Runner(BaseRunner[None, None, None]):
                     code_block=[(secret.line_number, line_text_censored)],
                     file_path=relative_file_path,
                     file_line_range=[secret.line_number, secret.line_number + 1],
-                    resource=secret.secret_hash,
+                    resource=f'{added_commit_hash}:{secret.secret_hash}' if added_commit_hash else secret.secret_hash,
                     check_class="",
                     evaluations=None,
                     file_abs_path=os.path.abspath(secret.filename),

--- a/tests/secrets/test_secret_git_history.py
+++ b/tests/secrets/test_secret_git_history.py
@@ -309,11 +309,11 @@ def test_scan_git_history_multiline_keyword_terraform() -> None:
                         runner_filter=RunnerFilter(framework=['secrets'], enable_git_history_secret_scan=True))
     #  then
     failing_resources = {
-        "dcbf46de362e1b6942054b89ee293984e9a8a40a",
-        "ac236b0474a9a702f99dbe244a14548783ace5c5",
-        "9ed4f1457a9c27dd868c1f21276c6d7098d2bacf",
-        "06af723e58378574456be0b4c41a89194aaed0c3",
-        "5db2fafebcfed9b4c9ffc570c46ef2ca94a3881a",
+        "6bee3eb2f69e06095395ae1d54c810c3a2a99841:9ed4f1457a9c27dd868c1f21276c6d7098d2bacf",
+        "6bee3eb2f69e06095395ae1d54c810c3a2a99841:5db2fafebcfed9b4c9ffc570c46ef2ca94a3881a",
+        "6bee3eb2f69e06095395ae1d54c810c3a2a99841:ac236b0474a9a702f99dbe244a14548783ace5c5",
+        "6bee3eb2f69e06095395ae1d54c810c3a2a99841:06af723e58378574456be0b4c41a89194aaed0c3",
+        "6bee3eb2f69e06095395ae1d54c810c3a2a99841:dcbf46de362e1b6942054b89ee293984e9a8a40a",
     }
 
     failed_check_resources = {c.resource for c in report.failed_checks}


### PR DESCRIPTION
This PR fixes resource for git history scan by concating commit hash with resource_id.
This is needed since for git history that is the definition of violation resouce.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
