### PR TITLE
fix(terraform): Fix range issue in OCI RDP check

### DIFF
--- a/checkov/terraform/checks/graph_checks/oci/OCI_NSGNotAllowRDP.yaml
+++ b/checkov/terraform/checks/graph_checks/oci/OCI_NSGNotAllowRDP.yaml
@@ -48,11 +48,17 @@ definition:
           operator: "not_equals"
           value: 3389
 
-        - cond_type: "attribute"
-          resource_types: "oci_core_network_security_group_security_rule"
-          attribute: "tcp_options.destination_port_range.min"
-          operator: "greater_than"
-          value: 3389
+        - or: 
+            - cond_type: "attribute"
+              resource_types: "oci_core_network_security_group_security_rule"
+              attribute: "tcp_options.destination_port_range.min"
+              operator: "greater_than"
+              value: 3389
+            - cond_type: "attribute"
+              resource_types: "oci_core_network_security_group_security_rule"
+              attribute: "tcp_options.destination_port_range.max"
+              operator: "less_than"
+              value: 3389
 
     - and:
         - cond_type: "attribute"
@@ -61,8 +67,14 @@ definition:
           operator: "not_equals"
           value: 3389
 
-        - cond_type: "attribute"
-          resource_types: "oci_core_network_security_group_security_rule"
-          attribute: "udp_options.destination_port_range.min"
-          operator: "greater_than"
-          value: 3389
+        - or:
+            - cond_type: "attribute"
+              resource_types: "oci_core_network_security_group_security_rule"
+              attribute: "udp_options.destination_port_range.min"
+              operator: "greater_than"
+              value: 3389
+            - cond_type: "attribute"
+              resource_types: "oci_core_network_security_group_security_rule"
+              attribute: "udp_options.destination_port_range.max"
+              operator: "less_than"
+              value: 3389

--- a/tests/terraform/graph/checks/resources/OCI_NSGNotAllowRDP/expected.yaml
+++ b/tests/terraform/graph/checks/resources/OCI_NSGNotAllowRDP/expected.yaml
@@ -1,6 +1,7 @@
 pass:
   - "oci_core_network_security_group_security_rule.pass_1"
   - "oci_core_network_security_group_security_rule.pass_2"
+  - "oci_core_network_security_group_security_rule.pass_3"
 
 fail:
   - "oci_core_network_security_group_security_rule.fail_1"

--- a/tests/terraform/graph/checks/resources/OCI_NSGNotAllowRDP/main.tf
+++ b/tests/terraform/graph/checks/resources/OCI_NSGNotAllowRDP/main.tf
@@ -92,3 +92,21 @@ resource "oci_core_network_security_group_security_rule" "fail_2" {
 }
 
 
+resource "oci_core_network_security_group_security_rule" "pass_3" {
+  count = (var.nsg_id == "" ? 1:0)
+
+  network_security_group_id = oci_core_network_security_group.network_security_group[0].id
+  direction = "EGRESS"
+  protocol = "6" #tcp
+
+  description = "rule_allow_22_e_within"
+  destination = oci_core_network_security_group.network_security_group[0].id
+  destination_type = "NETWORK_SECURITY_GROUP"
+
+  tcp_options {
+    destination_port_range {
+      max = 22
+      min = 22
+    }
+  }
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixes issue where the check was looking for port ranges above 3389, but not maxes below 3389

Fixes #4971


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
