### PR TITLE
feat(kubernetes): add kubernetes labels as entity_tags

### DIFF
--- a/checkov/kubernetes/kubernetes_utils.py
+++ b/checkov/kubernetes/kubernetes_utils.py
@@ -235,6 +235,20 @@ def get_resource_id(resource: dict[str, Any] | None) -> str | None:
         return build_resource_id_from_labels(resource_type, namespace, labels, resource)
     return None
 
+def get_resource_tags(resource: dict[str, Any] | None) -> dict[str, str] | None:
+    if not resource:
+        return None
+
+    metadata = resource.get("metadata") or {}
+    labels = metadata.get("labels")
+
+    ## Delete __startline__ and __endline__ from the attribute
+
+    remove_metadata_from_attribute(labels)
+    
+    if labels:
+        return labels
+    return None
 
 def build_resource_id_from_labels(resource_type: str,
                                   namespace: str,

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -25,6 +25,7 @@ from checkov.kubernetes.image_referencer.manager import KubernetesImageReference
 from checkov.kubernetes.kubernetes_utils import (
     create_definitions,
     build_definitions_context,
+    get_resource_tags,
     get_skipped_checks,
     get_resource_id,
     K8_POSSIBLE_ENDINGS,
@@ -219,6 +220,7 @@ class Runner(ImageReferencerMixin[None], BaseRunner[_KubernetesDefinitions, _Kub
                     continue
 
                 entity_context = self.context[k8_file][resource_id]
+                tags = get_resource_tags(entity_conf)
 
                 record = Record(
                     check_id=check.id,
@@ -233,6 +235,7 @@ class Runner(ImageReferencerMixin[None], BaseRunner[_KubernetesDefinitions, _Kub
                     check_class=check.__class__.__module__,
                     file_abs_path=file_abs_path,
                     severity=check.severity,
+                    entity_tags=tags,
                 )
                 record.set_guideline(check.guideline)
                 report.add_record(record=record)
@@ -276,6 +279,9 @@ class Runner(ImageReferencerMixin[None], BaseRunner[_KubernetesDefinitions, _Kub
                     check_result=check_result, entity_context=entity_context, check_id=check.id
                 )
 
+                entity_conf = entity[CustomAttributes.CONFIG]
+                tags = get_resource_tags(entity_conf)
+                
                 record = Record(
                     check_id=check.id,
                     check_name=check.name,
@@ -287,7 +293,8 @@ class Runner(ImageReferencerMixin[None], BaseRunner[_KubernetesDefinitions, _Kub
                     evaluations={},
                     check_class=check.__class__.__module__,
                     file_abs_path=entity_file_abs_path,
-                    severity=check.severity
+                    severity=check.severity,
+                    entity_tags=tags,
                 )
                 record.set_guideline(check.guideline)
                 report.add_record(record=record)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- Add a new function for retrieving K8S resource tags from metadata.
- Updated Runner class in runner.py to include entity tags retrieved using the new function.

#### Before

```
{
    "check_type": "kubernetes",
    "results": {
        "failed_checks": [
            {
                "check_id": "CKV_K8S_156",
                "bc_check_id": null,
                "check_name": "Minimize ClusterRoles that grant permissions to approve CertificateSigningRequests",
                "check_result": {
                    "result": "FAILED",
                    "evaluated_keys": []
                },
                "code_block": null,
                "file_path": "/yaml/ClusterRole_cluster-admin.yaml",
                "file_abs_path": "redacted",
                "repo_file_path": "/yaml/ClusterRole_cluster-admin.yaml",
                "file_line_range": [
                    1,
                    22
                ],
                "resource": "ClusterRole.default.cluster-admin",
                "evaluations": {},
                "check_class": "checkov.kubernetes.checks.resource.k8s.RbacApproveCertificateSigningRequests",
                "fixed_definition": null,
                "entity_tags": null, <------------------------ No entity tags present
```

#### After


```
{
    "check_type": "kubernetes",
    "results": {
        "passed_checks": [],
        "failed_checks": [
            {
                "check_id": "CKV_K8S_156",
                "bc_check_id": null,
                "check_name": "Minimize ClusterRoles that grant permissions to approve CertificateSigningRequests",
                "check_result": {
                    "result": "FAILED",
                    "evaluated_keys": []
                },
                "code_block": null,
                "file_path": "/yaml/ClusterRole_cluster-admin.yaml",
                "file_abs_path": "redacted",
                "repo_file_path": "yaml/ClusterRole_cluster-admin.yaml",
                "file_line_range": [
                    1,
                    22
                ],
                "resource": "ClusterRole.default.cluster-admin",
                "evaluations": {},
                "check_class": "checkov.kubernetes.checks.resource.k8s.RbacApproveCertificateSigningRequests",
                "fixed_definition": null,
                "entity_tags": {        <------------------------   entity_tags populated with manifest label, if present
                    "kubernetes.io/bootstrapping": "rbac-defaults"
                },
                "caller_file_path": null,
                "caller_file_line_range": null,
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass locally with my changes
