### PR TITLE
feat(terraform): Ensure basic authentication for SCM is disabled

### DIFF
--- a/checkov/terraform/checks/resource/azure/AppServiceSCMBasicAuthenticationDisabled.py
+++ b/checkov/terraform/checks/resource/azure/AppServiceSCMBasicAuthenticationDisabled.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class AppServiceSCMBasicAuthenticationDisabled(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that basic authentication for SCM is disabled for app services"
+        id = "CKV_AZURE_237"
+        supported_resources = ('azurerm_linux_web_app', 'azurerm_windows_web_app')
+        categories = (CheckCategories.IAM,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
+                         missing_block_result=CheckResult.PASSED)
+
+    def get_inspected_key(self) -> str:
+        return "webdeploy_publish_basic_authentication_enabled"
+
+    def get_expected_value(self) -> Any:
+        return False
+
+
+check = AppServiceSCMBasicAuthenticationDisabled()

--- a/tests/terraform/checks/resource/azure/example_AppServiceSCMBasicAuthenticationDisabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AppServiceSCMBasicAuthenticationDisabled/main.tf
@@ -1,0 +1,53 @@
+resource "azurerm_linux_web_app" "fail1" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+  webdeploy_publish_basic_authentication_enabled = true
+  site_config {}
+}
+
+resource "azurerm_linux_web_app" "fail2" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+  site_config {}
+}
+
+resource "azurerm_windows_web_app" "fail1" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+  webdeploy_publish_basic_authentication_enabled = true
+  site_config {}
+}
+
+resource "azurerm_windows_web_app" "fail2" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+  site_config {}
+}
+
+resource "azurerm_linux_web_app" "good" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+  webdeploy_publish_basic_authentication_enabled = false
+
+  site_config {}
+}
+
+resource "azurerm_windows_web_app" "good" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+  webdeploy_publish_basic_authentication_enabled = false
+
+  site_config {}
+}

--- a/tests/terraform/checks/resource/azure/test_AppServiceSCMBasicAuthenticationDisabled.py
+++ b/tests/terraform/checks/resource/azure/test_AppServiceSCMBasicAuthenticationDisabled.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.AppServiceSCMBasicAuthenticationDisabled import check
+
+
+class TestAppServiceSCMBasicAuthenticationDisabled(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AppServiceSCMBasicAuthenticationDisabled")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_linux_web_app.good',
+            'azurerm_windows_web_app.good',
+        }
+        failing_resources = {
+            'azurerm_linux_web_app.fail1',
+            'azurerm_windows_web_app.fail1',
+            'azurerm_linux_web_app.fail2',
+            'azurerm_windows_web_app.fail2',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fixes #6096

## New/Edited policies (Delete if not relevant)

### Description

App Service provides basic authentication for FTP and WebDeploy clients to connect to it by using [deployment credentials](https://learn.microsoft.com/en-us/azure/app-service/deploy-configure-credentials). These APIs are great for browsing your site’s file system, uploading drivers and utilities, and deploying with MsBuild. However, enterprises often require more secure deployment methods than basic authentication, such as [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) authentication (see [Authentication types by deployment methods in Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/deploy-authentication-types)).

cc https://learn.microsoft.com/en-us/azure/app-service/configure-basic-auth-disable?tabs=portal

### Fix

Set 'webdeploy_publish_basic_authentication_enabled' to 'False' 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
