### PR TITLE
fix(terraform): CKV_GCP_79  Upgrade CloudSQL SQLSERVER major version to 2022

### DIFF
--- a/checkov/terraform/checks/resource/gcp/CloudSqlMajorVersion.py
+++ b/checkov/terraform/checks/resource/gcp/CloudSqlMajorVersion.py
@@ -14,8 +14,8 @@ class CloudSqlMajorVersion(BaseResourceValueCheck):
         return 'database_version'
 
     def get_expected_values(self):
-        return ["POSTGRES_15", "MYSQL_8_0", "SQLSERVER_2019_STANDARD", "SQLSERVER_2019_WEB",
-                "SQLSERVER_2019_ENTERPRISE", "SQLSERVER_2019_EXPRESS"]
+        return ["POSTGRES_15", "MYSQL_8_0", "SQLSERVER_2022_STANDARD", "SQLSERVER_2022_WEB",
+                "SQLSERVER_2022_ENTERPRISE", "SQLSERVER_2022_EXPRESS"]
 
 
 check = CloudSqlMajorVersion()

--- a/tests/terraform/checks/resource/gcp/example_CloudSqlMajorVersion/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_CloudSqlMajorVersion/main.tf
@@ -154,7 +154,7 @@ resource "google_sql_database_instance" "pass2" {
 }
 
 resource "google_sql_database_instance" "fail3" {
-  database_version = "SQLSERVER_2017_STANDARD"
+  database_version = "SQLSERVER_2019_STANDARD"
   name             = "general-sqlserver12"
   project          = "gcp-bridgecrew-deployment"
   region           = "us-central1"
@@ -210,7 +210,7 @@ resource "google_sql_database_instance" "fail3" {
 }
 
 resource "google_sql_database_instance" "pass3" {
-  database_version = "SQLSERVER_2019_STANDARD"
+  database_version = "SQLSERVER_2022_STANDARD"
   name             = "general-sqlserver12"
   project          = "gcp-bridgecrew-deployment"
   region           = "us-central1"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
The latest major version of SQLSERVER on Google CloudSQL is now 2022. 
Upgraded the terraform CloudSQL SQLSERVER major check to reflect this change.

Google docs: https://cloud.google.com/sdk/gcloud/reference/sql/instances/create#--database-version


Fixes #5935

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
