### PR TITLE
feat(terraform): Add various vertex related policies

### DIFF
--- a/checkov/terraform/checks/graph_checks/gcp/GCPDialogFlowAgentLoggingEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPDialogFlowAgentLoggingEnabled.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "CKV2_GCP_29"
+  name: "Ensure logging is enabled for Dialogflow agents"
+  category: "LOGGING"
+definition:
+  cond_type: attribute
+  resource_types:
+  - google_dialogflow_agent
+  attribute: enable_logging
+  operator: equals
+  value: "true"

--- a/checkov/terraform/checks/graph_checks/gcp/GCPDialogFlowCxAgentLoggingEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPDialogFlowCxAgentLoggingEnabled.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "CKV2_GCP_30"
+  name: "Ensure logging is enabled for Dialogflow CX agents"
+  category: "LOGGING"
+definition:
+  cond_type: attribute
+  resource_types:
+  - google_dialogflow_cx_agent
+  attribute: enable_stackdriver_logging
+  operator: equals
+  value: "true"

--- a/checkov/terraform/checks/graph_checks/gcp/GCPDialogFlowCxWebhookLoggingEnabled.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPDialogFlowCxWebhookLoggingEnabled.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "CKV2_GCP_31"
+  name: "Ensure logging is enabled for Dialogflow CX webhooks"
+  category: "LOGGING"
+definition:
+  cond_type: attribute
+  resource_types:
+  - google_dialogflow_cx_webhook
+  attribute: enable_stackdriver_logging
+  operator: equals
+  value: "true"

--- a/checkov/terraform/checks/graph_checks/gcp/GCPDocumentAIProcessorEncryptedWithCMK.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPDocumentAIProcessorEncryptedWithCMK.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "CKV2_GCP_22"
+  name: "Ensure Document AI Processors are encrypted with a Customer Managed Key (CMK)"
+  category: "ENCRYPTION"
+scope:
+  provider: "GCP"
+definition:
+  resource_types:
+    - google_document_ai_processor
+  operator: exists
+  attribute: kms_key_name
+  cond_type: attribute

--- a/checkov/terraform/checks/graph_checks/gcp/GCPDocumentAIWarehouseLocationEncryptedWithCMK.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPDocumentAIWarehouseLocationEncryptedWithCMK.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "CKV2_GCP_23"
+  name: "Ensure Document AI Warehouse Location is configured to use a Customer Managed Key (CMK)"
+  category: "ENCRYPTION"
+scope:
+  provider: "GCP"
+definition:
+  resource_types:
+    - google_document_ai_warehouse_location
+  operator: exists
+  attribute: kms_key
+  cond_type: attribute

--- a/checkov/terraform/checks/graph_checks/gcp/GCPTpuV2VmPrivateEndpoint.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPTpuV2VmPrivateEndpoint.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "CKV2_GCP_32"
+  name: "Ensure TPU v2 is private"
+  category: "NETWORKING"
+definition:
+  cond_type: attribute
+  resource_types:
+  - google_tpu_v2_vm
+  attribute: network_config.enable_external_ips
+  operator: jsonpath_equals
+  value: "false"

--- a/checkov/terraform/checks/graph_checks/gcp/GCPVertexAIEndpointEncryptedWithCMK.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPVertexAIEndpointEncryptedWithCMK.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "CKV2_GCP_24"
+  name: "Ensure Vertex AI endpoint uses a Customer Managed Key (CMK)"
+  category: "ENCRYPTION"
+scope:
+  provider: "GCP"
+definition:
+  resource_types:
+    - google_vertex_ai_endpoint
+  operator: exists
+  attribute: encryption_spec
+  cond_type: attribute

--- a/checkov/terraform/checks/graph_checks/gcp/GCPVertexAIFeaturestoreEncryptedWithCMK.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPVertexAIFeaturestoreEncryptedWithCMK.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "CKV2_GCP_25"
+  name: "Ensure Vertex AI featurestore uses a Customer Managed Key (CMK)"
+  category: "ENCRYPTION"
+scope:
+  provider: "GCP"
+definition:
+  resource_types:
+    - google_vertex_ai_featurestore
+  operator: exists
+  attribute: encryption_spec
+  cond_type: attribute

--- a/checkov/terraform/checks/graph_checks/gcp/GCPVertexAIPrivateEndpoint.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPVertexAIPrivateEndpoint.yaml
@@ -1,0 +1,10 @@
+metadata:
+  id: "CKV2_GCP_33"
+  name: "Ensure Vertex AI endpoint is private"
+  category: "NETWORKING"
+definition:
+  cond_type: attribute
+  resource_types:
+  - google_vertex_ai_endpoint
+  attribute: network
+  operator: exists

--- a/checkov/terraform/checks/graph_checks/gcp/GCPVertexAIPrivateIndexEndpoint.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPVertexAIPrivateIndexEndpoint.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "CKV2_GCP_34"
+  name: "Ensure Vertex AI index endpoint is private"
+  category: "NETWORKING"
+definition:
+  cond_type: attribute
+  resource_types:
+  - google_vertex_ai_index_endpoint
+  attribute: public_endpoint_enabled
+  operator: not_equals
+  value: "true"

--- a/checkov/terraform/checks/graph_checks/gcp/GCPVertexAITensorboardEncryptedWithCMK.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPVertexAITensorboardEncryptedWithCMK.yaml
@@ -1,0 +1,12 @@
+metadata:
+  id: "CKV2_GCP_26"
+  name: "Ensure Vertex AI tensorboard uses a Customer Managed Key (CMK)"
+  category: "ENCRYPTION"
+scope:
+  provider: "GCP"
+definition:
+  resource_types:
+    - google_vertex_ai_tensorboard
+  operator: exists
+  attribute: encryption_spec
+  cond_type: attribute

