### PR TITLE
platform(general): Do not crash the run if S3 integration fails during setup, upload, or finalize

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -661,7 +661,7 @@ class BcPlatformIntegration:
                 self.s3_setup_failed = True
             except JSONDecodeError:
                 if request:
-                    logging.warning(f"Response (status: {request.status}) of {self.integrations_api_url}: {request.data.decode('utf8')}")  # nosec
+                    logging.warning(f"Response (status: {request.status}) of {self.integrations_api_url}: {request.data.decode('utf8')}")  # danger:ignore - we won't be here if the response contains valid data
                 logging.error(f"Response of {self.integrations_api_url} is not a valid JSON", exc_info=True)
                 self.s3_setup_failed = True
             finally:

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -19,7 +19,7 @@ from checkov.common.models.enums import CheckResult, ErrorStatus
 from checkov.common.output.ai import OpenAi
 from checkov.common.typing import _ExitCodeThresholds, _ScaExitCodeThresholds
 from checkov.common.output.record import Record, SCA_PACKAGE_SCAN_CHECK_NAME
-from checkov.common.util.consts import PARSE_ERROR_FAIL_FLAG, CHECKOV_RUN_SCA_PACKAGE_SCAN_V2
+from checkov.common.util.consts import PARSE_ERROR_FAIL_FLAG, CHECKOV_RUN_SCA_PACKAGE_SCAN_V2, S3_UPLOAD_DETAILS_MESSAGE
 from checkov.common.util.json_utils import CustomJSONEncoder
 from checkov.runner_filter import RunnerFilter
 from checkov.sast.consts import POLICIES_ERRORS, POLICIES_ERRORS_COUNT, ENGINE_NAME, SOURCE_FILES_COUNT, POLICY_COUNT
@@ -101,7 +101,7 @@ class Report:
         if not url and not s3_setup_failed:
             url = "Add an api key '--bc-api-key <api-key>' to see more detailed insights via https://bridgecrew.cloud"
         elif s3_setup_failed:
-            url = "An error occurred uploading results to the platform. A details URL is not available for this run."
+            url = S3_UPLOAD_DETAILS_MESSAGE
         if is_quiet:
             return {
                 "check_type": self.check_type,

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -97,9 +97,11 @@ class Report:
     def get_all_records(self) -> List[Record]:
         return self.failed_checks + self.passed_checks + self.skipped_checks
 
-    def get_dict(self, is_quiet: bool = False, url: str | None = None, full_report: bool = False) -> dict[str, Any]:
-        if not url:
+    def get_dict(self, is_quiet: bool = False, url: str | None = None, full_report: bool = False, s3_setup_failed: bool = False) -> dict[str, Any]:
+        if not url and not s3_setup_failed:
             url = "Add an api key '--bc-api-key <api-key>' to see more detailed insights via https://bridgecrew.cloud"
+        elif s3_setup_failed:
+            url = "An error occurred uploading results to the platform. A details URL is not available for this run."
         if is_quiet:
             return {
                 "check_type": self.check_type,

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -38,6 +38,7 @@ from checkov.common.resource_code_logger_filter import add_resource_code_filter_
 from checkov.common.typing import _ExitCodeThresholds, _BaseRunner, _ScaExitCodeThresholds, LibraryGraph
 from checkov.common.util import data_structures_utils
 from checkov.common.util.banner import tool as tool_name
+from checkov.common.util.consts import S3_UPLOAD_DETAILS_MESSAGE
 from checkov.common.util.data_structures_utils import pickle_deepcopy
 from checkov.common.util.json_utils import CustomJSONEncoder
 from checkov.common.util.secrets_omitter import SecretsOmitter
@@ -481,7 +482,7 @@ class RunnerRegistry:
                     if url:
                         print(f"More details: {url}")
                     elif bc_integration.s3_setup_failed:
-                        print("An error occurred uploading results to the platform. A details URL is not available for this run.")
+                        print(S3_UPLOAD_DETAILS_MESSAGE)
                 if CONSOLE_OUTPUT in output_formats.values():
                     print(OUTPUT_DELIMITER)
 
@@ -621,7 +622,7 @@ class RunnerRegistry:
             if url:
                 print(f"More details: {url}")
             elif bc_integration.s3_setup_failed:
-                print("An error occurred uploading results to the platform. A details URL is not available for this run.")
+                print(S3_UPLOAD_DETAILS_MESSAGE)
 
             if CONSOLE_OUTPUT in output_formats.values():
                 print(OUTPUT_DELIMITER)

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -390,7 +390,7 @@ class RunnerRegistry:
         for report in scan_reports:
             if not report.is_empty():
                 if "json" in config.output:
-                    report_jsons.append(report.get_dict(is_quiet=config.quiet, url=url))
+                    report_jsons.append(report.get_dict(is_quiet=config.quiet, url=url, s3_setup_failed=bc_integration.s3_setup_failed))
                 if "junitxml" in config.output:
                     junit_reports.append(report)
                 if "github_failed_only" in config.output:
@@ -477,8 +477,11 @@ class RunnerRegistry:
 
                 del output_formats["sarif"]
 
-                if "cli" not in config.output and url:
-                    print(f"More details: {url}")
+                if "cli" not in config.output:
+                    if url:
+                        print(f"More details: {url}")
+                    elif bc_integration.s3_setup_failed:
+                        print("An error occurred uploading results to the platform. A details URL is not available for this run.")
                 if CONSOLE_OUTPUT in output_formats.values():
                     print(OUTPUT_DELIMITER)
 
@@ -617,6 +620,8 @@ class RunnerRegistry:
                 print(output)
             if url:
                 print(f"More details: {url}")
+            elif bc_integration.s3_setup_failed:
+                print("An error occurred uploading results to the platform. A details URL is not available for this run.")
 
             if CONSOLE_OUTPUT in output_formats.values():
                 print(OUTPUT_DELIMITER)

--- a/checkov/common/util/consts.py
+++ b/checkov/common/util/consts.py
@@ -29,3 +29,6 @@ MAX_IAC_FILE_SIZE = int(os.getenv('CHECKOV_MAX_IAC_FILE_SIZE', '50_000_000'))  #
 CHECKOV_RUN_SCA_PACKAGE_SCAN_V2 = os.getenv('CHECKOV_RUN_SCA_PACKAGE_SCAN_V2', 'true').lower() == 'true'
 
 RESOURCE_ATTRIBUTES_TO_OMIT_UNIVERSAL_MASK = '*'
+
+S3_UPLOAD_DETAILS_MESSAGE = 'An error occurred uploading results to the platform. A details URL is not available for this run. ' \
+                            'See the error log output and enable debug logs for more information.'

--- a/checkov/contributor_metrics.py
+++ b/checkov/contributor_metrics.py
@@ -22,10 +22,13 @@ def report_contributor_metrics(repository: str, source: str,
     contributors_report_api_url = f"{bc_integration.api_url}/api/v2/contributors/report"
     if request_body:
         while number_of_attempts <= 4:
+            logging.debug(f'Uploading contributor metrics to {contributors_report_api_url}')
             response = request_wrapper(
                 "POST", contributors_report_api_url,
                 headers=bc_integration.get_default_headers("POST"), data=json.dumps(request_body)
             )
+            logging.debug(f'Request ID: {response.headers.get("x-amzn-requestid")}')
+            logging.debug(f'Trace ID: {response.headers.get("x-amzn-trace-id")}')
             if response.status_code < 300:
                 logging.debug(
                     f"Successfully uploaded contributor metrics with status: {response.status_code}. number of attempts: {number_of_attempts}")

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -529,7 +529,8 @@ class Checkov:
                     if bc_integration.is_integration_configured() \
                             and bc_integration.bc_source \
                             and bc_integration.bc_source.upload_results \
-                            and not self.config.skip_results_upload:
+                            and not self.config.skip_results_upload \
+                            and not bc_integration.s3_setup_failed:
                         included_paths = [self.config.external_modules_download_path]
                         for r in runner_registry.runners:
                             included_paths.extend(r.included_paths())

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -597,7 +597,7 @@ class Checkov:
 
                 integration_feature_registry.run_post_runner(self.scan_reports[0])
 
-                if not self.config.skip_results_upload:
+                if not self.config.skip_results_upload and not bc_integration.s3_setup_failed:
                     bc_integration.persist_repository(os.path.dirname(self.config.dockerfile_path), files=files)
                     bc_integration.persist_scan_results(self.scan_reports)
                     bc_integration.persist_image_scan_results(sca_runner.raw_report, self.config.dockerfile_path,
@@ -643,7 +643,8 @@ class Checkov:
                 if bc_integration.is_integration_configured() \
                         and bc_integration.bc_source \
                         and bc_integration.bc_source.upload_results \
-                        and not self.config.skip_results_upload:
+                        and not self.config.skip_results_upload \
+                        and not bc_integration.s3_setup_failed:
                     files = [os.path.abspath(file) for file in self.config.file]
                     root_folder = os.path.split(os.path.commonprefix(files))[0]
                     absolute_root_folder = os.path.abspath(root_folder)

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -611,6 +611,7 @@ class Checkov:
                         self.url = self.commit_repository()
                     except Exception:
                         logging.error('An error occurred while uploading scan results to the platform', exc_info=True)
+                        bc_integration.s3_setup_failed = True
 
                 should_run_contributor_metrics = bc_integration.bc_api_key and self.config.repo_id and self.config.prisma_api_url
                 logger.debug(f"Should run contributor metrics report: {should_run_contributor_metrics}")
@@ -689,7 +690,7 @@ class Checkov:
             if bc_integration.support_flag_enabled:
                 if bc_integration.s3_setup_failed:
                     print_to_stderr = os.getenv('CKV_STDERR_DEBUG', 'FALSE').upper() == 'TRUE'
-                    log_level = os.getenv('LOG_LEVEL', '').upper()
+                    log_level = os.getenv('LOG_LEVEL', '')
                     if log_level == 'DEBUG':
                         print('Unable to upload support logs. However, LOG_LEVEL is already set to DEBUG, so debug logs are available locally.')
                     elif print_to_stderr:

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -27,6 +27,7 @@ const FIND_CODE_INSIDE_BRACES_OR_AFTER_COMMA = /^.*\{[^}]*code[^}]*\}.*|.*,.*cod
 const FSTRING_PATTERN = /f(["'])(.*?{.*?}.*?)(\1)/;
 const SUPPORTED_EXTENSIONS = ['.py'];
 const EXCLUDED_FILES = ['__init__.py', 'dangerfile.ts'];
+const IGNORE_COMMENT = '# danger:ignore'
 
 function varMayContainData(varString) {
   if (IGNORE_VAR.includes(varString)) return false;
@@ -60,7 +61,7 @@ async function failIfLoggingLineContainsSensitiveData() {
       const removedLinesLength = fileDiff.removed.split('\n');
       const allLines = [...addedLinesLength, ...removedLinesLength];
       for (let line of allLines) {
-        if (FIND_LOGGING_LEVEL_PY.test(line) && FSTRING_PATTERN.test(line) && !line.includes(PY_MASK_STR)) {
+        if (FIND_LOGGING_LEVEL_PY.test(line) && FSTRING_PATTERN.test(line) && !line.includes(PY_MASK_STR) && !line.includes(IGNORE_COMMENT)) {
           if (FIND_CODE_INSIDE_BRACES_OR_AFTER_COMMA.test(line)) {
             const varsInLog = line.match(VAR_IN_LOG) || line.match(VAR_IN_FUNC)?.[1].split(',').slice(1) || [];
             for (const varString of varsInLog) {


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Adds logic to gracefully handle issues that occur during the integrations API calls or S3 uploads to still allow results to be visible locally.

If at any point we encounter a failure with this flow, then we still stop trying subsequent actions and just save that an error occurred. The scan will continue locally, and instead of a details URL, we will show an error message.

Actual auth errors will still stop the run, so this mainly guards against bugs or crashes in the integrations API, which has caused us some issues lately.

This also fixes an issue where a bug-based error response from the integrations POST request results in an infinite loop that blocks checkov.

Note that we intentionally still stop the run if the `runConfiguration` call fails (unless the customer uses the flag to ignore it), because we know from experience that missing this data (enforcement rules, custom policies, etc) gives the user unexpected results that they then raise an issue about anyways.

Also also adds some logic to handle the edge case of when this happens and the customer uses the `--support` flag, so that we can still attempt to save their debug logs somewhere they can access.

Also also also logs some response headers to make finding requests easier from the logs.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
