### PR TITLE
fix(terraform): Nested source_module_objects with missing foreach key

### DIFF
--- a/checkov/terraform/graph_builder/foreach/abstract_handler.py
+++ b/checkov/terraform/graph_builder/foreach/abstract_handler.py
@@ -82,7 +82,7 @@ class ForeachAbstractHandler:
             original_foreach_or_count_key, original_module_key, nested_module)
         return TFModule(name=tf_moudle.name, path=tf_moudle.path,
                         nested_tf_module=updated_module,
-                        foreach_idx=tf_moudle.foreach_idx)
+                        foreach_idx=original_foreach_or_count_key)
 
     @staticmethod
     def _pop_foreach_attrs(attrs: dict[str, Any]) -> None:

--- a/checkov/terraform/graph_builder/foreach/abstract_handler.py
+++ b/checkov/terraform/graph_builder/foreach/abstract_handler.py
@@ -82,7 +82,7 @@ class ForeachAbstractHandler:
             original_foreach_or_count_key, original_module_key, nested_module)
         return TFModule(name=tf_moudle.name, path=tf_moudle.path,
                         nested_tf_module=updated_module,
-                        foreach_idx=original_foreach_or_count_key)
+                        foreach_idx=tf_moudle.foreach_idx)
 
     @staticmethod
     def _pop_foreach_attrs(attrs: dict[str, Any]) -> None:

--- a/checkov/terraform/graph_builder/foreach/abstract_handler.py
+++ b/checkov/terraform/graph_builder/foreach/abstract_handler.py
@@ -68,15 +68,21 @@ class ForeachAbstractHandler:
         return sub_graph
 
     @staticmethod
-    def _update_nested_tf_module_foreach_idx(original_foreach_or_count_key: int | str, original_module_key: TFModule,
-                                             tf_moudle: TFModule | None) -> None:
-        # TODO update this usage to be immutable
-        original_module_key.foreach_idx = None  # Make sure it is always None even if we didn't override it previously
-        while tf_moudle is not None:
-            if tf_moudle == original_module_key:
-                tf_moudle.foreach_idx = original_foreach_or_count_key
-                break
-            tf_moudle = tf_moudle.nested_tf_module
+    def _get_module_with_only_relevant_foreach_idx(original_foreach_or_count_key: int | str,
+                                                   original_module_key: TFModule,
+                                                   tf_moudle: TFModule | None) -> TFModule | None:
+        if tf_moudle is None:
+            return None
+        if tf_moudle == original_module_key:
+            return TFModule(name=tf_moudle.name, path=tf_moudle.path,
+                            nested_tf_module=tf_moudle.nested_tf_module,
+                            foreach_idx=original_foreach_or_count_key)
+        nested_module = tf_moudle.nested_tf_module
+        updated_module = ForeachAbstractHandler._get_module_with_only_relevant_foreach_idx(
+            original_foreach_or_count_key, original_module_key, nested_module)
+        return TFModule(name=tf_moudle.name, path=tf_moudle.path,
+                        nested_tf_module=updated_module,
+                        foreach_idx=tf_moudle.foreach_idx)
 
     @staticmethod
     def _pop_foreach_attrs(attrs: dict[str, Any]) -> None:

--- a/checkov/terraform/graph_builder/foreach/abstract_handler.py
+++ b/checkov/terraform/graph_builder/foreach/abstract_handler.py
@@ -70,6 +70,7 @@ class ForeachAbstractHandler:
     @staticmethod
     def _update_nested_tf_module_foreach_idx(original_foreach_or_count_key: int | str, original_module_key: TFModule,
                                              tf_moudle: TFModule | None) -> None:
+        # TODO update this usage to be immutable
         original_module_key.foreach_idx = None  # Make sure it is always None even if we didn't override it previously
         while tf_moudle is not None:
             if tf_moudle == original_module_key:

--- a/checkov/terraform/graph_builder/foreach/abstract_handler.py
+++ b/checkov/terraform/graph_builder/foreach/abstract_handler.py
@@ -7,7 +7,6 @@ import typing
 from typing import Any
 
 from checkov.common.util.data_structures_utils import pickle_deepcopy
-from checkov.terraform import TFModule
 from checkov.terraform.graph_builder.foreach.consts import COUNT_STRING, FOREACH_STRING, COUNT_KEY, EACH_VALUE, \
     EACH_KEY, REFERENCES_VALUES
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
@@ -66,23 +65,6 @@ class ForeachAbstractHandler:
         sub_graph.in_edges = self.local_graph.in_edges
         sub_graph.out_edges = self.local_graph.out_edges
         return sub_graph
