### PR TITLE
fix(terraform): check min TLS version also on azure app slots

### DIFF
--- a/checkov/terraform/checks/resource/azure/FunctionAppMinTLSVersion.py
+++ b/checkov/terraform/checks/resource/azure/FunctionAppMinTLSVersion.py
@@ -4,9 +4,15 @@ from checkov.terraform.checks.resource.base_resource_value_check import BaseReso
 
 class FunctionAppMinTLSVersion(BaseResourceValueCheck):
     def __init__(self):
+        """
+        The minimum supported TLS version for the function app.
+        Defaults to 1.2 for new function apps.
+        """
         name = "Ensure Function app is using the latest version of TLS encryption"
         id = "CKV_AZURE_145"
-        supported_resources = ['azurerm_function_app']
+        supported_resources = ['azurerm_function_app', 'azurerm_linux_function_app', 'azurerm_windows_function_app',
+                               'azurerm_function_app_slot', 'azurerm_linux_function_app_slot',
+                               'azurerm_windows_function_app_slot']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
                          missing_block_result=CheckResult.PASSED)

--- a/checkov/terraform/checks/resource/azure/FunctionAppMinTLSVersion.py
+++ b/checkov/terraform/checks/resource/azure/FunctionAppMinTLSVersion.py
@@ -7,6 +7,9 @@ class FunctionAppMinTLSVersion(BaseResourceValueCheck):
         """
         The minimum supported TLS version for the function app.
         Defaults to 1.2 for new function apps.
+        field name is:
+         - min_tls_version in azurerm_function_app, azurerm_function_app_slot.
+         - minimum_tls_version in newer resources (with linux/windows).
         """
         name = "Ensure Function app is using the latest version of TLS encryption"
         id = "CKV_AZURE_145"
@@ -18,7 +21,10 @@ class FunctionAppMinTLSVersion(BaseResourceValueCheck):
                          missing_block_result=CheckResult.PASSED)
 
     def get_inspected_key(self):
-        return "site_config/[0]/min_tls_version"
+        if self.entity_type in ("azurerm_function_app", "azurerm_function_app_slot"):
+            return "site_config/[0]/min_tls_version"
+        else:
+            return "site_config/[0]/minimum_tls_version"
 
     def get_expected_value(self):
         return 1.2

--- a/tests/terraform/checks/resource/azure/example_FunctionAppMinTLSVersion/main.tf
+++ b/tests/terraform/checks/resource/azure/example_FunctionAppMinTLSVersion/main.tf
@@ -17,8 +17,21 @@ resource "azurerm_function_app" "fail" {
       allowed_origins = ["*"]
     }
   }
-
 }
+
+resource "azurerm_function_app_slot" "fail2" {
+  name                       = "test-azure-functions_slot"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  app_service_plan_id        = azurerm_app_service_plan.example.id
+  function_app_name          = azurerm_function_app.example.name
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  site_config {
+    min_tls_version = 1.1
+  }
+}
+
 resource "azurerm_function_app" "pass" {
   name                       = "test-azure-functions"
   location                   = azurerm_resource_group.example.location
@@ -38,6 +51,7 @@ resource "azurerm_function_app" "pass" {
     }
   }
 }
+
 resource "azurerm_function_app" "pass2" {
   name                       = "test-azure-functions"
   location                   = azurerm_resource_group.example.location
@@ -78,4 +92,14 @@ resource "azurerm_function_app" "pass3" {
       allowed_origins = ["*"]
     }
   }
+}
+
+resource "azurerm_function_app_slot" "pass4" {
+  name                       = "test-azure-functions_slot"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  app_service_plan_id        = azurerm_app_service_plan.example.id
+  function_app_name          = azurerm_function_app.example.name
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
 }

--- a/tests/terraform/checks/resource/azure/example_FunctionAppMinTLSVersion/main.tf
+++ b/tests/terraform/checks/resource/azure/example_FunctionAppMinTLSVersion/main.tf
@@ -32,6 +32,50 @@ resource "azurerm_function_app_slot" "fail2" {
   }
 }
 
