### PR TITLE
feat(terraform): fix for check VPCPeeringRouteTableOverlyPermissive and add tests

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/VPCPeeringRouteTableOverlyPermissive.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/VPCPeeringRouteTableOverlyPermissive.yaml
@@ -9,6 +9,12 @@ definition:
         - "aws_route_table"
       attribute: "route.*.vpc_peering_connection_id"
       operator: "not_exists"
+    - cond_type: "attribute"
+      resource_types:
+        - "aws_route_table"
+      attribute: "route.*.vpc_peering_connection_id"
+      operator: "equals"
+      value: ""
     - and:
         - cond_type: "attribute"
           resource_types:
@@ -33,12 +39,18 @@ definition:
             - "aws_route_table"
           attribute: "route.*.ipv6_cidr_block"
           operator: "not_contains"
-          value: "::/0"  
+          value: "::/0"
     - cond_type: "attribute"
       resource_types:
         - "aws_route"
-      attribute: "vpc_peering_connection_id"          
+      attribute: "vpc_peering_connection_id"
       operator: "not_exists"
+    - cond_type: "attribute"
+      resource_types:
+        - "aws_route"
+      attribute: "vpc_peering_connection_id"
+      operator: "equals"
+      value: ""
     - and:
         - cond_type: "attribute"
           resource_types:

--- a/tests/terraform/runner/resources/plan/tfplan.json
+++ b/tests/terraform/runner/resources/plan/tfplan.json
@@ -747,7 +747,7 @@
               "delete": null
             },
             "transit_gateway_id": null,
-            "vpc_peering_connection_id": null
+            "vpc_peering_connection_id": ""
           }
         },
         {

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -225,6 +225,26 @@ class TestRunnerValid(unittest.TestCase):
         all_checks = report.failed_checks + report.passed_checks
         self.assertTrue(any(c.check_id == custom_check_id for c in all_checks))
 
+    def test_plan_runner_with_empty_vpc_connection(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_plan_path = current_dir + "/resources/plan/tfplan.json"
+        runner = Runner()
+        runner.graph_registry.checks = []
+        report = runner.run(
+            root_folder=None,
+            files=[valid_plan_path],
+            external_checks_dir=None,
+            runner_filter=RunnerFilter(framework=["all"]),
+        )
+        report_json = report.get_json()
+        self.assertIsInstance(report_json, str)
+        self.assertIsNotNone(report_json)
+        self.assertIsNotNone(report.get_test_suite())
+        self.assertEqual(report.get_exit_code({'soft_fail': False, 'soft_fail_checks': [], 'soft_fail_threshold': None, 'hard_fail_checks': [], 'hard_fail_threshold': None}), 1)
+        self.assertEqual(report.get_exit_code({'soft_fail': True, 'soft_fail_checks': [], 'soft_fail_threshold': None, 'hard_fail_checks': [], 'hard_fail_threshold': None}), 0)
+
+        self.assertEqual(report.get_summary()["failed"], 106)
+
     def test_runner_child_modules(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         valid_plan_path = current_dir + "/resources/plan_with_child_modules/tfplan.json"
@@ -815,7 +835,7 @@ class TestRunnerValid(unittest.TestCase):
             self.assertIn(check.resource, valid_resources_ids)
 
         self.assertEqual(len(report.resources), 3)
-        
+
     def test_plan_resources_created_by_modules(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         valid_plan_path = current_dir + "/extra_tf_plan_checks/modules.json"
@@ -826,12 +846,12 @@ class TestRunnerValid(unittest.TestCase):
         )
         passed_checks_CKV2_GCP_12 = [check for check in report.passed_checks if check.check_id == 'CKV2_GCP_12']
         passed_checks_CKV_GCP_88 = [check for check in report.passed_checks if check.check_id == 'CKV_GCP_88']
-        
+
         assert passed_checks_CKV2_GCP_12[0].resource == 'module.achia_test_valid_443.google_compute_firewall.custom[0]'
         assert passed_checks_CKV2_GCP_12[1].resource == 'module.achia_test_valid_ports.google_compute_firewall.custom[0]'
         assert passed_checks_CKV2_GCP_12[2].resource == 'module.achia_test_violating_no_ports.google_compute_firewall.custom[0]'
         assert passed_checks_CKV2_GCP_12[3].resource == 'module.achia_test_violating_port.google_compute_firewall.custom[0]'
-        
+
         assert passed_checks_CKV_GCP_88[0].resource == 'module.achia_test_valid_443.google_compute_firewall.custom[0]'
         assert passed_checks_CKV_GCP_88[1].resource == 'module.achia_test_valid_ports.google_compute_firewall.custom[0]'
         assert passed_checks_CKV_GCP_88[2].resource == 'module.achia_test_violating_no_ports.google_compute_firewall.custom[0]'


### PR DESCRIPTION
This PR fixes the VPCPeeringRouteTableOverlyPermissive check and adds appropriate tests to make sure we do not flag empty vpc_peering_connection_id string as failed.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
