### PR TITLE
feat(terraform): Ensure that the SQL database is zone-redundant

### DIFF
--- a/checkov/terraform/checks/resource/azure/SQLDatabaseZoneRedundant.py
+++ b/checkov/terraform/checks/resource/azure/SQLDatabaseZoneRedundant.py
@@ -8,17 +8,27 @@ class SQLDatabaseZoneRedundant(BaseResourceValueCheck):
     def __init__(self) -> None:
         """
         This is a best practise which helps to:
-        - Improved High Availability: Zone redundancy ensures that your database is replicated across Availability Zones within an Azure region. If one Availability Zone experiences an outage, your database continues to operate from the other zones, minimizing downtime.
-        - Reduced Maintenance Downtime: Zone-redundant configurations often require less planned maintenance downtime because updates and patches can be applied to one zone at a time while the other zones continue to serve traffic.
-        - Improved Scalability: Zone-redundant configurations are designed to scale with your workload. You can take advantage of features like Hyperscale to dynamically adjust resources based on your database's performance needs.
-        - Improved SLA: Azure SQL Database zone-redundant configurations typically offer a higher service-level agreement (SLA) for availability compared to non-zone-redundant configurations.
-        
+        - Improved High Availability: Zone redundancy ensures that your database is replicated
+          across Availability Zones within an Azure region. If one Availability Zone experiences an outage,
+          your database continues to operate from the other zones, minimizing downtime.
+        - Reduced Maintenance Downtime: Zone-redundant configurations often require
+          less planned maintenance downtime because updates and patches can be applied to
+          one zone at a time while the other zones continue to serve traffic.
+        - Improved Scalability: Zone-redundant configurations are designed to scale with your workload.
+          You can take advantage of features like Hyperscale to dynamically adjust resources based on
+          your database's performance needs.
+        - Improved SLA: Azure SQL Database zone-redundant configurations typically offer
+          a higher service-level agreement (SLA) for availability compared to non-zone-redundant configurations.
+
         However, it's critical to note that:
         Note that:
-        - Zone-redundant availability is available to databases in the General Purpose, Premium, Business Critical and Hyperscale service tiers of the vCore purchasing model, and not the Basic and Standard service tiers of the DTU-based purchasing model.
+        - Zone-redundant availability is available to databases in the
+          General Purpose, Premium, Business Critical and Hyperscale service tiers of the vCore purchasing model,
+          and not the Basic and Standard service tiers of the DTU-based purchasing model.
         - This may not be required for:
            - Databases that supports applications which doesn't a high maturity in terms of "High Availability"
-           - Databases that are very sensitive to network latency that may increase the transaction commit time, and thus impact the performance of some OLTP workloads.
+           - Databases that are very sensitive to network latency that may increase the transaction commit time,
+             and thus impact the performance of some OLTP workloads.
         """
         name = "Ensure the Azure SQL Database Namespace is zone redundant"
         id = "CKV_AZURE_223"

