### PR TITLE
fix(terraform_json): correctly parse data blocks in Terraform JSON

### DIFF
--- a/checkov/terraform_json/parser.py
+++ b/checkov/terraform_json/parser.py
@@ -94,8 +94,8 @@ def prepare_definition(definition: dict[str, Any]) -> dict[str, Any]:
             if block_name == COMMENT_FIELD_NAME or block_name in LINE_FIELD_NAMES:
                 continue
 
-            if block_type == BlockType.RESOURCE:
-                # resource have an extra nested level resource_type -> resource_name -> resource_config
+            if block_type in (BlockType.RESOURCE, BlockType.DATA):
+                # data/resource have an extra nested level resource_type -> resource_name -> resource_config
                 for resource_name, resource_config in config.items():
                     if resource_name in IGNORE_FILED_NAMES:
                         continue

--- a/checkov/terraform_json/runner.py
+++ b/checkov/terraform_json/runner.py
@@ -48,7 +48,7 @@ class TerraformJsonRunner(TerraformRunner):
             external_registries=external_registries,
             source=source,
         )
-        self.file_extensions = TF_JSON_POSSIBLE_FILE_ENDINGS  # override what gets set from the TF runner
+        self.file_extensions = (".json",)  # just '.json' not 'tf.json' otherwise it will be filtered out
         self.graph_registry = get_graph_checks_registry(super().check_type)
 
         self.definitions: dict[str, dict[str, Any]] = {}  # type:ignore[assignment]  # need to check, how to support subclass differences

--- a/checkov/terraform_json/runner.py
+++ b/checkov/terraform_json/runner.py
@@ -19,7 +19,7 @@ from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.registry import resource_registry
 from checkov.terraform.graph_builder.local_graph import TerraformLocalGraph
 from checkov.terraform.runner import Runner as TerraformRunner
-from checkov.terraform_json.utils import get_scannable_file_paths, TF_JSON_POSSIBLE_FILE_ENDINGS, create_definitions
+from checkov.terraform_json.utils import get_scannable_file_paths, create_definitions
 
 if TYPE_CHECKING:
     from checkov.common.graph.checks_infra.registry import BaseRegistry

--- a/tests/terraform_json/examples/cdk.tf.json
+++ b/tests/terraform_json/examples/cdk.tf.json
@@ -16,6 +16,18 @@
       }
     }
   },
+  "data": {
+    "aws_caller_identity": {
+      "current": {
+        "//": {
+          "metadata": {
+            "path": "AppStack/current",
+            "uniqueId": "current"
+          }
+        }
+      }
+    }
+  },
   "output": {
     "bucket_arn": {
       "value": "${aws_s3_bucket.bucket.arn}"

--- a/tests/terraform_json/test_graph_manager.py
+++ b/tests/terraform_json/test_graph_manager.py
@@ -33,7 +33,7 @@ def test_build_graph_from_definitions(graph_connector):
     )
 
     # then
-    assert len(local_graph.vertices) == 5
+    assert len(local_graph.vertices) == 6
 
     bucket_idx = local_graph.vertices_block_name_map["resource"]["aws_s3_bucket.bucket"][0]
     bucket = local_graph.vertices[bucket_idx]
@@ -42,8 +42,8 @@ def test_build_graph_from_definitions(graph_connector):
     assert bucket.id == "aws_s3_bucket.bucket"
     assert bucket.source == "Terraform"
     assert bucket.attributes[CustomAttributes.RESOURCE_TYPE] == ["aws_s3_bucket"]
-    assert bucket.attributes[START_LINE] == 34
-    assert bucket.attributes[END_LINE] == 53
+    assert bucket.attributes[START_LINE] == 46
+    assert bucket.attributes[END_LINE] == 65
     assert bucket.config == {
         "aws_s3_bucket": {
             "bucket": {
@@ -53,32 +53,25 @@ def test_build_graph_from_definitions(graph_connector):
                             {
                                 "comment": "Access logging not needed",
                                 "id": "CKV_AWS_18",
-                                "__startline__": 38,
-                                "__endline__": 41,
+                                "__startline__": 50,
+                                "__endline__": 53,
                             }
                         ],
-                        "__startline__": 36,
-                        "__endline__": 43,
+                        "__startline__": 48,
+                        "__endline__": 55,
                     },
                     "metadata": {
                         "path": "AppStack/bucket",
                         "uniqueId": "bucket",
-                        "__startline__": 44,
-                        "__endline__": 47,
+                        "__startline__": 56,
+                        "__endline__": 59,
                     },
-                    "__startline__": 35,
-                    "__endline__": 48,
+                    "__startline__": 47,
+                    "__endline__": 60,
                 },
-                "tags": [
-                    {
-                        "Name": "example",
-                        "Private": "true",
-                        "__startline__": 49,
-                        "__endline__": 52,
-                    }
-                ],
-                "__startline__": 34,
-                "__endline__": 53,
+                "tags": [{"Name": "example", "Private": "true", "__startline__": 61, "__endline__": 64}],
+                "__startline__": 46,
+                "__endline__": 65,
                 "__address__": "aws_s3_bucket.bucket",
             }
         }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- correctly handles data blocks in TF JSON files
- fix issue with single file scans of TF JSON files

Fixes #5498 
Fixes #5504

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
