### PR TITLE
fix(sca): adding optional flag for reseting the http manager

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -1329,7 +1329,7 @@ class BcPlatformIntegration:
             return {}
         if reset_http_manager:
             # for cases the http isn't set yet. e.g: when calling from the platform's BE
-            self.setup_http_manager(self.ca_certificate,self.no_cert_verify)
+            self.setup_http_manager(self.ca_certificate, self.no_cert_verify)
         if request_type.upper() == "GET":
             return merge_dicts(get_default_get_headers(self.bc_source, self.bc_source_version),
                                {"Authorization": self.get_auth_token()},

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -1323,11 +1323,13 @@ class BcPlatformIntegration:
         # matches xyz_org/repo or org/repo (where xyz is the BC org name and the CLI repo prefix from the platform)
         return re.match(re.compile(f'^(\\w+_)?{self.repo_id}$'), repo_name) is not None
 
-    def get_default_headers(self, request_type: str) -> dict[str, Any]:
+    def get_default_headers(self, request_type: str, reset_http_manager: bool = False) -> dict[str, Any]:
         if not self.bc_source:
             logging.warning("Source was not set")
             return {}
-
+        if reset_http_manager:
+            # for cases the http isn't set yet. e.g: when calling from the platform's BE
+            self.setup_http_manager(self.ca_certificate,self.no_cert_verify)
         if request_type.upper() == "GET":
             return merge_dicts(get_default_get_headers(self.bc_source, self.bc_source_version),
                                {"Authorization": self.get_auth_token()},

--- a/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
@@ -148,7 +148,7 @@ class ImageScanner:
         try:
             image_id_encode = quote_plus(image_id)
             url = f"{bc_integration.api_url}/api/v1/vulnerabilities/scan-results/{image_id_encode}"
-            headers = bc_integration.get_default_headers("GET")
+            headers = bc_integration.get_default_headers("GET", reset_http_manager=True)
             logging.debug(f"Invoking API {url}")
             async with session.request("GET", URL(url, encoded=True), headers=headers) as response:
                 response_json = await response.json()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

adding optional flag for reseting the http manager
will be useful in case of importing some specific methods from the platform without fully initializing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