--- a/checkov/terraform/checks/graph_checks/gcp/GCPVertexInstanceEncryptedWithCMK.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPVertexInstanceEncryptedWithCMK.yaml
@@ -1,0 +1,19 @@
+metadata:
+  id: "CKV2_GCP_21"
+  name: "Ensure Vertex AI instance disks are encrypted with a Customer Managed Key (CMK)"
+  category: "ENCRYPTION"
+scope:
+  provider: "GCP"
+definition:
+  and:
+    - resource_types:
+        - google_notebooks_instance
+      operator: exists
+      attribute: kms_key
+      cond_type: attribute
+    - resource_types:
+        - google_notebooks_instance
+      operator: equals
+      value: CMEK
+      attribute: disk_encryption
+      cond_type: attribute

--- a/checkov/terraform/checks/graph_checks/gcp/GCPVertexRuntimeEncryptedWithCMK.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPVertexRuntimeEncryptedWithCMK.yaml
@@ -1,0 +1,10 @@
+metadata:
+  id: "CKV2_GCP_35"
+  name: "Ensure Vertex AI runtime is encrypted with a Customer Managed Key (CMK)"
+  category: "ENCRYPTION"
+definition:
+  cond_type: attribute
+  resource_types:
+  - google_notebooks_runtime
+  attribute: virtual_machine.virtual_machine_config.encryption_config.kms_key
+  operator: jsonpath_exists

--- a/checkov/terraform/checks/graph_checks/gcp/GCPVertexRuntimePrivate.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPVertexRuntimePrivate.yaml
@@ -1,0 +1,11 @@
+metadata:
+  id: "CKV2_GCP_36"
+  name: "Ensure Vertex AI runtime is private"
+  category: "NETWORKING"
+definition:
+  cond_type: attribute
+  resource_types:
+  - google_notebooks_runtime
+  attribute: virtual_machine.virtual_machine_config.internal_ip_only
+  operator: jsonpath_equals
+  value: "true"

--- a/checkov/terraform/checks/graph_checks/gcp/GCPVertexWorkbenchInstanceEncryptedWithCMK.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPVertexWorkbenchInstanceEncryptedWithCMK.yaml
@@ -1,0 +1,24 @@
+metadata:
+  id: "CKV2_GCP_27"
+  name: "Ensure Vertex AI workbench instance disks are encrypted with a Customer Managed Key (CMK)"
+  category: "ENCRYPTION"
+scope:
+  provider: "GCP"
+definition:
+  and:
+    - cond_type: attribute
+      resource_types:
+        - google_workbench_instance
+      attribute: "gce_setup.boot_disk.kms_key"
+      operator: jsonpath_exists
+    - or:
+      - cond_type: attribute
+        resource_types:
+          - google_workbench_instance
+        attribute: "gce_setup.data_disks"
+        operator: jsonpath_not_exists
+      - cond_type: attribute
+        resource_types:
+          - google_workbench_instance
+        attribute: "gce_setup.data_disks.kms_key"
+        operator: jsonpath_exists

--- a/checkov/terraform/checks/graph_checks/gcp/GCPVertexWorkbenchInstanceNoPublicIp.yaml
+++ b/checkov/terraform/checks/graph_checks/gcp/GCPVertexWorkbenchInstanceNoPublicIp.yaml
@@ -1,0 +1,13 @@
+metadata:
+  id: "CKV2_GCP_28"
+  name: "Ensure Vertex AI workbench instances are private"
+  category: "GENERAL_SECURITY"
+scope:
+  provider: "GCP"
+definition:
+  cond_type: attribute
+  resource_types:
+    - google_workbench_instance
+  attribute: "gce_setup.disable_public_ip"
+  operator: jsonpath_equals
+  value: "true"

--- a/tests/terraform/graph/checks/resources/GCPDialogFlowAgentLoggingEnabled/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPDialogFlowAgentLoggingEnabled/expected.yaml
@@ -1,0 +1,5 @@
+pass:
+  - "google_dialogflow_agent.agent_good"
+fail:
+  - "google_dialogflow_agent.agent_bad"
+  - "google_dialogflow_agent.agent_bad_unset"

--- a/tests/terraform/graph/checks/resources/GCPDialogFlowAgentLoggingEnabled/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPDialogFlowAgentLoggingEnabled/main.tf
@@ -1,0 +1,31 @@
+resource "google_dialogflow_agent" "agent_good" {
+  display_name = "dialogflow-agent-good"
+  default_language_code = "en"
+  time_zone = "America/New_York"
+  enable_logging = true
+  match_mode = "MATCH_MODE_ML_ONLY"
+  classification_threshold = 0.3
+  api_version = "API_VERSION_V2_BETA_1"
+  tier = "TIER_STANDARD"
+}
+
+resource "google_dialogflow_agent" "agent_bad" {
+  display_name = "dialogflow-agent-bad"
+  default_language_code = "en"
+  time_zone = "America/New_York"
+  enable_logging = false
+  match_mode = "MATCH_MODE_ML_ONLY"
+  classification_threshold = 0.3
+  api_version = "API_VERSION_V2_BETA_1"
+  tier = "TIER_STANDARD"
+}
+
+resource "google_dialogflow_agent" "agent_bad_unset" {
+  display_name = "dialogflow-agent-bad-unset"
+  default_language_code = "en"
+  time_zone = "America/New_York"
+  match_mode = "MATCH_MODE_ML_ONLY"
+  classification_threshold = 0.3
+  api_version = "API_VERSION_V2_BETA_1"
+  tier = "TIER_STANDARD"
+}

--- a/tests/terraform/graph/checks/resources/GCPDialogFlowCxAgentLoggingEnabled/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPDialogFlowCxAgentLoggingEnabled/expected.yaml
@@ -1,0 +1,5 @@
+pass:
+  - "google_dialogflow_cx_agent.good"
+fail:
+  - "google_dialogflow_cx_agent.bad"
+  - "google_dialogflow_cx_agent.bad_unset"

