### PR TITLE
feat(terraform): add public network checks for Azure Function and Web Apps

### DIFF
--- a/checkov/terraform/checks/resource/azure/AppServicePublicAccessDisabled.py
+++ b/checkov/terraform/checks/resource/azure/AppServicePublicAccessDisabled.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class AppServicePublicAccessDisabled(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that Azure Web App public network access is disabled"
+        id = "CKV_AZURE_222"
+        supported_resources = ("azurerm_linux_web_app", "azurerm_windows_web_app")
+        categories = (CheckCategories.NETWORKING,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "public_network_access_enabled"
+
+    def get_expected_value(self) -> Any:
+        return False
+
+
+check = AppServicePublicAccessDisabled()

--- a/checkov/terraform/checks/resource/azure/DataLakeStoreEncryption.py
+++ b/checkov/terraform/checks/resource/azure/DataLakeStoreEncryption.py
@@ -6,8 +6,8 @@ class DataLakeStoreEncryption(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure that Data Lake Store accounts enables encryption"
         id = "CKV_AZURE_105"
-        supported_resources = ['azurerm_data_lake_store']
-        categories = [CheckCategories.IAM]
+        supported_resources = ('azurerm_data_lake_store',)
+        categories = (CheckCategories.ENCRYPTION,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources, missing_block_result=CheckResult.PASSED)
 
     def get_inspected_key(self):

--- a/checkov/terraform/checks/resource/azure/FunctionAppPublicAccessDisabled.py
+++ b/checkov/terraform/checks/resource/azure/FunctionAppPublicAccessDisabled.py
@@ -7,7 +7,7 @@ from checkov.terraform.checks.resource.base_resource_value_check import BaseReso
 class FunctionAppPublicAccessDisabled(BaseResourceValueCheck):
     def __init__(self) -> None:
         name = "Ensure that Azure Function App public network access is disabled"
-        id = "CKV_AZURE_223"
+        id = "CKV_AZURE_221"
         supported_resources = (
             "azurerm_linux_function_app",
             "azurerm_linux_function_app_slot",

--- a/checkov/terraform/checks/resource/azure/FunctionAppPublicAccessDisabled.py
+++ b/checkov/terraform/checks/resource/azure/FunctionAppPublicAccessDisabled.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class FunctionAppPublicAccessDisabled(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that Azure Function App public network access is disabled"
+        id = "CKV_AZURE_223"
+        supported_resources = (
+            "azurerm_linux_function_app",
+            "azurerm_linux_function_app_slot",
+            "azurerm_windows_function_app",
+            "azurerm_windows_function_app_slot",
+        )
+        categories = (CheckCategories.NETWORKING,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "public_network_access_enabled"
+
+    def get_expected_value(self) -> Any:
+        return False
+
+
+check = FunctionAppPublicAccessDisabled()

--- a/checkov/terraform/checks/resource/azure/RedisCachePublicNetworkAccessEnabled.py
+++ b/checkov/terraform/checks/resource/azure/RedisCachePublicNetworkAccessEnabled.py
@@ -6,8 +6,8 @@ class RedisCachePublicNetworkAccessEnabled(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure that Azure Cache for Redis disables public network access"
         id = "CKV_AZURE_89"
-        supported_resources = ['azurerm_redis_cache']
-        categories = [CheckCategories.IAM]
+        supported_resources = ('azurerm_redis_cache',)
+        categories = (CheckCategories.NETWORKING,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):

--- a/tests/terraform/checks/resource/azure/example_AppServicePublicAccessDisabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AppServicePublicAccessDisabled/main.tf
@@ -1,0 +1,53 @@
+# pass
+
+resource "azurerm_linux_web_app" "disabled" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+
+  public_network_access_enabled = false
+}
+
+resource "azurerm_windows_web_app" "disabled" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+
+  public_network_access_enabled = false
+}
+
+# fail
+
+resource "azurerm_linux_web_app" "default" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+}
+
+resource "azurerm_windows_web_app" "default" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+}
+
+resource "azurerm_linux_web_app" "enabled" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+
+  public_network_access_enabled = true
+}
+
+resource "azurerm_windows_web_app" "enabled" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+
+  public_network_access_enabled = true
+}

--- a/tests/terraform/checks/resource/azure/example_FunctionAppPublicAccessDisabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_FunctionAppPublicAccessDisabled/main.tf
@@ -1,0 +1,109 @@
+# pass
+
+resource "azurerm_linux_function_app" "disabled" {
+  name                       = "example-linux-function-app"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+
+  public_network_access_enabled = false
+}
+
+resource "azurerm_linux_function_app_slot" "disabled" {
+  name                 = "example-linux-function-app-slot"
+  function_app_id      = azurerm_linux_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  public_network_access_enabled = false
+}
+
+resource "azurerm_windows_function_app" "disabled" {
+  name                       = "example-windows-function-app"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+
+  public_network_access_enabled = false
+}
+
+resource "azurerm_windows_function_app_slot" "disabled" {
+  name                 = "example-slot"
+  function_app_id      = azurerm_windows_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  public_network_access_enabled = false
+}
+
+# fail
+
+resource "azurerm_linux_function_app" "default" {
+  name                       = "example-linux-function-app"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+}
+
+resource "azurerm_linux_function_app_slot" "default" {
+  name                 = "example-linux-function-app-slot"
+  function_app_id      = azurerm_linux_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+}
+
+resource "azurerm_windows_function_app" "default" {
+  name                       = "example-windows-function-app"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+}
+
+resource "azurerm_windows_function_app_slot" "default" {
+  name                 = "example-slot"
+  function_app_id      = azurerm_windows_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+}
+
+resource "azurerm_linux_function_app" "enabled" {
+  name                       = "example-linux-function-app"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+
+  public_network_access_enabled = true
+}
+
+resource "azurerm_linux_function_app_slot" "enabled" {
+  name                 = "example-linux-function-app-slot"
+  function_app_id      = azurerm_linux_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  public_network_access_enabled = true
+}
+
+resource "azurerm_windows_function_app" "enabled" {
+  name                       = "example-windows-function-app"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+
+  public_network_access_enabled = true
+}
+
+resource "azurerm_windows_function_app_slot" "enabled" {
+  name                 = "example-slot"
+  function_app_id      = azurerm_windows_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  public_network_access_enabled = true
+}

--- a/tests/terraform/checks/resource/azure/test_AppServicePublicAccessDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_AppServicePublicAccessDisabled.py
@@ -1,0 +1,45 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.azure.AppServicePublicAccessDisabled import check
+from checkov.terraform.runner import Runner
+
+
+class TestAppServicePublicAccessDisabled(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_AppServicePublicAccessDisabled"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "azurerm_linux_web_app.disabled",
+            "azurerm_windows_web_app.disabled",
+        }
+
+        failing_resources = {
+            "azurerm_linux_web_app.default",
+            "azurerm_windows_web_app.default",
+            "azurerm_linux_web_app.enabled",
+            "azurerm_windows_web_app.enabled",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/azure/test_FunctionAppPublicAccessDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_FunctionAppPublicAccessDisabled.py
@@ -1,0 +1,51 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.azure.FunctionAppPublicAccessDisabled import check
+from checkov.terraform.runner import Runner
+
+
+class TestFunctionAppPublicAccessDisabled(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_FunctionAppPublicAccessDisabled"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "azurerm_linux_function_app.disabled",
+            "azurerm_linux_function_app_slot.disabled",
+            "azurerm_windows_function_app.disabled",
+            "azurerm_windows_function_app_slot.disabled",
+        }
+
+        failing_resources = {
+            "azurerm_linux_function_app.default",
+            "azurerm_linux_function_app_slot.default",
+            "azurerm_windows_function_app.default",
+            "azurerm_windows_function_app_slot.default",
+            "azurerm_linux_function_app.enabled",
+            "azurerm_linux_function_app_slot.enabled",
+            "azurerm_windows_function_app.enabled",
+            "azurerm_windows_function_app_slot.enabled",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/image_referencer/test_runner_azure_resources.py
+++ b/tests/terraform/image_referencer/test_runner_azure_resources.py
@@ -134,7 +134,7 @@ def test_app_service_linux_function_resources(mocker: MockerFixture, graph_frame
 
     assert len(tf_report.resources) == 2
     assert len(tf_report.passed_checks) == 0
-    assert len(tf_report.failed_checks) == 0
+    assert len(tf_report.failed_checks) == 2
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0
 
@@ -181,7 +181,7 @@ def test_app_service_linux_web_resources(mocker: MockerFixture, graph_framework)
 
     assert len(tf_report.resources) == 2
     assert len(tf_report.passed_checks) == 4
-    assert len(tf_report.failed_checks) == 12
+    assert len(tf_report.failed_checks) == 13
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0
 
@@ -270,7 +270,7 @@ def test_app_service_windows_web_resources(mocker: MockerFixture, graph_framewor
 
     assert len(tf_report.resources) == 2
     assert len(tf_report.passed_checks) == 4
-    assert len(tf_report.failed_checks) == 12
+    assert len(tf_report.failed_checks) == 13
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added 2 new checks, which look for `public_network_access_enabled` in Azure Function and Web App resources

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
