### PR TITLE
fix(terraform): CKV_AWS_208 valid Amazon MQ versions

### DIFF
--- a/checkov/terraform/checks/resource/aws/MQBrokerVersion.py
+++ b/checkov/terraform/checks/resource/aws/MQBrokerVersion.py
@@ -5,7 +5,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 ENGINE_VERSION_PATTERN = re.compile(r"(\d+\.\d+.\d+)")
 ENGINE_VERSION_SHORT_PATTERN = re.compile(r"(\d+\.\d+)")
 MINIMUM_ACTIVEMQ_VERSION = 5.17
-MINIMUM_RABBITMQ_VERSION = 3.8
+MINIMUM_RABBITMQ_VERSION = 3.11
 
 
 class MQBrokerVersion(BaseResourceCheck):

--- a/checkov/terraform/checks/resource/aws/MQBrokerVersion.py
+++ b/checkov/terraform/checks/resource/aws/MQBrokerVersion.py
@@ -4,7 +4,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 
 ENGINE_VERSION_PATTERN = re.compile(r"(\d+\.\d+.\d+)")
 ENGINE_VERSION_SHORT_PATTERN = re.compile(r"(\d+\.\d+)")
-MINIMUM_ACTIVEMQ_VERSION = 5.16
+MINIMUM_ACTIVEMQ_VERSION = 5.17
 MINIMUM_RABBITMQ_VERSION = 3.8
 
 

--- a/tests/terraform/checks/resource/aws/example_MQBrokerVersion/main.tf
+++ b/tests/terraform/checks/resource/aws/example_MQBrokerVersion/main.tf
@@ -35,7 +35,7 @@ resource "aws_mq_broker" "pass" {
   broker_name = "example"
 
   engine_type         = "ActiveMQ"
-  engine_version      = "5.16.0"
+  engine_version      = "5.17.6"
   host_instance_type  = "mq.t2.micro"
   publicly_accessible = true
   deployment_mode     = "SINGLE_INSTANCE"
@@ -52,7 +52,7 @@ resource "aws_mq_broker" "pass2" {
   broker_name = "example"
 
   engine_type         = "RabbitMQ"
-  engine_version      = "3.8.6"
+  engine_version      = "3.11.20"
   host_instance_type  = "mq.t2.micro"
   publicly_accessible = true
   deployment_mode     = "SINGLE_INSTANCE"
@@ -105,7 +105,7 @@ resource "aws_mq_configuration" "pass" {
   description    = "Example Configuration"
   name           = "example"
   engine_type    = "ActiveMQ"
-  engine_version = "5.16.3"
+  engine_version = "5.17.6"
 
   data = <<DATA
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>


### PR DESCRIPTION
Apache ActiveMQ support for version5.16 ended on Mar 18, 2023

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

The change in valid versions, as now 5.17 is the lowest supported version and the newest available.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
