### PR TITLE
feat(terraform): Added support for `try` function in evaluate_terraform

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import logging
 import re
@@ -257,8 +259,30 @@ def formatdate(format_str: str, input_str: str) -> str:
     return dt.strftime(processed_format_str)
 
 
+def terraform_try(*args) -> Any:
+    """
+    From terraform docs:
+        "try evaluates all of its argument expressions in turn and returns the result of the first one that does not
+        produce any errors."
+    """
+    for arg in args:
+        try:
+            return evaluate(arg) if isinstance(arg, str) else arg
+        except Exception as e:
+            logging.warning(f"Error in evaluate_try of argument {arg} - {e}")
+            continue
+    raise Exception(f"No argument can be avaluted for try of {args}")
+
+
 SAFE_EVAL_FUNCTIONS: List[str] = []
 SAFE_EVAL_DICT = dict([(k, locals().get(k, None)) for k in SAFE_EVAL_FUNCTIONS])
+
+
+# type conversion functions
+# As `try` is a saved word in python, we can't override it like other functions as `eval` won't accept it.
+# Instead, we are manually replacing this string with our own custom string, so we can pass it to `eval`.
+TRY_STR_REPLACEMENT = "__terraform_try__"
+SAFE_EVAL_DICT[TRY_STR_REPLACEMENT] = terraform_try
 
 # math functions
 SAFE_EVAL_DICT["abs"] = abs
@@ -331,6 +355,7 @@ SAFE_EVAL_DICT["timeadd"] = timeadd
 SAFE_EVAL_DICT["formatdate"] = formatdate
 
 
+
 def evaluate(input_str: str) -> Any:
     if "__" in input_str:
         logging.debug(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")
@@ -338,6 +363,9 @@ def evaluate(input_str: str) -> Any:
     if input_str == "...":
         # don't create an Ellipsis object
         return input_str
+    if input_str.startswith("try"):
+        # Don't use str.replace to make sure we replace just the first occurrence
+        input_str = f"{TRY_STR_REPLACEMENT}{input_str[3:]}"
     evaluated = eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
     return evaluated if not isinstance(evaluated, str) else remove_unicode_null(evaluated)
 

--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -279,8 +279,6 @@ SAFE_EVAL_DICT = dict([(k, locals().get(k, None)) for k in SAFE_EVAL_FUNCTIONS])
 
 
 # type conversion functions
-# As `try` is a saved word in python, we can't override it like other functions as `eval` won't accept it.
-# Instead, we are manually replacing this string with our own custom string, so we can pass it to `eval`.
 TRY_STR_REPLACEMENT = "__terraform_try__"
 SAFE_EVAL_DICT[TRY_STR_REPLACEMENT] = terraform_try
 
@@ -364,6 +362,9 @@ def evaluate(input_str: str) -> Any:
         # don't create an Ellipsis object
         return input_str
     if input_str.startswith("try"):
+        # As `try` is a saved word in python, we can't override it like other functions as `eval` won't accept it.
+        # Instead, we are manually replacing this string with our own custom string, so we can pass it to `eval`.
+
         # Don't use str.replace to make sure we replace just the first occurrence
         input_str = f"{TRY_STR_REPLACEMENT}{input_str[3:]}"
     evaluated = eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec

--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -353,7 +353,6 @@ SAFE_EVAL_DICT["timeadd"] = timeadd
 SAFE_EVAL_DICT["formatdate"] = formatdate
 
 
-
 def evaluate(input_str: str) -> Any:
     if "__" in input_str:
         logging.debug(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")

--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -259,7 +259,7 @@ def formatdate(format_str: str, input_str: str) -> str:
     return dt.strftime(processed_format_str)
 
 
-def terraform_try(*args) -> Any:
+def terraform_try(*args: Any) -> Any:
     """
     From terraform docs:
         "try evaluates all of its argument expressions in turn and returns the result of the first one that does not

--- a/tests/terraform/graph/variable_rendering/test_string_evaluation.py
+++ b/tests/terraform/graph/variable_rendering/test_string_evaluation.py
@@ -479,6 +479,18 @@ class TestTerraformEvaluation(TestCase):
         expected = ["dGVzdA=="]
         self.assertEqual(expected, evaluate_terraform(input_str))
 
+    def test_try_block(self):
+        input_str = 'try("local.foo.boop", "{}")'
+        expected = {}
+        result = evaluate_terraform(input_str)
+        self.assertEqual(expected, result)
+
+    def test_try_then_merge_block(self):
+        input_str = "try((merge({}, {})), 1, 2)"
+        expected = {}
+        result = evaluate_terraform(input_str)
+        self.assertEqual(expected, result)
+
 
 @pytest.mark.parametrize(
     "origin_str,str_to_replace,new_value,expected",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Added support for the `try` function in terraform, [relevant docs](https://developer.hashicorp.com/terraform/language/functions/try).
This function was tricky as `try` is a saved word in `python`, so we couldn't just add a function that handles it which `eval` will accept. Instead, I looked for it in the evaluated string and replaced it with our own custom value so we can call it with `eval` properly.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
