### PR TITLE
fix(terraform): Ensure HTTPS in Azure Function App and App Slots

### DIFF
--- a/checkov/terraform/checks/resource/azure/FunctionAppsAccessibleOverHttps.py
+++ b/checkov/terraform/checks/resource/azure/FunctionAppsAccessibleOverHttps.py
@@ -1,17 +1,44 @@
-from checkov.common.models.enums import CheckCategories
-from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
 
 
-class FunctionAppsAccessibleOverHttps(BaseResourceValueCheck):
-    def __init__(self):
+class FunctionAppsAccessibleOverHttps(BaseResourceCheck):
+
+    def __init__(self) -> None:
         name = "Ensure that Function apps is only accessible over HTTPS"
         id = "CKV_AZURE_70"
-        supported_resources = ['azurerm_function_app']
+        supported_resources = ['azurerm_function_app', 'azurerm_linux_function_app', 'azurerm_windows_function_app',
+                               'azurerm_function_app_slot', 'azurerm_linux_function_app_slot',
+                               'azurerm_windows_function_app_slot']
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return 'https_only'
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        # default=false for https_only
+        if 'https_only' not in conf.keys():
+            return CheckResult.FAILED
+
+        https_only = conf.get('https_only')[0]
+        if not https_only:
+            return CheckResult.FAILED
+
+        # relevant for linux/windows resources
+        if 'auth_settings_v2' in conf.keys():
+            auth_settings_v2 = conf['auth_settings_v2'][0]
+
+            # default=true for require_https
+            if 'require_https' not in auth_settings_v2.keys():
+                return CheckResult.PASSED
+
+            require_https = auth_settings_v2.get('require_https')[0]
+            if not require_https:
+                return CheckResult.FAILED
+
+        return CheckResult.PASSED
 
 
 check = FunctionAppsAccessibleOverHttps()

--- a/tests/terraform/checks/resource/azure/example_FunctionAppAccessibleOverHttps/main.tf
+++ b/tests/terraform/checks/resource/azure/example_FunctionAppAccessibleOverHttps/main.tf
@@ -1,0 +1,177 @@
+
+## app
+
+resource "azurerm_function_app" "fail" {
+  name                       = "test-azure-functions"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  app_service_plan_id        = azurerm_app_service_plan.example.id
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+}
+resource "azurerm_function_app" "fail2" {
+  name                       = "test-azure-functions"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  app_service_plan_id        = azurerm_app_service_plan.example.id
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  https_only = false
+}
+resource "azurerm_function_app" "pass" {
+  name                       = "test-azure-functions"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  app_service_plan_id        = azurerm_app_service_plan.example.id
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  https_only = true
+}
+
+## app_slot
+
+resource "azurerm_function_app_slot" "fail" {
+  name                       = "test-azure-functions_slot"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  app_service_plan_id        = azurerm_app_service_plan.example.id
+  function_app_name          = azurerm_function_app.example.name
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+}
+resource "azurerm_function_app_slot" "fail2" {
+  name                       = "test-azure-functions_slot"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  app_service_plan_id        = azurerm_app_service_plan.example.id
+  function_app_name          = azurerm_function_app.example.name
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  https_only = false
+}
+resource "azurerm_function_app_slot" "pass" {
+  name                       = "test-azure-functions_slot"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  app_service_plan_id        = azurerm_app_service_plan.example.id
+  function_app_name          = azurerm_function_app.example.name
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  https_only = true
+}
+
+#### linux/windows
+
+## app
+
+resource "azurerm_linux_function_app" "fail" {
+  name                = "example-linux-function-app"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+
+  site_config {}
+}
+resource "azurerm_linux_function_app" "fail2" {
+  name                = "example-linux-function-app"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+
+  site_config {}
+  https_only = false
+}
+resource "azurerm_linux_function_app" "fail3" {
+  name                = "example-linux-function-app"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+
+  site_config {}
+
+  https_only = true
+  auth_settings_v2 {
+    require_https = false
+  }
+}
+resource "azurerm_linux_function_app" "pass" {
+  name                = "example-linux-function-app"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+
+  site_config {}
+  https_only = true
+}
+resource "azurerm_linux_function_app" "pass2" {
+  name                = "example-linux-function-app"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  service_plan_id            = azurerm_service_plan.example.id
+
+  site_config {}
+
+  https_only = true
+  auth_settings_v2 {
+    require_https = true
+  }
+}
+
+## app slot
+
+resource "azurerm_linux_function_app_slot" "fail" {
+  name                 = "example-linux-function-app-slot"
+  function_app_id      = azurerm_linux_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {}
+}
+resource "azurerm_linux_function_app_slot" "fail2" {
+  name                 = "example-linux-function-app-slot"
+  function_app_id      = azurerm_linux_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {}
+  https_only = false
+}
+resource "azurerm_linux_function_app_slot" "fail3" {
+  name                 = "example-linux-function-app-slot"
+  function_app_id      = azurerm_linux_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {}
+  auth_settings_v2 {
+    require_https = false
+  }
+  https_only = true
+}
+resource "azurerm_linux_function_app_slot" "pass" {
+  name                 = "example-linux-function-app-slot"
+  function_app_id      = azurerm_linux_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {}
+  auth_settings_v2 {}
+  https_only = true
+}
+resource "azurerm_linux_function_app_slot" "pass2" {
+  name                 = "example-linux-function-app-slot"
+  function_app_id      = azurerm_linux_function_app.example.id
+  storage_account_name = azurerm_storage_account.example.name
+
+  site_config {}
+  auth_settings_v2 {
+    require_https = true
+  }
+  https_only = true
+}

--- a/tests/terraform/image_referencer/test_runner_azure_resources.py
+++ b/tests/terraform/image_referencer/test_runner_azure_resources.py
@@ -135,7 +135,7 @@ def test_app_service_linux_function_resources(mocker: MockerFixture, graph_frame
 
     assert len(tf_report.resources) == 2
     assert len(tf_report.passed_checks) == 2
-    assert len(tf_report.failed_checks) == 2
+    assert len(tf_report.failed_checks) == 4
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0
 


### PR DESCRIPTION
hi, this closes #5720.

*`require_https` was in the `auth_settings_v2` block (not in site_config as mentioned in issue).