### PR TITLE
fix(general): Revert parallelization commit

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/custom_policies_integration.py
@@ -48,7 +48,7 @@ class CustomPoliciesIntegration(BaseIntegrationFeature):
                 self.integration_feature_failures = True
                 return
 
-            policies: list[dict[str, Any]] = self.bc_integration.customer_run_config_response.get('customPolicies', [])
+            policies = self.bc_integration.customer_run_config_response.get('customPolicies')
             for policy in policies:
                 try:
                     logging.debug(f"Loading policy id: {policy.get('id')}")

--- a/checkov/common/bridgecrew/integration_features/features/licensing_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/licensing_integration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, List, cast, Any
+from typing import TYPE_CHECKING, List, cast
 
 from checkov.common.bridgecrew.code_categories import CodeCategoryMapping, CodeCategoryType
 from checkov.common.bridgecrew.integration_features.base_integration_feature import BaseIntegrationFeature
@@ -43,12 +43,12 @@ class LicensingIntegration(BaseIntegrationFeature):
             self.open_source_only = True
         else:
             logging.debug('Found customer run config and using it for licensing')
-            license_details: dict[str, Any] = self.bc_integration.customer_run_config_response.get(LICENSE_KEY, {})
+            license_details = self.bc_integration.customer_run_config_response.get(LICENSE_KEY)
             logging.debug(f'User license details: {license_details}')
 
             self.open_source_only = False
             # the API will return True for all modules if they are on resource mode, so we don't actually need the billing plan explicitly here
-            self.enabled_modules = [CustomerSubscription(m) for m, e in license_details.get(MODULES_KEY, {}).items() if e]
+            self.enabled_modules = [CustomerSubscription(m) for m, e in license_details.get(MODULES_KEY).items() if e]
             self.enabled_modules.append(CustomerSubscription.SAST)  # TODO: Remove after we have a SAST module
 
     def is_runner_valid(self, runner_check_type: str) -> bool:

--- a/checkov/common/bridgecrew/integration_features/features/policies_3d_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/policies_3d_integration.py
@@ -64,7 +64,7 @@ class Policies3DIntegration(BaseIntegrationFeature):
                 self.integration_feature_failures = True
                 return None
 
-            policies: list[dict[str, Any]] = self.bc_integration.customer_run_config_response.get('Policies3D', [])
+            policies = self.bc_integration.customer_run_config_response.get('Policies3D')
             logging.debug(f'Got {len(policies)} 3d policies from the platform.')
             if not policies:
                 return None

--- a/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
     from checkov.common.bridgecrew.severities import Severity
     from checkov.common.output.report import Report
-    from checkov.common.typing import _BaseRunner, _CoreCheck
+    from checkov.common.typing import _BaseRunner
 
 
 class PolicyMetadataIntegration(BaseIntegrationFeature):
@@ -46,7 +46,7 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
                 self.integration_feature_failures = True
                 return
 
-            all_checks: list[_CoreCheck] = BaseCheckRegistry.get_all_registered_checks()  # type:ignore[assignment]  # looks like a mypy bug
+            all_checks = BaseCheckRegistry.get_all_registered_checks()
 
             if self.config and self.config.framework and "all" not in self.config.framework:
                 registries = self.config.framework
@@ -73,7 +73,7 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
                     # fall back on plain severity if there is no PC severity
                     check.severity = get_severity(metadata.get(self.severity_key, metadata.get('severity')))
                     check.bc_category = metadata.get('category')
-                    check.benchmarks = metadata.get('benchmarks', {})
+                    check.benchmarks = metadata.get('benchmarks')
 
                     if use_prisma_metadata and metadata.get('descriptiveTitle'):
                         check.name = metadata['descriptiveTitle']
@@ -155,7 +155,7 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
                 if source_incident_id:
                     self.ckv_id_to_source_incident_id_mapping[custom_policy['id']] = source_incident_id
 
-    def _handle_customer_prisma_policy_metadata(self, prisma_policy_metadata: list[dict[str, Any]] | None) -> None:
+    def _handle_customer_prisma_policy_metadata(self, prisma_policy_metadata: list[dict[str, Any]]) -> None:
         if isinstance(prisma_policy_metadata, list):
             for metadata in prisma_policy_metadata:
                 logging.debug(f"Parsing filtered_policy_ids from metadata: {json.dumps(metadata)}")

