### PR TITLE
fix(cloudformation): ignore unresolved references in CKV_AWS_45

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentCredentials.py
+++ b/checkov/cloudformation/checks/resource/aws/LambdaEnvironmentCredentials.py
@@ -24,6 +24,10 @@ class LambdaEnvironmentCredentials(BaseResourceCheck):
                 variables = environment.get("Variables")
                 if variables and isinstance(variables, dict):
                     for var_name, value in variables.items():
+                        if isinstance(value, dict):
+                            # if it is a resolved instrinsic function like !Ref: xyz, then it can't be a secret
+                            continue
+
                         secrets = get_secrets_from_string(str(value), AWS, GENERAL)
                         if secrets:
                             self.evaluated_keys = [f"Properties/Environment/Variables/{var_name}"]

--- a/tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentCredentials/PASS.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_LambdaEnvironmentCredentials/PASS.yaml
@@ -41,3 +41,18 @@ Resources:
       Description: Invoke a function during stack creation.
       TracingConfig:
         Mode: Active
+  UnresolvedEnv:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: nodejs12.x
+      Role: arn:aws:iam::123456789012:role/lambda-role
+      Handler: index.handler
+      Environment:
+        Variables:
+          MY_COOL_STATE_MACHINE: !Ref MySuperCoolFortyCharLongStateMachineeeee
+      Code:
+        ZipFile: |
+          print('hi')
+      Description: Invoke a function during stack creation.
+      TracingConfig:
+        Mode: Active

--- a/tests/cloudformation/checks/resource/aws/test_LambdaEnvironmentCredentials.py
+++ b/tests/cloudformation/checks/resource/aws/test_LambdaEnvironmentCredentials.py
@@ -17,6 +17,7 @@ class TestLambdaEnvironmentCredentials(unittest.TestCase):
             "AWS::Lambda::Function.NoEnv",
             "AWS::Lambda::Function.NoSecret",
             "AWS::Lambda::Function.EnvNull",
+            "AWS::Lambda::Function.UnresolvedEnv",
             "AWS::Serverless::Function.NoEnv",
             "AWS::Serverless::Function.NoProperties",
             "AWS::Serverless::Function.NoSecret",
@@ -29,8 +30,8 @@ class TestLambdaEnvironmentCredentials(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 6)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added a skip, if the value is a `dict`, which usually occurs with unresolved function calls, like `!Ref`
- small optimization around the secrets detection

Fixes #5743

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
