### PR TITLE
feat(ansible): add CKV_PAN_18 PAN-OS BPA Check for NTP Primary server

### DIFF
--- a/checkov/ansible/checks/graph_checks/PanosDeviceMgmtNTP.yaml
+++ b/checkov/ansible/checks/graph_checks/PanosDeviceMgmtNTP.yaml
@@ -1,0 +1,16 @@
+metadata:
+  id: "CKV_PAN_18"
+  name: "Ensure that the primary NTP server is configured under Device Management"
+  category: "NETWORKING"
+definition:
+  and:
+    - cond_type: attribute
+      resource_types:
+        - tasks.paloaltonetworks.panos.panos_mgtconfig
+      attribute: ntp_server_primary
+      operator: exists
+    - cond_type: attribute
+      resource_types:
+        - tasks.paloaltonetworks.panos.panos_mgtconfig
+      attribute: ntp_server_primary
+      operator: is_not_empty

--- a/checkov/ansible/checks/graph_checks/PanosDeviceMgmtVerifyUpdateSrv.yaml
+++ b/checkov/ansible/checks/graph_checks/PanosDeviceMgmtVerifyUpdateSrv.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "CKV_PAN_20"
+  name: "Ensure verify update server is enabled under Device Management"
+  category: "NETWORKING"
+definition:
+  # Verify update server not set to true
+  cond_type: attribute
+  resource_types:
+    - tasks.paloaltonetworks.panos.panos_mgtconfig
+  attribute: verify_update_server
+  operator: not_equals
+  value: false

--- a/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtNTP/expected.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtNTP/expected.yaml
@@ -1,0 +1,7 @@
+pass:
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_1"
+fail:
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_fail_1"
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_fail_2"
+evaluated_keys:
+  - "ntp_server_primary"

--- a/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtNTP/fail.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtNTP/fail.yaml
@@ -1,0 +1,38 @@
+---
+- name: Verify tests
+  hosts: all
+  connection: local
+  gather_facts: false
+
+  vars:
+    device:
+      ip_address: "{{ ip_address }}"
+      username: "{{ username | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      api_key: "{{ api_key | default(omit) }}"
+
+  tasks:
+    - name: Security_rule_fail_1
+      paloaltonetworks.panos.panos_mgtconfig:
+        provider: '{{ provider }}'
+        login_banner: "This is a login banner"
+        hostname: "hostname1"
+        dns_server_primary: "1.1.1.1"
+        dns_server_secondary: "1.1.1.2"
+        panorama_primary: "1.1.1.3"
+        panorama_secondary: "1.1.1.4"
+        # ntp_server_primary: "1.1.1.5" # No NTP primary - fail
+        # ntp_server_secondary: "1.1.1.6"
+
+
+    - name: Security_rule_fail_2
+      paloaltonetworks.panos.panos_mgtconfig:
+        provider: '{{ provider }}'
+        login_banner: "This is a login banner"
+        hostname: "hostname1"
+        dns_server_primary: "1.1.1.1"
+        dns_server_secondary: "1.1.1.2"
+        panorama_primary: "1.1.1.3"
+        panorama_secondary: "1.1.1.4"
+        ntp_server_primary: "" # No value for NTP primary - fail
+        # ntp_server_secondary: "1.1.1.6"

--- a/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtNTP/pass.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtNTP/pass.yaml
@@ -1,0 +1,25 @@
+---
+- name: Verify tests
+  hosts: all
+  connection: local
+  gather_facts: false
+
+  vars:
+    device:
+      ip_address: "{{ ip_address }}"
+      username: "{{ username | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      api_key: "{{ api_key | default(omit) }}"
+
+  tasks:
+    - name: Security_rule_pass_1
+      paloaltonetworks.panos.panos_mgtconfig:
+        provider: '{{ provider }}'
+        login_banner: "This is a login banner"
+        hostname: "hostname1"
+        dns_server_primary: "1.1.1.1"
+        dns_server_secondary: "1.1.1.2"
+        panorama_primary: "1.1.1.3"
+        panorama_secondary: "1.1.1.4"
+        ntp_server_primary: "1.1.1.5"
+        ntp_server_secondary: "1.1.1.6"