--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -49,7 +49,7 @@ class SuppressionsIntegration(BaseIntegrationFeature):
                 self.integration_feature_failures = True
                 return
 
-            suppressions: list[dict[str, Any]] = self.bc_integration.customer_run_config_response.get('suppressions', [])
+            suppressions = self.bc_integration.customer_run_config_response.get('suppressions')
 
             for suppression in suppressions:
                 if suppression['policyId'] in metadata_integration.bc_to_ckv_id_mapping:

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -111,8 +111,8 @@ class BcPlatformIntegration:
         self.prisma_policies_url: str | None = None
         self.prisma_policy_filters_url: str | None = None
         self.setup_api_urls()
-        self.customer_run_config_response: dict[str, Any] | None = None
-        self.prisma_policies_response: list[dict[str, Any]] | None = None
+        self.customer_run_config_response = None
+        self.prisma_policies_response = None
         self.public_metadata_response = None
         self.use_s3_integration = False
         self.s3_setup_failed = False
@@ -142,13 +142,11 @@ class BcPlatformIntegration:
         self.bucket = platform_integration_data["bucket"]
         self.cicd_details = platform_integration_data["cicd_details"]
         self.credentials = platform_integration_data["credentials"]
-        self.customer_run_config_response = platform_integration_data["customer_run_config_response"]
         self.platform_integration_configured = platform_integration_data["platform_integration_configured"]
         self.prisma_api_url = platform_integration_data["prisma_api_url"]
         self.repo_branch = platform_integration_data["repo_branch"]
         self.repo_id = platform_integration_data["repo_id"]
         self.repo_path = platform_integration_data["repo_path"]
-        self.skip_download = platform_integration_data["skip_download"]
         self.skip_fixes = platform_integration_data["skip_fixes"]
         self.timestamp = platform_integration_data["timestamp"]
         self.use_s3_integration = platform_integration_data["use_s3_integration"]
@@ -168,13 +166,11 @@ class BcPlatformIntegration:
             "bucket": self.bucket,
             "cicd_details": self.cicd_details,
             "credentials": self.credentials,
-            "customer_run_config_response": self.customer_run_config_response,
             "platform_integration_configured": self.platform_integration_configured,
             "prisma_api_url": self.prisma_api_url,
             "repo_branch": self.repo_branch,
             "repo_id": self.repo_id,
             "repo_path": self.repo_path,
-            "skip_download": self.skip_download,
             "skip_fixes": self.skip_fixes,
             "timestamp": self.timestamp,
             "use_s3_integration": self.use_s3_integration,

--- a/checkov/common/checks/base_check.py
+++ b/checkov/common/checks/base_check.py
@@ -4,15 +4,12 @@ import logging
 import os
 from abc import abstractmethod, ABC
 from collections.abc import Iterable
-from typing import List, Dict, Any, Optional, TYPE_CHECKING
+from typing import List, Dict, Any, Optional
 
 from checkov.common.resource_code_logger_filter import add_resource_code_filter_to_logger
 from checkov.common.typing import _SkippedCheck, _CheckResult
 from checkov.common.util.type_forcers import force_list
 from checkov.common.models.enums import CheckResult, CheckCategories, CheckFailLevel
-
-if TYPE_CHECKING:
-    from checkov.common.bridgecrew.severities import Severity
 
 
 class BaseCheck(ABC):
@@ -40,8 +37,8 @@ class BaseCheck(ABC):
         self.entity_type = ""
         self.guideline = guideline
         self.benchmarks: dict[str, list[str]] = {}
-        self.severity: Severity | None = None
-        self.bc_category: str | None = None
+        self.severity = None
+        self.bc_category = None
         if self.guideline:
             logging.debug(f'Found custom guideline for check {id}')
         self.details: List[str] = []

--- a/checkov/common/graph/checks_infra/base_check.py
+++ b/checkov/common/graph/checks_infra/base_check.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class BaseGraphCheck:
     def __init__(self) -> None:
         self.id = ""
-        self.bc_id: str | None = None
+        self.bc_id = None
         self.name = ""
         self.category = ""
         self.resource_types: List[str] = []

--- a/checkov/common/parallelizer/parallel_runner.py
+++ b/checkov/common/parallelizer/parallel_runner.py
@@ -27,7 +27,7 @@ class ParallelRunner:
 
         custom_type = os.getenv("CHECKOV_PARALLELIZATION_TYPE")
         if custom_type:
