### PR TITLE
feat(general): add possibility to change parallelization type

### DIFF
--- a/checkov/ansible/runner.py
+++ b/checkov/ansible/runner.py
@@ -41,12 +41,13 @@ class Runner(YamlRunner):
     def import_registry(self) -> BaseCheckRegistry:
         return registry
 
+    @staticmethod
     def _parse_file(
-        self, f: str, file_content: str | None = None
+        f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         content = get_relevant_file_content(file_path=f)
         if content:
-            return super()._parse_file(f=f, file_content=content)
+            return YamlRunner._parse_file(f=f, file_content=content)
 
         return None
 

--- a/checkov/argo_workflows/runner.py
+++ b/checkov/argo_workflows/runner.py
@@ -31,16 +31,18 @@ class Runner(YamlRunner, ImageReferencer):
     def import_registry(self) -> BaseCheckRegistry:
         return self.block_type_registries["template"]
 
+    @staticmethod
     def _parse_file(
-        self, f: str, file_content: str | None = None
+        f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
-        content = self._get_workflow_file_content(file_path=f)
+        content = Runner._get_workflow_file_content(file_path=f)
         if content:
-            return super()._parse_file(f=f, file_content=content)
+            return YamlRunner._parse_file(f=f, file_content=content)
 
         return None
 
-    def _get_workflow_file_content(self, file_path: str) -> str | None:
+    @staticmethod
+    def _get_workflow_file_content(file_path: str) -> str | None:
         if not file_path.endswith((".yaml", ".yml")):
             return None
 

--- a/checkov/azure_pipelines/runner.py
+++ b/checkov/azure_pipelines/runner.py
@@ -27,14 +27,16 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, Any] | list[dict[str, Any
     def import_registry(self) -> BaseCheckRegistry:
         return registry
 
+    @staticmethod
     def _parse_file(
-        self, f: str, file_content: str | None = None
+        f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
-        if self.is_workflow_file(f):
-            return super()._parse_file(f=f)
+        if Runner.is_workflow_file(f):
+            return YamlRunner._parse_file(f=f)
         return None
 
-    def is_workflow_file(self, file_path: str) -> bool:
+    @staticmethod
+    def is_workflow_file(file_path: str) -> bool:
         return file_path.endswith(('azure-pipelines.yml', 'azure-pipelines.yaml'))
 
     def get_resource(self, file_path: str, key: str, supported_entities: Iterable[str],

--- a/checkov/bitbucket_pipelines/runner.py
+++ b/checkov/bitbucket_pipelines/runner.py
@@ -25,15 +25,17 @@ class Runner(YamlRunner, ImageReferencer):
     def import_registry(self) -> BaseCheckRegistry:
         return registry
 
+    @staticmethod
     def _parse_file(
-        self, f: str, file_content: str | None = None
+        f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
-        if self.is_workflow_file(f):
-            return super()._parse_file(f)
+        if Runner.is_workflow_file(f):
+            return YamlRunner._parse_file(f)
 
         return None
 
-    def is_workflow_file(self, file_path: str) -> bool:
+    @staticmethod
+    def is_workflow_file(file_path: str) -> bool:
         """
         :return: True if the file mentioned is named bitbucket-pipelines.yml. Otherwise: False
         """

--- a/checkov/circleci_pipelines/runner.py
+++ b/checkov/circleci_pipelines/runner.py
@@ -31,15 +31,17 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, Any] | list[dict[str, Any
     def included_paths(self) -> list[str]:
         return [".circleci"]
 
+    @staticmethod
     def _parse_file(
-        self, f: str, file_content: str | None = None
+        f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
-        if self.is_workflow_file(f):
-            return super()._parse_file(f)
+        if Runner.is_workflow_file(f):
+            return YamlRunner._parse_file(f)
 
         return None
 
-    def is_workflow_file(self, file_path: str) -> bool:
+    @staticmethod
+    def is_workflow_file(file_path: str) -> bool:
         """
         :return: True if the file mentioned is named config.yml/yaml in .circleci dir from included_paths(). Otherwise: False
         """

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -144,7 +144,7 @@ class BcPlatformIntegration:
         self.timestamp = platform_integration_data["timestamp"]
         self.setup_api_urls()
         # 'mypy' doesn't like, when you try to override an instance method
-        self.get_auth_token = MethodType(lambda: platform_integration_data["get_auth_token"], self)  # type:ignore[method-assign]
+        self.get_auth_token = MethodType(lambda _=None: platform_integration_data["get_auth_token"], self)  # type:ignore[method-assign]
 
     def generate_instance_data(self) -> dict[str, Any]:
         """This output is used to re-initialize the instance and should be kept in sync with 'init_instance()'"""

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -132,37 +132,37 @@ class BcPlatformIntegration:
     def init_instance(self, platform_integration_data: dict[str, Any]) -> None:
         """This is mainly used for recreating the instance without interacting with the platform again"""
 
-        bc_integration.bc_api_url = platform_integration_data["bc_api_url"]
-        bc_integration.bc_api_key = platform_integration_data["bc_api_key"]
-        bc_integration.bc_source = platform_integration_data["bc_source"]
-        bc_integration.bc_source_version = platform_integration_data["bc_source_version"]
-        bc_integration.cicd_details = platform_integration_data["cicd_details"]
-        bc_integration.prisma_api_url = platform_integration_data["prisma_api_url"]
-        bc_integration.repo_branch = platform_integration_data["repo_branch"]
-        bc_integration.repo_id = platform_integration_data["repo_id"]
-        bc_integration.repo_path = platform_integration_data["repo_path"]
-        bc_integration.timestamp = platform_integration_data["timestamp"]
-        bc_integration.setup_api_urls()
+        self.bc_api_url = platform_integration_data["bc_api_url"]
+        self.bc_api_key = platform_integration_data["bc_api_key"]
+        self.bc_source = platform_integration_data["bc_source"]
+        self.bc_source_version = platform_integration_data["bc_source_version"]
+        self.cicd_details = platform_integration_data["cicd_details"]
+        self.prisma_api_url = platform_integration_data["prisma_api_url"]
+        self.repo_branch = platform_integration_data["repo_branch"]
+        self.repo_id = platform_integration_data["repo_id"]
+        self.repo_path = platform_integration_data["repo_path"]
+        self.timestamp = platform_integration_data["timestamp"]
+        self.setup_api_urls()
         # 'mypy' doesn't like, when you try to override an instance method
-        bc_integration.get_auth_token = MethodType(lambda: platform_integration_data["get_auth_token"], bc_integration)  # type:ignore[method-assign]
+        self.get_auth_token = MethodType(lambda: platform_integration_data["get_auth_token"], self)  # type:ignore[method-assign]
 
     def generate_instance_data(self) -> dict[str, Any]:
         """This output is used to re-initialize the instance and should be kept in sync with 'init_instance()'"""
 
         return {
             # 'api_url' will be set by invoking 'setup_api_urls()'
-            "bc_api_url": bc_integration.bc_api_url,
-            "bc_api_key": bc_integration.bc_api_key,
-            "bc_source": bc_integration.bc_source,
-            "bc_source_version": bc_integration.bc_source_version,
-            "cicd_details": bc_integration.cicd_details,
-            "prisma_api_url": bc_integration.prisma_api_url,
-            "repo_branch": bc_integration.repo_branch,
-            "repo_id": bc_integration.repo_id,
-            "repo_path": bc_integration.repo_path,
-            "timestamp": bc_integration.timestamp,
+            "bc_api_url": self.bc_api_url,
+            "bc_api_key": self.bc_api_key,
+            "bc_source": self.bc_source,
+            "bc_source_version": self.bc_source_version,
+            "cicd_details": self.cicd_details,
+            "prisma_api_url": self.prisma_api_url,
+            "repo_branch": self.repo_branch,
+            "repo_id": self.repo_id,
+            "repo_path": self.repo_path,
+            "timestamp": self.timestamp,
             # will be overriden with a simple lambda expression
-            "get_auth_token": bc_integration.get_auth_token() if bc_integration.bc_api_key else ""
+            "get_auth_token": self.get_auth_token() if self.bc_api_key else ""
         }
 
     def set_bc_api_url(self, new_url: str) -> None:

--- a/checkov/common/models/enums.py
+++ b/checkov/common/models/enums.py
@@ -60,3 +60,14 @@ class ErrorStatus(IntEnum):
 class CheckFailLevel:
     WARNING = 'WARNING'
     ERROR = 'ERROR'
+
+
+class ParallelizationType(str, Enum):
+    FORK = "fork"
+    SPAWN = "spawn"
+    THREAD = "thread"
+    NONE = "none"
+
+    def __str__(self) -> str:
+        # needed, because of a Python 3.11 change
+        return self.value

--- a/checkov/common/parallelizer/parallel_runner.py
+++ b/checkov/common/parallelizer/parallel_runner.py
@@ -5,7 +5,11 @@ import logging
 import multiprocessing
 import os
 import platform
-from typing import Any, List, Generator, Iterator, Callable, Optional, TypeVar, TYPE_CHECKING
+from collections.abc import Iterator, Iterable
+from multiprocessing.pool import Pool
+from typing import Any, List, Generator, Callable, Optional, TypeVar, TYPE_CHECKING
+
+from checkov.common.models.enums import ParallelizationType
 
 if TYPE_CHECKING:
     from multiprocessing.connection import Connection
@@ -14,44 +18,74 @@ _T = TypeVar("_T")
 
 
 class ParallelRunner:
-    def __init__(self, workers_number: int | None = None) -> None:
+    def __init__(
+        self, workers_number: int | None = None, parallelization_type: ParallelizationType = ParallelizationType.FORK
+    ) -> None:
         self.workers_number = (workers_number if workers_number else os.cpu_count()) or 1
         self.os = platform.system()
+        self.type: str | ParallelizationType = parallelization_type
 
-    def run_function(self, func: Callable[[Any], _T], items: List[Any], group_size: Optional[int] = None, run_multiprocess: Optional[bool] = False) -> Iterator[_T]:
-        if self.os == 'Windows' or (not run_multiprocess and os.getenv("PYCHARM_HOSTED") == "1"):
+        custom_type = os.getenv("CHECKOV_PARALLELIZATION_TYPE")
+        if custom_type:
+            self.type = custom_type
+
+        if not custom_type and os.getenv("PYCHARM_HOSTED") == "1":
             # PYCHARM_HOSTED env variable equals 1 when debugging via jetbrains IDE.
-            # To prevent JetBrains IDE from crashing on debug use multi threading
-            # Override this condition if run_multiprocess is set to True
-            return self._run_function_multithreaded(func, items)
-        else:
-            return self._run_function_multiprocess(func, items, group_size)
+            # To prevent JetBrains IDE from crashing on debug run sequentially
+            self.type = ParallelizationType.NONE
+        elif self.os == "Windows" and self.type == ParallelizationType.FORK:
+            # 'fork' mode is not supported on 'Windows'
+            self.type = ParallelizationType.SPAWN
 
-    def _run_function_multiprocess(self, func: Callable[[Any], Any], items: List[Any], group_size: Optional[int]) \
-            -> Generator[Any, None, None]:
+    def run_function(
+        self,
+        func: Callable[..., _T],
+        items: List[Any],
+        group_size: Optional[int] = None,
+    ) -> Iterable[_T]:
+        if self.type == ParallelizationType.THREAD:
+            return self._run_function_multithreaded(func, items)
+        elif self.type == ParallelizationType.FORK:
+            return self._run_function_multiprocess_fork(func, items, group_size)
+        elif self.type == ParallelizationType.SPAWN:
+            return self._run_function_multiprocess_spawn(func, items, group_size)
+        else:
+            return self._run_function_sequential(func, items)
+
+    def _run_function_multiprocess_fork(
+        self, func: Callable[[Any], _T], items: List[Any], group_size: Optional[int]
+    ) -> Generator[_T, None, None]:
         if not group_size:
             group_size = int(len(items) / self.workers_number) + 1
-        groups_of_items = [items[i: i + group_size] for i in range(0, len(items), group_size)]
+        groups_of_items = [items[i : i + group_size] for i in range(0, len(items), group_size)]
 
-        def func_wrapper(original_func: Callable[[Any], Any], items_group: List[Any], connection: Connection) -> None:
+        def func_wrapper(original_func: Callable[[Any], _T], items_group: List[Any], connection: Connection) -> None:
             for item in items_group:
                 try:
-                    result = original_func(item)
+                    if isinstance(item, tuple):
+                        # unpack a tuple to pass multiple arguments to the target function
+                        result = original_func(*item)
+                    else:
+                        result = original_func(item)
                 except Exception:
                     logging.error(
-                        f"Failed to invoke function {func.__code__.co_filename.replace('.py', '')}.{func.__name__} with {item}"
-                        , exc_info=True
+                        f"Failed to invoke function {func.__code__.co_filename.replace('.py', '')}.{func.__name__} with {item}",
+                        exc_info=True,
                     )
                     result = None
 
                 connection.send(result)
             connection.close()
 
+        logging.debug(
+            f"Running function {func.__code__.co_filename.replace('.py', '')}.{func.__name__} with parallelization type 'fork'"
+        )
         processes = []
         for group_of_items in groups_of_items:
             parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
-            process = multiprocessing.get_context("fork").Process(target=func_wrapper,
-                                                                  args=(func, group_of_items, child_conn))
+            process = multiprocessing.get_context("fork").Process(
+                target=func_wrapper, args=(func, group_of_items, child_conn)
+            )
             processes.append((process, parent_conn, len(group_of_items)))
             process.start()
 
@@ -62,9 +96,42 @@ class ParallelRunner:
                 except EOFError:
                     pass
 
+    def _run_function_multiprocess_spawn(
+        self, func: Callable[[Any], _T], items: list[Any], group_size: int | None
+    ) -> Iterable[_T]:
+        if multiprocessing.current_process().daemon:
+            # can't create a new pool, when already inside a pool
+            return self._run_function_multithreaded(func, items)
+
+        if not group_size:
+            group_size = int(len(items) / self.workers_number) + 1
+
+        logging.debug(
+            f"Running function {func.__code__.co_filename.replace('.py', '')}.{func.__name__} with parallelization type 'spawn'"
+        )
+        with Pool(processes=self.workers_number, context=multiprocessing.get_context("spawn")) as p:
+            return p.starmap(func, items, chunksize=group_size)
+
     def _run_function_multithreaded(self, func: Callable[[Any], _T], items: List[Any]) -> Iterator[_T]:
+        logging.debug(
+            f"Running function {func.__code__.co_filename.replace('.py', '')}.{func.__name__} with parallelization type 'thread'"
+        )
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.workers_number) as executor:
+            if items and isinstance(items[0], tuple):
+                # split a list of tuple into tuples of the positioned values of the tuple
+                return executor.map(func, *list(zip(*items)))  # noqa[B905]  # no need to set 'strict' otherwise 'mypy' complains
+
             return executor.map(func, items)
+
+    def _run_function_sequential(self, func: Callable[[Any], _T], items: List[Any]) -> Iterator[_T]:
+        logging.debug(
+            f"Running function {func.__code__.co_filename.replace('.py', '')}.{func.__name__} with parallelization type 'none'"
+        )
+        if items and isinstance(items[0], tuple):
+            # unpack a tuple to pass multiple arguments to the target function
+            return (func(*item) for item in items)
+
+        return (func(item) for item in items)
 
 
 parallel_runner = ParallelRunner()

--- a/checkov/common/runners/object_runner.py
+++ b/checkov/common/runners/object_runner.py
@@ -88,10 +88,9 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
                     self.map_file_path_to_gha_metadata_dict[file] = \
                         {"triggers": triggers, "workflow_name": workflow_name, "jobs": jobs}
 
+    @staticmethod
     @abstractmethod
-    def _parse_file(
-            self, f: str
-    ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
+    def _parse_file(f: str) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         raise Exception("parser should be imported by deriving class")
 
     def run(

--- a/checkov/common/vcs/base_vcs_dal.py
+++ b/checkov/common/vcs/base_vcs_dal.py
@@ -31,7 +31,6 @@ class BaseVCSDAL:
         self.http: urllib3.PoolManager | None = None
         self.http_timeout = urllib3.Timeout(connect=REQUEST_CONNECT_TIMEOUT, read=REQUEST_READ_TIMEOUT)
         self.http_retry = urllib3.Retry(REQUEST_RETRIES, redirect=3)
-        self.setup_http_manager(ca_certificate=os.getenv('BC_CA_BUNDLE', None))
         self.discover()
         self.setup_conf_dir()
 
@@ -88,6 +87,7 @@ class BaseVCSDAL:
         url_endpoint = f"{self.api_url}/{endpoint}"
         try:
             headers = self._headers()
+            self.setup_http_manager(ca_certificate=os.getenv('BC_CA_BUNDLE', None))
             if self.http:
                 request = self.http.request("GET", url_endpoint, headers=headers)  # type:ignore[no-untyped-call]
                 if request.status in allowed_status_codes:
@@ -114,6 +114,7 @@ class BaseVCSDAL:
 
         body = json.dumps({'query': query, 'variables': variables})
         try:
+            self.setup_http_manager(ca_certificate=os.getenv('BC_CA_BUNDLE', None))
             if self.http:
                 request = self.http.request("POST", self.graphql_api_url, body=body, headers=headers)  # type:ignore[no-untyped-call]
                 if request.status == 200:

--- a/checkov/example_runner/runner.py
+++ b/checkov/example_runner/runner.py
@@ -43,15 +43,16 @@ class Runner(YamlRunner):
         # This is specific to how the IaC is broken into checkable subcomponents
         return self.block_type_registries["jobs"]
 
+    @staticmethod
     def _parse_file(
-        self, f: str, file_content: str | None = None
+        f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         # EDIT" add conditional here to ensure this file is something we should parse.
         # Below is this example for github actions
         # as the file is always located in a predictable path
         # There should always be a conditional otherwise you'll parse ALL files.
         if ".github/workflows/" in os.path.abspath(f):
-            return super()._parse_file(f)
+            return YamlRunner._parse_file(f)
 
         return None
 

--- a/checkov/github_actions/runner.py
+++ b/checkov/github_actions/runner.py
@@ -54,10 +54,11 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, Any] | list[dict[str, Any
     def import_registry(self) -> BaseCheckRegistry:
         return registry
 
-    def _parse_file(self, f: str, file_content: str | None = None) -> \
+    @staticmethod
+    def _parse_file(f: str, file_content: str | None = None) -> \
             tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         if is_workflow_file(f):
-            entity_schema: tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None = super()._parse_file(f)
+            entity_schema: tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None = YamlRunner._parse_file(f)
             if not entity_schema:
                 # Indicates that there was an exception/error while trying to read the file,
                 # hence no need to check the schema validity.

--- a/checkov/gitlab_ci/runner.py
+++ b/checkov/gitlab_ci/runner.py
@@ -30,15 +30,17 @@ class Runner(ImageReferencerMixin["dict[str, dict[str, Any] | list[dict[str, Any
     def import_registry(self) -> BaseCheckRegistry:
         return registry
 
+    @staticmethod
     def _parse_file(
-        self, f: str, file_content: str | None = None
+        f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
-        if self.is_workflow_file(f):
-            return super()._parse_file(f=f, file_content=file_content)
+        if Runner.is_workflow_file(f):
+            return YamlRunner._parse_file(f=f, file_content=file_content)
 
         return None
 
-    def is_workflow_file(self, file_path: str) -> bool:
+    @staticmethod
+    def is_workflow_file(file_path: str) -> bool:
         """
         :return: True if the file mentioned is in the gitlab workflow name .gitlab-ci.yml. Otherwise: False
         """

--- a/checkov/json_doc/runner.py
+++ b/checkov/json_doc/runner.py
@@ -36,8 +36,9 @@ class Runner(ObjectRunner):
         from checkov.json_doc.registry import registry
         return registry
 
+    @staticmethod
     def _parse_file(
-        self, f: str, file_content: str | None = None
+        f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         if not f.endswith(".json"):
             return None

--- a/checkov/openapi/runner.py
+++ b/checkov/openapi/runner.py
@@ -15,8 +15,7 @@ from pathlib import Path
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
-_ParseFormatJsonCallable: TypeAlias = "Callable[[JsonRunner, str, str | None], tuple[dict[str, Any] | list[dict[str, Any]] | None, list[tuple[int, str]] | None] | None]"
-_ParseFormatYamlCallable: TypeAlias = "Callable[[YamlRunner, str, str | None], tuple[dict[str, Any] | list[dict[str, Any]] | None, list[tuple[int, str]] | None] | None]"
+_ParseFormatCallable: TypeAlias = "Callable[[str, str | None], tuple[dict[str, Any] | list[dict[str, Any]] | None, list[tuple[int, str]] | None] | None]"
 
 logger = logging.getLogger(__name__)
 add_resource_code_filter_to_logger(logger)
@@ -34,29 +33,29 @@ class Runner(YamlRunner, JsonRunner):
 
         return openapi_registry
 
+    @staticmethod
     def _parse_file(
-        self, f: str, file_content: str | None = None
+        f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         if f.endswith(".json"):
-            return self.parse_format(f, JsonRunner._parse_file)
+            return Runner.parse_format(f, JsonRunner._parse_file)
         elif f.endswith(".yml") or f.endswith(".yaml"):
-            return self.parse_format(f, YamlRunner._parse_file)
+            return Runner.parse_format(f, YamlRunner._parse_file)
         return None
 
+    @staticmethod
     def parse_format(
-        self,
-        f: str,
-        func: _ParseFormatJsonCallable | _ParseFormatYamlCallable,
+        f: str, func: _ParseFormatCallable
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         try:
-            content = self.load_file(f)
-            valid_openapi_file = self.pre_validate_file(content)
+            content = Runner.load_file(f)
+            valid_openapi_file = Runner.pre_validate_file(content)
             if not valid_openapi_file:
                 return None
 
-            parsed_file = func(self, f, content)
+            parsed_file = func(f, content)
 
-            if isinstance(parsed_file, tuple) and self.is_valid(parsed_file[0]):
+            if isinstance(parsed_file, tuple) and Runner.is_valid(parsed_file[0]):
                 return parsed_file  # type:ignore[return-value]  # is_valid checks for being not empty
         except ValueError:
             logger.debug(f"Could not parse {f}, skipping file", exc_info=True)
@@ -78,7 +77,8 @@ class Runner(YamlRunner, JsonRunner):
     def require_external_checks(self) -> bool:
         return False
 
-    def is_valid(self, conf: dict[str, Any] | list[dict[str, Any]] | None) -> bool:
+    @staticmethod
+    def is_valid(conf: dict[str, Any] | list[dict[str, Any]] | None) -> bool:
         """validate openAPI configuration."""
         # 'swagger' is a required element on v2.0, and 'openapi' is required on v3.
         # 'info' object is required in v2.0 and v3:
@@ -98,11 +98,13 @@ class Runner(YamlRunner, JsonRunner):
                      start_line: int = -1, end_line: int = -1, graph_resource: bool = False) -> str:
         return ",".join(supported_entities)
 
-    def load_file(self, filename: str | Path) -> str:
+    @staticmethod
+    def load_file(filename: str | Path) -> str:
         content = read_file_with_any_encoding(file_path=filename)
         return content
 
-    def pre_validate_file(self, file_content: str) -> bool:
+    @staticmethod
+    def pre_validate_file(file_content: str) -> bool:
         openapi_keywords = ["swagger", "openapi"]
         match = any(keyword in file_content for keyword in openapi_keywords)
         if match:

--- a/checkov/sca_package_2/runner.py
+++ b/checkov/sca_package_2/runner.py
@@ -56,12 +56,16 @@ class Runner(BaseRunner[None, None, None]):
 
         if bc_integration.bc_source and bc_integration.bc_source.name in IDEsSourceTypes \
                 and not bc_integration.is_prisma_integration():
-            logging.info("The --bc-api-key flag needs to be set to a Prisma token for SCA scan for vscode or jetbrains extention")
+            logging.info("The --bc-api-key flag needs to be set to a Prisma token for SCA scan for vscode or jetbrains extension")
             return {}, dict()  # should just return an empty result
 
         self._code_repo_path = Path(root_folder) if root_folder else None
 
         if not bc_integration.timestamp and bc_integration.bc_source and not bc_integration.bc_source.upload_results:
+            bc_integration.set_s3_integration()
+        if not bc_integration.credentials:
+            # only happens for 'ParallelizationType.SPAWN'
+            bc_integration.setup_http_manager()
             bc_integration.set_s3_integration()
 
         excluded_paths = {*ignored_directories}

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -331,11 +331,11 @@ class Runner(BaseRunner[None, None, None]):
     def _scan_files(files_to_scan: list[str], secrets: SecretsCollection, pbar: ProgressBar) -> None:
         # implemented the scan function like secrets.scan_files
         base_path = secrets.root
-        results = parallel_runner.run_function(
-            func=lambda f: Runner._safe_scan(f, base_path),
-            items=files_to_scan,
-            run_multiprocess=os.getenv("RUN_SECRETS_MULTIPROCESS", "").lower() == "true"
-        )
+        items = [
+            (file, base_path)
+            for file in files_to_scan
+        ]
+        results = parallel_runner.run_function(func=Runner._safe_scan, items=items)
 
         for filename, secrets_results in results:
             pbar.set_additional_data({'Current File Scanned': str(filename)})

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -288,7 +288,7 @@ class Runner(BaseRunner):
 
 def get_files_definitions(files: List[str], filepath_fn=None) \
         -> Tuple[Dict[str, DictNode], Dict[str, List[Tuple[int, str]]]]:
-    results = parallel_runner.run_function(func=parse, items=files)
+    results = parallel_runner.run_function(lambda f: (f, parse(f)), files)
     definitions = {}
     definitions_raw = {}
     for file, result in results:

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -288,7 +288,7 @@ class Runner(BaseRunner):
 
 def get_files_definitions(files: List[str], filepath_fn=None) \
         -> Tuple[Dict[str, DictNode], Dict[str, List[Tuple[int, str]]]]:
-    results = parallel_runner.run_function(lambda f: (f, parse(f)), files)
+    results = parallel_runner.run_function(func=parse, items=files)
     definitions = {}
     definitions_raw = {}
     for file, result in results:

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -5,12 +5,15 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import List, Callable
+from typing import List, Callable, TYPE_CHECKING
 
 from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.util.file_utils import read_file_with_any_encoding
 from checkov.common.util.type_forcers import convert_str_to_bool
 from checkov.terraform.module_loading.registry import module_loader_registry
+
+if TYPE_CHECKING:
+    from checkov.terraform.module_loading.registry import ModuleLoaderRegistry
 
 MODULE_NAME_PATTERN = re.compile(r'[^#]*\bmodule\s*"(?P<name>.*)"')
 MODULE_SOURCE_PATTERN = re.compile(r'[^#]*\bsource\s*=\s*"(?P<link>.*)"')
@@ -102,42 +105,49 @@ def load_tf_modules(
     if not modules_to_load:
         modules_to_load = find_modules(path)
 
-    def _download_module(m: ModuleDownload) -> bool:
-        if should_download_module(m.module_link):
-            logging.info(f'Downloading module {m.address}')
-            try:
-                content = module_loader_registry.load(
-                    current_dir=m.source_dir,
-                    source=m.module_link,
-                    source_version="latest" if not m.version else m.version,
-                    module_address=m.address,
-                    tf_managed=m.tf_managed,
-                )
-                if content is None or not content.loaded():
-                    log_message = f'Failed to download module {m.address}'
-                    if not module_loader_registry.download_external_modules:
-                        log_message += ' (for external modules, the --download-external-modules flag is required)'
-                    logging.warning(log_message)
-                    return False
-            except Exception as e:
-                logging.warning(f"Unable to load module ({m.address}): {e}")
-                return False
-        return True
-
     # To avoid duplicate work, we need to get the distinct module sources
     distinct_modules = list({m.address: m for m in modules_to_load}.values())
 
     replaced_modules = replace_terraform_managed_modules(path=path, found_modules=distinct_modules)
 
+    downloadable_modules = [
+        (module_loader_registry, m)
+        for m in {m.address: m for m in replaced_modules if should_download_module(m.module_link)}.values()
+    ]
+
     if run_parallel:
-        list(parallel_runner.run_function(_download_module, replaced_modules))
+        list(parallel_runner.run_function(_download_module, downloadable_modules))
     else:
         logging.info(f"Starting download of modules of length {len(replaced_modules)}")
-        for m in replaced_modules:
+        for m in downloadable_modules:
             success = _download_module(m)
             if not success and stop_on_failure:
-                logging.info(f"Stopping downloading of modules due to failed attempt on {m.address}")
+                logging.info(f"Stopping downloading of modules due to failed attempt on {m[1].address}")
                 break
+
+
+def _download_module(args: tuple[ModuleLoaderRegistry, ModuleDownload]) -> bool:
+    ml_registry, m = args
+    logging.info(f'Downloading module {m.address}')
+    try:
+        content = ml_registry.load(
+            current_dir=m.source_dir,
+            source=m.module_link,
+            source_version="latest" if not m.version else m.version,
+            module_address=m.address,
+            tf_managed=m.tf_managed,
+        )
+        if content is None or not content.loaded():
+            log_message = f'Failed to download module {m.address}'
+            if not ml_registry.download_external_modules:
+                log_message += ' (for external modules, the --download-external-modules flag is required)'
+            logging.warning(log_message)
+            return False
+    except Exception as e:
+        logging.warning(f"Unable to load module ({m.address}): {e}")
+        return False
+
+    return True
 
 
 def replace_terraform_managed_modules(path: str, found_modules: list[ModuleDownload]) -> list[ModuleDownload]:

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -66,7 +66,6 @@ class Runner(BaseTerraformRunner[_TerraformDefinitions, _TerraformContext, TFDef
         runner_filter: RunnerFilter | None = None,
         collect_skip_comments: bool = True,
     ) -> Report | list[Report]:
-        bc_integration.bc_api_key
         runner_filter = runner_filter or RunnerFilter()
         if not runner_filter.show_progress_bar:
             self.pbar.turn_off_progress_bar()

--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -8,7 +8,6 @@ from typing import Any, TYPE_CHECKING, Optional
 from typing_extensions import TypeAlias  # noqa[TC002]
 
 from checkov.common.bridgecrew.check_type import CheckType
-from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.graph.checks_infra.registry import BaseRegistry
 from checkov.common.graph.graph_builder.consts import GraphSource
 from checkov.common.output.extra_resource import ExtraResource

--- a/checkov/yaml_doc/runner.py
+++ b/checkov/yaml_doc/runner.py
@@ -37,8 +37,9 @@ class Runner(ObjectRunner):
 
         return registry
 
+    @staticmethod
     def _parse_file(
-        self, f: str, file_content: str | None = None
+        f: str, file_content: str | None = None
     ) -> tuple[dict[str, Any] | list[dict[str, Any]], list[tuple[int, str]]] | None:
         return parse(f, file_content)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added the possibility to adjust the parallelization type via the env var `CHECKOV_PARALLELIZATION_TYPE`
  - possible values are `fork`, `spawn`, `thread` or `none`
- the current default is still kept as `fork`, but will be changed to `spawn` after more testing is done
- the singleton `bc_integration` got some extra methods to easily recreate for usage inside of `sast` and `sca` runners when using `spawn` mode

Fixes #5700

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
