### PR TITLE
fix(bicep): enforce encryption flag to be string for CKV_AZURE_97

### DIFF
--- a/checkov/arm/checks/resource/VMEncryptionAtHostEnabled.py
+++ b/checkov/arm/checks/resource/VMEncryptionAtHostEnabled.py
@@ -28,7 +28,7 @@ class VMEncryptionAtHostEnabled(BaseResourceCheck):
                 input_dict=conf, key_path="properties/virtualMachineProfile/securityProfile/encryptionAtHost"
             )
 
-        if encryption == "true":
+        if str(encryption).lower() == "true":
             return CheckResult.PASSED
 
         return CheckResult.FAILED

--- a/tests/bicep/checks/resource/azure/example_VMEncryptionAtHostEnabled/main.bicep
+++ b/tests/bicep/checks/resource/azure/example_VMEncryptionAtHostEnabled/main.bicep
@@ -1,0 +1,23 @@
+// pass
+
+resource enabled 'Microsoft.Compute/virtualMachines@2021-11-01' = {
+  name: virtualMachineName
+  location: location
+  properties: {
+    securityProfile: {
+      encryptionAtHost: true
+    }
+  }
+}
+
+// fail
+
+resource disabled 'Microsoft.Compute/virtualMachines@2021-11-01' = {
+  name: virtualMachineName
+  location: location
+  properties: {
+    securityProfile: {
+      encryptionAtHost: false
+    }
+  }
+}

--- a/tests/bicep/checks/resource/azure/test_VMEncryptionAtHostEnabled.py
+++ b/tests/bicep/checks/resource/azure/test_VMEncryptionAtHostEnabled.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from checkov.bicep.runner import Runner
+from checkov.arm.checks.resource.VMEncryptionAtHostEnabled import check
+from checkov.runner_filter import RunnerFilter
+
+
+def test_examples():
+    # given
+    test_files_dir = Path(__file__).parent / "example_VMEncryptionAtHostEnabled"
+
+    # when
+    report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+    # then
+    summary = report.get_summary()
+
+    passing_resources = {
+        "Microsoft.Compute/virtualMachines.enabled",
+    }
+
+    failing_resources = {
+        "Microsoft.Compute/virtualMachines.disabled",
+    }
+
+    passed_check_resources = {c.resource for c in report.passed_checks}
+    failed_check_resources = {c.resource for c in report.failed_checks}
+
+    assert summary["passed"] == len(passing_resources)
+    assert summary["failed"] == len(failing_resources)
+    assert summary["skipped"] == 0
+    assert summary["parsing_errors"] == 0
+
+    assert passed_check_resources == passing_resources
+    assert failed_check_resources == failing_resources


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- fixes an issue with Bicep templates defining the flag as boolean

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
