### PR TITLE
fix(terraform): extend CKV2_AWS_5 to include aws_appstream_fleet (#5487)

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/SGAttachedToResource.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/SGAttachedToResource.yaml
@@ -14,6 +14,7 @@ definition:
       connected_resource_types:
         - aws_alb
         - aws_apprunner_vpc_connector
+        - aws_appstream_fleet
         - aws_batch_compute_environment
         - aws_cloudwatch_event_target
         - aws_codebuild_project
@@ -55,6 +56,6 @@ definition:
         - aws_transfer_server
         - aws_vpc_endpoint
         - aws_vpclattice_service_network_vpc_association
-      operator:  exists
+      operator: exists
       attribute: networking
       cond_type: connection

--- a/tests/terraform/graph/checks/resources/SGAttachedToResource/expected.yaml
+++ b/tests/terraform/graph/checks/resources/SGAttachedToResource/expected.yaml
@@ -1,6 +1,7 @@
 pass:
   - "aws_security_group.pass_alb"
   - "aws_security_group.pass_app_runner"
+  - "aws_security_group.pass_appstream_fleet"
   - "aws_security_group.pass_batch"
   - "aws_security_group.pass_cloudwatch_event"
   - "aws_security_group.pass_codebuild"

--- a/tests/terraform/graph/checks/resources/SGAttachedToResource/main.tf
+++ b/tests/terraform/graph/checks/resources/SGAttachedToResource/main.tf
@@ -18,6 +18,29 @@ resource "aws_apprunner_vpc_connector" "pass_app_runner" {
   security_groups    = [aws_security_group.pass_app_runner.id]
 }
 
+# App Stream Fleet
+
+resource "aws_security_group" "pass_appstream_fleet" {
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_appstream_fleet" "pass_appstream_fleet" {
+  name          = "name"
+  instance_type = "stream.standard.large"
+  compute_capacity {
+    desired_instances = 1
+  }
+  vpc_config {
+    security_groups_ids = [aws_security_group.pass_appstream_fleet.id]
+  }
+}
+
 # Batch
 
 resource "aws_security_group" "pass_batch" {
@@ -674,7 +697,7 @@ resource "aws_quicksight_vpc_connection" "pass_quicksight" {
   name               = "Example Connection"
   role_arn           = "aws_iam_role.vpc_connection_role.arn"
   security_group_ids = [aws_security_group.pass_quicksight.id]
-  subnet_ids = ["subnet-00000000000000000"]
+  subnet_ids         = ["subnet-00000000000000000"]
 }
 
 # RDS


### PR DESCRIPTION
* Add aws_appstream_fleet as connected resource for CKV2_AWS_5

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Include `aws_appstream_fleet` as a connected resources for `aws_security_group` for graph check CKV2_AWS_5

Fixes #5487 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