--- a/checkov/terraform/checks/resource/azure/SQLDatabaseZoneRedundant.py
+++ b/checkov/terraform/checks/resource/azure/SQLDatabaseZoneRedundant.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class SQLDatabaseZoneRedundant(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        """
+        This is a best practise which helps to:
+        - Improved High Availability: Zone redundancy ensures that your database is replicated across Availability Zones within an Azure region. If one Availability Zone experiences an outage, your database continues to operate from the other zones, minimizing downtime.
+        - Reduced Maintenance Downtime: Zone-redundant configurations often require less planned maintenance downtime because updates and patches can be applied to one zone at a time while the other zones continue to serve traffic.
+        - Improved Scalability: Zone-redundant configurations are designed to scale with your workload. You can take advantage of features like Hyperscale to dynamically adjust resources based on your database's performance needs.
+        - Improved SLA: Azure SQL Database zone-redundant configurations typically offer a higher service-level agreement (SLA) for availability compared to non-zone-redundant configurations.
+        
+        However, it's critical to note that:
+        Note that:
+        - Zone-redundant availability is available to databases in the General Purpose, Premium, Business Critical and Hyperscale service tiers of the vCore purchasing model, and not the Basic and Standard service tiers of the DTU-based purchasing model.
+        - This may not be required for:
+           - Databases that supports applications which doesn't a high maturity in terms of "High Availability"
+           - Databases that are very sensitive to network latency that may increase the transaction commit time, and thus impact the performance of some OLTP workloads.
+        """
+        name = "Ensure the Azure SQL Database Namespace is zone redundant"
+        id = "CKV_AZURE_223"
+        supported_resources = ("azurerm_mssql_database",)
+        categories = (CheckCategories.BACKUP_AND_RECOVERY,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "zone_redundant"
+
+
+check = SQLDatabaseZoneRedundant()

--- a/checkov/terraform/checks/resource/azure/SQLDatabaseZoneRedundant.py
+++ b/checkov/terraform/checks/resource/azure/SQLDatabaseZoneRedundant.py
@@ -31,7 +31,7 @@ class SQLDatabaseZoneRedundant(BaseResourceValueCheck):
              and thus impact the performance of some OLTP workloads.
         """
         name = "Ensure the Azure SQL Database Namespace is zone redundant"
-        id = "CKV_AZURE_223"
+        id = "CKV_AZURE_229"
         supported_resources = ("azurerm_mssql_database",)
         categories = (CheckCategories.BACKUP_AND_RECOVERY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/tests/terraform/checks/resource/azure/example_SQLDatabaseZoneRedundant/main.tf
+++ b/tests/terraform/checks/resource/azure/example_SQLDatabaseZoneRedundant/main.tf
@@ -1,0 +1,44 @@
+resource "azurerm_mssql_database" "pass" {
+  name           = "example-database"
+  server_id      = azurerm_mssql_server.example.id
+  collation      = "SQL_Latin1_General_CP1_CI_AS"
+  license_type   = "LicenseIncluded"
+  max_size_gb    = 4
+  read_scale     = true
+  sku_name       = "S0"
+  zone_redundant = true
+
+  tags = {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_mssql_database" "fail2" {
+    name           = "example-database"
+    server_id      = azurerm_mssql_server.example.id
+    collation      = "SQL_Latin1_General_CP1_CI_AS"
+    license_type   = "LicenseIncluded"
+    max_size_gb    = 4
+    read_scale     = true
+    sku_name       = "S0"
+    zone_redundant = false
+
+    tags = {
+        environment = "Production"
+    }
+}
+
+resource "azurerm_mssql_database" "fail" {
+    name           = "example-database"
+    server_id      = azurerm_mssql_server.example.id
+    collation      = "SQL_Latin1_General_CP1_CI_AS"
+    license_type   = "LicenseIncluded"
+    max_size_gb    = 4
+    read_scale     = true
+    sku_name       = "S0"
+
+    tags = {
+        environment = "Production"
+    }
+
+}

--- a/tests/terraform/checks/resource/azure/test_SQLDatabaseZoneRedundant.py
+++ b/tests/terraform/checks/resource/azure/test_SQLDatabaseZoneRedundant.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.SQLDatabaseZoneRedundant import check
+
+
+class TestSQLDatabaseZoneRedundant (unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_SQLDatabaseZoneRedundant ")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_mssql_database.pass',
+        }
+        failing_resources = {
+            'azurerm_mssql_database.fail',
+            'azurerm_mssql_database.fail2',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/azure/test_SQLDatabaseZoneRedundant.py
+++ b/tests/terraform/checks/resource/azure/test_SQLDatabaseZoneRedundant.py
@@ -12,7 +12,7 @@ class TestSQLDatabaseZoneRedundant (unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = os.path.join(current_dir, "example_SQLDatabaseZoneRedundant ")
+        test_files_dir = os.path.join(current_dir, "example_SQLDatabaseZoneRedundant")
         report = runner.run(root_folder=test_files_dir,
                             runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixes #5537

## New/Edited policies (Delete if not relevant)

### Description

Having SQL Database zone-redundant comes with the following advantages:

- High Availability: Zone redundancy ensures that your database is replicated across Availability Zones within an Azure region. If one Availability Zone experiences an outage, your database continues to operate from the other zones, minimizing downtime.
- Reduced Maintenance Downtime: Zone-redundant configurations often require less planned maintenance downtime because updates and patches can be applied to one zone at a time while the other zones continue to serve traffic.
- Scalability: Zone-redundant configurations are designed to scale with your workload. You can take advantage of features like Hyperscale to dynamically adjust resources based on your database's performance needs.
- Improved SLA: Azure SQL Database zone-redundant configurations typically offer a higher service-level agreement (SLA) for availability compared to non-zone-redundant configurations.

Note that:

- Zone-redundant availability is available to databases in the General Purpose, Premium, Business Critical and Hyperscale service tiers of the vCore purchasing model, and not the Basic and Standard service tiers of the DTU-based purchasing model.
- This may not be required for:
  - Databases that supports applications which doesn't a high maturity in terms of "High Availability"
  - Databases that are very sensitive to network latency that may increase the transaction commit time, and thus impact the performance of some OLTP workloads.

### Fix

Set the 'zone_redundant' to 'True'

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
