### PR TITLE
feat(terraform): Ensure that backups are geo-redundants for Azure SQL Databases

### DIFF
--- a/checkov/terraform/checks/resource/azure/SQLDatabaseGeoRedundantBackupEnabled.py
+++ b/checkov/terraform/checks/resource/azure/SQLDatabaseGeoRedundantBackupEnabled.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class SQLDatabaseGeoRedundantBackupEnabled(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that backups are geo-redundants for Azure SQL Databases"
+        id = "CKV_AZURE_224"
+        supported_resources = ("azurerm_mssql_database",)
+        categories = (CheckCategories.BACKUP_AND_RECOVERY,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "storage_account_type"
+    
+    def get_expected_value(self):
+        return 'Geo'
+
+check = SQLDatabaseGeoRedundantBackupEnabled()

--- a/tests/terraform/checks/resource/azure/example_SQLDatabaseGeoRedundantBackupEnabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_SQLDatabaseGeoRedundantBackupEnabled/main.tf
@@ -1,0 +1,45 @@
+resource "azurerm_mssql_database" "good1" {
+  name           = "example-database"
+  server_id      = azurerm_mssql_server.example.id
+  collation      = "SQL_Latin1_General_CP1_CI_AS"
+  license_type   = "LicenseIncluded"
+  max_size_gb    = 4
+  read_scale     = true
+  sku_name       = "S0"
+
+  tags = {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_mssql_database" "good2" {
+    name                 = "example-database"
+    server_id            = azurerm_mssql_server.example.id
+    collation            = "SQL_Latin1_General_CP1_CI_AS"
+    license_type         = "LicenseIncluded"
+    max_size_gb          = 4
+    read_scale           = true
+    sku_name             = "S0"
+    storage_account_type = "Geo"
+
+    tags = {
+        environment = "Production"
+    }
+}
+
+resource "azurerm_mssql_database" "fail" {
+    name                 = "example-database"
+    server_id            = azurerm_mssql_server.example.id
+    collation            = "SQL_Latin1_General_CP1_CI_AS"
+    license_type         = "LicenseIncluded"
+    max_size_gb          = 4
+    read_scale           = true
+    sku_name             = "S0"
+    storage_account_type = "Local"
+
+
+    tags = {
+        environment = "Production"
+    }
+
+}

--- a/tests/terraform/checks/resource/azure/test_SQLDatabaseGeoRedundantBackupEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_SQLDatabaseGeoRedundantBackupEnabled.py
@@ -6,7 +6,7 @@ from checkov.terraform.runner import Runner
 from checkov.terraform.checks.resource.azure.SQLDatabaseGeoRedundantBackupEnabled import check
 
 
-class TestAppServiceIPRestrictionDefaultActionDeny(unittest.TestCase):
+class TestSQLDatabaseGeoRedundantBackupEnabled(unittest.TestCase):
 
     def test(self):
         runner = Runner()

--- a/tests/terraform/checks/resource/azure/test_SQLDatabaseGeoRedundantBackupEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_SQLDatabaseGeoRedundantBackupEnabled.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.SQLDatabaseGeoRedundantBackupEnabled import check
+
+
+class TestAppServiceIPRestrictionDefaultActionDeny(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_SQLDatabaseGeoRedundantBackupEnabled")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_mssql_database.good1',
+            'azurerm_mssql_database.good2',
+        }
+        failing_resources = {
+            'azurerm_mssql_database.fail',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fixes #6111 

## New/Edited policies (Delete if not relevant)

### Description

"Geo-Backup" is a pre-requisite in order to use "Geo-Restore".

Geo-restore uses geo-replicated backups as the source. You can restore a database on any logical server in any Azure region from the most recent geo-replicated backups. You can request a geo-restore even if an outage has made the database or the entire region inaccessible.

Geo-restore is the default recovery option when your database is unavailable because of an incident in the hosting region. You can restore the database to a server in any other region.

https://learn.microsoft.com/en-us/azure/azure-sql/database/recovery-using-backups?view=azuresql&tabs=azure-portal#geo-restore

### Fix

Change "storage_account_type" to "Geo"

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
