### PR TITLE
fix(terraform): fix check CKV2_AZURE_10

### DIFF
--- a/checkov/terraform/checks/graph_checks/azure/AzureAntimalwareIsConfiguredWithAutoUpdatesForVMs.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/AzureAntimalwareIsConfiguredWithAutoUpdatesForVMs.yaml
@@ -10,7 +10,7 @@ definition:
         - azurerm_virtual_machine
       operator: within
     - cond_type: connection
-      operator: exists
+      operator: one_exists
       resource_types:
         - azurerm_virtual_machine
       connected_resource_types:

--- a/docs/3.Custom Policies/YAML Custom Policies.md
+++ b/docs/3.Custom Policies/YAML Custom Policies.md
@@ -209,6 +209,7 @@ definition:
 | ----- | ----- |
 | Exists | `exists` |
 | Not Exists | `not_exists` |
+| One Exists | `one_exists` |
 
 ### Connection State Condition: Keys and Values
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**


## Description
Validate that there is only one `azurerm_virtual_machine_extension` connection with type attribute equals `IaaSAntimalware` instead of enforcing all `azurerm_virtual_machine_extension` connections


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