--- a/tests/terraform/graph/checks/resources/GCPDialogFlowCxAgentLoggingEnabled/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPDialogFlowCxAgentLoggingEnabled/main.tf
@@ -1,0 +1,42 @@
+resource "google_dialogflow_cx_agent" "good" {
+  display_name = "dialogflowcx-agent"
+  location = "global"
+  default_language_code = "en"
+  supported_language_codes = ["it","de","es"]
+  time_zone = "America/New_York"
+  description = "Example description."
+  enable_spell_correction    = true
+  enable_stackdriver_logging = true
+  speech_to_text_settings {
+    enable_speech_adaptation = true
+  }
+}
+
+resource "google_dialogflow_cx_agent" "bad" {
+  display_name = "dialogflowcx-agent"
+  location = "global"
+  default_language_code = "en"
+  supported_language_codes = ["it","de","es"]
+  time_zone = "America/New_York"
+  description = "Example description."
+  enable_spell_correction    = true
+  enable_stackdriver_logging = false
+  speech_to_text_settings {
+    enable_speech_adaptation = true
+  }
+}
+
+resource "google_dialogflow_cx_agent" "bad_unset" {
+  display_name = "dialogflowcx-agent"
+  location = "global"
+  default_language_code = "en"
+  supported_language_codes = ["it","de","es"]
+  time_zone = "America/New_York"
+  description = "Example description."
+  enable_spell_correction    = true
+  speech_to_text_settings {
+    enable_speech_adaptation = true
+  }
+}
+
+

--- a/tests/terraform/graph/checks/resources/GCPDialogFlowCxWebhookLoggingEnabled/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPDialogFlowCxWebhookLoggingEnabled/expected.yaml
@@ -1,0 +1,5 @@
+pass:
+  - "google_dialogflow_cx_webhook.good_webhook"
+fail:
+  - "google_dialogflow_cx_webhook.bad_webhook"
+  - "google_dialogflow_cx_webhook.bad_unset_webhook"

--- a/tests/terraform/graph/checks/resources/GCPDialogFlowCxWebhookLoggingEnabled/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPDialogFlowCxWebhookLoggingEnabled/main.tf
@@ -1,0 +1,39 @@
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name = "dialogflowcx-agent"
+  location = "global"
+  default_language_code = "en"
+  supported_language_codes = ["it","de","es"]
+  time_zone = "America/New_York"
+  description = "Example description."
+  enable_spell_correction    = true
+  speech_to_text_settings {
+    enable_speech_adaptation = true
+  }
+}
+
+
+resource "google_dialogflow_cx_webhook" "good_webhook" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  display_name = "GoodWebhook"
+  enable_stackdriver_logging = true
+  generic_web_service {
+        uri = "https://paloaltonetworks.com"
+    }
+}
+
+resource "google_dialogflow_cx_webhook" "bad_webhook" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  display_name = "BadWebhook"
+  enable_stackdriver_logging = false
+  generic_web_service {
+        uri = "https://paloaltonetworks.com"
+    }
+}
+
+resource "google_dialogflow_cx_webhook" "bad_unset_webhook" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  display_name = "BadUnsetWebhook"
+  generic_web_service {
+        uri = "https://paloaltonetworks.com"
+    }
+}

--- a/tests/terraform/graph/checks/resources/GCPDocumentAIProcessorEncryptedWithCMK/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPDocumentAIProcessorEncryptedWithCMK/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "google_document_ai_processor.processor_good"
+fail:
+  - "google_document_ai_processor.processor_bad"

--- a/tests/terraform/graph/checks/resources/GCPDocumentAIProcessorEncryptedWithCMK/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPDocumentAIProcessorEncryptedWithCMK/main.tf
@@ -1,0 +1,12 @@
+resource "google_document_ai_processor" "processor_bad" {
+  location = "us"
+  display_name = "bad-processor"
+  type = "OCR_PROCESSOR"
+}
+
+resource "google_document_ai_processor" "processor_good" {
+  location = "us"
+  display_name = "good-processor"
+  type = "OCR_PROCESSOR"
+  kms_key_name = "my_super_secret_key_name"
+}

--- a/tests/terraform/graph/checks/resources/GCPDocumentAIWarehouseLocationEncryptedWithCMK/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPDocumentAIWarehouseLocationEncryptedWithCMK/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "google_document_ai_warehouse_location.location_good"
+fail:
+  - "google_document_ai_warehouse_location.location_bad"

--- a/tests/terraform/graph/checks/resources/GCPDocumentAIWarehouseLocationEncryptedWithCMK/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPDocumentAIWarehouseLocationEncryptedWithCMK/main.tf
@@ -1,0 +1,16 @@
+resource "google_document_ai_warehouse_location" "location_good" {
+    location = "us"
+    project_number = data.google_project.project.number
+    access_control_mode = "ACL_MODE_DOCUMENT_LEVEL_ACCESS_CONTROL_GCI"
+    database_type = "DB_INFRA_SPANNER"
+    kms_key = "dummy_key"
+    document_creator_default_role = "DOCUMENT_ADMIN"
+}
+
+resource "google_document_ai_warehouse_location" "location_bad" {
+    location = "us"
+    project_number = data.google_project.project.number
+    access_control_mode = "ACL_MODE_DOCUMENT_LEVEL_ACCESS_CONTROL_GCI"
+    database_type = "DB_INFRA_SPANNER"
+    document_creator_default_role = "DOCUMENT_ADMIN"
+}

--- a/tests/terraform/graph/checks/resources/GCPTpuV2VmPrivateEndpoint/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPTpuV2VmPrivateEndpoint/expected.yaml
@@ -1,0 +1,5 @@
+pass:
+  - "google_tpu_v2_vm.tpu_good"
+fail:
+  - "google_tpu_v2_vm.tpu_bad"
+  - "google_tpu_v2_vm.tpu_bad_unset"

