### PR TITLE
fix(secrets): fix secret FP of client_secret_setting_name

### DIFF
--- a/checkov/secrets/plugins/detector_utils.py
+++ b/checkov/secrets/plugins/detector_utils.py
@@ -108,7 +108,13 @@ FOLLOWED_BY_EQUAL_VALUE_SECRET_REGEX = re.compile(
     flags=re.IGNORECASE,
 )
 
-ALLOW_LIST = ('secretsmanager', "secretName", "secret_name", "creation_token")  # can add more keys like that
+ALLOW_LIST = (  # can add more keys like that
+    'secretsmanager',
+    "secretName",
+    "secret_name",
+    "creation_token",
+    "client_secret_setting_name",
+)
 ALLOW_LIST_REGEX = r'|'.join(ALLOW_LIST)
 # Support for suffix of function name i.e "secretsmanager:GetSecretValue"
 CAMEL_CASE_NAMES = r'[A-Z]([A-Z0-9]*[a-z][a-z0-9]*[A-Z]|[a-z0-9]*[A-Z][A-Z0-9]*[a-z])[A-Za-z0-9]*'

--- a/tests/secrets/sanity/iac_fp/main.tf
+++ b/tests/secrets/sanity/iac_fp/main.tf
@@ -1,3 +1,5 @@
 secret_name       = "example_secret_name"
 
 creation_token                  = "my-product"
+
+client_secret_setting_name  = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- add the FP to the secrets allow list

Fixes #5634

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
