### PR TITLE
fix(terraform): fix variable rendering for foreach resources with dot included names

### DIFF
--- a/checkov/terraform/graph_builder/utils.py
+++ b/checkov/terraform/graph_builder/utils.py
@@ -394,3 +394,34 @@ def get_attribute_is_leaf(vertex: TerraformBlock) -> Dict[str, bool]:
         if other in attribute_is_leaf:
             attribute_is_leaf[other] = False
     return attribute_is_leaf
+
+
+def join_double_quote_surrounded_dot_split(str_parts: list[str]) -> list[str]:
+    """Joins back split strings which enclosed a dot by double quotes
+
+    ex.
+
+    ['google_project_iam_binding', 'role["roles/logging', 'admin"]'] -> ['google_project_iam_binding', 'role["roles/logging.admin"]']
+
+    If someone finds a better solution feel free to replace it!
+    """
+
+    new_str_parts = []
+    joined_str_parts: list[str] = []
+    for part in str_parts:
+        if not joined_str_parts:
+            if '"' not in part:
+                new_str_parts.append(part)
+            elif part.count('"') >= 2:
+                new_str_parts.append(part)
+            else:
+                joined_str_parts.append(part)
+            continue
+
+        joined_str_parts.append(part)
+
+        if '"' in part:
+            new_str_parts.append(".".join(joined_str_parts))
+            joined_str_parts = []
+
+    return new_str_parts

--- a/tests/terraform/graph/graph_builder/test_utils.py
+++ b/tests/terraform/graph/graph_builder/test_utils.py
@@ -1,0 +1,41 @@
+import pytest
+
+from checkov.terraform.graph_builder.utils import join_double_quote_surrounded_dot_split
+
+
+@pytest.mark.parametrize(
+    "input_parts,expected_parts",
+    [
+        (
+            ["google_project_iam_binding", 'role["roles/logging', 'admin"]'],
+            ["google_project_iam_binding", 'role["roles/logging.admin"]'],
+        ),
+        (
+            ["module", "google_project_iam_binding", 'role["roles/logging', 'admin"]'],
+            ["module", "google_project_iam_binding", 'role["roles/logging.admin"]'],
+        ),
+        (
+            [
+                "module",
+                "google_project_iam_binding",
+                'role["roles/logging',
+                'admin"]',
+                "module",
+                "google_project_iam_binding",
+                'role["roles/logging',
+                'admin"]',
+            ],
+            [
+                "module",
+                "google_project_iam_binding",
+                'role["roles/logging.admin"]',
+                "module",
+                "google_project_iam_binding",
+                'role["roles/logging.admin"]',
+            ],
+        ),
+    ],
+    ids=["resource", "module_resource", "complex"],
+)
+def test_join_double_quote_surrounded_dot_split(input_parts, expected_parts):
+    assert join_double_quote_surrounded_dot_split(str_parts=input_parts) == expected_parts

--- a/tests/terraform/graph/variable_rendering/resources/foreach_examples/foreach_tfvars/main.tf
+++ b/tests/terraform/graph/variable_rendering/resources/foreach_examples/foreach_tfvars/main.tf
@@ -1,0 +1,19 @@
+variable "project_id" {
+  type = string
+}
+
+locals {
+    roles = [
+        "roles/run.developer",
+    ]
+}
+
+resource "google_project_iam_binding" "role" {
+  for_each = toset(local.roles)
+  project = var.project_id
+  role    = each.key
+
+  members = [
+    "user:captain.america@marvel.com"
+  ]
+}

--- a/tests/terraform/graph/variable_rendering/resources/foreach_examples/foreach_tfvars/terraform.tfvars
+++ b/tests/terraform/graph/variable_rendering/resources/foreach_examples/foreach_tfvars/terraform.tfvars
@@ -1,0 +1,1 @@
+project_id = "avengers"

--- a/tests/terraform/graph/variable_rendering/test_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_renderer.py
@@ -485,3 +485,26 @@ class TestRenderer(TestCase):
                 'dynamic'][1]['authorized_networks']['content'][0]['value']
             # TODO - for now we don't support multiple dynamic blocks - the value_block_1 and value_block_2 needs to be diffrent and not overide each other
             assert not value_block_1 != value_block_2
+
+
+    def test_foreach_with_tfvars(self):
+        # given
+        resources_dir = Path(TEST_DIRNAME) / "resources/foreach_examples/foreach_tfvars"
+        graph_manager = TerraformGraphManager("m", ["m"])
+
+        # when
+        local_graph, _ = graph_manager.build_graph_from_source_directory(str(resources_dir), render_variables=True)
+
+        # then
+        resource = local_graph.vertices[local_graph.vertices_by_block_type["resource"][0]]
+        self.assertDictEqual(
+            resource.config["google_project_iam_binding"]['role["roles/run.developer"]'],
+            {
+                "__address__": 'google_project_iam_binding.role["roles/run.developer"]',
+                "__end_line__": 19,
+                "__start_line__": 11,
+                "members": [["user:captain.america@marvel.com"]],
+                "project": ["avengers"],  # this is important it is correctly rendered
+                "role": ["roles/run.developer"],
+            },
+        )


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added a function to join back strings, which were split by a dot and wrongfully applied to dots inside a quoted string, this is happens mainly to a `for_each` resource key `google_project_iam_binding.role["roles/logging.admin"]` and results in failing to correctly propagate rendered variables
- I tried it with regex, but couldn't find one, which would do the job for me, so if anyone has a good idea to tackle it more elegant, feel free 🍻 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
