### PR TITLE
fix(terraform): continue processing of TF modules in the same file

### DIFF
--- a/checkov/terraform/tf_parser.py
+++ b/checkov/terraform/tf_parser.py
@@ -241,10 +241,15 @@ class TFParser:
                         resolved_loc_list = self.module_to_resolved[current_nested_data]
                     self.module_to_resolved[current_nested_data] = resolved_loc_list
 
-                    specified_vars = {k: v[0] if isinstance(v, list) and v else v for k, v in module_call_data.items()
-                                      if k != "source" and k != "version"}
-                    skipped_a_module = self.should_skip_a_module(specified_vars, ignore_unresolved_params)
-                    if skipped_a_module:
+                    specified_vars = {
+                        k: v[0] if isinstance(v, list) and v else v
+                        for k, v in module_call_data.items()
+                        if k != "source" and k != "version"
+                    }
+                    skip_module = self.should_skip_a_module(specified_vars, ignore_unresolved_params)
+                    if skip_module:
+                        # keep module skip info till the end
+                        skipped_a_module = True
                         continue
 
                     version = self.get_module_version(module_call_data)

--- a/tests/terraform/parser/resources/parse_backtrack_module/example/main.tf
+++ b/tests/terraform/parser/resources/parse_backtrack_module/example/main.tf
@@ -1,0 +1,12 @@
+module "bucket_local" {
+  source = "../"
+
+  bucket_name = var.name
+}
+
+# the remote module needs to be at the end to properly test the issue
+module "bucket_remote" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  bucket = "remote"
+}

--- a/tests/terraform/parser/resources/parse_backtrack_module/main.tf
+++ b/tests/terraform/parser/resources/parse_backtrack_module/main.tf
@@ -1,0 +1,7 @@
+variable "bucket_name" {
+  type = string
+}
+
+resource "aws_s3_bucket" "root" {
+  bucket = var.bucket_name
+}

--- a/tests/terraform/parser/test_new_parser_modules.py
+++ b/tests/terraform/parser/test_new_parser_modules.py
@@ -202,3 +202,18 @@ class TestParserInternals(unittest.TestCase):
         directory = os.path.join(self.resources_dir, "parser_tfvars")
         module, tf_definitions = parser.parse_hcl_module(source_dir=directory, source='terraform')
         assert module
+
+    def test_backtrack_module(self):
+        # given
+        directory = os.path.join(self.resources_dir, "parse_backtrack_module/example")
+
+        # when
+        module, tf_definitions = TFParser().parse_hcl_module(
+            source_dir=directory,
+            source="terraform",
+            download_external_modules=False,  # important to keep it 'False'
+        )
+
+        # then
+        assert module
+        assert len(tf_definitions) == 2  # need to be 2 files (the module reference and the actual module content)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- fixed an issue with TF module processing in the same file, if the last module indicates no further needed processing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