-
-    @staticmethod
-    def _get_module_with_only_relevant_foreach_idx(original_foreach_or_count_key: int | str,
-                                                   original_module_key: TFModule,
-                                                   tf_moudle: TFModule | None) -> TFModule | None:
-        if tf_moudle is None:
-            return None
-        if tf_moudle == original_module_key:
-            return TFModule(name=tf_moudle.name, path=tf_moudle.path,
-                            nested_tf_module=tf_moudle.nested_tf_module,
-                            foreach_idx=original_foreach_or_count_key)
-        nested_module = tf_moudle.nested_tf_module
-        updated_module = ForeachAbstractHandler._get_module_with_only_relevant_foreach_idx(
-            original_foreach_or_count_key, original_module_key, nested_module)
-        return TFModule(name=tf_moudle.name, path=tf_moudle.path,
-                        nested_tf_module=updated_module,
-                        foreach_idx=tf_moudle.foreach_idx)
 
     @staticmethod
     def _pop_foreach_attrs(attrs: dict[str, Any]) -> None:

--- a/checkov/terraform/graph_builder/foreach/module_handler.py
+++ b/checkov/terraform/graph_builder/foreach/module_handler.py
@@ -112,7 +112,9 @@ class ForeachModuleHandler(ForeachAbstractHandler):
         foreach_idx = original_foreach_or_count_key if not should_override_foreach_key else None
         original_module_key = TFModule(path=main_resource.path, name=main_resource.name,
                                        nested_tf_module=main_resource.source_module_object, foreach_idx=foreach_idx)
-
+        if should_override_foreach_key:
+            # Important to handle the first batch of vertices which already existed in the graph
+            original_module_key = self._get_tf_module_with_no_foreach(original_module_key)
         self._update_children_foreach_index(original_foreach_or_count_key, original_module_key,
                                             should_override_foreach_key=should_override_foreach_key)
 

--- a/checkov/terraform/graph_builder/foreach/module_handler.py
+++ b/checkov/terraform/graph_builder/foreach/module_handler.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from checkov.common.util.consts import RESOLVED_MODULE_ENTRY_NAME
 from checkov.common.util.data_structures_utils import pickle_deepcopy
-from checkov.terraform import TFModule
+from checkov.terraform import TFModule, TFDefinitionKey
 from checkov.terraform.graph_builder.foreach.abstract_handler import ForeachAbstractHandler
 from checkov.terraform.graph_builder.foreach.consts import FOREACH_STRING, COUNT_STRING
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
@@ -276,8 +276,11 @@ class ForeachModuleHandler(ForeachAbstractHandler):
         if isinstance(config, dict):
             resolved_module_name = config.get(RESOLVED_MODULE_ENTRY_NAME)
             if resolved_module_name is not None and len(resolved_module_name) > 0:
-                config[RESOLVED_MODULE_ENTRY_NAME][0].tf_source_modules = ForeachAbstractHandler._get_module_with_only_relevant_foreach_idx(
+                original_definition_key = config[RESOLVED_MODULE_ENTRY_NAME][0]
+                tf_source_modules = ForeachAbstractHandler._get_module_with_only_relevant_foreach_idx(
                     original_foreach_or_count_key,
                     original_module_key,
                     resolved_module_name[0].tf_source_modules,
                 )
+                config[RESOLVED_MODULE_ENTRY_NAME][0] = TFDefinitionKey(file_path=original_definition_key.file_path,
+                                                                        tf_source_modules=tf_source_modules)

--- a/checkov/terraform/graph_builder/foreach/module_handler.py
+++ b/checkov/terraform/graph_builder/foreach/module_handler.py
@@ -281,10 +281,27 @@ class ForeachModuleHandler(ForeachAbstractHandler):
             resolved_module_name = config.get(RESOLVED_MODULE_ENTRY_NAME)
             if resolved_module_name is not None and len(resolved_module_name) > 0:
                 original_definition_key = config[RESOLVED_MODULE_ENTRY_NAME][0]
-                tf_source_modules = ForeachAbstractHandler._get_module_with_only_relevant_foreach_idx(
+                tf_source_modules = ForeachModuleHandler._get_module_with_only_relevant_foreach_idx(
                     original_foreach_or_count_key,
                     original_module_key,
                     resolved_module_name[0].tf_source_modules,
                 )
                 config[RESOLVED_MODULE_ENTRY_NAME][0] = TFDefinitionKey(file_path=original_definition_key.file_path,
                                                                         tf_source_modules=tf_source_modules)
+
+    @staticmethod
+    def _get_module_with_only_relevant_foreach_idx(original_foreach_or_count_key: int | str,
+                                                   original_module_key: TFModule,
+                                                   tf_moudle: TFModule | None) -> TFModule | None:
+        if tf_moudle is None:
+            return None
+        if tf_moudle == original_module_key:
+            return TFModule(name=tf_moudle.name, path=tf_moudle.path,
+                            nested_tf_module=tf_moudle.nested_tf_module,
+                            foreach_idx=original_foreach_or_count_key)
+        nested_module = tf_moudle.nested_tf_module
+        updated_module = ForeachModuleHandler._get_module_with_only_relevant_foreach_idx(
+            original_foreach_or_count_key, original_module_key, nested_module)
+        return TFModule(name=tf_moudle.name, path=tf_moudle.path,
+                        nested_tf_module=updated_module,
+                        foreach_idx=tf_moudle.foreach_idx)

--- a/checkov/terraform/graph_builder/foreach/module_handler.py
+++ b/checkov/terraform/graph_builder/foreach/module_handler.py
@@ -112,9 +112,9 @@ class ForeachModuleHandler(ForeachAbstractHandler):
         foreach_idx = original_foreach_or_count_key if not should_override_foreach_key else None
         original_module_key = TFModule(path=main_resource.path, name=main_resource.name,
                                        nested_tf_module=main_resource.source_module_object, foreach_idx=foreach_idx)
-        if should_override_foreach_key:
-            # Important to handle the first batch of vertices which already existed in the graph
-            original_module_key = self._get_tf_module_with_no_foreach(original_module_key)
+        # if should_override_foreach_key:
+        #     # Important to handle the first batch of vertices which already existed in the graph
+        #     original_module_key = self._get_tf_module_with_no_foreach(original_module_key)
         self._update_children_foreach_index(original_foreach_or_count_key, original_module_key,
                                             should_override_foreach_key=should_override_foreach_key)
 
@@ -135,7 +135,12 @@ class ForeachModuleHandler(ForeachAbstractHandler):
         Go through all child vertices and update source_module_object with foreach_idx
         """
         if current_module_key is None:
-            current_module_key = original_module_key
+            if should_override_foreach_key and original_module_key.foreach_idx is not None:
+                # Important to handle the first batch of vertices which already existed in the graph
+                current_module_key = self._get_tf_module_with_no_foreach(original_module_key)
+                # current_module_key = original_module_key
+            else:
+                current_module_key = original_module_key
         if current_module_key not in self.local_graph.vertices_by_module_dependency:
             return
         values = self.local_graph.vertices_by_module_dependency[current_module_key].values()

--- a/checkov/terraform/graph_builder/foreach/module_handler.py
+++ b/checkov/terraform/graph_builder/foreach/module_handler.py
@@ -141,8 +141,9 @@ class ForeachModuleHandler(ForeachAbstractHandler):
             for child_index in child_indexes:
                 child = self.local_graph.vertices[child_index]
 
-                self._update_nested_tf_module_foreach_idx(original_foreach_or_count_key, original_module_key,
-                                                          child.source_module_object)
+                child.source_module_object = self._get_module_with_only_relevant_foreach_idx(original_foreach_or_count_key,
+                                                                                      original_module_key,
+                                                                                      child.source_module_object)
                 self._update_resolved_entry_for_tf_definition(child, original_foreach_or_count_key, original_module_key)
 
                 # Important to copy to avoid changing the object by reference
@@ -184,7 +185,7 @@ class ForeachModuleHandler(ForeachAbstractHandler):
         main_resource_module_key = TFModule(
             path=new_resource.path,
             name=main_resource.name,
-            nested_tf_module=new_resource.source_module_object,
+            nested_tf_module=self._get_tf_module_with_no_foreach(new_resource.source_module_object)
         )
 
         # Without making this copy the test don't pass, as we might access the data structure in the middle of an update
@@ -275,9 +276,8 @@ class ForeachModuleHandler(ForeachAbstractHandler):
         if isinstance(config, dict):
             resolved_module_name = config.get(RESOLVED_MODULE_ENTRY_NAME)
             if resolved_module_name is not None and len(resolved_module_name) > 0:
-                tf_moudle: TFModule = resolved_module_name[0].tf_source_modules
-                ForeachAbstractHandler._update_nested_tf_module_foreach_idx(
+                config[RESOLVED_MODULE_ENTRY_NAME][0].tf_source_modules = ForeachAbstractHandler._get_module_with_only_relevant_foreach_idx(
                     original_foreach_or_count_key,
                     original_module_key,
-                    tf_moudle,
+                    resolved_module_name[0].tf_source_modules,
                 )

--- a/checkov/terraform/modules/module_objects.py
+++ b/checkov/terraform/modules/module_objects.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Optional, Any
+from typing import Any
 
 
 @dataclass(frozen=True)

--- a/checkov/terraform/modules/module_objects.py
+++ b/checkov/terraform/modules/module_objects.py
@@ -40,17 +40,10 @@ class TFModule:
                             'nested_tf_module') else None) if json_dct else None
 
 
+@dataclass(frozen=True)
 class TFDefinitionKey:
-    __slots__ = ("tf_source_modules", "file_path")
-
-    def __init__(self, file_path: str, tf_source_modules: Optional[TFModule] = None) -> None:
-        self.tf_source_modules = tf_source_modules
-        self.file_path = file_path
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, TFDefinitionKey):
-            return False
-        return self.tf_source_modules == other.tf_source_modules and self.file_path == other.file_path
+    file_path: str
+    tf_source_modules: TFModule | None = None
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, TFDefinitionKey):
@@ -59,9 +52,6 @@ class TFDefinitionKey:
 
     def __repr__(self) -> str:
         return f'tf_source_modules:{self.tf_source_modules}, file_path:{self.file_path}'
-
-    def __hash__(self) -> int:
-        return hash((self.file_path, self.tf_source_modules))
 
     def __iter__(self) -> Iterator[tuple[str, Any]]:
         yield from {

--- a/checkov/terraform/modules/module_objects.py
+++ b/checkov/terraform/modules/module_objects.py
@@ -1,23 +1,16 @@
 from __future__ import annotations
 import json
 from collections.abc import Iterator
+from dataclasses import dataclass
 from typing import Optional, Any
 
 
+@dataclass(frozen=True)
 class TFModule:
-    __slots__ = ("path", "name", "foreach_idx", "nested_tf_module")
-
-    def __init__(self, path: str, name: str | None, nested_tf_module: Optional[TFModule] = None,
-                 foreach_idx: Optional[int | str] = None) -> None:
-        self.path = path
-        self.name = name
-        self.foreach_idx = foreach_idx
-        self.nested_tf_module = nested_tf_module
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, TFModule):
-            return False
-        return self.path == other.path and self.name == other.name and self.nested_tf_module == other.nested_tf_module and self.foreach_idx == other.foreach_idx
+    path: str
+    name: str | None
+    nested_tf_module: TFModule | None = None
+    foreach_idx: int | str | None = None
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, TFModule):
@@ -27,9 +20,6 @@ class TFModule:
 
     def __repr__(self) -> str:
         return f'path:{self.path}, name:{self.name}, nested_tf_module:{self.nested_tf_module}, foreach_idx:{self.foreach_idx}'
-
-    def __hash__(self) -> int:
-        return hash((self.path, self.name, self.nested_tf_module, self.foreach_idx))
 
     def __iter__(self) -> Iterator[tuple[str, Any]]:
         yield from {

--- a/tests/terraform/graph/variable_rendering/expected_foreach_module_dup_foreach.json
+++ b/tests/terraform/graph/variable_rendering/expected_foreach_module_dup_foreach.json
@@ -1,0 +1,1255 @@
+{
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"tf_source_modules\": null}": {
+    "module": [
+      {
+        "s3_module[\"a\"]": {
+          "__end_line__": 12,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}"
+          ],
+          "__start_line__": 7,
+          "bucket": [
+            false
+          ],
+          "bucket2": [
+            ""
+          ],
+          "source": [
+            "./module"
+          ],
+          "__address__": "s3_module[\"a\"]"
+        }
+      },
+      {
+        "s3_module2[0]": {
+          "__end_line__": 19,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}"
+          ],
+          "__start_line__": 14,
+          "bucket": [
+            ""
+          ],
+          "bucket2": [
+            true
+          ],
+          "source": [
+            "./module"
+          ],
+          "__address__": "s3_module2[0]"
+        }
+      },
+      {
+        "s3_module[\"b\"]": {
+          "__end_line__": 12,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"b\", \"nested_tf_module\": null}}"
+          ],
+          "__start_line__": 7,
+          "bucket": [
+            false
+          ],
+          "bucket2": [
+            ""
+          ],
+          "source": [
+            "./module"
+          ],
+          "__address__": "s3_module[\"b\"]"
+        }
+      },
+      {
+        "s3_module2[1]": {
+          "__end_line__": 19,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 1, \"nested_tf_module\": null}}"
+          ],
+          "__start_line__": 14,
+          "bucket": [
+            ""
+          ],
+          "bucket2": [
+            true
+          ],
+          "source": [
+            "./module"
+          ],
+          "__address__": "s3_module2[1]"
+        }
+      }
+    ],
+    "provider": [
+      {
+        "aws": {
+          "__end_line__": 5,
+          "__start_line__": 1,
+          "alias": [
+            "test_provider"
+          ],
+          "region": [
+            "us-west-2"
+          ],
+          "test_provider": [
+            true
+          ],
+          "__address__": "aws.test_provider"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}": {
+    "module": [
+      {
+        "inner_s3_module[\"c\"]": {
+          "__end_line__": 5,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 1,
+          "bucket2": [
+            "var.bucket"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module[\"a\"].inner_s3_module[\"c\"]"
+        }
+      },
+      {
+        "inner_s3_module2[\"e\"]": {
+          "__end_line__": 11,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 7,
+          "bucket2": [
+            "var.bucket2"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module[\"a\"].inner_s3_module2[\"e\"]"
+        }
+      },
+      {
+        "inner_s3_module[\"d\"]": {
+          "__end_line__": 5,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 1,
+          "bucket2": [
+            "var.bucket"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module[\"a\"].inner_s3_module[\"d\"]"
+        }
+      },
+      {
+        "inner_s3_module2[\"f\"]": {
+          "__end_line__": 11,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 7,
+          "bucket2": [
+            "var.bucket2"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module[\"a\"].inner_s3_module2[\"f\"]"
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"a\"].bucket"
+        }
+      },
+      {
+        "bucket2": {
+          "__end_line__": 20,
+          "__start_line__": 18,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"a\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}": {
+    "module": [
+      {
+        "inner_s3_module[\"c\"]": {
+          "__end_line__": 5,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 1,
+          "bucket2": [
+            "var.bucket"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module2[0].inner_s3_module[\"c\"]"
+        }
+      },
+      {
+        "inner_s3_module2[\"e\"]": {
+          "__end_line__": 11,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 7,
+          "bucket2": [
+            "var.bucket2"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module2[0].inner_s3_module2[\"e\"]"
+        }
+      },
+      {
+        "inner_s3_module[\"d\"]": {
+          "__end_line__": 5,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 1,
+          "bucket2": [
+            "var.bucket"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module2[0].inner_s3_module[\"d\"]"
+        }
+      },
+      {
+        "inner_s3_module2[\"f\"]": {
+          "__end_line__": 11,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 7,
+          "bucket2": [
+            "var.bucket2"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module2[0].inner_s3_module2[\"f\"]"
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[0].bucket"
+        }
+      },
+      {
+        "bucket2": {
+          "__end_line__": 20,
+          "__start_line__": 18,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[0].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": \"c\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module[\"a\"].module.inner_s3_module[\"c\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module[\"a\"].module.inner_s3_module[\"c\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"a\"].module.inner_s3_module[\"c\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": \"c\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module2[0].module.inner_s3_module[\"c\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module2[0].module.inner_s3_module[\"c\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[0].module.inner_s3_module[\"c\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": \"e\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module[\"a\"].module.inner_s3_module2[\"e\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module[\"a\"].module.inner_s3_module2[\"e\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"a\"].module.inner_s3_module2[\"e\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": \"e\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module2[0].module.inner_s3_module2[\"e\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module2[0].module.inner_s3_module2[\"e\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[0].module.inner_s3_module2[\"e\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/variable.tf\", \"tf_source_modules\": null}": {
+    "variable": [
+      {
+        "count_var": {
+          "__end_line__": 4,
+          "__start_line__": 2,
+          "default": [
+            2
+          ],
+          "__address__": "count_var"
+        }
+      },
+      {
+        "foreach_var": {
+          "__end_line__": 8,
+          "__start_line__": 6,
+          "default": [
+            [
+              "a",
+              "b"
+            ]
+          ],
+          "__address__": "foreach_var"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"b\", \"nested_tf_module\": null}}": {
+    "module": [
+      {
+        "inner_s3_module[\"c\"]": {
+          "__end_line__": 5,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 1,
+          "bucket2": [
+            "var.bucket"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module[\"b\"].inner_s3_module[\"c\"]"
+        }
+      },
+      {
+        "inner_s3_module2[\"e\"]": {
+          "__end_line__": 11,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 7,
+          "bucket2": [
+            "var.bucket2"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module[\"b\"].inner_s3_module2[\"e\"]"
+        }
+      },
+      {
+        "inner_s3_module[\"d\"]": {
+          "__end_line__": 5,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 1,
+          "bucket2": [
+            "var.bucket"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module[\"b\"].inner_s3_module[\"d\"]"
+        }
+      },
+      {
+        "inner_s3_module2[\"f\"]": {
+          "__end_line__": 11,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 7,
+          "bucket2": [
+            "var.bucket2"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module[\"b\"].inner_s3_module2[\"f\"]"
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"b\"].bucket"
+        }
+      },
+      {
+        "bucket2": {
+          "__end_line__": 20,
+          "__start_line__": 18,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"b\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": \"c\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"b\", \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module[\"b\"].module.inner_s3_module[\"c\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module[\"b\"].module.inner_s3_module[\"c\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"b\"].module.inner_s3_module[\"c\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": \"e\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"b\", \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module[\"b\"].module.inner_s3_module2[\"e\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module[\"b\"].module.inner_s3_module2[\"e\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"b\"].module.inner_s3_module2[\"e\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 1, \"nested_tf_module\": null}}": {
+    "module": [
+      {
+        "inner_s3_module[\"c\"]": {
+          "__end_line__": 5,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 1,
+          "bucket2": [
+            "var.bucket"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module2[1].inner_s3_module[\"c\"]"
+        }
+      },
+      {
+        "inner_s3_module2[\"e\"]": {
+          "__end_line__": 11,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 7,
+          "bucket2": [
+            "var.bucket2"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module2[1].inner_s3_module2[\"e\"]"
+        }
+      },
+      {
+        "inner_s3_module[\"d\"]": {
+          "__end_line__": 5,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 1,
+          "bucket2": [
+            "var.bucket"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module2[1].inner_s3_module[\"d\"]"
+        }
+      },
+      {
+        "inner_s3_module2[\"f\"]": {
+          "__end_line__": 11,
+          "__resolved__": [
+            "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": null, \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}"
+          ],
+          "__start_line__": 7,
+          "bucket2": [
+            "var.bucket2"
+          ],
+          "source": [
+            "./module2"
+          ],
+          "__address__": "module.s3_module2[1].inner_s3_module2[\"f\"]"
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[1].bucket"
+        }
+      },
+      {
+        "bucket2": {
+          "__end_line__": 20,
+          "__start_line__": 18,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[1].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": \"c\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 1, \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module2[1].module.inner_s3_module[\"c\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module2[1].module.inner_s3_module[\"c\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[1].module.inner_s3_module[\"c\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": \"e\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 1, \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module2[1].module.inner_s3_module2[\"e\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module2[1].module.inner_s3_module2[\"e\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[1].module.inner_s3_module2[\"e\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": \"d\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module[\"a\"].module.inner_s3_module[\"d\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module[\"a\"].module.inner_s3_module[\"d\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"a\"].module.inner_s3_module[\"d\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": \"f\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"a\", \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module[\"a\"].module.inner_s3_module2[\"f\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module[\"a\"].module.inner_s3_module2[\"f\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"a\"].module.inner_s3_module2[\"f\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": \"d\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module2[0].module.inner_s3_module[\"d\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module2[0].module.inner_s3_module[\"d\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[0].module.inner_s3_module[\"d\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": \"f\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 0, \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module2[0].module.inner_s3_module2[\"f\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module2[0].module.inner_s3_module2[\"f\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[0].module.inner_s3_module2[\"f\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": \"d\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"b\", \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module[\"b\"].module.inner_s3_module[\"d\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module[\"b\"].module.inner_s3_module[\"d\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"b\"].module.inner_s3_module[\"d\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": \"f\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module\", \"foreach_idx\": \"b\", \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module[\"b\"].module.inner_s3_module2[\"f\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module[\"b\"].module.inner_s3_module2[\"f\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module[\"b\"].module.inner_s3_module2[\"f\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module\", \"foreach_idx\": \"d\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 1, \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module2[1].module.inner_s3_module[\"d\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module2[1].module.inner_s3_module[\"d\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[1].module.inner_s3_module[\"d\"].bucket2"
+        }
+      }
+    ]
+  },
+  "{\"file_path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/module2/main.tf\", \"tf_source_modules\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/module/main.tf\", \"name\": \"inner_s3_module2\", \"foreach_idx\": \"f\", \"nested_tf_module\": {\"path\": \".../tests/terraform/graph/variable_rendering/resources/foreach_module_dup_foreach/main.tf\", \"name\": \"s3_module2\", \"foreach_idx\": 1, \"nested_tf_module\": null}}}": {
+    "locals": [
+      {
+        "bucket2": [
+          "var.bucket2"
+        ],
+        "__address__": "module.s3_module2[1].module.inner_s3_module2[\"f\"].bucket2"
+      }
+    ],
+    "resource": [
+      {
+        "aws_s3_bucket_public_access_block": {
+          "var_bucket": {
+            "__end_line__": 11,
+            "__start_line__": 5,
+            "block_public_acls": [
+              true
+            ],
+            "block_public_policy": [
+              true
+            ],
+            "bucket": [
+              "var.bucket2"
+            ],
+            "ignore_public_acls": [
+              true
+            ],
+            "restrict_public_buckets": [
+              true
+            ],
+            "__address__": "module.s3_module2[1].module.inner_s3_module2[\"f\"].aws_s3_bucket_public_access_block.var_bucket"
+          }
+        }
+      }
+    ],
+    "variable": [
+      {
+        "bucket2": {
+          "__end_line__": 16,
+          "__start_line__": 14,
+          "type": [
+            "string"
+          ],
+          "__address__": "module.s3_module2[1].module.inner_s3_module2[\"f\"].bucket2"
+        }
+      }
+    ]
+  }
+}

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -337,10 +337,12 @@ def test_foreach_module_in_both_levels_module(checkov_source_path):
     graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
     tf_definitions, _ = convert_graph_vertices_to_tf_definitions(vertices=graph.vertices, root_folder=dir_name)
 
+    resources = [block for block in graph.vertices if block.block_type == 'resource']
     assert len([block for block in graph.vertices if block.block_type == 'module']) == 20
-    assert len([block for block in graph.vertices if block.block_type == 'resource']) == 16
+    assert len(resources) == 16
     assert len(tf_definitions.keys()) == 22
-    assert graph.vertices[15].source_module_object.foreach_idx is not None
+    for resource in resources:
+        assert resource.source_module_object.foreach_idx is not None
 
 
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -306,18 +306,22 @@ def test_new_tf_parser_with_foreach_modules(checkov_source_path):
 
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})
 def test_tf_definitions_for_foreach_on_modules(checkov_source_path):
-    dir_name = 'parser_dup_nested'
-    local_graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
-    tf_definitions, _ = convert_graph_vertices_to_tf_definitions(vertices=local_graph.vertices, root_folder=dir_name)
+    dir_name_and_definitions_path = [
+        ('parser_dup_nested', 'expected_foreach_modules_tf_definitions.json'),
+        ('foreach_module_dup_foreach', 'expected_foreach_module_dup_foreach.json')
+    ]
+    for dir_name, definitions_path in dir_name_and_definitions_path:
+        local_graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
+        tf_definitions, _ = convert_graph_vertices_to_tf_definitions(vertices=local_graph.vertices, root_folder=dir_name)
 
-    file_path = os.path.join(os.path.dirname(__file__), 'expected_foreach_modules_tf_definitions.json')
-    with open(file_path, 'r') as f:
-        expected_data = json.load(f, object_hook=object_hook)
+        file_path = os.path.join(os.path.dirname(__file__), definitions_path)
+        with open(file_path, 'r') as f:
+            expected_data = json.load(f, object_hook=object_hook)
 
-    tf_definitions_json = json.dumps(tf_definitions, cls=CustomJSONEncoder)
-    tf_definitions_json = tf_definitions_json.replace(checkov_source_path, '...')
-    tf_definitions_after_handling_checkov_source = json.loads(tf_definitions_json, object_hook=object_hook)
-    assert tf_definitions_after_handling_checkov_source == expected_data
+        tf_definitions_json = json.dumps(tf_definitions, cls=CustomJSONEncoder)
+        tf_definitions_json = tf_definitions_json.replace(checkov_source_path, '...')
+        tf_definitions_after_handling_checkov_source = json.loads(tf_definitions_json, object_hook=object_hook)
+        assert tf_definitions_after_handling_checkov_source == expected_data
 
 
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -338,6 +338,7 @@ def test_foreach_module_in_both_levels_module(checkov_source_path):
     assert len([block for block in graph.vertices if block.block_type == 'module']) == 20
     assert len([block for block in graph.vertices if block.block_type == 'resource']) == 16
     assert len(tf_definitions.keys()) == 22
+    assert graph.vertices[15].source_module_object.foreach_idx is not None
 
 
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -337,12 +337,28 @@ def test_foreach_module_in_both_levels_module(checkov_source_path):
     graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
     tf_definitions, _ = convert_graph_vertices_to_tf_definitions(vertices=graph.vertices, root_folder=dir_name)
 
-    resources = [(i, block) for i, block in enumerate(graph.vertices) if block.block_type == 'resource']
-    assert len([block for block in graph.vertices if block.block_type == 'module']) == 20
+    resources = [block for block in graph.vertices if block.block_type == 'resource']
+    locals = [block for block in graph.vertices if block.block_type == 'locals']
+    vars = [block for block in graph.vertices if block.block_type == 'variable']
+    modules = [block for block in graph.vertices if block.block_type == 'module']
+
+    assert len(modules) == 20
     assert len(resources) == 16
     assert len(tf_definitions.keys()) == 22
+
     for resource in resources:
-        assert resource[1].source_module_object.foreach_idx is not None
+        assert resource.source_module_object.foreach_idx is not None
+
+    for local in locals:
+        assert local.source_module_object.foreach_idx is not None
+
+    for var in vars:
+        if var.source_module_object:
+            assert var.source_module_object.foreach_idx is not None
+
+    for module in modules:
+        if module.source_module_object:
+            assert module.source_module_object.foreach_idx is not None
 
 
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -337,12 +337,12 @@ def test_foreach_module_in_both_levels_module(checkov_source_path):
     graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
     tf_definitions, _ = convert_graph_vertices_to_tf_definitions(vertices=graph.vertices, root_folder=dir_name)
 
-    resources = [block for block in graph.vertices if block.block_type == 'resource']
+    resources = [(i, block) for i, block in enumerate(graph.vertices) if block.block_type == 'resource']
     assert len([block for block in graph.vertices if block.block_type == 'module']) == 20
     assert len(resources) == 16
     assert len(tf_definitions.keys()) == 22
     for resource in resources:
-        assert resource.source_module_object.foreach_idx is not None
+        assert resource[1].source_module_object.foreach_idx is not None
 
 
 @mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -5,8 +5,10 @@ from unittest import mock
 import pytest
 
 from checkov.common.util.json_utils import object_hook, CustomJSONEncoder
+from checkov.terraform import TFModule
 from checkov.terraform.graph_builder.foreach.abstract_handler import ForeachAbstractHandler
 from checkov.terraform.graph_builder.foreach.builder import ForeachBuilder
+from checkov.terraform.graph_builder.foreach.module_handler import ForeachModuleHandler
 from checkov.terraform.graph_builder.foreach.resource_handler import ForeachResourceHandler
 from checkov.terraform.graph_builder.graph_to_tf_definitions import convert_graph_vertices_to_tf_definitions
 
@@ -390,3 +392,11 @@ def test_foreach_with_lookup():
     graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
     assert graph.vertices[0].attributes.get('uniform_bucket_level_access') == [True]
     assert graph.vertices[1].attributes.get('uniform_bucket_level_access') == [True]
+
+
+def test__get_tf_module_with_no_foreach():
+    module = TFModule(name='1', path='1', foreach_idx='1',
+                      nested_tf_module=TFModule(name='2', path='2', foreach_idx='2', nested_tf_module=None))
+    result = ForeachModuleHandler._get_tf_module_with_no_foreach(module)
+    assert result == TFModule(name='1', path='1', foreach_idx=None,
+                      nested_tf_module=TFModule(name='2', path='2', foreach_idx=None, nested_tf_module=None))

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -400,3 +400,21 @@ def test__get_tf_module_with_no_foreach():
     result = ForeachModuleHandler._get_tf_module_with_no_foreach(module)
     assert result == TFModule(name='1', path='1', foreach_idx=None,
                       nested_tf_module=TFModule(name='2', path='2', foreach_idx=None, nested_tf_module=None))
+
+
+def test__get_module_with_only_relevant_foreach_idx():
+    module = TFModule(name='1', path='1', foreach_idx='1',
+                      nested_tf_module=TFModule(name='2', path='2', foreach_idx='2',
+                                                nested_tf_module=TFModule(name='3', path='3', foreach_idx='3',
+                                                                          nested_tf_module=None)
+                                                )
+                      )
+    original_key = TFModule(name='2', path='2', foreach_idx='2',
+                            nested_tf_module=TFModule(name='3', path='3', foreach_idx='3', nested_tf_module=None))
+    result = ForeachAbstractHandler._get_module_with_only_relevant_foreach_idx('test', original_key, module)
+    assert result == TFModule(name='1', path='1', foreach_idx='1',
+                      nested_tf_module=TFModule(name='2', path='2', foreach_idx='test',
+                                                nested_tf_module=TFModule(name='3', path='3', foreach_idx='3',
+                                                                          nested_tf_module=None)
+                                                )
+                      )

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -433,7 +433,7 @@ def test__get_module_with_only_relevant_foreach_idx():
                       )
     original_key = TFModule(name='2', path='2', foreach_idx='2',
                             nested_tf_module=TFModule(name='3', path='3', foreach_idx='3', nested_tf_module=None))
-    result = ForeachAbstractHandler._get_module_with_only_relevant_foreach_idx('test', original_key, module)
+    result = ForeachModuleHandler._get_module_with_only_relevant_foreach_idx('test', original_key, module)
     assert result == TFModule(name='1', path='1', foreach_idx='1',
                       nested_tf_module=TFModule(name='2', path='2', foreach_idx='test',
                                                 nested_tf_module=TFModule(name='3', path='3', foreach_idx='3',


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

A bug was found where the `source_module_object` of `TerraformLocalGraph.vertices` might had missing/unassigned foreach_idx in cases with nested foreach terraform objects (see changed test for example).
To solve it I:
- Made `TFModule` and `TFDefinitionKey` immutable objects (as we use them as dictionary keys, which is extremely bad with mutable objects and caused bugs while debugging).
- Changed all usages of those objects to create new instances rather than mutating existing ones.
- Fixed the bug itself by correctly finding the vertices to update under `ForeachModuleHandler._update_children_foreach_index`
- Improved test to check all created vertices contain source_module_objects with foreach_idx assigned


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
