### PR TITLE
fix(terraform): CKV_AWS_308 - checked if caching was enabled and only then check for encryption of cache

### DIFF
--- a/checkov/terraform/checks/resource/aws/APIGatewayMethodSettingsCacheEncrypted.py
+++ b/checkov/terraform/checks/resource/aws/APIGatewayMethodSettingsCacheEncrypted.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class APIGatewayMethodSettingCacheEncrypted(BaseResourceValueCheck):
@@ -17,6 +21,14 @@ class APIGatewayMethodSettingCacheEncrypted(BaseResourceValueCheck):
 
     def get_inspected_key(self):
         return "settings/[0]/cache_data_encrypted"
+
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        settings = conf.get("settings", {})[0]
+        cache_enabled = settings.get("caching_enabled", [False])[0]
+        if cache_enabled:
+            if not settings.get("cache_data_encrypted", [False])[0]:
+                return CheckResult.FAILED
+        return CheckResult.PASSED
 
 
 check = APIGatewayMethodSettingCacheEncrypted()

--- a/checkov/terraform/checks/resource/aws/APIGatewayMethodSettingsCacheEncrypted.py
+++ b/checkov/terraform/checks/resource/aws/APIGatewayMethodSettingsCacheEncrypted.py
@@ -23,10 +23,17 @@ class APIGatewayMethodSettingCacheEncrypted(BaseResourceValueCheck):
         return "settings/[0]/cache_data_encrypted"
 
     def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
-        settings = conf.get("settings", {})[0]
-        cache_enabled = settings.get("caching_enabled", [False])[0]
+        settings = conf.get("settings", {})
+        if settings and len(settings) == 1:
+            settings = settings[0]
+        cache_enabled = settings.get("caching_enabled", [False])
+        if isinstance(cache_enabled, list) and len(cache_enabled) == 1:
+            cache_enabled = cache_enabled[0]
         if cache_enabled:
-            if not settings.get("cache_data_encrypted", [False])[0]:
+            cache_encrypted = settings.get("cache_data_encrypted", [False])
+            if isinstance(cache_encrypted, list) and len(cache_encrypted) == 1:
+                cache_encrypted = cache_encrypted[0]
+            if not cache_encrypted:
                 return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/tests/terraform/checks/resource/aws/example_APIGatewayMethodSettingsCacheEncrypted/main.tf
+++ b/tests/terraform/checks/resource/aws/example_APIGatewayMethodSettingsCacheEncrypted/main.tf
@@ -4,7 +4,7 @@ resource "aws_api_gateway_method_settings" "fail" {
   method_path = "path1/GET"
 
   settings {
-    caching_enabled      = false
+    caching_enabled      = true
     metrics_enabled      = false
     logging_level        = "INFO"
     cache_data_encrypted = false
@@ -22,6 +22,18 @@ resource "aws_api_gateway_method_settings" "pass" {
     metrics_enabled      = false
     logging_level        = "INFO"
     cache_data_encrypted = true
+    data_trace_enabled   = false
+  }
+}
+
+resource "aws_api_gateway_method_settings" "pass2" {
+  rest_api_id = aws_api_gateway_rest_api.fail.id
+  stage_name  = aws_api_gateway_stage.fail.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    metrics_enabled      = false
+    logging_level        = "INFO"
     data_trace_enabled   = false
   }
 }

--- a/tests/terraform/checks/resource/aws/test_APIGatewayMethodSettingCacheEncrypted.py
+++ b/tests/terraform/checks/resource/aws/test_APIGatewayMethodSettingCacheEncrypted.py
@@ -17,6 +17,7 @@ class TestAPIGatewayMethodSettingsCacheEncrypted(unittest.TestCase):
 
         passing_resources = {
             "aws_api_gateway_method_settings.pass",
+            "aws_api_gateway_method_settings.pass2",
         }
         failing_resources = {
             "aws_api_gateway_method_settings.fail",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

CKV_AWS_308 - checked if caching was enabled and only then check for encryption of cache


## New/Edited policies

CKV_AWS_308

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