+resource "azurerm_linux_function_app" "fail3" {
+  name                 = "example-linux-function-app"
+  resource_group_name  = azurerm_resource_group.example.name
+  location             = azurerm_resource_group.example.location
+  service_plan_id      = azurerm_service_plan.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {
+    minimum_tls_version = 1.1
+  }
+}
+resource "azurerm_windows_function_app" "fail4" {
+  name                = "example-windows-function-app"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+
+  site_config {
+    minimum_tls_version = 1.1
+  }
+}
+
+resource "azurerm_linux_function_app_slot" "fail5" {
+  name                 = "example-linux-function-app-slot"
+  function_app_id      = azurerm_linux_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {
+    minimum_tls_version = 1.1
+  }
+}
+resource "azurerm_windows_function_app_slot" "fail6" {
+  name                 = "example-slot"
+  function_app_id      = azurerm_windows_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {
+    minimum_tls_version = 1.1
+  }
+}
+
 resource "azurerm_function_app" "pass" {
   name                       = "test-azure-functions"
   location                   = azurerm_resource_group.example.location
@@ -102,4 +146,55 @@ resource "azurerm_function_app_slot" "pass4" {
   function_app_name          = azurerm_function_app.example.name
   storage_account_name       = azurerm_storage_account.example.name
   storage_account_access_key = azurerm_storage_account.example.primary_access_key
+}
+
+resource "azurerm_linux_function_app" "pass5" {
+  name                 = "example-linux-function-app"
+  resource_group_name  = azurerm_resource_group.example.name
+  location             = azurerm_resource_group.example.location
+  service_plan_id      = azurerm_service_plan.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {
+    minimum_tls_version = 1.2
+  }
+}
+resource "azurerm_windows_function_app" "pass6" {
+  name                = "example-windows-function-app"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+
+  site_config {
+    minimum_tls_version = 1.2
+  }
+}
+
+resource "azurerm_linux_function_app_slot" "pass7" {
+  name                 = "example-linux-function-app-slot"
+  function_app_id      = azurerm_linux_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {
+    minimum_tls_version = 1.2
+  }
+}
+resource "azurerm_windows_function_app_slot" "pass8" {
+  name                 = "example-slot"
+  function_app_id      = azurerm_windows_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {
+    minimum_tls_version = 1.2
+  }
+}
+resource "azurerm_windows_function_app_slot" "pass9" {
+  name                 = "example-slot"
+  function_app_id      = azurerm_windows_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {}
 }

--- a/tests/terraform/checks/resource/azure/test_FunctionAppMinTLSVersion.py
+++ b/tests/terraform/checks/resource/azure/test_FunctionAppMinTLSVersion.py
@@ -18,10 +18,19 @@ class TestFunctionAppMinTLSVersion(unittest.TestCase):
             "azurerm_function_app.pass2",
             "azurerm_function_app.pass3",
             "azurerm_function_app_slot.pass4",
+            "azurerm_linux_function_app.pass5",
+            "azurerm_windows_function_app.pass6",
+            "azurerm_linux_function_app_slot.pass7",
+            "azurerm_windows_function_app_slot.pass8",
+            "azurerm_windows_function_app_slot.pass9",
         }
         failing_resources = {
             "azurerm_function_app.fail",
             "azurerm_function_app_slot.fail2",
+            "azurerm_linux_function_app.fail3",
+            "azurerm_windows_function_app.fail4",
+            "azurerm_linux_function_app_slot.fail5",
+            "azurerm_windows_function_app_slot.fail6",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}

--- a/tests/terraform/checks/resource/azure/test_FunctionAppMinTLSVersion.py
+++ b/tests/terraform/checks/resource/azure/test_FunctionAppMinTLSVersion.py
@@ -17,16 +17,18 @@ class TestFunctionAppMinTLSVersion(unittest.TestCase):
             "azurerm_function_app.pass",
             "azurerm_function_app.pass2",
             "azurerm_function_app.pass3",
+            "azurerm_function_app_slot.pass4",
         }
         failing_resources = {
             "azurerm_function_app.fail",
+            "azurerm_function_app_slot.fail2",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 3)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 

--- a/tests/terraform/image_referencer/test_runner_azure_resources.py
+++ b/tests/terraform/image_referencer/test_runner_azure_resources.py
@@ -134,7 +134,7 @@ def test_app_service_linux_function_resources(mocker: MockerFixture, graph_frame
     sca_image_report = next(report for report in reports if report.check_type == CheckType.SCA_IMAGE)
 
     assert len(tf_report.resources) == 2
-    assert len(tf_report.passed_checks) == 0
+    assert len(tf_report.passed_checks) == 2
     assert len(tf_report.failed_checks) == 2
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0


### PR DESCRIPTION
hi, this closes #5721.
notes:
- deprecation: azurerm_function_app will be replaced in version 4.0 by azurerm_linux_function_app and azurerm_windows_function_app. (same thing for slots) 
- similar: [here](https://github.com/bridgecrewio/checkov/blob/5796faf8523acbe4fb5f5fb340c682a27b7851d8/checkov/terraform/checks/resource/azure/AppServiceMinTLSVersion.py#L9) you can also add slots (azurerm_linux_web_app_slot, azurerm_windows_web_app_slot)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