--- a/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtVerifyUpdateSrv/expected.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtVerifyUpdateSrv/expected.yaml
@@ -1,0 +1,6 @@
+pass:
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_pass_1"
+fail:
+  - "tasks.paloaltonetworks.panos.panos_security_rule.Security_rule_fail_1"
+evaluated_keys:
+  - "verify_update_server"

--- a/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtVerifyUpdateSrv/fail.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtVerifyUpdateSrv/fail.yaml
@@ -1,0 +1,26 @@
+---
+- name: Verify tests
+  hosts: all
+  connection: local
+  gather_facts: false
+
+  vars:
+    device:
+      ip_address: "{{ ip_address }}"
+      username: "{{ username | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      api_key: "{{ api_key | default(omit) }}"
+
+  tasks:
+    - name: Security_rule_fail_1
+      paloaltonetworks.panos.panos_mgtconfig:
+        provider: '{{ provider }}'
+        login_banner: "This is a login banner"
+        hostname: "hostname1"
+        dns_server_primary: "1.1.1.1"
+        dns_server_secondary: "1.1.1.2"
+        panorama_primary: "1.1.1.3"
+        panorama_secondary: "1.1.1.4"
+        ntp_server_primary: "1.1.1.5"
+        ntp_server_secondary: "1.1.1.6"
+        verify_update_server: false # false = fail

--- a/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtVerifyUpdateSrv/pass.yaml
+++ b/tests/ansible/checks/graph_checks/resources/PanosDeviceMgmtVerifyUpdateSrv/pass.yaml
@@ -1,0 +1,26 @@
+---
+- name: Verify tests
+  hosts: all
+  connection: local
+  gather_facts: false
+
+  vars:
+    device:
+      ip_address: "{{ ip_address }}"
+      username: "{{ username | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      api_key: "{{ api_key | default(omit) }}"
+
+  tasks:
+    - name: Security_rule_pass_1
+      paloaltonetworks.panos.panos_mgtconfig:
+        provider: '{{ provider }}'
+        login_banner: "This is a login banner"
+        hostname: "hostname1"
+        dns_server_primary: "1.1.1.1"
+        dns_server_secondary: "1.1.1.2"
+        panorama_primary: "1.1.1.3"
+        panorama_secondary: "1.1.1.4"
+        ntp_server_primary: "1.1.1.5"
+        ntp_server_secondary: "1.1.1.6"
+        verify_update_server: true

--- a/tests/ansible/checks/graph_checks/test_yaml_policies.py
+++ b/tests/ansible/checks/graph_checks/test_yaml_policies.py
@@ -93,6 +93,9 @@ class TestYamlPolicies(TestYamlPoliciesBase):
     def test_PanosDeviceMgmtNTP(self):
         self.go("PanosDeviceMgmtNTP", local_graph_class=AnsibleLocalGraph)
 
+    def test_PanosDeviceMgmtVerifyUpdateSrv(self):
+        self.go("PanosDeviceMgmtVerifyUpdateSrv", local_graph_class=AnsibleLocalGraph)
+
     def test_registry_load(self):
         registry = self.get_checks_registry()
         self.assertGreater(len(registry.checks), 0)

--- a/tests/ansible/checks/graph_checks/test_yaml_policies.py
+++ b/tests/ansible/checks/graph_checks/test_yaml_policies.py
@@ -90,6 +90,9 @@ class TestYamlPolicies(TestYamlPoliciesBase):
     def test_PanosPolicyLogSessionStart(self):
         self.go("PanosPolicyLogSessionStart", local_graph_class=AnsibleLocalGraph)
 
+    def test_PanosDeviceMgmtNTP(self):
+        self.go("PanosDeviceMgmtNTP", local_graph_class=AnsibleLocalGraph)
+
     def test_registry_load(self):
         registry = self.get_checks_registry()
         self.assertGreater(len(registry.checks), 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Add PAN-OS BPA Check 18 for NTP primary server*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Add PAN-OS BPA Check 18 for NTP primary server, primary NTP server does not exist or does not have a value are fails*

### Fix
*Add a primary NTP server*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
