### PR TITLE
platform(general): print the log upload location if the --support flag is used

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -571,7 +571,7 @@ class BcPlatformIntegration:
         persist_run_metadata(run_metadata, self.s3_client, self.bucket, self.repo_path, True)
         if self.support_bucket and self.support_repo_path:
             logging.debug(f'Also uploading run_metadata.json to support location: {self.support_bucket}/{self.support_repo_path}')
-            persist_run_metadata(run_metadata, self.s3_client, cast(str, self.support_bucket), cast(str, self.support_repo_path), False)
+            persist_run_metadata(run_metadata, self.s3_client, self.support_bucket, self.support_repo_path, False)
 
     def persist_logs_stream(self, logs_stream: StringIO) -> None:
         if not self.use_s3_integration or not self.s3_client or self.s3_setup_failed:

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -337,7 +337,7 @@ class BcPlatformIntegration:
             )
 
             if self.support_flag_enabled:
-                self.support_bucket, self.support_repo_path = support_path.split("/", 1)
+                self.support_bucket, self.support_repo_path = cast(str, support_path).split("/", 1)
 
             self.use_s3_integration = True
         except MaxRetryError:
@@ -568,9 +568,9 @@ class BcPlatformIntegration:
         if not self.bucket or not self.repo_path:
             logging.error(f"Something went wrong: bucket {self.bucket}, repo path {self.repo_path}")
             return
-        persist_run_metadata(run_metadata, self.s3_client, self.bucket, self.repo_path, True)
+        persist_run_metadata(run_metadata, self.s3_client, self.bucket, self.repo_path, True)\
         logging.debug(f'Also uploading run_metadata.json to support location: {self.support_repo_path}')
-        persist_run_metadata(run_metadata, self.s3_client, self.support_bucket, self.support_repo_path, False)
+        persist_run_metadata(run_metadata, self.s3_client, cast(str, self.support_bucket), cast(str, self.support_repo_path), False)
 
     def persist_logs_stream(self, logs_stream: StringIO) -> None:
         if not self.use_s3_integration or not self.s3_client or self.s3_setup_failed:

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -569,8 +569,9 @@ class BcPlatformIntegration:
             logging.error(f"Something went wrong: bucket {self.bucket}, repo path {self.repo_path}")
             return
         persist_run_metadata(run_metadata, self.s3_client, self.bucket, self.repo_path, True)
-        logging.debug(f'Also uploading run_metadata.json to support location: {self.support_repo_path}')
-        persist_run_metadata(run_metadata, self.s3_client, cast(str, self.support_bucket), cast(str, self.support_repo_path), False)
+        if self.support_bucket and self.support_repo_path:
+            logging.debug(f'Also uploading run_metadata.json to support location: {self.support_bucket}/{self.support_repo_path}')
+            persist_run_metadata(run_metadata, self.s3_client, cast(str, self.support_bucket), cast(str, self.support_repo_path), False)
 
     def persist_logs_stream(self, logs_stream: StringIO) -> None:
         if not self.use_s3_integration or not self.s3_client or self.s3_setup_failed:

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -336,13 +336,8 @@ class BcPlatformIntegration:
                 config=config,
             )
 
-            if support_path:
+            if self.support_flag_enabled:
                 self.support_bucket, self.support_repo_path = support_path.split("/", 1)
-            elif self.support_flag_enabled:
-                logging.debug(
-                    '--support was used, but we did not get a support file upload path in the platform response. Using the old location.')
-                self.support_bucket = self.bucket
-                self.support_repo_path = self.repo_path
 
             self.use_s3_integration = True
         except MaxRetryError:
@@ -574,10 +569,8 @@ class BcPlatformIntegration:
             logging.error(f"Something went wrong: bucket {self.bucket}, repo path {self.repo_path}")
             return
         persist_run_metadata(run_metadata, self.s3_client, self.bucket, self.repo_path, True)
-        # only upload it if we did not fall back to use the same location
-        if self.support_bucket and self.support_repo_path and self.support_repo_path != self.repo_path:
-            logging.debug('Also uploading run_metadata.json to support location')
-            persist_run_metadata(run_metadata, self.s3_client, self.support_bucket, self.support_repo_path, False)
+        logging.debug(f'Also uploading run_metadata.json to support location: {self.support_repo_path}')
+        persist_run_metadata(run_metadata, self.s3_client, self.support_bucket, self.support_repo_path, False)
 
     def persist_logs_stream(self, logs_stream: StringIO) -> None:
         if not self.use_s3_integration or not self.s3_client or self.s3_setup_failed:
@@ -586,9 +579,7 @@ class BcPlatformIntegration:
             logging.error(
                 f"Something went wrong with the log upload location: bucket {self.support_bucket}, repo path {self.support_repo_path}")
             return