--- a/tests/terraform/graph/checks/resources/GCPTpuV2VmPrivateEndpoint/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPTpuV2VmPrivateEndpoint/main.tf
@@ -1,0 +1,55 @@
+resource "google_tpu_v2_vm" "tpu_good" {
+  name = "good-tpu"
+  zone = "us-central1-c"
+
+  runtime_version  = "tpu-vm-tf-2.13.0"
+
+  accelerator_config {
+    type     = "V2"
+    topology = "2x2"
+  }
+
+  cidr_block = "10.0.0.0/29"
+
+  network_config {
+    can_ip_forward      = true
+    enable_external_ips = false
+  }
+}
+
+resource "google_tpu_v2_vm" "tpu_bad" {
+  name = "good-tpu"
+  zone = "us-central1-c"
+
+  runtime_version  = "tpu-vm-tf-2.13.0"
+
+  accelerator_config {
+    type     = "V2"
+    topology = "2x2"
+  }
+
+  cidr_block = "10.0.0.0/29"
+
+  network_config {
+    can_ip_forward      = true
+    enable_external_ips = true
+  }
+}
+
+resource "google_tpu_v2_vm" "tpu_bad_unset" {
+  name = "good-tpu"
+  zone = "us-central1-c"
+
+  runtime_version  = "tpu-vm-tf-2.13.0"
+
+  accelerator_config {
+    type     = "V2"
+    topology = "2x2"
+  }
+
+  cidr_block = "10.0.0.0/29"
+
+  network_config {
+    can_ip_forward      = true
+  }
+}

--- a/tests/terraform/graph/checks/resources/GCPVertexAIEndpointEncryptedWithCMK/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPVertexAIEndpointEncryptedWithCMK/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "google_vertex_ai_endpoint.endpoint_good"
+fail:
+  - "google_vertex_ai_endpoint.endpoint_bad"

--- a/tests/terraform/graph/checks/resources/GCPVertexAIEndpointEncryptedWithCMK/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPVertexAIEndpointEncryptedWithCMK/main.tf
@@ -1,0 +1,32 @@
+resource "google_vertex_ai_endpoint" "endpoint_good" {
+  name         = "endpoint-name"
+  display_name = "sample-endpoint"
+  description  = "A sample vertex endpoint"
+  location     = "us-central1"
+  region       = "us-central1"
+  labels       = {
+    label-one = "value-one"
+  }
+  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
+  encryption_spec {
+    kms_key_name = "some_key"
+  }
+  depends_on   = [
+    google_service_networking_connection.vertex_vpc_connection
+  ]
+}
+
+resource "google_vertex_ai_endpoint" "endpoint_bad" {
+  name         = "endpoint-name"
+  display_name = "sample-endpoint"
+  description  = "A sample vertex endpoint"
+  location     = "us-central1"
+  region       = "us-central1"
+  labels       = {
+    label-one = "value-one"
+  }
+  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
+  depends_on   = [
+    google_service_networking_connection.vertex_vpc_connection
+  ]
+}

--- a/tests/terraform/graph/checks/resources/GCPVertexAIFeaturestoreEncryptedWithCMK/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPVertexAIFeaturestoreEncryptedWithCMK/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "google_vertex_ai_featurestore.featurestore_good"
+fail:
+  - "google_vertex_ai_featurestore.featurestore_bad"

--- a/tests/terraform/graph/checks/resources/GCPVertexAIFeaturestoreEncryptedWithCMK/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPVertexAIFeaturestoreEncryptedWithCMK/main.tf
@@ -1,0 +1,26 @@
+resource "google_vertex_ai_featurestore" "featurestore_good" {
+  name     = "terraform"
+  labels = {
+    foo = "bar"
+  }
+  region   = "us-central1"
+  online_serving_config {
+    fixed_node_count = 2
+  }
+  encryption_spec {
+    kms_key_name = "kms-name"
+  }
+  force_destroy = true
+}
+
+resource "google_vertex_ai_featurestore" "featurestore_bad" {
+  name     = "terraform"
+  labels = {
+    foo = "bar"
+  }
+  region   = "us-central1"
+  online_serving_config {
+    fixed_node_count = 2
+  }
+  force_destroy = true
+}

--- a/tests/terraform/graph/checks/resources/GCPVertexAIPrivateEndpoint/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPVertexAIPrivateEndpoint/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "google_vertex_ai_endpoint.endpoint_good"
+fail:
+  - "google_vertex_ai_endpoint.endpoint_bad"

--- a/tests/terraform/graph/checks/resources/GCPVertexAIPrivateEndpoint/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPVertexAIPrivateEndpoint/main.tf
@@ -1,0 +1,14 @@
+resource "google_vertex_ai_endpoint" "endpoint_good" {
+  name         = "good-endpoint"
+  display_name = "good-endpoint"
+  location     = "us-central1"
+  region       = "us-central1"
+  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
+}
+
+resource "google_vertex_ai_endpoint" "endpoint_bad" {
+  name         = "good-endpoint"
+  display_name = "good-endpoint"
+  location     = "us-central1"
+  region       = "us-central1"
+}

--- a/tests/terraform/graph/checks/resources/GCPVertexAIPrivateIndexEndpoint/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPVertexAIPrivateIndexEndpoint/expected.yaml
@@ -1,0 +1,5 @@
+pass:
+  - "google_vertex_ai_index_endpoint.index_endpoint_good"
+  - "google_vertex_ai_index_endpoint.index_endpoint_good_explicit"
+fail:
+  - "google_vertex_ai_index_endpoint.index_endpoint_bad"

