### PR TITLE
feat(terraform): support scanning of Terraform managed modules instead of downloading them

### DIFF
--- a/checkov/terraform/module_loading/loaders/local_path_loader.py
+++ b/checkov/terraform/module_loading/loaders/local_path_loader.py
@@ -24,6 +24,10 @@ class LocalPathLoader(ModuleLoader):
         pass
 
     def _is_matching_loader(self, module_params: ModuleParams) -> bool:
+        if module_params.tf_managed:
+            # Terraform managed modules are already downloaded and can be handled as local modules
+            return True
+
         if module_params.module_source.startswith(("./", "../", module_params.current_dir, "/")):
             return True
 

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -56,7 +56,7 @@ def find_modules(path: str) -> List[ModuleDownload]:
                             # also extract the name for easier mapping against the TF modules.json file
                             match = re.match(MODULE_NAME_PATTERN, line)
                             if match:
-                                curr_md.module_name= match.group("name")
+                                curr_md.module_name = match.group("name")
 
                             continue
                     else:

--- a/checkov/terraform/module_loading/module_params.py
+++ b/checkov/terraform/module_loading/module_params.py
@@ -4,8 +4,17 @@ from typing import Optional
 
 @dataclass
 class ModuleParams:
-    def __init__(self, root_dir: str, current_dir: str, source: str, source_version: Optional[str], dest_dir: str,
-                 external_modules_folder_name: str, inner_module: Optional[str] = None):
+    def __init__(
+        self,
+        root_dir: str,
+        current_dir: str,
+        source: str,
+        source_version: Optional[str],
+        dest_dir: str,
+        external_modules_folder_name: str,
+        inner_module: Optional[str] = None,
+        tf_managed: bool = False,
+    ):
         self.root_dir: str = root_dir
         self.current_dir: str = current_dir
         self.module_source: str = source
@@ -13,6 +22,7 @@ class ModuleParams:
         self.dest_dir: str = dest_dir
         self.external_modules_folder_name: str = external_modules_folder_name
         self.inner_module: Optional[str] = inner_module
+        self.tf_managed = tf_managed
 
         self.token: Optional[str] = None
         self.username: Optional[str] = None

--- a/checkov/terraform/module_loading/registry.py
+++ b/checkov/terraform/module_loading/registry.py
@@ -28,7 +28,14 @@ class ModuleLoaderRegistry:
         self.failed_urls_cache: Set[str] = set()
         self.root_dir = ""  # root dir for storing external modules
 
