### PR TITLE
fix(terraform): Fixed bug in evaluate_conditional_expression and added zipmap support

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
@@ -203,9 +203,9 @@ def strip_interpolation_marks(input_str: str) -> str:
 
 def evaluate_conditional_expression(input_str: str) -> str:
     if input_str.startswith("['${") and input_str.endswith("}']"):
-        condition = find_conditional_expression_groups(input_str[5:-3])
+        condition = find_conditional_expression_groups(input_str[4:-3])
         if condition is not None:
-            input_str = input_str[5:-3]
+            input_str = input_str[4:-3]
     else:
         condition = find_conditional_expression_groups(input_str)
     if condition is None:

--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -271,7 +271,7 @@ def terraform_try(*args: Any) -> Any:
         except Exception as e:
             logging.warning(f"Error in evaluate_try of argument {arg} - {e}")
             continue
-    raise Exception(f"No argument can be avaluted for try of {args}")
+    raise Exception(f"No argument can be evaluated for try of {args}")
 
 
 SAFE_EVAL_FUNCTIONS: List[str] = []
@@ -334,6 +334,7 @@ SAFE_EVAL_DICT["merge"] = merge
 # SAFE_EVAL_DICT['range']
 SAFE_EVAL_DICT["reverse"] = reverse
 SAFE_EVAL_DICT["sort"] = sort
+SAFE_EVAL_DICT["zipmap"] = lambda *lists: dict(zip(*lists))
 
 
 # type conversion

--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -334,7 +334,7 @@ SAFE_EVAL_DICT["merge"] = merge
 # SAFE_EVAL_DICT['range']
 SAFE_EVAL_DICT["reverse"] = reverse
 SAFE_EVAL_DICT["sort"] = sort
-SAFE_EVAL_DICT["zipmap"] = lambda *lists: dict(zip(*lists))
+SAFE_EVAL_DICT["zipmap"] = lambda *lists: dict(zip(*lists))  # noqa: B905
 
 
 # type conversion

--- a/tests/terraform/graph/variable_rendering/test_string_evaluation.py
+++ b/tests/terraform/graph/variable_rendering/test_string_evaluation.py
@@ -10,6 +10,11 @@ from checkov.terraform.graph_builder.variable_rendering.evaluate_terraform impor
 
 
 class TestTerraformEvaluation(TestCase):
+    def test_zipmap(self):
+        input_str = '"zipmap(["a", "b"], [1, 2])"'
+        expected = {'a': 1, 'b': 2}
+        self.assertEqual(expected, evaluate_terraform(input_str))
+
     def test_directive(self):
         input_str = '"Hello, %{ if "d" != "" }named%{ else }unnamed%{ endif }!"'
         expected = 'Hello, named!'


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

* In `evaluate_conditional_expression` we used incorrect slicing which caused a bug.
* Added `zipmap` implementation for `evaluate_terraform`

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
