### PR TITLE
feat(ansible)-add-CKV_PAN_17-PAN-OS-BPA-Check-for-src-dst-zone-any

### DIFF
--- a/checkov/ansible/checks/graph_checks/PanosPolicyNoSrcZoneAnyNoDstZoneAny.yaml
+++ b/checkov/ansible/checks/graph_checks/PanosPolicyNoSrcZoneAnyNoDstZoneAny.yaml
@@ -1,0 +1,40 @@
+metadata:
+  id: "CKV_PAN_17"
+  name: "Ensure security rules do not have 'source_zone' and 'destination_zone' both containing values of 'any'"
+  category: "NETWORKING"
+definition:
+  or:
+  - and:
+    - cond_type: attribute
+      resource_types:
+        - tasks.paloaltonetworks.panos.panos_security_rule
+      attribute: source_zone
+      operator: exists
+    - cond_type: attribute
+      resource_types:
+        - tasks.paloaltonetworks.panos.panos_security_rule
+      attribute: source_zone
+      operator: is_not_empty
+    - cond_type: attribute
+      resource_types:
+        - tasks.paloaltonetworks.panos.panos_security_rule
+      attribute: source_zone
+      operator: not_equals_ignore_case
+      value: 'any'
+  - and:
+    - cond_type: attribute
+      resource_types:
+        - tasks.paloaltonetworks.panos.panos_security_rule
+      attribute: destination_zone
+      operator: exists
+    - cond_type: attribute
+      resource_types:
+        - tasks.paloaltonetworks.panos.panos_security_rule
+      attribute: destination_zone
+      operator: is_not_empty
+    - cond_type: attribute
+      resource_types:
+        - tasks.paloaltonetworks.panos.panos_security_rule
+      attribute: destination_zone
+      operator: not_equals_ignore_case
+      value: 'any'

--- a/tests/ansible/checks/graph_checks/resources/PanosPolicyNoSrcZoneAnyNoDstZoneAny/expected.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosPolicyNoSrcZoneAnyNoDstZoneAny/expected.yaml
@@ -1,0 +1,20 @@
+pass:
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_1"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_2"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_3"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_4"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_5"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_6"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_7"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_8"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_9"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_10"
+fail:
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_fail_1"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_fail_2"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_fail_3"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_fail_4"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_fail_5"
+evaluated_keys:
+  - "source_zone"
+  - "destination_zone"

--- a/tests/ansible/checks/graph_checks/resources/PanosPolicyNoSrcZoneAnyNoDstZoneAny/fail.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosPolicyNoSrcZoneAnyNoDstZoneAny/fail.yaml
@@ -1,0 +1,93 @@
+---
+- name: Verify tests
+  hosts: all
+  connection: local
+  gather_facts: false
+
+  vars:
+    device:
+      ip_address: "{{ ip_address }}"
+      username: "{{ username | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      api_key: "{{ api_key | default(omit) }}"
+
+  tasks:
+    - name: Security_rule_fail_1
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['any']
+        destination_zone: ['any']
+        # Source and destination Zone are 'any'
+        source_ip: ['1.1.1.1']
+        destination_ip: ['2.2.2.2']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_fail_2
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        # source_zone: ['any']
+        # destination_zone: ['any']
+        # Source zone and destination zone are not provided, defaults to 'any'
+        source_ip: ['1.1.1.1']
+        destination_ip: ['2.2.2.2']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_fail_3
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['any']
+        # destination_zone: ['any']
+        # Source Zone is 'any' and destination Zone is undefined and defaults to 'any'
+        source_ip: ['1.1.1.1']
+        destination_ip: ['2.2.2.2']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_fail_4
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        # source_zone: ['any']
+        destination_zone: ['any']
+        # Destination Zone is 'any' and source Zone is undefined and defaults to 'any'
+        source_ip: ['1.1.1.1']
+        destination_ip: ['2.2.2.2']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_fail_5
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['']
+        destination_zone: ['']
+        # Source and destination Zone are empty
+        source_ip: ['1.1.1.1']
+        destination_ip: ['2.2.2.2']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'

