### PR TITLE
fix(sast): remove SAST frameworks for OSS users

### DIFF
--- a/checkov/common/bridgecrew/code_categories.py
+++ b/checkov/common/bridgecrew/code_categories.py
@@ -21,7 +21,7 @@ CodeCategoryMapping: Dict[str, Union[CodeCategoryType, List[CodeCategoryType]]] 
     CheckType.AZURE_PIPELINES: CodeCategoryType.BUILD_INTEGRITY,
     CheckType.BICEP: CodeCategoryType.IAC,
     CheckType.BITBUCKET_PIPELINES: CodeCategoryType.BUILD_INTEGRITY,
-    CheckType.CDK: CodeCategoryType.IAC,
+    CheckType.CDK: CodeCategoryType.SAST,
     CheckType.CIRCLECI_PIPELINES: CodeCategoryType.BUILD_INTEGRITY,
     CheckType.CLOUDFORMATION: CodeCategoryType.IAC,
     CheckType.DOCKERFILE: CodeCategoryType.IAC,

--- a/checkov/common/bridgecrew/licensing.py
+++ b/checkov/common/bridgecrew/licensing.py
@@ -28,4 +28,4 @@ for sub, cats in SubscriptionCategoryMapping.items():
         CategoryToSubscriptionMapping[cat] = sub
 
 
-open_source_categories = [CodeCategoryType.IAC, CodeCategoryType.SECRETS, CodeCategoryType.BUILD_INTEGRITY, CodeCategoryType.SAST]
+open_source_categories = [CodeCategoryType.IAC, CodeCategoryType.SECRETS, CodeCategoryType.BUILD_INTEGRITY]


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- SAST was still mapped to OSS usage
- changed CDK framework to SAST category

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
