### PR TITLE
chore: reinitialize platform integration in SAST runner

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -128,9 +128,12 @@ class BcPlatformIntegration:
         self.ca_certificate: str | None = None
         self.no_cert_verify: bool = False
         self.on_prem: bool = False
+        self.daemon_process = False  # set to 'True' when running in multiprocessing 'spawn' mode
 
     def init_instance(self, platform_integration_data: dict[str, Any]) -> None:
         """This is mainly used for recreating the instance without interacting with the platform again"""
+
+        self.daemon_process = True
 
         self.bc_api_url = platform_integration_data["bc_api_url"]
         self.bc_api_key = platform_integration_data["bc_api_key"]
@@ -377,6 +380,7 @@ class BcPlatformIntegration:
                 self.support_bucket, self.support_repo_path = cast(str, support_path).split("/", 1)
 
             self.use_s3_integration = True
+            self.platform_integration_configured = True
         except MaxRetryError:
             logging.error("An SSL error occurred connecting to the platform. If you are on a VPN, please try "
                           "disabling it and re-running the command.", exc_info=True)

--- a/checkov/sast/runner.py
+++ b/checkov/sast/runner.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 from checkov.common.bridgecrew.check_type import CheckType
+from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.output.report import Report
 from checkov.common.runners.base_runner import BaseRunner
 from checkov.common.sast.consts import SUPPORT_FILE_EXT, FILE_EXT_TO_SAST_LANG
@@ -45,6 +46,11 @@ class Runner(BaseRunner[None, None, None]):
         if not runner_filter:
             logger.warning('no runner filter')
             return [Report(self.check_type)]
+
+        if bc_integration.daemon_process:
+            # only happens for 'ParallelizationType.SPAWN'
+            bc_integration.setup_http_manager()
+            bc_integration.set_s3_integration()
 
         # registry get all the paths
         self.registry.set_runner_filter(runner_filter)

--- a/checkov/sca_package_2/runner.py
+++ b/checkov/sca_package_2/runner.py
@@ -63,7 +63,7 @@ class Runner(BaseRunner[None, None, None]):
 
         if not bc_integration.timestamp and bc_integration.bc_source and not bc_integration.bc_source.upload_results:
             bc_integration.set_s3_integration()
-        if not bc_integration.credentials:
+        if bc_integration.daemon_process:
             # only happens for 'ParallelizationType.SPAWN'
             bc_integration.setup_http_manager()
             bc_integration.set_s3_integration()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- added a flag in platform integration to mark multiprocessing `spawn` mode
- reinitialized platform integration in SAST runner

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
