### PR TITLE
fix(graph): keep resource_types empty for filter blocks

### DIFF
--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -127,7 +127,7 @@ operators_to_complex_solver_classes: dict[str, Type[BaseComplexSolver]] = {
 operator_to_connection_solver_classes: dict[str, Type[BaseConnectionSolver]] = {
     "exists": ConnectionExistsSolver,
     "one_exists": ConnectionOneExistsSolver,
-    "not_exists": ConnectionNotExistsSolver
+    "not_exists": ConnectionNotExistsSolver,
 }
 
 operator_to_complex_connection_solver_classes: dict[str, Type[ComplexConnectionSolver]] = {
@@ -209,7 +209,9 @@ class GraphCheckParser(BaseGraphCheckParser):
         else:
             return [""]
 
-    def _parse_raw_check(self, raw_check: Dict[str, Any], resources_types: Optional[List[str]], providers: Optional[List[str]]) -> BaseGraphCheck:
+    def _parse_raw_check(
+        self, raw_check: Dict[str, Any], resources_types: Optional[List[str]], providers: Optional[List[str]]
+    ) -> BaseGraphCheck:
         check = BaseGraphCheck()
         complex_operator = get_complex_operator(raw_check)
         if complex_operator:
@@ -233,10 +235,14 @@ class GraphCheckParser(BaseGraphCheckParser):
 
         else:
             resource_type = raw_check.get("resource_types", [])
-            if (
-                    not resource_type
-                    or (isinstance(resource_type, str) and resource_type.lower() == "all")
-                    or (isinstance(resource_type, list) and resource_type[0].lower() == "all")
+            if raw_check.get("cond_type") == "filter":
+                # filter blocks are only used in combination with others,
+                # which anyway have the needed resource types defined
+                check.resource_types = []
+            elif (
+                not resource_type
+                or (isinstance(resource_type, str) and resource_type.lower() == "all")
+                or (isinstance(resource_type, list) and resource_type[0].lower() == "all")
             ):
                 check.resource_types = resources_types or []
             elif "provider" in resource_type and providers:

--- a/tests/common/checks_infra/test_checks_parser.py
+++ b/tests/common/checks_infra/test_checks_parser.py
@@ -4,6 +4,7 @@ import yaml
 from _pytest.logging import LogCaptureFixture
 
 from checkov.common.checks_infra.checks_parser import GraphCheckParser
+from checkov.common.graph.checks_infra.enums import SolverType
 
 EXAMPLES_DIR = Path(__file__).parent / "examples"
 
@@ -76,3 +77,31 @@ def test_validate_check_config_invalid_definition(caplog: LogCaptureFixture):
         f"Custom policy {file_path} has an invalid 'definition' block type 'NoneType', "
         "needs to be either a 'list' or 'dict'"
     ]
+
+
+def test__parse_raw_check_with_filter_type():
+    # https://github.com/bridgecrewio/checkov/issues/5928
+
+    # given
+    raw_check = {
+        "attribute": "resource_type",
+        "cond_type": "filter",
+        "operator": "within",
+        "value": ["aws_codecommit_repository"],
+    }
+    resources_types = [
+        "aws_root",
+        "aws_root_access_key",
+    ]
+    providers = ["aws"]
+
+    # when
+    check = GraphCheckParser()._parse_raw_check(
+        raw_check=raw_check, resources_types=resources_types, providers=providers
+    )
+
+    # then
+    assert check.attribute == "resource_type"
+    assert check.attribute_value == ["aws_codecommit_repository"]
+    assert not check.resource_types  # this should be empty and not include 'aws_root', etc.
+    assert check.type == SolverType.FILTER


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- if `scope.provider` and a `filter` block is used, then it will add all resource types defined for the provider to be checked

Fixes #5928

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
