### PR TITLE
fix(general): check both path types for suppression

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/suppressions_integration.py
@@ -13,6 +13,7 @@ from checkov.common.bridgecrew.integration_features.features.policy_metadata_int
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.models.enums import CheckResult
 from checkov.common.output.record import SCA_PACKAGE_SCAN_CHECK_NAME
+from checkov.common.util.file_utils import convert_to_unix_path
 
 if TYPE_CHECKING:
     from checkov.common.bridgecrew.platform_integration import BcPlatformIntegration
@@ -140,7 +141,8 @@ class SuppressionsIntegration(BaseIntegrationFeature):
         elif type == 'Resources':
             for resource in suppression['resources']:
                 if self.bc_integration.repo_matches(resource['accountId']) \
-                        and resource['resourceId'] == f'{record.repo_file_path}:{record.resource}':
+                        and (resource['resourceId'] == f'{record.repo_file_path}:{record.resource}'
+                             or resource['resourceId'] == f'{convert_to_unix_path(record.file_path)}:{record.resource}'):
                     return True
             return False
         elif type == 'Tags':


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Handles cases where a user runs checkov with an absolute path to the repo from somewhere outside the scan dir. This causes checkov to fail to match suppressions applied in the platform to the local run, because the platform suppression file path will not match the local `repo_file_path`. This fix also checks the `file_path`, which should be relative to the scan root.

This code is pretty old, and `repo_file_path` is used in many places, so I did not change the logic for setting that. It seems like the (converted to unix) `file_path` value should really just be the correct one to use, but I do not know the reason for using the special `repo_file_path` value, other than knowing that this needs to be a unix path.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