-    def load(self, current_dir: str, source: str | None, source_version: Optional[str]) -> ModuleContent | None:
+    def load(
+        self,
+        current_dir: str,
+        source: str | None,
+        source_version: str | None,
+        module_address: str | None = None,
+        tf_managed: bool = False,
+    ) -> ModuleContent | None:
         """
 Search all registered loaders for the first one which is able to load the module source type. For more
 information, see `loader.ModuleLoader.load`.
@@ -36,7 +43,8 @@ information, see `loader.ModuleLoader.load`.
         if source is None:
             return None
 
-        module_address = f'{source}:{source_version}'
+        if module_address is None:
+            module_address = f'{source}:{source_version}'
         if module_address in self.module_content_cache:
             logging.debug(f'Used the cache for module {module_address}')
             return self.module_content_cache[module_address]
@@ -64,13 +72,16 @@ information, see `loader.ModuleLoader.load`.
                 if not self.download_external_modules and loader.is_external:
                     continue
                 try:
-                    module_params = ModuleParams(root_dir=self.root_dir,
-                                                 current_dir=current_dir,
-                                                 source=source,
-                                                 source_version=source_version,
-                                                 dest_dir=local_dir,
-                                                 external_modules_folder_name=self.external_modules_folder_name,
-                                                 inner_module=inner_module)
+                    module_params = ModuleParams(
+                        root_dir=self.root_dir,
+                        current_dir=current_dir,
+                        source=source,
+                        source_version=source_version,
+                        dest_dir=local_dir,
+                        external_modules_folder_name=self.external_modules_folder_name,
+                        inner_module=inner_module,
+                        tf_managed=tf_managed,
+                    )
                     logging.info(f"Attempting loading via {loader.__class__} loader")
                     content = loader.load(module_params)
                 except Exception as e:

--- a/docs/7.Scan Examples/Terraform.md
+++ b/docs/7.Scan Examples/Terraform.md
@@ -44,6 +44,13 @@ To adjust the download path you can leverage the flag `--external-modules-downlo
 checkov -d . --download-external-modules true --external-modules-download-path example/path
 ```
 
+> [!NOTE]
+> **Experimental**
+> By setting the env var `CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES=True` instead of downloading external modules `checkov` will use the ones already downloaded by Terraform stored in `.terraform` folder. This only works for scans of the root folder, where also `terraform init` was executed.
+> ```shell
+> CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES=True checkov -d .
+> ```
+
 ### Scanning Private Terraform Modules
 
 If you have modules stored in a private repository or a private Terraform registry (hosted on Terraform Cloud, Terraform Enterprise or a third-party provider like GitLab), you can grant Checkov access by providing access tokens as environment variables. This will enable Checkov to attempt to clone and scan those modules.

--- a/tests/terraform/module_loading/data/tf_managed_modules/.terraform/modules/log_group/modules/log-group/main.tf
+++ b/tests/terraform/module_loading/data/tf_managed_modules/.terraform/modules/log_group/modules/log-group/main.tf
@@ -1,0 +1,10 @@
+resource "aws_cloudwatch_log_group" "this" {
+  count = var.create ? 1 : 0
+
+  name              = var.name
+  name_prefix       = var.name_prefix
+  retention_in_days = var.retention_in_days
+  kms_key_id        = var.kms_key_id
+
+  tags = var.tags
+}

--- a/tests/terraform/module_loading/data/tf_managed_modules/.terraform/modules/log_group/modules/log-group/outputs.tf
+++ b/tests/terraform/module_loading/data/tf_managed_modules/.terraform/modules/log_group/modules/log-group/outputs.tf
@@ -1,0 +1,9 @@
+output "cloudwatch_log_group_name" {
+  description = "Name of Cloudwatch log group"
+  value       = try(aws_cloudwatch_log_group.this[0].name, "")
+}
+
+output "cloudwatch_log_group_arn" {
+  description = "ARN of Cloudwatch log group"
+  value       = try(aws_cloudwatch_log_group.this[0].arn, "")
+}

--- a/tests/terraform/module_loading/data/tf_managed_modules/.terraform/modules/log_group/modules/log-group/variables.tf
+++ b/tests/terraform/module_loading/data/tf_managed_modules/.terraform/modules/log_group/modules/log-group/variables.tf
@@ -1,0 +1,40 @@
+variable "create" {
+  description = "Whether to create the Cloudwatch log group"
+  type        = bool
+  default     = true
+}
+
+variable "name" {
+  description = "A name for the log group"
+  type        = string
+  default     = null
+}
+
+variable "name_prefix" {
+  description = "A name prefix for the log group"
+  type        = string
+  default     = null
+}
+
+variable "retention_in_days" {
+  description = "Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.retention_in_days == null ? true : contains([0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653], var.retention_in_days)
+    error_message = "Must be 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653 or 0 (zero indicates never expire logs)."
+  }
+}
+
+variable "kms_key_id" {
+  description = "The ARN of the KMS Key to use when encrypting logs"
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "A map of tags to add to Cloudwatch log group"
+  type        = map(string)
+  default     = {}
+}

--- a/tests/terraform/module_loading/data/tf_managed_modules/.terraform/modules/log_group/modules/log-group/versions.tf
+++ b/tests/terraform/module_loading/data/tf_managed_modules/.terraform/modules/log_group/modules/log-group/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}

--- a/tests/terraform/module_loading/data/tf_managed_modules/.terraform/modules/modules.json
+++ b/tests/terraform/module_loading/data/tf_managed_modules/.terraform/modules/modules.json
@@ -1,0 +1,10 @@
+{
+  "Modules": [
+    {
+      "Key": "log_group",
+      "Source": "registry.terraform.io/terraform-aws-modules/cloudwatch/aws//modules/log-group",
+      "Version": "4.1.0",
+      "Dir": ".terraform/modules/log_group/modules/log-group"
+    }
+  ]
+}

--- a/tests/terraform/module_loading/data/tf_managed_modules/main.tf
+++ b/tests/terraform/module_loading/data/tf_managed_modules/main.tf
@@ -1,0 +1,14 @@
+module "log_group" {
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
+
+  name_prefix       = "my-log-group-"
+  retention_in_days = 7
+}
+
+module "log_group_v4" {
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
+  version = "~> 4.0"
+
+  name_prefix       = "my-log-group-"
+  retention_in_days = 7
+}

--- a/tests/terraform/module_loading/test_runner.py
+++ b/tests/terraform/module_loading/test_runner.py
@@ -1,0 +1,52 @@
+import os
+from pathlib import Path
+from unittest import mock
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+@mock.patch.dict(os.environ, {"CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES": "True"})
+def test_runner_with_tf_managed_modules():
+    # given
+    root_dir = Path(__file__).parent / "data/tf_managed_modules"
+
+    # when
+    result = Runner().run(
+        root_folder=str(root_dir),
+        runner_filter=RunnerFilter(checks=["CKV_AWS_338"], framework=["terraform"], download_external_modules=False),
+    )
+
+    # then
+    summary = result.get_summary()
+
+    assert summary["passed"] == 0
+    assert summary["failed"] == 1
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0
+
+    failed_resources = [check.resource for check in result.failed_checks]
+    expected_failed_resources = ["module.log_group.aws_cloudwatch_log_group.this[0]"]
+
+    assert failed_resources == expected_failed_resources
+
+
+# test can be removed after setting this flow as default
+@mock.patch.dict(os.environ, {"CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES": "False"})
+def test_runner_without_tf_managed_modules():
+    # given
+    root_dir = Path(__file__).parent / "data/tf_managed_modules"
+
+    # when
+    result = Runner().run(
+        root_folder=str(root_dir),
+        runner_filter=RunnerFilter(checks=["CKV_AWS_338"], framework=["terraform"], download_external_modules=False),
+    )
+
+    # then
+    summary = result.get_summary()
+
+    assert summary["passed"] == 0
+    assert summary["failed"] == 0
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0

--- a/tests/terraform/module_loading/test_tf_module_finder.py
+++ b/tests/terraform/module_loading/test_tf_module_finder.py
@@ -1,9 +1,16 @@
 import os
 import shutil
 import unittest
+from pathlib import Path
+from unittest import mock
 
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
-from checkov.terraform.module_loading.module_finder import find_modules, should_download, load_tf_modules
+from checkov.terraform.module_loading.module_finder import (
+    find_modules,
+    should_download,
+    load_tf_modules,
+    replace_terraform_managed_modules,
+)
 from checkov.terraform.module_loading.registry import module_loader_registry
 
 
@@ -20,7 +27,7 @@ class TestModuleFinder(unittest.TestCase):
         self.assertEqual(1, len(remote_modules))
         for m in remote_modules:
             if 'terraform-aws-modules' in m.module_link:
-                self.assertEqual('~>2.1.0', m.version)
+                self.assertEqual('~> 2.1.0', m.version)
             else:
                 self.assertIsNone(m.version)
 
@@ -42,3 +49,23 @@ class TestModuleFinder(unittest.TestCase):
         shutil.rmtree(os.path.join(self.get_src_dir(), DEFAULT_EXTERNAL_MODULES_DIR))
         self.assertEqual(len(downloaded_modules), 1)
         self.assertEqual(len(distinct_roots), 1)
+
+
+@mock.patch.dict(os.environ, {"CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES": "True"})
+def test_tf_managed_modules():
+    # this test leverages the modules, which Terraform downloads on its own
+
+    # given
+    src_path = Path(__file__).parent / "data/tf_managed_modules"
+    modules = find_modules(str(src_path))
+
+    # when
+    replaced_modules = replace_terraform_managed_modules(path=str(src_path), found_modules=modules)
+
+    tf_managed_modules = [module for module in replaced_modules if module.tf_managed]
+    assert len(replaced_modules) == 2
+    assert len(tf_managed_modules) == 1
+
+    assert tf_managed_modules[0].tf_managed is True
+    assert tf_managed_modules[0].address == "terraform-aws-modules/cloudwatch/aws//modules/log-group:latest"
+    assert tf_managed_modules[0].module_link == ".terraform/modules/log_group/modules/log-group"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added support for using the `modules.json` and the downloaded modules content by Terraform instead of downloading it on our own. This means `terraform init` before scanning the root folder with `checkov` will only download modules, which couldn't be found inside the `modules.json` file
- this flow also works, when `--download-external-modules` is disabled
- to enable the new behaviour you need to set `CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES=True` as env var
- current limitation is, no support for nested modules, then the normal flow will pick it up

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