-        # use checkov_results if we fall back to using the same location
-        log_path = f'{self.support_repo_path}/checkov_results' if self.support_repo_path == self.repo_path else self.support_repo_path
-        persist_logs_stream(logs_stream, self.s3_client, self.support_bucket, log_path)
+        persist_logs_stream(logs_stream, self.s3_client, self.support_bucket, self.support_repo_path)
 
     def persist_graphs(self, graphs: dict[str, list[tuple[LibraryGraph, Optional[str]]]], absolute_root_folder: str = '') -> None:
         if not self.use_s3_integration or not self.s3_client or self.s3_setup_failed:

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -568,7 +568,7 @@ class BcPlatformIntegration:
         if not self.bucket or not self.repo_path:
             logging.error(f"Something went wrong: bucket {self.bucket}, repo path {self.repo_path}")
             return
-        persist_run_metadata(run_metadata, self.s3_client, self.bucket, self.repo_path, True)\
+        persist_run_metadata(run_metadata, self.s3_client, self.bucket, self.repo_path, True)
         logging.debug(f'Also uploading run_metadata.json to support location: {self.support_repo_path}')
         persist_run_metadata(run_metadata, self.s3_client, cast(str, self.support_bucket), cast(str, self.support_repo_path), False)
 

--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -97,11 +97,12 @@ class Report:
     def get_all_records(self) -> List[Record]:
         return self.failed_checks + self.passed_checks + self.skipped_checks
 
-    def get_dict(self, is_quiet: bool = False, url: str | None = None, full_report: bool = False, s3_setup_failed: bool = False) -> dict[str, Any]:
+    def get_dict(self, is_quiet: bool = False, url: str | None = None, full_report: bool = False, s3_setup_failed: bool = False, support_path: str | None = None) -> dict[str, Any]:
         if not url and not s3_setup_failed:
             url = "Add an api key '--bc-api-key <api-key>' to see more detailed insights via https://bridgecrew.cloud"
         elif s3_setup_failed:
             url = S3_UPLOAD_DETAILS_MESSAGE
+
         if is_quiet:
             return {
                 "check_type": self.check_type,
@@ -121,7 +122,7 @@ class Report:
                 "image_cached_results": [res.__dict__ for res in self.image_cached_results]
             }
         else:
-            return {
+            result = {
                 "check_type": self.check_type,
                 "results": {
                     "passed_checks": [check.__dict__ for check in self.passed_checks],
@@ -132,6 +133,11 @@ class Report:
                 "summary": self.get_summary(),
                 "url": url,
             }
+
+            if support_path:
+                result["support_path"] = support_path
+
+            return result
 
     def get_exit_code(self, exit_code_thresholds: Union[_ExitCodeThresholds, _ScaExitCodeThresholds]) -> int:
         """

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -395,7 +395,7 @@ class RunnerRegistry:
         for report in scan_reports:
             if not report.is_empty():
                 if "json" in config.output:
-                    report_jsons.append(report.get_dict(is_quiet=config.quiet, url=url, s3_setup_failed=bc_integration.s3_setup_failed))
+                    report_jsons.append(report.get_dict(is_quiet=config.quiet, url=url, s3_setup_failed=bc_integration.s3_setup_failed, support_path=bc_integration.support_repo_path))
                 if "junitxml" in config.output:
                     junit_reports.append(report)
                 if "github_failed_only" in config.output:
@@ -452,6 +452,7 @@ class RunnerRegistry:
                 output_format="cli",
                 output=cli_output,
                 url=url,
+                support_path=bc_integration.support_repo_path
             )
 
             # Remove colors from the cli output
@@ -487,6 +488,8 @@ class RunnerRegistry:
                         print(f"More details: {url}")
                     elif bc_integration.s3_setup_failed:
                         print(S3_UPLOAD_DETAILS_MESSAGE)
+                    if bc_integration.support_repo_path:
+                        print(f"\nPath for uploaded logs (give this to support if raising an issue): {bc_integration.support_repo_path}")
                 if CONSOLE_OUTPUT in output_formats.values():
                     print(OUTPUT_DELIMITER)
 
@@ -613,7 +616,7 @@ class RunnerRegistry:
         exit_code = 1 if 1 in exit_codes else 0
         return cast(Literal[0, 1], exit_code)
 
-    def _print_to_console(self, output_formats: dict[str, str], output_format: str, output: str, url: str | None = None) -> None:
+    def _print_to_console(self, output_formats: dict[str, str], output_format: str, output: str, url: str | None = None, support_path: str | None = None) -> None:
         """Prints the output to console, if needed"""
         output_dest = output_formats[output_format]
         if output_dest == CONSOLE_OUTPUT:
@@ -627,6 +630,9 @@ class RunnerRegistry:
                 print(f"More details: {url}")
             elif bc_integration.s3_setup_failed:
                 print(S3_UPLOAD_DETAILS_MESSAGE)
+
+            if support_path:
+                print(f"\nPath for uploaded logs (give this to support if raising an issue): {support_path}")
 
             if CONSOLE_OUTPUT in output_formats.values():
                 print(OUTPUT_DELIMITER)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Print the support log upload path alongside the details URL if the `--support` flag is used.

Also cleans up some code that is no longer needed, because the platform always returns a support path S3 URL. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