--- a/tests/terraform/graph/checks/resources/GCPVertexAIPrivateIndexEndpoint/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPVertexAIPrivateIndexEndpoint/main.tf
@@ -1,0 +1,27 @@
+resource "google_vertex_ai_index_endpoint" "index_endpoint_good" {
+  display_name = "good-endpoint"
+  description  = "A good vertex endpoint"
+  region       = "us-central1"
+
+  private_service_connect_config {
+    enable_private_service_connect = true
+    project_allowlist = [
+        data.google_project.project.number,
+    ]
+  }
+}
+
+resource "google_vertex_ai_index_endpoint" "index_endpoint_good_explicit" {
+  display_name = "good-explicit-endpoint"
+  description  = "A good vertex endpoint"
+  region       = "us-central1"
+
+  public_endpoint_enabled = false
+}
+
+resource "google_vertex_ai_index_endpoint" "index_endpoint_bad" {
+  display_name = "bad-endpoint"
+  description  = "A bad vertex endpoint"
+  region       = "us-central1"
+  public_endpoint_enabled = true
+}

--- a/tests/terraform/graph/checks/resources/GCPVertexAITensorboardEncryptedWithCMK/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPVertexAITensorboardEncryptedWithCMK/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "google_vertex_ai_tensorboard.tensorboard_good"
+fail:
+  - "google_vertex_ai_tensorboard.tensorboard_bad"

--- a/tests/terraform/graph/checks/resources/GCPVertexAITensorboardEncryptedWithCMK/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPVertexAITensorboardEncryptedWithCMK/main.tf
@@ -1,0 +1,22 @@
+resource "google_vertex_ai_tensorboard" "tensorboard_bad" {
+  display_name = "terraform"
+  description  = "sample description"
+  labels       = {
+    "key1" : "value1",
+    "key2" : "value2"
+  }
+  region       = "us-central1"
+}
+
+resource "google_vertex_ai_tensorboard" "tensorboard_good" {
+  display_name = "terraform"
+  description  = "sample description"
+  labels       = {
+    "key1" : "value1",
+    "key2" : "value2"
+  }
+  region       = "us-central1"
+  encryption_spec {
+    kms_key_name = "some_key"
+  }
+}

--- a/tests/terraform/graph/checks/resources/GCPVertexInstanceEncryptedWithCMK/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPVertexInstanceEncryptedWithCMK/expected.yaml
@@ -1,0 +1,7 @@
+pass:
+  - "google_notebooks_instance.instance_good_vm"
+fail:
+  - "google_notebooks_instance.instance_bad_vm"
+  - "google_notebooks_instance.instance_bad_container"
+  - "google_notebooks_instance.instance_bad"
+  - "google_notebooks_instance.instance_bad_crafty_container"

--- a/tests/terraform/graph/checks/resources/GCPVertexInstanceEncryptedWithCMK/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPVertexInstanceEncryptedWithCMK/main.tf
@@ -1,0 +1,91 @@
+resource "google_notebooks_instance" "instance_bad_vm" {
+  name = "notebooks-instance"
+  location = "us-west1-a"
+  machine_type = "e2-medium"
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+}
+
+resource "google_notebooks_instance" "instance_bad_container" {
+  name = "notebooks-instance"
+  location = "us-west1-a"
+  machine_type = "e2-medium"
+  metadata = {
+    proxy-mode = "service_account"
+    terraform  = "true"
+  }
+  container_image {
+    repository = "gcr.io/deeplearning-platform-release/base-cpu"
+    tag = "latest"
+  }
+}
+
+resource "google_notebooks_instance" "instance_bad" {
+  name = "notebooks-instance"
+  location = "us-central1-a"
+  machine_type = "e2-medium"
+
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+
+  instance_owners = [ "my@service-account.com"]
+  service_account = "my@service-account.com"
+
+  install_gpu_driver = true
+  boot_disk_type = "PD_SSD"
+  boot_disk_size_gb = 110
+
+  no_public_ip = true
+  no_proxy_access = true
+
+  network = data.google_compute_network.my_network.id
+  subnet = data.google_compute_subnetwork.my_subnetwork.id
+
+  labels = {
+    k = "val"
+  }
+
+  metadata = {
+    terraform = "true"
+  }
+}
+
+data "google_compute_network" "my_network" {
+  name = "default"
+}
+
+data "google_compute_subnetwork" "my_subnetwork" {
+  name   = "default"
+  region = "us-central1"
+}
+
+resource "google_notebooks_instance" "instance_bad_crafty_container" {
+  name = "notebooks-instance"
+  location = "us-west1-a"
+  machine_type = "e2-medium"
+  kms_key = var.kms_key
+  metadata = {
+    proxy-mode = "service_account"
+    terraform  = "true"
+  }
+  container_image {
+    repository = "gcr.io/deeplearning-platform-release/base-cpu"
+    tag = "latest"
+  }
+}
+
+resource "google_notebooks_instance" "instance_good_vm" {
+  name = "notebooks-instance"
+  location = "us-west1-a"
+  machine_type = "e2-medium"
+  disk_encryption = "CMEK"
+  kms_key = var.kms_key
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+}

--- a/tests/terraform/graph/checks/resources/GCPVertexRuntimeEncryptedWithCMK/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPVertexRuntimeEncryptedWithCMK/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "google_notebooks_runtime.runtime_good"
+fail:
+  - "google_notebooks_runtime.runtime_bad_unset"

--- a/tests/terraform/graph/checks/resources/GCPVertexRuntimeEncryptedWithCMK/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPVertexRuntimeEncryptedWithCMK/main.tf
@@ -1,0 +1,42 @@
+resource "google_notebooks_runtime" "runtime_good" {
+  name = "notebooks-runtime-good"
+  location = "us-central1"
+  access_config {
+    access_type = "SINGLE_USER"
+    runtime_owner = "example@paloaltonetworks.com"
+  }
+  virtual_machine {
+    virtual_machine_config {
+      encryption_config {
+        kms_key = "an-actual-key"
+      }
+      machine_type = "n1-standard-4"
+      data_disk {
+        initialize_params {
+          disk_size_gb = "100"
+          disk_type = "PD_STANDARD"
+        }
+      }
+    }
+  }
+}
+
+resource "google_notebooks_runtime" "runtime_bad_unset" {
+  name = "notebooks-runtime-bad-unset"
+  location = "us-central1"
+  access_config {
+    access_type = "SINGLE_USER"
+    runtime_owner = "example@paloaltonetworks.com"
+  }
+  virtual_machine {
+    virtual_machine_config {
+      machine_type = "n1-standard-4"
+      data_disk {
+        initialize_params {
+          disk_size_gb = "100"
+          disk_type = "PD_STANDARD"
+        }
+      }
+    }
+  }
+}