-            self.type = custom_type.lower()
+            self.type = custom_type
 
         if not custom_type and os.getenv("PYCHARM_HOSTED") == "1":
             # PYCHARM_HOSTED env variable equals 1 when debugging via jetbrains IDE.
@@ -56,12 +56,6 @@ class ParallelRunner:
     def _run_function_multiprocess_fork(
         self, func: Callable[[Any], _T], items: List[Any], group_size: Optional[int]
     ) -> Generator[_T, None, None]:
-        if multiprocessing.current_process().daemon:
-            # can't fork, when already inside a pool
-            for result in self._run_function_multithreaded(func, items):
-                yield result
-            return
-
         if not group_size:
             group_size = int(len(items) / self.workers_number) + 1
         groups_of_items = [items[i : i + group_size] for i in range(0, len(items), group_size)]

--- a/checkov/common/typing.py
+++ b/checkov/common/typing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, TypeVar, Set, Union, TypedDict, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Dict, TypeVar, Set, Union, TypedDict
 from typing_extensions import TypeAlias  # noqa[TC002]
 
 if TYPE_CHECKING:
@@ -142,13 +142,3 @@ class _EntityContext(TypedDict, total=False):
     code_lines: list[tuple[int, str]]
     skipped_checks: list[_SkippedCheck]
     origin_relative_path: str
-
-
-class _CoreCheck(Protocol):
-    name: str
-    id: str
-    bc_id: str | None
-    guideline: str | None
-    severity: Severity | None
-    bc_category: str | None
-    benchmarks: dict[str, list[str]]

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -45,9 +45,7 @@ from checkov.common.bridgecrew.integration_features.integration_feature_registry
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.bridgecrew.severities import BcSeverities
 from checkov.common.goget.github.get_git import GitGetter
-from checkov.common.models.enums import ParallelizationType
 from checkov.common.output.baseline import Baseline
-from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.resource_code_logger_filter import add_resource_code_filter_to_logger
 from checkov.common.runners.runner_registry import RunnerRegistry
 from checkov.common.sast.consts import SastLanguages
@@ -283,10 +281,6 @@ class Checkov:
                 else:
                     logger.debug('Using API key and not --include-all-checkov-policies - only running platform policies '
                                  '(this is the default behavior, and this message is just for debugging purposes)')
-
-            # set parallelization type for CLI runs to 'spawn' mode,
-            # this can be adjusted by setting the env var CHECKOV_PARALLELIZATION_TYPE
-            parallel_runner.type = ParallelizationType.THREAD if parallel_runner.os == "Windows" else ParallelizationType.SPAWN
 
             # bridgecrew uses both the urllib3 and requests libraries, while checkov uses the requests library.
             # Allow the user to specify a CA bundle to be used by both libraries.

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -21,7 +21,7 @@ from checkov.common.output.secrets_record import SecretsRecord
 from checkov.common.util.http_utils import request_wrapper, DEFAULT_TIMEOUT
 from detect_secrets import SecretsCollection
 from detect_secrets.core import scan
-from detect_secrets.settings import transient_settings, get_settings
+from detect_secrets.settings import transient_settings
 
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import \
@@ -29,7 +29,7 @@ from checkov.common.bridgecrew.integration_features.features.policy_metadata_int
 from checkov.common.bridgecrew.severities import Severity
 from checkov.common.comment.enum import COMMENT_REGEX
 from checkov.common.models.consts import SUPPORTED_FILE_EXTENSIONS
-from checkov.common.models.enums import CheckResult, ParallelizationType
+from checkov.common.models.enums import CheckResult
 from checkov.common.output.report import Report
 from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.runners.base_runner import BaseRunner, filter_ignored_paths
@@ -48,7 +48,6 @@ from checkov.secrets.utils import filter_excluded_paths, EXCLUDED_PATHS
 if TYPE_CHECKING:
     from checkov.common.util.tqdm_utils import ProgressBar
     from detect_secrets.core.potential_secret import PotentialSecret
-    from detect_secrets.settings import Settings
 
 SOURCE_CODE_EXTENSION = ['.py', '.js', '.properties', '.pem', '.php', '.xml', '.ts', '.env', '.java', '.rb',
                          'go', 'cs', '.txt']
