### PR TITLE
feat(terraform): add CKV2_AZURE_47, ensure storage account is configured without blob anonymous access

### DIFF
--- a/checkov/terraform/checks/graph_checks/azure/AzureStorageAccConfigWithoutBlobAnonymousAccess.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/AzureStorageAccConfigWithoutBlobAnonymousAccess.yaml
@@ -1,0 +1,17 @@
+metadata:
+  id: "CKV2_AZURE_47"
+  name: "Ensure storage account is configured without blob anonymous access"
+  category: "IAM"
+
+definition:
+  and:
+    - cond_type: "attribute"
+      resource_types: "azurerm_storage_account"
+      attribute: "allow_nested_items_to_be_public"
+      operator: "exists"
+
+    - cond_type: "attribute"
+      resource_types: "azurerm_storage_account"
+      attribute: "allow_nested_items_to_be_public"
+      operator: "equals_ignore_case"
+      value: "false"

--- a/tests/terraform/graph/checks/resources/AzureStorageAccConfigWithoutBlobAnonymousAccess/expected.yaml
+++ b/tests/terraform/graph/checks/resources/AzureStorageAccConfigWithoutBlobAnonymousAccess/expected.yaml
@@ -1,0 +1,5 @@
+pass:
+  - "azurerm_storage_account.pass"
+fail:
+  - "azurerm_storage_account.fail_1"
+  - "azurerm_storage_account.fail_2"

--- a/tests/terraform/graph/checks/resources/AzureStorageAccConfigWithoutBlobAnonymousAccess/main.tf
+++ b/tests/terraform/graph/checks/resources/AzureStorageAccConfigWithoutBlobAnonymousAccess/main.tf
@@ -1,0 +1,52 @@
+variable "rg-name" {
+  default = "pud-bc-rg"
+}
+
+variable "location" {
+  default = "northeurope"
+}
+
+# Case 1: Pass: allow_nested_items_to_be_public = False
+
+resource "azurerm_storage_account" "pass" {
+  name                     = "pud-storage2023abc1"
+  resource_group_name      = var.rg-name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  allow_nested_items_to_be_public = false
+
+  tags = {
+    bc_status = "pass"
+  }
+}
+
+# Case 2: Fail: allow_nested_items_to_be_public does NOT exist
+
+resource "azurerm_storage_account" "fail_1" {
+  name                     = "pud-storage2023abc2"
+  resource_group_name      = var.rg-name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+
+  tags = {
+    bc_status = "fail_1"
+  }
+}
+
+# Case 3: Fail: allow_nested_items_to_be_public = True
+
+resource "azurerm_storage_account" "fail_2" {
+  name                     = "pud-storage2023abc3"
+  resource_group_name      = var.rg-name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  allow_nested_items_to_be_public = true
+
+
+  tags = {
+    bc_status = "fail_2"
+  }
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

For any organization serious about security, it does not make sense to have the possibility to add anonymous public blob containers at all. Therefore, ensure that allow_nested_public_items (= allow blob anonymous access in web UI) is set to false.

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

https://learn.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-configure?tabs=portal

"Warning: When a container is configured for anonymous access, any client can read data in that container. Anonymous access presents a potential security risk, so if your scenario does not require it, we recommend that you remediate anonymous access for the storage account."

### Fix
*How does someone fix the issue in code and/or in runtime?*

Code: Add Terraform code allow_nested_public_items set to false for storage account resources. Web UI: disable allow blob anymous access, but we want to do this with code.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [?] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