--- a/tests/terraform/graph/checks/resources/GCPVertexRuntimePrivate/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPVertexRuntimePrivate/expected.yaml
@@ -1,0 +1,5 @@
+pass:
+  - "google_notebooks_runtime.runtime_good"
+fail:
+  - "google_notebooks_runtime.runtime_bad"
+  - "google_notebooks_runtime.runtime_bad_unset"

--- a/tests/terraform/graph/checks/resources/GCPVertexRuntimePrivate/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPVertexRuntimePrivate/main.tf
@@ -1,0 +1,61 @@
+resource "google_notebooks_runtime" "runtime_good" {
+  name = "notebooks-runtime-good"
+  location = "us-central1"
+  access_config {
+    access_type = "SINGLE_USER"
+    runtime_owner = "example@paloaltonetworks.com"
+  }
+  virtual_machine {
+    virtual_machine_config {
+      internal_ip_only = true
+      machine_type = "n1-standard-4"
+      data_disk {
+        initialize_params {
+          disk_size_gb = "100"
+          disk_type = "PD_STANDARD"
+        }
+      }
+    }
+  }
+}
+
+resource "google_notebooks_runtime" "runtime_bad" {
+  name = "notebooks-runtime-bad"
+  location = "us-central1"
+  access_config {
+    access_type = "SINGLE_USER"
+    runtime_owner = "example@paloaltonetworks.com"
+  }
+  virtual_machine {
+    virtual_machine_config {
+      internal_ip_only = false
+      machine_type = "n1-standard-4"
+      data_disk {
+        initialize_params {
+          disk_size_gb = "100"
+          disk_type = "PD_STANDARD"
+        }
+      }
+    }
+  }
+}
+
+resource "google_notebooks_runtime" "runtime_bad_unset" {
+  name = "notebooks-runtime-bad-unset"
+  location = "us-central1"
+  access_config {
+    access_type = "SINGLE_USER"
+    runtime_owner = "example@paloaltonetworks.com"
+  }
+  virtual_machine {
+    virtual_machine_config {
+      machine_type = "n1-standard-4"
+      data_disk {
+        initialize_params {
+          disk_size_gb = "100"
+          disk_type = "PD_STANDARD"
+        }
+      }
+    }
+  }
+}

--- a/tests/terraform/graph/checks/resources/GCPVertexWorkbenchInstanceEncryptedWithCMK/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPVertexWorkbenchInstanceEncryptedWithCMK/expected.yaml
@@ -1,0 +1,7 @@
+pass:
+  - "google_workbench_instance.instance_good"
+  - "google_workbench_instance.instance_good_nodata"
+fail:
+  - "google_workbench_instance.instance_bad"
+  - "google_workbench_instance.instance_bad_nodata"
+  - "google_workbench_instance.instance_bad_nogcesetup"

--- a/tests/terraform/graph/checks/resources/GCPVertexWorkbenchInstanceEncryptedWithCMK/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPVertexWorkbenchInstanceEncryptedWithCMK/main.tf
@@ -1,0 +1,173 @@
+resource "google_workbench_instance" "instance_bad" {
+  name = "workbench-instance-bad"
+  location = "us-central1-a"
+
+  gce_setup {
+    machine_type = "n1-standard-4"
+    accelerator_configs {
+      type         = "NVIDIA_TESLA_T4"
+      core_count   = 1
+    }
+
+    disable_public_ip = false
+
+    service_accounts {
+      email = "my@service-account.com"
+    }
+
+    boot_disk {
+      disk_size_gb  = 310
+      disk_type = "PD_SSD"
+      disk_encryption = "GMEK"
+    }
+
+    data_disks {
+      disk_size_gb  = 330
+      disk_type = "PD_SSD"
+      disk_encryption = "GMEK"
+    }
+
+    network_interfaces {
+      network = google_compute_network.my_network.id
+      subnet = google_compute_subnetwork.my_subnetwork.id
+      nic_type = "GVNIC"
+    }
+
+    metadata = {
+      terraform = "true"
+    }
+
+    enable_ip_forwarding = true
+  }
+}
+
+resource "google_workbench_instance" "instance_bad_nodata" {
+  name = "workbench-instance-bad"
+  location = "us-central1-a"
+
+  gce_setup {
+    machine_type = "n1-standard-4"
+    accelerator_configs {
+      type         = "NVIDIA_TESLA_T4"
+      core_count   = 1
+    }
+
+    disable_public_ip = false
+
+    service_accounts {
+      email = "my@service-account.com"
+    }
+
+    boot_disk {
+      disk_size_gb  = 310
+      disk_type = "PD_SSD"
+      disk_encryption = "GMEK"
+    }
+
+    data_disks {
+      disk_size_gb  = 330
+      disk_type = "PD_SSD"
+      disk_encryption = "GMEK"
+    }
+
+    network_interfaces {
+      network = google_compute_network.my_network.id
+      subnet = google_compute_subnetwork.my_subnetwork.id
+      nic_type = "GVNIC"
+    }
+
+    metadata = {
+      terraform = "true"
+    }
+
+    enable_ip_forwarding = true
+  }
+}
+
+resource "google_workbench_instance" "instance_bad_nogcesetup" {
+  name = "workbench-instance-bad"
+  location = "us-central1-a"
+}
+
+resource "google_workbench_instance" "instance_good" {
+  name = "workbench-instance-good"
+  location = "us-central1-a"
+
+  gce_setup {
+    machine_type = "n1-standard-4"
+    accelerator_configs {
+      type         = "NVIDIA_TESLA_T4"
+      core_count   = 1
+    }
+
+    disable_public_ip = false
+
+    service_accounts {
+      email = "my@service-account.com"
+    }
+
+    boot_disk {
+      disk_size_gb  = 310
+      disk_type = "PD_SSD"
+      disk_encryption = "CMEK"
+      kms_key = google_kms_crypto_key.crypto-key.id
+    }
+
+    data_disks {
+      disk_size_gb  = 330
+      disk_type = "PD_SSD"
+      disk_encryption = "CMEK"
+      kms_key = google_kms_crypto_key.crypto-key.id
+    }
+
+    network_interfaces {
+      network = google_compute_network.my_network.id
+      subnet = google_compute_subnetwork.my_subnetwork.id
+      nic_type = "GVNIC"
+    }
+
+    metadata = {
+      terraform = "true"
+    }
+
+    enable_ip_forwarding = true
+  }
+}
+
+resource "google_workbench_instance" "instance_good_nodata" {
+  name = "workbench-instance-good"
+  location = "us-central1-a"
+
+  gce_setup {
+    machine_type = "n1-standard-4"
+    accelerator_configs {
+      type         = "NVIDIA_TESLA_T4"
+      core_count   = 1
+    }
+
+    disable_public_ip = false
+
+    service_accounts {
+      email = "my@service-account.com"
+    }
+
+    boot_disk {
+      disk_size_gb  = 310
+      disk_type = "PD_SSD"
+      disk_encryption = "CMEK"
+      kms_key = google_kms_crypto_key.crypto-key.id
+    }
+
+    network_interfaces {
+      network = google_compute_network.my_network.id
+      subnet = google_compute_subnetwork.my_subnetwork.id
+      nic_type = "GVNIC"
+    }
+
+    metadata = {
+      terraform = "true"
+    }
+
+    enable_ip_forwarding = true
+  }
+}