@@ -124,13 +123,6 @@ class Runner(BaseRunner[None, None, None]):
             {'name': 'TwilioKeyDetector'},
             {'name': 'EntropyKeywordCombinator', 'path': f'file://{current_dir}/plugins/entropy_keyword_combinator.py'}
         ]
-
-        if bc_integration.daemon_process:
-            # only happens for 'ParallelizationType.SPAWN'
-            bc_integration.setup_http_manager()
-            if bc_integration.bc_api_key:
-                # only initialize, if API key was used
-                bc_integration.set_s3_client()
 
         # load runnable plugins
         customer_run_config = bc_integration.customer_run_config_response
@@ -339,15 +331,8 @@ class Runner(BaseRunner[None, None, None]):
     def _scan_files(files_to_scan: list[str], secrets: SecretsCollection, pbar: ProgressBar) -> None:
         # implemented the scan function like secrets.scan_files
         base_path = secrets.root
-        # only needed to set up for 'ParallelizationType.SPAWN' otherwise they will have default values
-        secrets_settings = None
-        customer_run_config = None
-        if parallel_runner.type == ParallelizationType.SPAWN:
-            secrets_settings = get_settings()
-            customer_run_config = bc_integration.customer_run_config_response
-
         items = [
-            (file, base_path, secrets_settings, customer_run_config)
+            (file, base_path)
             for file in files_to_scan
         ]
         results = parallel_runner.run_function(func=Runner._safe_scan, items=items)
@@ -359,12 +344,7 @@ class Runner(BaseRunner[None, None, None]):
             pbar.update()
 
     @staticmethod
-    def _safe_scan(
-        file_path: str,
-        base_path: str,
-        secrets_settings: Settings | None = None,
-        customer_run_config: dict[str, Any] | None = None,
-    ) -> tuple[str, list[PotentialSecret]]:
+    def _safe_scan(file_path: str, base_path: str) -> tuple[str, list[PotentialSecret]]:
         full_file_path = os.path.join(base_path, file_path)
         file_size = os.path.getsize(full_file_path)
         if file_size > MAX_FILE_SIZE > 0:
@@ -374,12 +354,6 @@ class Runner(BaseRunner[None, None, None]):
                 f'to 0 or {file_size + 1}'
             )
             return file_path, []
-
-        if secrets_settings:
-            # only happens for 'ParallelizationType.SPAWN'
-            get_settings().set(secrets_settings)
-            bc_integration.customer_run_config_response = customer_run_config
-
         try:
             start_time = datetime.datetime.now()
             file_results = [*scan.scan_file(full_file_path)]

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import List, Dict, Tuple, Any
+from typing import List, Dict, Tuple
 
 from checkov.cloudformation import cfn_utils
 from checkov.cloudformation.context_parser import ContextParser as CfnContextParser
@@ -288,7 +288,7 @@ class Runner(BaseRunner):
 
 def get_files_definitions(files: List[str], filepath_fn=None) \
         -> Tuple[Dict[str, DictNode], Dict[str, List[Tuple[int, str]]]]:
-    results = parallel_runner.run_function(_parallel_parse, files)
+    results = parallel_runner.run_function(lambda f: (f, parse(f)), files)
     definitions = {}
     definitions_raw = {}
     for file, result in results:
@@ -297,8 +297,3 @@ def get_files_definitions(files: List[str], filepath_fn=None) \
             definitions[path], definitions_raw[path] = result
 
     return definitions, definitions_raw
