### PR TITLE
fix(terraform): Dont duplicate more vertices than needed for nested modules with large count/for each values + used cache to avoid extensive usage of os.path.realpath to drastically improve performance

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -59,8 +59,9 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         self.enable_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_FOREACH_HANDLING', 'True'))
         self.enable_modules_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_MODULES_FOREACH_HANDLING', 'True'))
         self.foreach_blocks: Dict[str, List[int]] = {BlockType.RESOURCE: [], BlockType.MODULE: []}
-        # Important for foreach performance, see issue TODO -add -issue
-        self._vertex_path_to_realpath_cache = {}
+
+        # Important for foreach performance, see issue https://github.com/bridgecrewio/checkov/issues/6068
+        self._vertex_path_to_realpath_cache: Dict[str, str] = {}
 
     def build_graph(self, render_variables: bool) -> None:
         self._create_vertices()

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -59,6 +59,8 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         self.enable_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_FOREACH_HANDLING', 'True'))
         self.enable_modules_foreach_handling = strtobool(os.getenv('CHECKOV_ENABLE_MODULES_FOREACH_HANDLING', 'True'))
         self.foreach_blocks: Dict[str, List[int]] = {BlockType.RESOURCE: [], BlockType.MODULE: []}
+        # Important for foreach performance, see issue TODO -add -issue
+        self._vertex_path_to_realpath_cache = {}
 
     def build_graph(self, render_variables: bool) -> None:
         self._create_vertices()
@@ -399,9 +401,16 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
         vertex_index_with_longest_common_prefix = -1
         longest_common_prefix = ""
         vertices_with_longest_common_prefix = []
+        origin_real_path = os.path.realpath(origin_path)
         for vertex_index in relevant_vertices_indexes:
             vertex = self.vertices[vertex_index]
-            common_prefix = os.path.commonpath([os.path.realpath(vertex.path), os.path.realpath(origin_path)])
+            if vertex.path in self._vertex_path_to_realpath_cache:
+                # Using cache to make sure performance stays stable
+                vertex_realpath = self._vertex_path_to_realpath_cache[vertex.path]
+            else:
+                vertex_realpath = os.path.realpath(vertex.path)
+                self._vertex_path_to_realpath_cache[vertex.path] = vertex_realpath
+            common_prefix = os.path.commonpath([vertex_realpath, origin_real_path])
             if len(common_prefix) > len(longest_common_prefix):
                 vertex_index_with_longest_common_prefix = vertex_index
                 longest_common_prefix = common_prefix

--- a/tests/terraform/graph/variable_rendering/resources/os_example_large_count_with_nested_module/child/main.tf
+++ b/tests/terraform/graph/variable_rendering/resources/os_example_large_count_with_nested_module/child/main.tf
@@ -1,0 +1,11 @@
+## child/main.tf
+variable "child-name" {
+  type = string
+}
+resource "terraform_data" "child-example" {
+  input = "1"
+}
+output "child-result" {
+  value = terraform_data.child-example.output
+}
+

--- a/tests/terraform/graph/variable_rendering/resources/os_example_large_count_with_nested_module/modules.tf
+++ b/tests/terraform/graph/variable_rendering/resources/os_example_large_count_with_nested_module/modules.tf
@@ -1,0 +1,9 @@
+# modules.tf
+module "modules" {
+  count = 12
+  source = "./parent"
+  parent   = count.index
+}
+output "modules-result" {
+  value = { for k, v in module.modules-parent : k => v }
+}

--- a/tests/terraform/graph/variable_rendering/resources/os_example_large_count_with_nested_module/parent/main.tf
+++ b/tests/terraform/graph/variable_rendering/resources/os_example_large_count_with_nested_module/parent/main.tf
@@ -1,0 +1,12 @@
+# parent/main.tf
+variable "parent" {
+  type = string
+}
+module "parent" {
+  source = "../child"
+  child-name   = "1"
+}
+
+output "parent-result" {
+  value = module.parent.child-result
+}

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -422,6 +422,13 @@ def test_foreach_with_lookup():
     assert graph.vertices[1].attributes.get('uniform_bucket_level_access') == [True]
 
 
+@mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})
+def test_foreach_large_count_with_nested_module(checkov_source_path):
+    dir_name = 'os_example_large_count_with_nested_module'
+    graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
+    assert len(graph.vertices) == 85
+
+
 def test__get_tf_module_with_no_foreach():
     module = TFModule(name='1', path='1', foreach_idx='1',
                       nested_tf_module=TFModule(name='2', path='2', foreach_idx='2', nested_tf_module=None))


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

This was found from the issue - https://github.com/bridgecrewio/checkov/issues/6068.

Fixed 2 things in this PR:

1.  Most importantly - we had a bug duplicating more resources than actually needed when using nested modules with foreach/count that uses more than 2 duplications. We mistakenly duplicated resources between different foreach indices.
2. Due to a lot of calls to `os.path.realpath` for large graphs we have a big effect on performance.
I implemented a cache mechanism to improve performance by at-least x2 for these usecases. 

## Fixes Issue
* [6068](https://github.com/bridgecrewio/checkov/issues/6068)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
