### PR TITLE
feat(secrets): fix entropy detector FP

### DIFF
--- a/tests/secrets/sanity/iac_fp/main.json
+++ b/tests/secrets/sanity/iac_fp/main.json
@@ -1,0 +1,3 @@
+{
+  "MetadataOptions": { "HttpsTokens": "optional" }
+}


### PR DESCRIPTION
This PR adds a pre-processing phase to the remove_fp_secrets_in_keys method, before we output a detected secret.
In this pre-processing phase we attempt to detect when a potential secret is in the middle of the line, followed by another delimeter (in our case ":") and in this case we treat that secret as the line start, so our FP detection mechanisms will kick in.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
