### PR TITLE
fix(cloudformation): Updated deprecated runtimes for CKV_AWS_363 

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/DeprecatedLambdaRuntime.py
+++ b/checkov/cloudformation/checks/resource/aws/DeprecatedLambdaRuntime.py
@@ -18,15 +18,12 @@ class DeprecatedLambdaRuntime(BaseResourceNegativeValueCheck):
     def get_forbidden_values(self) -> List[Any]:
         return ["dotnetcore3.1", "nodejs12.x", "python3.6", "python2.7", "dotnet5.0", "dotnetcore2.1", "ruby2.5",
                 "nodejs10.x", "nodejs8.10", "nodejs4.3", "nodejs6.10", "dotnetcore1.0", "dotnetcore2.0",
-                "nodejs4.3-edge", "nodejs",
-                # "python3.7", # Uncomment on Nov 27, 2023
-                # "nodejs14.x", # Uncomment on Nov 27, 2023
-                # "ruby2.7", # Uncomment on Dec 7, 2023
-                # "provided", # Uncomment on Dec 31, 2023
-                # "go1.x", # Uncomment on Dec 31, 2023
-                # "java8", # Uncomment on Dec 31, 2023
-                # "nodejs16.x", # Uncomment on Mar 11, 2024
+                "nodejs4.3-edge", "nodejs", "python3.7", "nodejs14.x", "ruby2.7", "provided", "go1.x", "java8",
                 # "dotnet7", # Uncomment on May 14, 2024
+                # "nodejs16.x", # Uncomment on Jun 12, 2024
+                # "Python 3.8", # Uncomment on Oct 14, 2024
+                # "dotnet6", # Uncomment on Nov 12, 2024
+                #  More info here: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
                 ]
 
 

--- a/tests/cloudformation/checks/resource/aws/example_DeprecatedLambdaRuntime/example.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DeprecatedLambdaRuntime/example.yaml
@@ -24,3 +24,12 @@ Resources:
         S3Bucket: 'myBucket'
         S3Key: 'code/myLambda.zip'
       Runtime: 'dotnetcore3.1'
+  Fail-java8:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: 'index.handler'
+      FunctionName: 'Java8Function'
+      Code:
+        S3Bucket: 'myBucket'
+        S3Key: 'code/myLambda.zip'
+      Runtime: 'java8'

--- a/tests/cloudformation/checks/resource/aws/test_DeprecatedLambdaRuntime.py
+++ b/tests/cloudformation/checks/resource/aws/test_DeprecatedLambdaRuntime.py
@@ -23,7 +23,8 @@ class TestDeprecatedLambdaRuntime(unittest.TestCase):
         }
         failing_resources = {
             "AWS::Lambda::Function.Fail",
-            "AWS::Serverless::Function.Fail2"
+            "AWS::Serverless::Function.Fail2",
+            "AWS::Lambda::Function.Fail-java8"
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Updated the deprecated runtimes for CKV_AWS_363: DeprecatedLambdaRuntime. Latest list includes everything deprecated up to Java8. Updated the comments with upcoming runtime deprecation dates, and a link to AWS docs that publishes dates for future deprecation of all runtimes. Added one additional test case to check for Java8 runtime in Lambda.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
