### PR TITLE
platform(general): expose retry and timeout configuration for interaction with the platform

### DIFF
--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -18,6 +18,7 @@ from checkov.common.resource_code_logger_filter import add_resource_code_filter_
 from checkov.common.util.consts import DEV_API_GET_HEADERS, DEV_API_POST_HEADERS, PRISMA_API_GET_HEADERS, \
     PRISMA_PLATFORM, BRIDGECREW_PLATFORM
 from checkov.common.util.data_structures_utils import merge_dicts
+from checkov.common.util.type_forcers import force_int, force_float
 from checkov.version import version as checkov_version
 
 if TYPE_CHECKING:
@@ -25,7 +26,12 @@ if TYPE_CHECKING:
     from requests import Response
 
 # https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
-DEFAULT_TIMEOUT = (3.1, 30)
+REQUEST_CONNECT_TIMEOUT = force_float(os.getenv("CHECKOV_REQUEST_CONNECT_TIMEOUT")) or 3.1
+REQUEST_READ_TIMEOUT = force_int(os.getenv("CHECKOV_REQUEST_READ_TIMEOUT")) or 30
+DEFAULT_TIMEOUT = (REQUEST_CONNECT_TIMEOUT, REQUEST_READ_TIMEOUT)
+
+# https://urllib3.readthedocs.io/en/stable/user-guide.html#retrying-requests
+REQUEST_RETRIES = force_int(os.getenv("CHECKOV_REQUEST_RETRIES")) or 3
 
 logger = logging.getLogger(__name__)
 add_resource_code_filter_to_logger(logger)

--- a/checkov/common/vcs/base_vcs_dal.py
+++ b/checkov/common/vcs/base_vcs_dal.py
@@ -10,7 +10,7 @@ from typing import Any
 import urllib3
 
 from checkov.common.util.data_structures_utils import merge_dicts
-from checkov.common.util.http_utils import get_user_agent_header
+from checkov.common.util.http_utils import get_user_agent_header, REQUEST_CONNECT_TIMEOUT, REQUEST_READ_TIMEOUT, REQUEST_RETRIES
 
 
 class BaseVCSDAL:
@@ -29,6 +29,8 @@ class BaseVCSDAL:
         self.org_complementary_metadata: dict[str, Any] = {}
         self.repo_complementary_metadata: dict[str, Any] = {}
         self.http: urllib3.PoolManager | None = None
+        self.http_timeout = urllib3.Timeout(connect=REQUEST_CONNECT_TIMEOUT, read=REQUEST_READ_TIMEOUT)
+        self.http_retry = urllib3.Retry(REQUEST_RETRIES, redirect=3)
         self.setup_http_manager(ca_certificate=os.getenv('BC_CA_BUNDLE', None))
         self.discover()
         self.setup_conf_dir()
@@ -51,18 +53,32 @@ class BaseVCSDAL:
             os.environ['REQUESTS_CA_BUNDLE'] = ca_certificate
             try:
                 parsed_url = urllib3.util.parse_url(os.environ['https_proxy'])
-                self.http = urllib3.ProxyManager(os.environ['https_proxy'], cert_reqs='REQUIRED',
-                                                 ca_certs=ca_certificate,
-                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth))  # type:ignore[no-untyped-call]
+                self.http = urllib3.ProxyManager(
+                    os.environ['https_proxy'],
+                    cert_reqs='REQUIRED',
+                    ca_certs=ca_certificate,
+                    proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth),  # type:ignore[no-untyped-call]
+                    timeout = self.http_timeout,
+                    retries=self.http_retry,
+                )
             except KeyError:
-                self.http = urllib3.PoolManager(cert_reqs='REQUIRED', ca_certs=ca_certificate)
+                self.http = urllib3.PoolManager(
+                    cert_reqs='REQUIRED',
+                    ca_certs=ca_certificate,
+                    timeout=self.http_timeout,
+                    retries=self.http_retry,
+                )
         else:
             try:
                 parsed_url = urllib3.util.parse_url(os.environ['https_proxy'])
-                self.http = urllib3.ProxyManager(os.environ['https_proxy'],
-                                                 proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth))  # type:ignore[no-untyped-call]
+                self.http = urllib3.ProxyManager(
+                    os.environ['https_proxy'],
+                    proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth),  # type:ignore[no-untyped-call]
+                    timeout = self.http_timeout,
+                    retries=self.http_retry,
+                )
             except KeyError:
-                self.http = urllib3.PoolManager()
+                self.http = urllib3.PoolManager(timeout=self.http_timeout, retries=self.http_retry)
 
     def _request(self, endpoint: str, allowed_status_codes: list[int]) -> dict[str, Any] | None:
         if allowed_status_codes is None:

--- a/checkov/common/vcs/base_vcs_dal.py
+++ b/checkov/common/vcs/base_vcs_dal.py
@@ -58,7 +58,7 @@ class BaseVCSDAL:
                     cert_reqs='REQUIRED',
                     ca_certs=ca_certificate,
                     proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth),  # type:ignore[no-untyped-call]
-                    timeout = self.http_timeout,
+                    timeout=self.http_timeout,
                     retries=self.http_retry,
                 )
             except KeyError:
@@ -74,7 +74,7 @@ class BaseVCSDAL:
                 self.http = urllib3.ProxyManager(
                     os.environ['https_proxy'],
                     proxy_headers=urllib3.make_headers(proxy_basic_auth=parsed_url.auth),  # type:ignore[no-untyped-call]
-                    timeout = self.http_timeout,
+                    timeout=self.http_timeout,
                     retries=self.http_retry,
                 )
             except KeyError:

--- a/docs/2.Basics/Visualizing Checkov Output.md
+++ b/docs/2.Basics/Visualizing Checkov Output.md
@@ -66,7 +66,7 @@ To enrich Bridgecrew's context with CI/CD systems data, we strongly recommend th
 | PRISMA_API_URL                  | URL of Prisma app for platform integration                                     | https://app3.prismacloud.io                                                             |
 | SLS_FILE_MASK                   | File names mask for all serverless files                                       | serverless.yaml,serverless.yml                                                          |
 | CHECKOV_REQUEST_CONNECT_TIMEOUT | Number of seconds requests will wait to establish a connection to the platform | 3.1                                                                                     |
-| CHECKOV_REQUEST_READ_TIMEOUT    | Number of seconds requests will wait for the platform to send a response       | 30                                                                                      |
+| CHECKOV_REQUEST_READ_TIMEOUT    | Number of seconds requests will wait for the platform to send a response. This duration matches our timeout settings, so changes are likely unnecessary.      | 30                                                                                      |
 | CHECKOV_REQUEST_RETRIES         | Number of retries requests will do towards the platform                        | 3                                                                                       |
 
 ## Bridgecrew platform view

--- a/docs/2.Basics/Visualizing Checkov Output.md
+++ b/docs/2.Basics/Visualizing Checkov Output.md
@@ -48,23 +48,26 @@ The table below details the arguments used when executing the API token:
 
 To enrich Bridgecrew's context with CI/CD systems data, we strongly recommend that Checkov uses environment variables.
 
-| Environment Variable | Description | Example |
-| -------- | ----------- | ----------- |
-| BC_FROM_BRANCH | Source branch | feature/foo |
-| BC_TO_BRANCH | Target branch | main |
-| BC_PR_ID | Pull request identifier | 825 |
-| BC_PR_URL | Link to pull request/merge request | https://github.com/bridgecrewio/checkov/pull/825 |
-| BC_COMMIT_HASH | Commit identifier | 5df50ab857e7a255e4e731877748b539915ad489 |
-| BC_COMMIT_URL | Link to commit in CI/VCS system | https://github.com/bridgecrewio/checkov/commit/5df50ab857e7a255e4e731877748b539915ad489 |
-| BC_AUTHOR_NAME | User associated with the CI trigger | schosterbarak |
-| BC_AUTHOR_URL | Link to the user profile page | https://github.com/schosterbarak |
-| BC_RUN_ID | CI run identifier | 525220526 |
-| BC_RUN_URL | Link to the run in the CI system | https://github.com/bridgecrewio/checkov/actions/runs/525220526 |
-| BC_REPOSITORY_URL | Link to the GitHub repository | https://github.com/bridgecrewio/checkov/ |
-| BC_SOURCE | Name of CI system being integrated | githubActions |
-| BC_API_URL | URL of BC app for platform integration | https://www.bridgecrew.cloud |
-| PRISMA_API_URL | URL of Prisma app for platform integration | https://app3.prismacloud.io |
-| SLS_FILE_MASK | File names mask for all serverless files | serverless.yaml,serverless.yml |
+| Environment Variable            | Description                                                                    | Example                                                                                 |
+|---------------------------------|--------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| BC_FROM_BRANCH                  | Source branch                                                                  | feature/foo                                                                             |
+| BC_TO_BRANCH                    | Target branch                                                                  | main                                                                                    |
+| BC_PR_ID                        | Pull request identifier                                                        | 825                                                                                     |
+| BC_PR_URL                       | Link to pull request/merge request                                             | https://github.com/bridgecrewio/checkov/pull/825                                        |
+| BC_COMMIT_HASH                  | Commit identifier                                                              | 5df50ab857e7a255e4e731877748b539915ad489                                                |
+| BC_COMMIT_URL                   | Link to commit in CI/VCS system                                                | https://github.com/bridgecrewio/checkov/commit/5df50ab857e7a255e4e731877748b539915ad489 |
+| BC_AUTHOR_NAME                  | User associated with the CI trigger                                            | schosterbarak                                                                           |
+| BC_AUTHOR_URL                   | Link to the user profile page                                                  | https://github.com/schosterbarak                                                        |
+| BC_RUN_ID                       | CI run identifier                                                              | 525220526                                                                               |
+| BC_RUN_URL                      | Link to the run in the CI system                                               | https://github.com/bridgecrewio/checkov/actions/runs/525220526                          |
+| BC_REPOSITORY_URL               | Link to the GitHub repository                                                  | https://github.com/bridgecrewio/checkov/                                                |
+| BC_SOURCE                       | Name of CI system being integrated                                             | githubActions                                                                           |
+| BC_API_URL                      | URL of BC app for platform integration                                         | https://www.bridgecrew.cloud                                                            |
+| PRISMA_API_URL                  | URL of Prisma app for platform integration                                     | https://app3.prismacloud.io                                                             |
+| SLS_FILE_MASK                   | File names mask for all serverless files                                       | serverless.yaml,serverless.yml                                                          |
+| CHECKOV_REQUEST_CONNECT_TIMEOUT | Number of seconds requests will wait to establish a connection to the platform | 3.1                                                                                     |
+| CHECKOV_REQUEST_READ_TIMEOUT    | Number of seconds requests will wait for the platform to send a response       | 30                                                                                      |
+| CHECKOV_REQUEST_RETRIES         | Number of retries requests will do towards the platform                        | 3                                                                                       |
 
 ## Bridgecrew platform view
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added the possibility to configure timeouts and retry counts for interacting with the platform
- CHECKOV_REQUEST_CONNECT_TIMEOUT
- CHECKOV_REQUEST_READ_TIMEOUT
- CHECKOV_REQUEST_RETRIES

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
