### PR TITLE
fix(terraform): Fix CKV_Azure_234

### DIFF
--- a/checkov/terraform/checks/resource/azure/AzureDefenderDisabledForResManager.py
+++ b/checkov/terraform/checks/resource/azure/AzureDefenderDisabledForResManager.py
@@ -16,9 +16,9 @@ class AzureDefenderDisabledForResManager(BaseResourceCheck):
 
     def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
         return (
-            CheckResult.PASSED
-            if conf.get("resource_type", [""])[0].lower() == "arm" and conf.get("tier", [""])[0].lower() == "standard"
-            else CheckResult.FAILED
+            CheckResult.FAILED
+            if conf.get("resource_type", [""])[0].lower() == "arm" and conf.get("tier", [""])[0].lower() != "standard"
+            else CheckResult.PASSED
         )
 
     def get_evaluated_keys(self) -> list[str]:

--- a/tests/terraform/checks/resource/azure/example_AzureDefenderDisabledForResManager/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AzureDefenderDisabledForResManager/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_security_center_subscription_pricing" "pass_2" {
 
 # Case 4: Pass as policy should only check if the resource_type is "Arm"
 
-resource "azurerm_security_center_subscription_pricing" "pass3" {
+resource "azurerm_security_center_subscription_pricing" "pass_3" {
   tier          = "Free"
   resource_type = "VirtualMachine"
 }

--- a/tests/terraform/checks/resource/azure/example_AzureDefenderDisabledForResManager/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AzureDefenderDisabledForResManager/main.tf
@@ -1,7 +1,7 @@
 
 # Case 1: Pass: tier is Standard and resource_type is Arm
 
-resource "azurerm_security_center_subscription_pricing" "pass" {
+resource "azurerm_security_center_subscription_pricing" "pass_1" {
   tier          = "Standard"
   resource_type = "Arm"
 }
@@ -13,10 +13,16 @@ resource "azurerm_security_center_subscription_pricing" "fail_1" {
   resource_type = "arm"
 }
 
-# Case 3: Fails as "resource_type" should be "Arm"
+# Case 3: Pass as policy should only check if the resource_type is "Arm"
 
-resource "azurerm_security_center_subscription_pricing" "fail_2" {
-  tier          = "Standard"
+resource "azurerm_security_center_subscription_pricing" "pass_2" {
+  tier          = "Free"
   resource_type = "Dns"
 }
 
+# Case 4: Pass as policy should only check if the resource_type is "Arm"
+
+resource "azurerm_security_center_subscription_pricing" "pass3" {
+  tier          = "Free"
+  resource_type = "VirtualMachine"
+}

--- a/tests/terraform/checks/resource/azure/test_AzureDefenderDisabledForResManager.py
+++ b/tests/terraform/checks/resource/azure/test_AzureDefenderDisabledForResManager.py
@@ -17,11 +17,12 @@ class TestAzureDefenderDisabledForResManager(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            'azurerm_security_center_subscription_pricing.pass',
+            'azurerm_security_center_subscription_pricing.pass_1',
+            'azurerm_security_center_subscription_pricing.pass_2',
+            'azurerm_security_center_subscription_pricing.pass_3',
         }
         failing_resources = {
             'azurerm_security_center_subscription_pricing.fail_1',
-            'azurerm_security_center_subscription_pricing.fail_2',
         }
         skipped_resources = {}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

CKV_Azure_234 is supposed to only flag if the resource_type is ARM and the pricing tier is not standard

Fix #5885 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
