### PR TITLE
fix(terraform): support vertex reference based on foreach key

### DIFF
--- a/checkov/terraform/graph_builder/foreach/utils.py
+++ b/checkov/terraform/graph_builder/foreach/utils.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Optional
+
+FOREACH_KEY_SEPERATOR = '["'
+FOREACH_KEY_ENDER = '"]'
+COUNT_KEY_SEPERATOR = "["
+COUNT_KEY_ENDER = "]"
+
+
+def get_terraform_foreach_or_count_key(resource_id: str) -> Optional[str]:
+    sanitized_id = get_sanitized_terraform_resource_id(resource_id)
+    if sanitized_id == resource_id:
+        return None
+    key = resource_id.split(sanitized_id)[-1]
+    while key.startswith(FOREACH_KEY_SEPERATOR) and key.endswith(FOREACH_KEY_ENDER):
+        key = key[2:-2]
+    while key.startswith(COUNT_KEY_SEPERATOR) and key.endswith(COUNT_KEY_ENDER):
+        key = key[1:-1]
+    return key
+
+
+def get_sanitized_terraform_resource_id(resource_id: str) -> str:
+    if FOREACH_KEY_SEPERATOR in resource_id:
+        original_id_parts = resource_id.split(FOREACH_KEY_SEPERATOR, maxsplit=1)
+        original_resource_name = original_id_parts[-2]  # As the last item will be the key itself,
+        return original_resource_name  # This will be the resource id before the foreach key was added
+    elif COUNT_KEY_SEPERATOR in resource_id:
+        original_id_parts = resource_id.split(COUNT_KEY_SEPERATOR)
+        original_resource_name = original_id_parts[-2]
+        return original_resource_name
+        return resource_id

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -434,9 +434,9 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
             vertex_foreach_value = vertex.for_each_index
             origin_address = origin_vertex.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS, '')
             origin_foreach_value = origin_vertex.for_each_index
-            if origin_foreach_value == vertex_foreach_value and \
-                    get_terraform_foreach_or_count_key(origin_address) == get_terraform_foreach_or_count_key(
-                vertex_address):
+            if origin_foreach_value == vertex_foreach_value and origin_address != '' and \
+                    get_terraform_foreach_or_count_key(origin_address) == \
+                    get_terraform_foreach_or_count_key(vertex_address):
                 return vertex_index
 
         return vertex_index_with_longest_common_prefix

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -29,8 +29,8 @@ from checkov.terraform.graph_builder.utils import (
     get_referenced_vertices_in_value,
     attribute_has_nested_attributes,
     remove_index_pattern_from_str,
-    join_double_quote_surrounded_dot_split,
-)
+    join_double_quote_surrounded_dot_split, )
+from checkov.terraform.graph_builder.foreach.utils import get_terraform_foreach_or_count_key
 from checkov.terraform.graph_builder.utils import is_local_path
 from checkov.terraform.graph_builder.variable_rendering.renderer import TerraformVariableRenderer
 
@@ -398,19 +398,47 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
                                      origin_vertex_index: Optional[int] = None) -> int:
         vertex_index_with_longest_common_prefix = -1
         longest_common_prefix = ""
+        vertices_with_longest_common_prefix = []
         for vertex_index in relevant_vertices_indexes:
             vertex = self.vertices[vertex_index]
             common_prefix = os.path.commonpath([os.path.realpath(vertex.path), os.path.realpath(origin_path)])
             if len(common_prefix) > len(longest_common_prefix):
                 vertex_index_with_longest_common_prefix = vertex_index
                 longest_common_prefix = common_prefix
-            elif len(common_prefix) == len(longest_common_prefix) and origin_vertex_index:
-                vertex_module_name = vertex.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS, '')
-                origin_module_name = self.vertices[origin_vertex_index].attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS, '')
-                if vertex_module_name.startswith(BlockType.MODULE) and origin_module_name.startswith(BlockType.MODULE):
-                    split_module_name = vertex_module_name.split('.')[1]
-                    if origin_module_name.startswith(f'{BlockType.MODULE}.{split_module_name}'):
-                        vertex_index_with_longest_common_prefix = vertex_index
+                vertices_with_longest_common_prefix = [(vertex_index, vertex)]
+            elif len(common_prefix) == len(longest_common_prefix):
+                vertices_with_longest_common_prefix.append((vertex_index, vertex))
+                if origin_vertex_index is not None:
+                    vertex_module_name = vertex.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS, '')
+                    origin_module_name = self.vertices[origin_vertex_index].attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS, '')
+                    if vertex_module_name.startswith(BlockType.MODULE) and origin_module_name.startswith(BlockType.MODULE):
+                        split_module_name = vertex_module_name.split('.')[1]
+                        if origin_module_name.startswith(f'{BlockType.MODULE}.{split_module_name}'):
+                            vertex_index_with_longest_common_prefix = vertex_index
+        if len(vertices_with_longest_common_prefix) <= 1:
+            return vertex_index_with_longest_common_prefix
+
+        # Try to compare based on foreach attributes if we have more than 1 vertex in the list
+        return self._find_best_match_based_on_foreach_key(origin_vertex_index, vertices_with_longest_common_prefix,
+                                                          vertex_index_with_longest_common_prefix)
+
+    def _find_best_match_based_on_foreach_key(
+            self,
+            origin_vertex_index: int,
+            vertices_with_longest_common_prefix: list[tuple[int, TerraformBlock]],
+            vertex_index_with_longest_common_prefix: int
+    ) -> int:
+        origin_vertex = self.vertices[origin_vertex_index]
+        for vertex_index, vertex in vertices_with_longest_common_prefix:
+            vertex_address = vertex.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS, '')
+            vertex_foreach_value = vertex.for_each_index
+            origin_address = origin_vertex.attributes.get(CustomAttributes.TF_RESOURCE_ADDRESS, '')
+            origin_foreach_value = origin_vertex.for_each_index
+            if origin_foreach_value == vertex_foreach_value and \
+                    get_terraform_foreach_or_count_key(origin_address) == get_terraform_foreach_or_count_key(
+                vertex_address):
+                return vertex_index
+
         return vertex_index_with_longest_common_prefix
 
     def get_vertices_hash_codes_to_attributes_map(self) -> Dict[str, Dict[str, Any]]:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixed an edge case in which we find several vertex references for edges and returns the incorrect one, now try to compare the foreach/count key of the resource to build the edge.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
