### PR TITLE
feat(terraform): Used parallel run to run all split_graph iterations

### DIFF
--- a/checkov/terraform/tf_parser.py
+++ b/checkov/terraform/tf_parser.py
@@ -9,6 +9,7 @@ from typing import Optional, Dict, Mapping, Set, Tuple, Callable, Any, List, cas
 
 import hcl2
 
+from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.runners.base_runner import filter_ignored_paths, IGNORE_HIDDEN_DIRECTORY_ENV
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR, RESOLVED_MODULE_ENTRY_NAME
 from checkov.common.util.data_structures_utils import pickle_deepcopy
@@ -364,10 +365,11 @@ class TFParser:
 
         dirs_to_definitions = self.create_definition_by_dirs(tf_definitions)
 
-        modules_and_definitions_tuple: list[tuple[Module, list[dict[TFDefinitionKey, dict[str, Any]]]]] = []
-        for source_path, definitions in dirs_to_definitions.items():
-            module, parsed_tf_definitions = self.parse_hcl_module_from_multi_tf_definitions(definitions, source_path, source)
-            modules_and_definitions_tuple.append((module, parsed_tf_definitions))
+        definitions_dir_and_source_iterable = [(definitions, source_path, source) for source_path, definitions in
+                                               dirs_to_definitions.items()]
+        modules_and_definitions_tuple: list[tuple[Module, list[dict[TFDefinitionKey, dict[str, Any]]]]] =\
+            list(parallel_runner.run_function(self.parse_hcl_module_from_multi_tf_definitions,
+                                              definitions_dir_and_source_iterable))
 
         return modules_and_definitions_tuple
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Used parallel run to run all split_graph iterations, should significantly lower running time when a large number of sub graphs exist.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