--- a/tests/ansible/checks/graph_checks/resources/PanosPolicyNoSrcZoneAnyNoDstZoneAny/pass.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosPolicyNoSrcZoneAnyNoDstZoneAny/pass.yaml
@@ -1,0 +1,172 @@
+---
+- name: Verify tests
+  hosts: all
+  connection: local
+  gather_facts: false
+
+  vars:
+    device:
+      ip_address: "{{ ip_address }}"
+      username: "{{ username | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      api_key: "{{ api_key | default(omit) }}"
+
+  tasks:
+    - name: Security_rule_pass_1
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['outside']
+        destination_zone: ['inside']
+        # Source and destination Zone addresses provided
+        source_ip: ['1.1.1.1']
+        destination_ip: ['10.10.10.10']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_pass_2
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['outside','b2b']
+        destination_zone: ['inside']
+        # Source and destination Zone provided, multiples
+        source_ip: ['1.1.1.1', '2.2.2.2']
+        destination_ip: ['10.10.10.10']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_pass_3
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['outside']
+        destination_zone: ['inside','trusted']
+        # Source and destination zone addresses provided, multiples
+        source_ip: ['1.1.1.1']
+        destination_ip: ['10.10.10.10', '10.10.10.11']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_pass_4
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['outside','b2b']
+        destination_zone: ['inside','trusted']
+        # Source and destination zone addresses provided, multiples
+        source_ip: ['1.1.1.1','2.2.2.2']
+        destination_ip: ['10.10.10.10', '10.10.10.11']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_pass_5
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['outside']
+        destination_zone: ['any']  # Only destination zone is any, source zone is provided
+        source_ip: ['1.1.1.1']
+        destination_ip: ['10.10.10.10']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_pass_6
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['outside']
+        # destination_zone: ['inside']
+        # Only destination zone is not provided (defaults to 'any'), source zone is provided
+        source_ip: ['1.1.1.1']
+        destination_ip: ['10.10.10.10']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_pass_7
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['outside']
+        destination_zone: ['']
+        # Only destination zone is empty, source zone is provided
+        source_ip: ['1.1.1.1']
+        destination_ip: ['10.10.10.10']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_pass_8
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['any']
+        destination_zone: ['inside']
+        # Only source zone is any, destination zone is provided
+        source_ip: ['1.1.1.1']
+        destination_ip: ['10.10.10.10']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_pass_9
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        # source_zone: ['outside']
+        destination_zone: ['inside']
+        # Only source zone is not provided (defaults to 'any'), destination zone is provided
+        source_ip: ['1.1.1.1']
+        destination_ip: ['10.10.10.10']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'
+
+    - name: Security_rule_pass_10
+      paloaltonetworks.panos.panos_security_rule:
+        provider: '{{ provider }}'
+        rule_name: 'Test rule'
+        source_zone: ['']
+        destination_zone: ['inside']
+        # Only source zone is empty, destination zone is provided
+        source_ip: ['1.1.1.1']
+        destination_ip: ['10.10.10.10']
+        category: ['any']
+        application: ['ssl']
+        service: ['service-http', 'service-https']
+        description: "A nice rule"
+        action: 'allow'
+        log_setting: 'default'

--- a/tests/ansible/checks/graph_checks/test_yaml_policies.py
+++ b/tests/ansible/checks/graph_checks/test_yaml_policies.py
@@ -90,6 +90,9 @@ class TestYamlPolicies(TestYamlPoliciesBase):
     def test_PanosPolicyLogSessionStart(self):
         self.go("PanosPolicyLogSessionStart", local_graph_class=AnsibleLocalGraph)
 
+    def test_PanosPolicyNoSrcZoneAnyDstZoneAny(self):
+        self.go("PanosPolicyNoSrcZoneAnyDstZoneAny", local_graph_class=AnsibleLocalGraph)
+
     def test_registry_load(self):
         registry = self.get_checks_registry()
         self.assertGreater(len(registry.checks), 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

new Ansible check for PAN-OS BPA source and dest zone 'any'

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
new Ansible check for PAN-OS BPA  CKV_PAN_17 source and dest zone 'any'

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
