### PR TITLE
feat(general): add policy name and guidelines to CSV output

### DIFF
--- a/checkov/common/output/csv.py
+++ b/checkov/common/output/csv.py
@@ -39,7 +39,7 @@ HEADER_CONTAINER_IMAGE = HEADER_OSS_PACKAGES
 FILE_NAME_CONTAINER_IMAGES = f"{date_now}_container_images.csv"
 
 FILE_NAME_IAC = f"{date_now}_iac.csv"
-HEADER_IAC = ["Resource", "Path", "Git Org", "Git Repository", "Misconfigurations", "Severity"]
+HEADER_IAC = ["Resource", "Path", "Git Org", "Git Repository", "Misconfigurations", "Severity", "Policy name", "Guidelines"]
 
 CTA_NO_API_KEY = "SCA, image and runtime findings are only available with a Prisma Cloud subscription."
 
@@ -131,6 +131,8 @@ class CSVSBOM:
             "Git Repository": git_repository,
             "Misconfigurations": misconfig,
             "Severity": severity,
+            "Policy name": resource.check_name,
+            "Guidelines": resource.guideline
         }
 
         if isinstance(resource, Record) and resource.details:

--- a/checkov/common/output/csv.py
+++ b/checkov/common/output/csv.py
@@ -39,7 +39,7 @@ HEADER_CONTAINER_IMAGE = HEADER_OSS_PACKAGES
 FILE_NAME_CONTAINER_IMAGES = f"{date_now}_container_images.csv"
 
 FILE_NAME_IAC = f"{date_now}_iac.csv"
-HEADER_IAC = ["Resource", "Path", "Git Org", "Git Repository", "Misconfigurations", "Severity", "Policy name", "Guidelines"]
+HEADER_IAC = ["Resource", "Path", "Git Org", "Git Repository", "Misconfigurations", "Severity", "Policy title", "Guideline"]
 
 CTA_NO_API_KEY = "SCA, image and runtime findings are only available with a Prisma Cloud subscription."
 
@@ -135,8 +135,8 @@ class CSVSBOM:
             "Git Repository": git_repository,
             "Misconfigurations": misconfig,
             "Severity": severity,
-            "Policy name": check_name,
-            "Guidelines": guideline
+            "Policy title": check_name,
+            "Guideline": guideline
         }
 
         if isinstance(resource, Record) and resource.details:

--- a/checkov/common/output/csv.py
+++ b/checkov/common/output/csv.py
@@ -115,11 +115,15 @@ class CSVSBOM:
 
         misconfig = None
         severity = None
+        check_name = None
+        guideline = None
         if isinstance(resource, Record) and resource.check_result["result"] == CheckResult.FAILED:
             # only failed resources should be added with their misconfiguration
             misconfig = resource.check_id
             if resource.severity is not None:
                 severity = resource.severity.name
+            check_name = resource.check_name
+            guideline = resource.guideline
         elif resource_id in self.iac_resource_cache:
             # IaC resources shouldn't be added multiple times, if they don't have any misconfiguration
             return
@@ -131,8 +135,8 @@ class CSVSBOM:
             "Git Repository": git_repository,
             "Misconfigurations": misconfig,
             "Severity": severity,
-            "Policy name": resource.check_name,
-            "Guidelines": resource.guideline
+            "Policy name": check_name,
+            "Guidelines": guideline
         }
 
         if isinstance(resource, Record) and resource.details:

--- a/tests/common/output/test_bom_report.py
+++ b/tests/common/output/test_bom_report.py
@@ -41,7 +41,7 @@ class TestBomOutput:
         with open(iac_file_path) as file:
             content = file.readlines()
             header = content[:1][0]
-            assert 'Resource,Path,Git Org,Git Repository,Misconfigurations,Severity\n' == header
+            assert 'Resource,Path,Git Org,Git Repository,Misconfigurations,Severity,Policy title,Guideline\n' == header
             rows = content[1:]
             assert 'aws_s3_bucket' in rows[0]
 

--- a/tests/common/runner_registry/test_runner_registry.py
+++ b/tests/common/runner_registry/test_runner_registry.py
@@ -167,7 +167,7 @@ class TestRunnerRegistry(unittest.TestCase):
         with open(iac_file_path) as file:
             content = file.readlines()
             header = content[:1][0]
-            self.assertEqual('Resource,Path,Git Org,Git Repository,Misconfigurations,Severity\n', header)
+            self.assertEqual('Resource,Path,Git Org,Git Repository,Misconfigurations,Severity,Policy title,Guideline\n', header)
             rows = content[1:]
             self.assertIn('aws_s3_bucket', rows[0])
         oss_file_path = re.search("Persisting SBOM to (.*oss_packages.csv)", output).group(1)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Adds the policy name and guidelines (URL or custom policy guidelines) to the CSV output.

I added them as columns at the end so that it doesn't break any automations that users may use that relies on the column order.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