-
-
-def _parallel_parse(f: str) -> tuple[str, tuple[dict[str, Any], list[tuple[int, str]]]]:
-    """Thin wrapper to return filename with parsed content"""
-    return f, parse(f)

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -150,7 +150,7 @@ def _download_module(ml_registry: ModuleLoaderRegistry, module_download: ModuleD
 
 
 def replace_terraform_managed_modules(path: str, found_modules: list[ModuleDownload]) -> list[ModuleDownload]:
-    """Replaces modules by Terraform managed ones to prevent additional downloading
+    """Replaces modules by Terraform managed ones to prevent addtional downloading
 
     It can't handle nested modules yet, ex.
     {
@@ -160,7 +160,7 @@ def replace_terraform_managed_modules(path: str, found_modules: list[ModuleDownl
     }
     """
 
-    if not convert_str_to_bool(os.getenv("CHECKOV_TERRAFORM_MANAGED_MODULES", True)):
+    if not convert_str_to_bool(os.getenv("CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES", False)):
         return found_modules
 
     # file used by Terraform internally to map modules to the downloaded path

--- a/docs/7.Scan Examples/Terraform.md
+++ b/docs/7.Scan Examples/Terraform.md
@@ -45,9 +45,10 @@ checkov -d . --download-external-modules true --external-modules-download-path e
 ```
 
 > [!NOTE]
-> Be default, `checkov` will use the modules already downloaded by Terraform stored in `.terraform` folder. This only works for scans of the root folder, where also `terraform init` was executed. This behaviour can be disabled by setting the env var `CHECKOV_TERRAFORM_MANAGED_MODULES=False`
+> **Experimental**
+> By setting the env var `CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES=True` instead of downloading external modules `checkov` will use the ones already downloaded by Terraform stored in `.terraform` folder. This only works for scans of the root folder, where also `terraform init` was executed.
 > ```shell
-> CHECKOV_TERRAFORM_MANAGED_MODULES=False checkov -d .
+> CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES=True checkov -d .
 > ```
 
 ### Scanning Private Terraform Modules

--- a/tests/secrets/test_plugin_multiline_json.py
+++ b/tests/secrets/test_plugin_multiline_json.py
@@ -34,7 +34,7 @@ class TestCombinatorPluginMultilineJson(unittest.TestCase):
         end_time = time.time()
 
         # then
-        assert end_time-start_time < 2  # assert the time limit is not too long for parsing long lines.
+        assert end_time-start_time < 1  # assert the time limit is not too long for parsing long lines.
         self.assertEqual(len(report.failed_checks), 6)
         # None of the results is related to multiline scanning - all is detected even if multiline scanning is disabled.
         # This is a different result compared to same data in .yml file.

--- a/tests/secrets/test_plugin_multiline_yml.py
+++ b/tests/secrets/test_plugin_multiline_yml.py
@@ -181,7 +181,7 @@ class TestCombinatorPluginMultilineYml(unittest.TestCase):
         end_time = time.time()
 
         # then
-        assert end_time-start_time < 2  # assert the time limit is not too long for parsing long lines.
+        assert end_time-start_time < 1  # assert the time limit is not too long for parsing long lines.
         self.assertEqual(len(report.failed_checks), 4)
         self.assertEqual(report.parsing_errors, [])
         self.assertEqual(report.passed_checks, [])

--- a/tests/terraform/module_loading/test_runner.py
+++ b/tests/terraform/module_loading/test_runner.py
@@ -31,8 +31,8 @@ def test_runner_with_tf_managed_modules():
     assert failed_resources == expected_failed_resources
 
 
-# keeping the test as long as the env var exists
-@mock.patch.dict(os.environ, {"CHECKOV_TERRAFORM_MANAGED_MODULES": "False"})
+# test can be removed after setting this flow as default
+@mock.patch.dict(os.environ, {"CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES": "False"})
 def test_runner_without_tf_managed_modules():
     # given
     root_dir = Path(__file__).parent / "data/tf_managed_modules"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,12 +4,10 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pytest
 from _pytest.logging import LogCaptureFixture
 from typing_extensions import Literal
 
 from checkov import main
-from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.runners.base_runner import BaseRunner
 from checkov.common.runners.runner_registry import RunnerRegistry
 from checkov.main import DEFAULT_RUNNERS, Checkov
@@ -35,14 +33,6 @@ class CustomRunnerRegistry(RunnerRegistry):
     ) -> Literal[0, 1]:
         # result doesn't matter, just don't want it to print to console
         return 0
-
-
-@pytest.fixture(autouse=True)
-def keep_parallelization_type():
-    """Save and restore the original parallelization type"""
-    mode = parallel_runner.type
-    yield
-    parallel_runner.type = mode
 
 
 def test_run_with_outer_registry_and_framework_flag():
@@ -145,8 +135,6 @@ def test_run_with_severity_skip_filter_without_api_key(caplog: LogCaptureFixture
         "--framework", "terraform",
         "--skip-check", "MEDIUM",
     ]
-
-    parallel_runner
 
     # when
     ckv = Checkov()


### PR DESCRIPTION
Reverting commit set default parallelization type to spawn and leverage Terraform downloaded module by default (#5760) due to error `AssertionError: daemonic processes are not allowed to have children`

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
