### PR TITLE
platform(general): handle the updated on prem response from the platform

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -1168,7 +1168,9 @@ class BcPlatformIntegration:
 
     def setup_on_prem(self) -> None:
         if self.customer_run_config_response:
-            self.on_prem = self.customer_run_config_response.get('onPrem', False)
+            self.on_prem = self.customer_run_config_response.get('tenantConfig', {}).get('preventCodeUploads', False)
+            if self.on_prem:
+                logging.debug('On prem mode is enabled')
 
 
 bc_integration = BcPlatformIntegration()

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -157,6 +157,39 @@ class TestBCApiUrl(unittest.TestCase):
                                                          valid_filters=mock_prisma_policy_filter_response()))
         self.assertFalse(instance.is_valid_policy_filter(policy_filter={'policy.label': ['A', 'B']}, valid_filters={}))
 
+    def test_setup_on_prem(self):
+        instance = BcPlatformIntegration()
+
+        instance.customer_run_config_response = None
+        instance.setup_on_prem()
+        self.assertFalse(instance.on_prem)
+
+        instance.customer_run_config_response = {}
+        instance.setup_on_prem()
+        self.assertFalse(instance.on_prem)
+
+        instance.customer_run_config_response = {
+            'tenantConfig': {}
+        }
+        instance.setup_on_prem()
+        self.assertFalse(instance.on_prem)
+
+        instance.customer_run_config_response = {
+            'tenantConfig': {
+                'preventCodeUploads': False
+            }
+        }
+        instance.setup_on_prem()
+        self.assertFalse(instance.on_prem)
+
+        instance.customer_run_config_response = {
+            'tenantConfig': {
+                'preventCodeUploads': True
+            }
+        }
+        instance.setup_on_prem()
+        self.assertTrue(instance.on_prem)
+
 
 def mock_customer_run_config():
     return {


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Handles the actual on prem response from the platform. The previous implementation was a placeholder until the platform tenant service changes were done. This changes how we decide if it is on prem mode, but the logic to actually run in on prem mode is already implemented. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
