### PR TITLE
fix(terraform): Remove empty foreach/count resources edges from graph

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -100,6 +100,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         This makes sure we won't find connections for resources which are not planned to be created.
         """
         relevant_indices = [index for list_of_indices in self.foreach_blocks.values() for index in list_of_indices]
+        copied_edges = copy.copy(self.edges)
         for foreach_vertex_index in relevant_indices:
             vertex = self.vertices[foreach_vertex_index]
             is_planned_to_be_empty_count = vertex.attributes.get("count", [])[0] == 0 \
@@ -107,7 +108,6 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
             is_planned_to_be_empty_foreach = vertex.attributes.get("for_each") in [{}, []] \
                 if "for_each" in vertex.attributes else False
             if is_planned_to_be_empty_count or is_planned_to_be_empty_foreach:
-                copied_edges = copy.copy(self.edges)
 
                 # Iterating over copy of self.edges to avoid changing it in place
                 for edge in copied_edges:

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -94,7 +94,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         else:
             self.update_vertices_fields()
 
-    def _remove_empty_foreach_edges(self):
+    def _remove_empty_foreach_edges(self) -> None:
         """
         Check for resources which are marked with empty `count/foreach` statements, and remove their matching edges.
         This makes sure we won't find connections for resources which are not planned to be created.
@@ -102,8 +102,8 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         relevant_indices = [index for list_of_indices in self.foreach_blocks.values() for index in list_of_indices]
         for foreach_vertex_index in relevant_indices:
             vertex = self.vertices[foreach_vertex_index]
-            is_planned_to_be_empty_count = vertex.attributes.get("count")[0] == 0 \
-                if "count" in vertex.attributes and len(vertex.attributes.get("count")) == 1 else False
+            is_planned_to_be_empty_count = vertex.attributes.get("count", [])[0] == 0 \
+                if "count" in vertex.attributes and len(vertex.attributes.get("count", [])) == 1 else False
             is_planned_to_be_empty_foreach = vertex.attributes.get("for_each") in [{}, []] \
                 if "for_each" in vertex.attributes else False
             if is_planned_to_be_empty_count or is_planned_to_be_empty_foreach:

--- a/tests/terraform/graph/checks/resources/AzureKeyVaultConfigPrivateEndpoint/expected.yaml
+++ b/tests/terraform/graph/checks/resources/AzureKeyVaultConfigPrivateEndpoint/expected.yaml
@@ -2,3 +2,4 @@ pass:
   - "azurerm_key_vault.pass"
 fail:
   - "azurerm_key_vault.fail"
+  - "azurerm_key_vault.empty_count"

--- a/tests/terraform/graph/checks/resources/AzureKeyVaultConfigPrivateEndpoint/main.tf
+++ b/tests/terraform/graph/checks/resources/AzureKeyVaultConfigPrivateEndpoint/main.tf
@@ -84,3 +84,32 @@ resource "azurerm_key_vault" "fail" {
 
   }
 }
+
+
+locals {
+  should_use = false
+}
+
+
+resource "azurerm_private_endpoint" "private_endpoint_pod_empty_count" {
+  count = local.should_use == true ? 1 : 0
+  name = "${azurerm_key_vault.empty_count.name}-test"
+  location = azurerm_resource_group.cfg.location
+  resource_group_name = azurerm_resource_group.cfg.name
+  subnet_id = data.azurerm_subnet.private_end_point_subnet[0].id
+  tags = var.tags
+  private_service_connection {
+    is_manual_connection = false
+    name = "${azurerm_key_vault.empty_count.name}-test"
+    private_connection_resource_id = azurerm_key_vault.empty_count.id
+    subresource_names = ["vault"]
+  }
+}
+
+resource "azurerm_key_vault" "empty_count" {
+  location            = ""
+  name                = "test"
+  resource_group_name = ""
+  sku_name            = ""
+  tenant_id           = ""
+}

--- a/tests/terraform/graph/graph_builder/test_local_graph.py
+++ b/tests/terraform/graph/graph_builder/test_local_graph.py
@@ -434,3 +434,13 @@ class TestLocalGraph(TestCase):
         # Check they point to 2 different modules
         self.assertEqual(2, len(module_variable_edges))
         self.assertNotEqual(local_graph.vertices[module_variable_edges[0].origin], local_graph.vertices[module_variable_edges[1].origin])
+
+    def test_remove_empty_resources_edges_from_graph(self):
+        resources_dir = os.path.realpath(os.path.join(TEST_DIRNAME, '../resources/empty_count_and_foreach'))
+        hcl_config_parser = TFParser()
+        module, _ = hcl_config_parser.parse_hcl_module(resources_dir, self.source)
+        local_graph = TerraformLocalGraph(module)
+        local_graph.build_graph(render_variables=True)
+        assert local_graph.edges == []
+        assert len([edge for edge_list in local_graph.out_edges.values() for edge in edge_list]) == 0
+        assert len([edge for edge_list in local_graph.in_edges.values() for edge in edge_list]) == 0

--- a/tests/terraform/graph/resources/empty_count_and_foreach/main.tf
+++ b/tests/terraform/graph/resources/empty_count_and_foreach/main.tf
@@ -1,0 +1,43 @@
+locals {
+  should_use = false
+}
+
+
+resource "azurerm_private_endpoint" "private_endpoint_pod_empty_count" {
+  count = local.should_use == true ? 1 : 0
+  name = "${azurerm_key_vault.empty_count.name}-test"
+  location = azurerm_resource_group.cfg.location
+  resource_group_name = azurerm_resource_group.cfg.name
+  subnet_id = data.azurerm_subnet.private_end_point_subnet[0].id
+  tags = var.tags
+  private_service_connection {
+    is_manual_connection = false
+    name = "${azurerm_key_vault.empty_count.name}-test"
+    private_connection_resource_id = azurerm_key_vault.empty_count.id
+    subresource_names = ["vault"]
+  }
+}
+
+resource "azurerm_private_endpoint" "private_endpoint_pod_empty_foreach" {
+  for_each = {}
+  name = "${azurerm_key_vault.empty_count.name}-test"
+  location = azurerm_resource_group.cfg.location
+  resource_group_name = azurerm_resource_group.cfg.name
+  subnet_id = data.azurerm_subnet.private_end_point_subnet[0].id
+  tags = var.tags
+  private_service_connection {
+    is_manual_connection = false
+    name = "${azurerm_key_vault.empty_count.name}-test"
+    private_connection_resource_id = azurerm_key_vault.empty_count.id
+    subresource_names = ["vault"]
+  }
+}
+
+
+resource "azurerm_key_vault" "empty_count" {
+  location            = ""
+  name                = "test"
+  resource_group_name = ""
+  sku_name            = ""
+  tenant_id           = ""
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

This PR aims to remove all edges related to terraform resources marked with `count=0` or `for_each = {}/[]`.
By that we remove connections to resources which are not planned to be built, affecting most of our graph checks.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