--- a/tests/terraform/graph/checks/resources/GCPVertexWorkbenchInstanceNoPublicIp/expected.yaml
+++ b/tests/terraform/graph/checks/resources/GCPVertexWorkbenchInstanceNoPublicIp/expected.yaml
@@ -1,0 +1,7 @@
+pass:
+  - "google_workbench_instance.instance_good"
+fail:
+  - "google_workbench_instance.instance_explicitly_bad"
+  - "google_workbench_instance.instance_bad"
+  - "google_workbench_instance.instance_bad_nogcesetup"
+  

--- a/tests/terraform/graph/checks/resources/GCPVertexWorkbenchInstanceNoPublicIp/main.tf
+++ b/tests/terraform/graph/checks/resources/GCPVertexWorkbenchInstanceNoPublicIp/main.tf
@@ -1,0 +1,68 @@
+resource "google_workbench_instance" "instance_explicitly_bad" {
+  name = "workbench-instance-bad"
+  location = "us-central1-a"
+
+  gce_setup {
+    machine_type = "n1-standard-4"
+    accelerator_configs {
+      type         = "NVIDIA_TESLA_T4"
+      core_count   = 1
+    }
+
+    disable_public_ip = false
+
+    boot_disk {
+      disk_size_gb  = 310
+      disk_type = "PD_SSD"
+      disk_encryption = "GMEK"
+      kms_key = google_kms_crypto_key.crypto-key.id
+    }
+  }
+}
+
+resource "google_workbench_instance" "instance_bad" {
+  name = "workbench-instance-bad"
+  location = "us-central1-a"
+
+  gce_setup {
+    machine_type = "n1-standard-4"
+    accelerator_configs {
+      type         = "NVIDIA_TESLA_T4"
+      core_count   = 1
+    }
+
+    boot_disk {
+      disk_size_gb  = 310
+      disk_type = "PD_SSD"
+      disk_encryption = "GMEK"
+      kms_key = google_kms_crypto_key.crypto-key.id
+    }
+  }
+}
+
+resource "google_workbench_instance" "instance_bad_nogcesetup" {
+  name = "workbench-instance-bad-nogcesetup"
+  location = "us-central1-a"
+}
+
+resource "google_workbench_instance" "instance_good" {
+  name = "workbench-instance-bad"
+  location = "us-central1-a"
+
+  gce_setup {
+    machine_type = "n1-standard-4"
+    accelerator_configs {
+      type         = "NVIDIA_TESLA_T4"
+      core_count   = 1
+    }
+
+    disable_public_ip = true
+
+    boot_disk {
+      disk_size_gb  = 310
+      disk_type = "PD_SSD"
+      disk_encryption = "GMEK"
+      kms_key = google_kms_crypto_key.crypto-key.id
+    }
+  }
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -148,6 +148,30 @@ class TestYamlPolicies(unittest.TestCase):
     def test_GCPProjectHasNoLegacyNetworks(self):
         self.go("GCPProjectHasNoLegacyNetworks")
 
+    def test_GCPDocumentAIProcessorEncryptedWithCMK(self):
+        self.go("GCPDocumentAIProcessorEncryptedWithCMK")
+
+    def test_GCPDocumentAIWarehouseLocationEncryptedWithCMK(self):
+        self.go("GCPDocumentAIWarehouseLocationEncryptedWithCMK")
+
+    def test_GCPVertexInstanceEncryptedWithCMK(self):
+        self.go("GCPVertexInstanceEncryptedWithCMK")
+    
+    def test_GCPVertexAIEndpointEncryptedWithCMK(self):
+        self.go("GCPVertexAIEndpointEncryptedWithCMK")
+
+    def test_GCPVertexAIFeaturestoreEncryptedWithCMK(self):
+        self.go("GCPVertexAIFeaturestoreEncryptedWithCMK")
+
+    def test_GCPVertexAITensorboardEncryptedWithCMK(self):
+        self.go("GCPVertexAITensorboardEncryptedWithCMK")
+
+    def test_GCPVertexWorkbenchInstanceEncryptedWithCMK(self):
+        self.go("GCPVertexWorkbenchInstanceEncryptedWithCMK")
+
+    def test_GCPVertexWorkbenchInstanceNoPublicIp(self):
+        self.go("GCPVertexWorkbenchInstanceNoPublicIp")
+        
     def test_GCRContainerVulnerabilityScanningEnabled(self):
         self.go("GCRContainerVulnerabilityScanningEnabled")    
 

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -324,6 +324,30 @@ class TestYamlPolicies(unittest.TestCase):
 
     def test_GCPContainerRegistryReposAreNotPubliclyAccessible(self):
         self.go("GCPContainerRegistryReposAreNotPubliclyAccessible")
+    
+    def test_GCPDialogFlowAgentLoggingEnabled(self):
+        self.go("GCPDialogFlowAgentLoggingEnabled")
+    
+    def test_GCPDialogFlowCxAgentLoggingEnabled(self):
+        self.go("GCPDialogFlowCxAgentLoggingEnabled")
+
+    def test_GCPDialogFlowCxWebhookLoggingEnabled(self):
+        self.go("GCPDialogFlowCxWebhookLoggingEnabled")
+
+    def test_GCPVertexAIPrivateEndpoint(self):
+        self.go("GCPVertexAIPrivateEndpoint")
+    
+    def test_GCPVertexAIPrivateIndexEndpoint(self):
+        self.go("GCPVertexAIPrivateIndexEndpoint")
+
+    def test_GCPTpuV2VmPrivateEndpoint(self):
+        self.go("GCPTpuV2VmPrivateEndpoint")
+    
+    def test_GCPVertexRuntimePrivate(self):
+        self.go("GCPVertexRuntimePrivate")
+
+    def test_GCPVertexRuntimeEncryptedWithCMK(self):
+        self.go("GCPVertexRuntimeEncryptedWithCMK")
 
     def test_S3BucketVersioning(self):
         self.go("S3BucketVersioning")


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Add various policies surrounding the usage of customer managed encryption keys, private networking, and logging in various Vertex AI/Dialogflow/Document AI related services for GCP.

## New policies
CKV2_GCP_21
CKV2_GCP_22
CKV2_GCP_23
CKV2_GCP_24
CKV2_GCP_25
CKV2_GCP_26
CKV2_GCP_27
CKV2_GCP_28
CKV2_GCP_29
CKV2_GCP_30
CKV2_GCP_31
CKV2_GCP_32
CKV2_GCP_33
CKV2_GCP_34
CKV2_GCP_35
CKV2_GCP_36

### Description
CKV2_GCP_21
Customer Managed Keys can be used with disks within Vertex AI instances.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/notebooks_instance

CKV2_GCP_22
Customer Managed Keys can be used with Document AI Processors.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/document_ai_processor

CKV2_GCP_23
Customer Managed Keys can be used with Document AI Warehouse Locations.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/document_ai_warehouse_location

CKV2_GCP_24
Customer Managed Keys can be used with Vertex AI endpoints.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_endpoint

CKV2_GCP_25
Customer Managed Keys can be used with Vertex AI featurestores.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_featurestore

CKV2_GCP_26
Customer Managed Keys can be used with Vertex AI tensorboard instances.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_tensorboard

CKV2_GCP_27
Customer Managed Keys can be used with disks within Vertex AI Workbench instances.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/workbench_instance

CKV2_GCP_28
Vertex AI workbench instances should not have public IPs.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/workbench_instance

CKV2_GCP_29
Dialogflow agents should have logging enabled.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dialogflow_agent#enable_logging

CKV2_GCP_30
Dialogflow CX agents should have logging enabled.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dialogflow_agent#enable_logging

CKV2_GCP_31
Dialogflow CX agent webhooks should have logging enabled.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dialogflow_cx_webhook#enable_stackdriver_logging

CKV2_GCP_32
TPU workers should not have public IP addresses.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/tpu_v2_vm#enable_external_ips

CKV2_GCP_33
Vertex AI Endpoints should be peered with private networks.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_endpoint#network

CKV2_GCP_34
Vertex AI Index Endpoints should not be publicly exposed. 
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_index_endpoint#public_endpoint_enabled

CKV2_GCP_35
Notebook runtimes should be encrypted with Customer Managed Keys.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/notebooks_runtime#kms_key

CKV2_GCP_36
Notebook runtimes should not be publicly exposed.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/notebooks_runtime#internal_ip_only

### Fix
CKV2_GCP_21
Set `disk_encryption = "CMEK"` and `kms_key` to a valid key.

CKV2_GCP_22
Set `kms_key_name` to a valid key.

CKV2_GCP_23
Set `kms_key` to a valid key.

CKV2_GCP_24
Set `encryption_spec.kms_key_name` to a valid key.

CKV2_GCP_25
Set `encryption_spec.kms_key_name` to a valid key.

CKV2_GCP_26
Set `encryption_spec.kms_key_name` to a valid key.

CKV2_GCP_27
Define `kms_key` within `boot_disk` and `data_disks` (if it exists).

CKV2_GCP_28
Set `gce_setup.disable_public_ip = true`.

CKV2_GCP_29
Set `enable_logging = true`

CKV2_GCP_30
Set `enable_stackdriver_logging = true`

CKV2_GCP_31
Set `enable_stackdriver_logging = true`

CKV2_GCP_32
Set `network_config.enable_external_ips = false`

CKV2_GCP_33
Peer the resource to a valid network via `network`.

CKV2_GCP_34
Set `public_endpoint_enabled = false`

CKV2_GCP_35
Set `virtual_machine.virtual_machine_config.encryption_config.kms_key` to a valid key.

CKV2_GCP_36
Set `virtual_machine.virtual_machine_config.internal_ip_only = true`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
