### PR TITLE
feat(terraform): fix for_each resource handling

### DIFF
--- a/checkov/terraform/modules/module_utils.py
+++ b/checkov/terraform/modules/module_utils.py
@@ -242,7 +242,7 @@ def get_module_name(file_path: TFDefinitionKey) -> str | None:
     if not file_path.tf_source_modules:
         return None
     module_name = file_path.tf_source_modules.name
-    if file_path.tf_source_modules.foreach_idx is not None:
+    if isinstance(file_path.tf_source_modules.foreach_idx, int) or file_path.tf_source_modules.foreach_idx:
         foreach_or_count = '"' if isinstance(file_path.tf_source_modules.foreach_idx, str) else ''
         module_name = f'{module_name}[{foreach_or_count}{file_path.tf_source_modules.foreach_idx}{foreach_or_count}]'
     return module_name

--- a/checkov/terraform/modules/module_utils.py
+++ b/checkov/terraform/modules/module_utils.py
@@ -242,7 +242,7 @@ def get_module_name(file_path: TFDefinitionKey) -> str | None:
     if not file_path.tf_source_modules:
         return None
     module_name = file_path.tf_source_modules.name
-    if file_path.tf_source_modules.foreach_idx:
+    if file_path.tf_source_modules.foreach_idx is not None:
         foreach_or_count = '"' if isinstance(file_path.tf_source_modules.foreach_idx, str) else ''
         module_name = f'{module_name}[{foreach_or_count}{file_path.tf_source_modules.foreach_idx}{foreach_or_count}]'
     return module_name

--- a/tests/terraform/runner/resources/for_each/main.tf
+++ b/tests/terraform/runner/resources/for_each/main.tf
@@ -1,0 +1,5 @@
+
+module "simple" {
+  source   = "./simple"
+  count = 2
+}

--- a/tests/terraform/runner/resources/for_each/simple/main.tf
+++ b/tests/terraform/runner/resources/for_each/simple/main.tf
@@ -1,0 +1,5 @@
+resource "aws_s3_bucket_object" "this_file" {
+  bucket   = "your_bucket_name"
+  key      = "readme.md"
+  source   = "readme.md"
+}

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -154,6 +154,24 @@ class TestRunnerValid(unittest.TestCase):
         assert 'aws_db_instance.default' in failed_resources
         assert 'aws_db_instance.disabled' in failed_resources
 
+    def test_for_each_check(self):
+        if not self.db_connector == RustworkxConnector:
+            return
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/resources/for_each"
+        runner = Runner(db_connector=self.db_connector())
+        checks_allowlist = ['CKV_AWS_186']
+        report = runner.run(root_folder=valid_dir_path, runner_filter=RunnerFilter(framework=["terraform"], checks=checks_allowlist))
+        report_json = report.get_json()
+        self.assertIsInstance(report_json, str)
+        self.assertIsNotNone(report_json)
+        self.assertIsNotNone(report.get_test_suite())
+        assert len(report.failed_checks) == 2
+        assert len(report.passed_checks) == 0
+        failed_resources = [c.resource for c in report.failed_checks]
+        assert 'module.simple[0].aws_s3_bucket_object.this_file' in failed_resources
+        assert 'module.simple[1].aws_s3_bucket_object.this_file' in failed_resources
+
     def test_runner_passing_valid_tf(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
This PR fixes the extraction of module from resource of for_each, preventing correct handling of first resource (index 0) and thus missing any violations for this resource.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
