### PR TITLE
fix(terraform_plan): TF plan resources connection fix

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -391,10 +391,10 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         if len(relative_vertices) == 1:
             relative_vertex = relative_vertices[0]
         else:
-            relative_vertex = self._find_vertex_with_longest_path_match(relative_vertices, block_path, origin_vertex_index)
+            relative_vertex = self._find_vertex_with_best_match(relative_vertices, block_path, origin_vertex_index)
         return relative_vertex
 
-    def _find_vertex_with_longest_path_match(self, relevant_vertices_indexes: List[int], origin_path: str,
+    def _find_vertex_with_best_match(self, relevant_vertices_indexes: List[int], origin_path: str,
                                              origin_vertex_index: Optional[int] = None) -> int:
         vertex_index_with_longest_common_prefix = -1
         longest_common_prefix = ""
@@ -405,11 +405,11 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
                 vertex_index_with_longest_common_prefix = vertex_index
                 longest_common_prefix = common_prefix
             elif len(common_prefix) == len(longest_common_prefix) and origin_vertex_index:
-                vertex_module_name = vertex.attributes.get('__address__', '')
-                origin_module_name = self.vertices[origin_vertex_index].attributes.get('__address__', '')
-                if vertex_module_name.startswith('module') and origin_module_name.startswith('module'):
+                vertex_module_name = vertex.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS, '')
+                origin_module_name = self.vertices[origin_vertex_index].attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS, '')
+                if vertex_module_name.startswith(BlockType.MODULE) and origin_module_name.startswith(BlockType.MODULE):
                     split_module_name = vertex_module_name.split('.')[1]
-                    if origin_module_name.startswith(f'module.{split_module_name}'):
+                    if origin_module_name.startswith(f'{BlockType.MODULE}.{split_module_name}'):
                         vertex_index_with_longest_common_prefix = vertex_index
         return vertex_index_with_longest_common_prefix
 

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -395,7 +395,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         return relative_vertex
 
     def _find_vertex_with_best_match(self, relevant_vertices_indexes: List[int], origin_path: str,
-                                             origin_vertex_index: Optional[int] = None) -> int:
+                                     origin_vertex_index: Optional[int] = None) -> int:
         vertex_index_with_longest_common_prefix = -1
         longest_common_prefix = ""
         for vertex_index in relevant_vertices_indexes:

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -225,7 +225,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
                     else:
                         dest_node_index = self._find_vertex_index_relative_to_path(
                             vertex_reference.block_type, reference_name, vertex.path,
-                            source_module_object=source_module_object
+                            source_module_object=source_module_object, origin_vertex_index=origin_node_index
                         )
                     if dest_node_index > -1 and origin_node_index > -1:
                         self._create_edge_from_reference(attribute_key, origin_node_index, dest_node_index, sub_values,
@@ -372,6 +372,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         block_path: str,
         relative_module_idx: Optional[int] = None,
         source_module_object: Optional[TFModule] = None,
+        origin_vertex_index: Optional[int] = None,
     ) -> int:
         relative_vertices: list[int] = []
         if relative_module_idx is None:
@@ -390,10 +391,11 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         if len(relative_vertices) == 1:
             relative_vertex = relative_vertices[0]
         else:
-            relative_vertex = self._find_vertex_with_longest_path_match(relative_vertices, block_path)
+            relative_vertex = self._find_vertex_with_longest_path_match(relative_vertices, block_path, origin_vertex_index)
         return relative_vertex
 
-    def _find_vertex_with_longest_path_match(self, relevant_vertices_indexes: List[int], origin_path: str) -> int:
+    def _find_vertex_with_longest_path_match(self, relevant_vertices_indexes: List[int], origin_path: str,
+                                             origin_vertex_index: Optional[int] = None) -> int:
         vertex_index_with_longest_common_prefix = -1
         longest_common_prefix = ""
         for vertex_index in relevant_vertices_indexes:
@@ -402,6 +404,13 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
             if len(common_prefix) > len(longest_common_prefix):
                 vertex_index_with_longest_common_prefix = vertex_index
                 longest_common_prefix = common_prefix
+            elif len(common_prefix) == len(longest_common_prefix) and origin_vertex_index:
+                vertex_module_name = vertex.attributes.get('__address__', '')
+                origin_module_name = self.vertices[origin_vertex_index].attributes.get('__address__', '')
+                if vertex_module_name.startswith('module') and origin_module_name.startswith('module'):
+                    split_module_name = vertex_module_name.split('.')[1]
+                    if origin_module_name.startswith(f'module.{split_module_name}'):
+                        vertex_index_with_longest_common_prefix = vertex_index
         return vertex_index_with_longest_common_prefix
 
     def get_vertices_hash_codes_to_attributes_map(self) -> Dict[str, Dict[str, Any]]:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
For the TF plan, we failed to match the connection between resources when we had two resources with the same name from two different modules, 
Fixed by asserting the address, it is not the same as Terraform that we are checking the path because everything is in the same file.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
