### PR TITLE
platform(general): Add SAST enforcement rules and check severity thresholds

### DIFF
--- a/checkov/common/bridgecrew/severities.py
+++ b/checkov/common/bridgecrew/severities.py
@@ -12,6 +12,9 @@ class Severity:
     def __repr__(self) -> str:
         return self.name
 
+    def __str__(self) -> str:
+        return self.name
+
 
 @dataclass
 class BcSeverities:

--- a/checkov/sast/engines/prisma_engine.py
+++ b/checkov/sast/engines/prisma_engine.py
@@ -7,7 +7,7 @@ import platform
 import re
 import stat
 from pathlib import Path
-from typing import Optional, List, Set, Union, Dict, Any, Tuple
+from typing import Optional, List, Set, Union, Dict, Any, Tuple, cast
 
 from cachetools import cached, TTLCache
 from pydantic import ValidationError
@@ -357,8 +357,8 @@ class PrismaEngine(SastEngine):
             'policies': [],
             'checks': [],
             'skip_checks': [],
-            'check_threshold': None,
-            'skip_check_threshold': None,
+            'check_threshold': Severities[BcSeverities.NONE],
+            'skip_check_threshold': Severities[BcSeverities.NONE],
             'skip_path': [],
             'report_imports': False,
             'report_reachability': False

--- a/checkov/sast/engines/prisma_engine.py
+++ b/checkov/sast/engines/prisma_engine.py
@@ -7,7 +7,7 @@ import platform
 import re
 import stat
 from pathlib import Path
-from typing import Optional, List, Set, Union, Dict, Any
+from typing import Optional, List, Set, Union, Dict, Any, Tuple
 
 from cachetools import cached, TTLCache
 from pydantic import ValidationError
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.bridgecrew.platform_key import bridgecrew_dir
-from checkov.common.bridgecrew.severities import get_severity
+from checkov.common.bridgecrew.severities import get_severity, Severity, Severities, BcSeverities
 from checkov.common.models.enums import CheckResult
 from checkov.common.output.report import Report
 from checkov.common.sca.reachability.sast_contract.data_fetcher_sast_lib import SastReachabilityDataFetcher
@@ -43,6 +43,24 @@ class PrismaEngine(SastEngine):
         self.prisma_sast_dir_path = Path(bridgecrew_dir) / "sast"
         self.sast_platform_base_path = "api/v1/sast"
 
+    def get_check_thresholds(self, registry: Registry) -> Tuple[Severity, Severity]:
+        """
+        Returns a tuple of check threshold and skip check threshold..
+
+        If a severity was specified in --check and / or --skip-check, then return a tuple of those values (these override enforcement rules).
+        Else if enforcement rules are enabled, return a tuple of the enforcement rule's SAST soft fail threshold and NONE.
+        Else return a tuple of NONE, NONE
+        """
+        none = Severities[BcSeverities.NONE]
+
+        check_threshold: Optional[Severity] = registry.runner_filter.check_threshold
+        skip_check_threshold: Optional[Severity] = registry.runner_filter.skip_check_threshold
+        enforcement_threshold: Optional[Severity] = registry.runner_filter.enforcement_rule_configs[self.check_type] if registry.runner_filter.use_enforcement_rules else None
+
+        return (check_threshold or none, skip_check_threshold or none) if (check_threshold or skip_check_threshold) else \
+            (enforcement_threshold, none) if enforcement_threshold else \
+            (none, none)
+
     def get_reports(self, targets: List[str], registry: Registry, languages: Set[SastLanguages]) -> List[Report]:
         if not bc_integration.bc_api_key:
             logging.info("The --bc-api-key flag needs to be set to run Sast prisma scanning")
@@ -55,12 +73,16 @@ class PrismaEngine(SastEngine):
 
         self.lib_path = str(prisma_lib_path)
 
+        check_threshold, skip_check_threshold = self.get_check_thresholds(registry)
+
         library_input: LibraryInput = {
             'languages': languages,
             'source_codes': targets,
             'policies': registry.checks_dirs_path,
             'checks': registry.runner_filter.checks if registry.runner_filter else [],
             'skip_checks': registry.runner_filter.skip_checks if registry.runner_filter else [],
+            'check_threshold': check_threshold,
+            'skip_check_threshold': skip_check_threshold,
             'skip_path': registry.runner_filter.excluded_paths if registry.runner_filter else [],
             'report_imports': registry.runner_filter.report_sast_imports if registry.runner_filter else False,
             'remove_default_policies': registry.runner_filter.remove_default_sast_policies if registry.runner_filter else False,
@@ -157,6 +179,8 @@ class PrismaEngine(SastEngine):
                        checks: List[str],
                        skip_checks: List[str],
                        skip_path: List[str],
+                       check_threshold: Severity,
+                       skip_check_threshold: Severity,
                        list_policies: bool = False,
                        report_imports: bool = True,
                        report_reachability: bool = False,
@@ -183,6 +207,8 @@ class PrismaEngine(SastEngine):
                 "checks": checks,
                 "skip_checks": skip_checks,
                 "skip_path": skip_path,
+                "check_threshold": str(check_threshold),
+                "skip_check_threshold": str(skip_check_threshold),
                 "list_policies": list_policies,
                 "report_imports": report_imports,
                 "remove_default_policies": remove_default_policies,

--- a/checkov/sast/engines/prisma_engine.py
+++ b/checkov/sast/engines/prisma_engine.py
@@ -53,9 +53,9 @@ class PrismaEngine(SastEngine):
         """
         none = Severities[BcSeverities.NONE]
 
-        check_threshold: Optional[Severity] = registry.runner_filter.check_threshold
-        skip_check_threshold: Optional[Severity] = registry.runner_filter.skip_check_threshold
-        enforcement_threshold: Optional[Severity] = registry.runner_filter.enforcement_rule_configs[self.check_type] if registry.runner_filter.use_enforcement_rules else None
+        check_threshold: Optional[Severity] = registry.runner_filter.check_threshold  # type:ignore[union-attr] # not null
+        skip_check_threshold: Optional[Severity] = registry.runner_filter.skip_check_threshold  # type:ignore[union-attr] # not null
+        enforcement_threshold: Optional[Severity] = cast(Severity, registry.runner_filter.enforcement_rule_configs[self.check_type]) if registry.runner_filter.use_enforcement_rules else None  # type:ignore[union-attr] # not null
 
         return (check_threshold or none, skip_check_threshold or none) if (check_threshold or skip_check_threshold) else \
             (enforcement_threshold, none) if enforcement_threshold else \
@@ -357,6 +357,8 @@ class PrismaEngine(SastEngine):
             'policies': [],
             'checks': [],
             'skip_checks': [],
+            'check_threshold': None,
+            'skip_check_threshold': None,
             'skip_path': [],
             'report_imports': False,
             'report_reachability': False

--- a/checkov/sast/prisma_models/library_input.py
+++ b/checkov/sast/prisma_models/library_input.py
@@ -1,4 +1,6 @@
 from typing import Set, List
+
+from checkov.common.bridgecrew.severities import Severity
 from checkov.sast.consts import SastLanguages
 import sys
 if sys.version_info < (3, 11):
@@ -14,6 +16,8 @@ class LibraryInput(TypedDict):
     checks: List[str]
     skip_checks: List[str]
     skip_path: List[str]
+    check_threshold: Severity
+    skip_check_threshold: Severity
     list_policies: NotRequired[bool]
     report_imports: bool
     remove_default_policies: NotRequired[bool]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Adds logic to pass severity thresholds from `--check` / `--skip-check` and enforcement rules (soft fail level) to sast-core for policy filtering.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
