### PR TITLE
feat(terraform): node pools should be configured separately from a cl…

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GKEDontUseNodePools.py
+++ b/checkov/terraform/checks/resource/gcp/GKEDontUseNodePools.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+
+
+class GKEDontUseNodePools(BaseResourceNegativeValueCheck):
+    def __init__(self) -> None:
+        """
+        Node pools are better configured in the separate resource google_container_node_pool
+        or to quote the provider docs:
+        "It is recommended that node pools be created and managed as separate resources as in the example above.
+        This allows node pools to be added and removed without recreating the cluster.
+        Node pools defined directly in the google_container_cluster resource cannot be removed
+        without re-creating the cluster."
+        Recreating a cluster in Production would be unwise.
+        """
+
+        name = "GKE Don't Use NodePools in the Cluster configuration"
+        id = "CKV_GCP_123"
+        supported_resources = ['google_container_cluster',]
+        categories = [CheckCategories.KUBERNETES,]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return 'node_pool'
+
+    def get_forbidden_values(self) -> list[Any]:
+        return [ANY_VALUE]
+
+
+check = GKEDontUseNodePools()

--- a/tests/terraform/checks/resource/gcp/example_GKEDontUseNodePools/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GKEDontUseNodePools/main.tf
@@ -1,0 +1,45 @@
+resource "google_container_cluster" "pass" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  node_config {
+    # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
+    service_account = google_service_account.default.email
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+    labels = {
+      foo = "bar"
+    }
+    tags = ["foo", "bar"]
+  }
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "fail" {
+  name               = "theDude"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  node_pool {
+    node_config {
+      # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
+      service_account = google_service_account.default.email
+      oauth_scopes = [
+        "https://www.googleapis.com/auth/cloud-platform"
+      ]
+      labels = {
+        foo = "bar"
+      }
+      tags = ["foo", "bar"]
+    }
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/tests/terraform/checks/resource/gcp/test_GKEDontUseNodePools.py
+++ b/tests/terraform/checks/resource/gcp/test_GKEDontUseNodePools.py
@@ -1,0 +1,39 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.GKEDontUseNodePools import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestGKEDontUseNodePools(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_GKEDontUseNodePools"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_container_cluster.pass',
+        }
+        failing_resources = {
+            'google_container_cluster.fail',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…uster

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
