### PR TITLE
feat(general): add policy metadata filter exception flag

### DIFF
--- a/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
@@ -174,11 +174,12 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
                         policy_ids.append(ckv_id)
             if exclude_policies:
                 self.filtered_exception_policy_ids = policy_ids
+                self._add_ckv_id_for_filtered_cloned_checks(self.filtered_exception_policy_ids, exclude_policies)
             else:
                 self.filtered_policy_ids = policy_ids
-            self._add_ckv_id_for_filtered_cloned_checks(exclude_policies)
+                self._add_ckv_id_for_filtered_cloned_checks(self.filtered_policy_ids, exclude_policies)
 
-    def _add_ckv_id_for_filtered_cloned_checks(self, exclude_policies: bool) -> None:
+    def _add_ckv_id_for_filtered_cloned_checks(self, policy_ids, exclude_policies: bool) -> None:
         """
         Filtered checks are the policies that are returned by --policy-metadata-filter.
         Filtered exclusion checks are the policies that are returned by --policy-metadata-filter-exclusion.
@@ -195,7 +196,7 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
                 filtered_policy_ids = [ "org_AWS_1609123441", "CKV_AWS_123" ]
         """
         ckv_ids = []
-        for policy_id in self.filtered_policy_ids:
+        for policy_id in policy_ids:
             source_bc_id = self.get_source_incident_id_from_ckv_id(policy_id)
             if not source_bc_id:
                 continue

--- a/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
+++ b/checkov/common/bridgecrew/integration_features/features/policy_metadata_integration.py
@@ -179,7 +179,7 @@ class PolicyMetadataIntegration(BaseIntegrationFeature):
                 self.filtered_policy_ids = policy_ids
                 self._add_ckv_id_for_filtered_cloned_checks(self.filtered_policy_ids, exclude_policies)
 
-    def _add_ckv_id_for_filtered_cloned_checks(self, policy_ids, exclude_policies: bool) -> None:
+    def _add_ckv_id_for_filtered_cloned_checks(self, policy_ids: list[str], exclude_policies: bool) -> None:
         """
         Filtered checks are the policies that are returned by --policy-metadata-filter.
         Filtered exclusion checks are the policies that are returned by --policy-metadata-filter-exclusion.

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -124,8 +124,8 @@ class BcPlatformIntegration:
         self.setup_api_urls()
         self.customer_run_config_response = None
         self.runtime_run_config_response = None
-        self.prisma_policies_response = None
-        self.prisma_policies_exception_response = None
+        self.prisma_policies_response: dict[str, str] | None = None
+        self.prisma_policies_exception_response: dict[str, str] | None = None
         self.public_metadata_response = None
         self.use_s3_integration = False
         self.s3_setup_failed = False
@@ -1084,7 +1084,7 @@ class BcPlatformIntegration:
         self.prisma_policies_response = self.get_prisma_policies_for_filter(policy_filter)
         self.prisma_policies_exception_response = self.get_prisma_policies_for_filter(policy_filter_exception)
 
-    def get_prisma_policies_for_filter(self, policy_filter: dict[str, str]) -> dict[Any, Any]:
+    def get_prisma_policies_for_filter(self, policy_filter: str) -> dict[Any, Any] | None:
         request = None
         filtered_policies = None
         try:
@@ -1094,7 +1094,7 @@ class BcPlatformIntegration:
             self.setup_http_manager()
             if not self.http:
                 logging.error("HTTP manager was not correctly created")
-                return
+                return filtered_policies
 
             logging.debug(f'Prisma policy URL: {self.prisma_policies_url}')
             query_params = convert_prisma_policy_filter_to_dict(policy_filter)

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -125,6 +125,7 @@ class BcPlatformIntegration:
         self.customer_run_config_response = None
         self.runtime_run_config_response = None
         self.prisma_policies_response = None
+        self.prisma_policies_exception_response = None
         self.public_metadata_response = None
         self.use_s3_integration = False
         self.s3_setup_failed = False
@@ -1061,17 +1062,18 @@ class BcPlatformIntegration:
         except Exception:
             logging.debug('could not get runtime info for this repo')
 
-    def get_prisma_build_policies(self, policy_filter: str) -> None:
+    def get_prisma_build_policies(self, policy_filter: str, policy_filter_exception: str) -> None:
         """
         Get Prisma policy for enriching runConfig with metadata
         Filters: https://prisma.pan.dev/api/cloud/cspm/policy#operation/get-policy-filters-and-options
         :param policy_filter: comma separated filter string. Example, policy.label=A,cloud.type=aws
+        :param policy_filter_exception: comma separated filter string. Example, policy.label=A,cloud.type=aws
         :return:
         """
         if self.skip_download is True:
             logging.debug("Skipping prisma policy API call")
             return
-        if not policy_filter:
+        if not policy_filter and not policy_filter_exception:
             return
         if not self.is_prisma_integration():
             return
@@ -1079,9 +1081,12 @@ class BcPlatformIntegration:
             raise Exception(
                 "Tried to get prisma build policy metadata, "
                 "but the API key was missing or the integration was not set up")
+        self.prisma_policies_response = self.get_prisma_policies_for_filter(policy_filter)
+        self.prisma_policies_exception_response = self.get_prisma_policies_for_filter(policy_filter_exception)
 
+    def get_prisma_policies_for_filter(self, policy_filter: dict[str, str]) -> dict[Any, Any]:
         request = None
-
+        filtered_policies = None
         try:
             token = self.get_auth_token()
             headers = merge_dicts(get_prisma_auth_header(token), get_prisma_get_headers(), self.custom_auth_headers)
@@ -1103,14 +1108,13 @@ class BcPlatformIntegration:
                     headers=headers,
                     fields=query_params,
                 )
-                self.prisma_policies_response = json.loads(request.data.decode("utf8"))
                 logging.debug("Got Prisma build policy metadata")
-            else:
-                logging.warning("Skipping get prisma build policies. --policy-metadata-filter will not be applied.")
+                filtered_policies = json.loads(request.data.decode("utf8"))
         except Exception:
             response_message = f': {request.status} - {request.reason}' if request else ''
             logging.warning(
                 f"Failed to get prisma build policy metadata from {self.prisma_policies_url}{response_message}", exc_info=True)
+        return filtered_policies
 
     def get_prisma_policy_filters(self) -> Dict[str, Dict[str, Any]]:
         request = None
@@ -1162,7 +1166,7 @@ class BcPlatformIntegration:
                 logging.warning(f"Filter value not allowed: {filter_value}")
                 logging.warning("Available options: True")
                 return False
-        logging.debug("--policy-metadata-filter is valid")
+        logging.debug("policy filter is valid")
         return True
 
     def get_public_run_config(self) -> None:

--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -464,6 +464,8 @@ class ExtArgumentParser(configargparse.ArgumentParser):
         self.add(
             "--policy-metadata-filter",
             help="comma separated key:value string to filter policies based on Prisma Cloud policy metadata. "
+                 "When used with --policy-metadata-filter-exception, the exceptions override any policies selected as"
+                 "a result of the --policy-metadata-filter flag."
                  "See https://prisma.pan.dev/api/cloud/cspm/policy#operation/get-policy-filters-and-options for "
                  "information on allowed filters. Format: policy.label=test,cloud.type=aws ",
             default=None,
@@ -471,6 +473,8 @@ class ExtArgumentParser(configargparse.ArgumentParser):
         self.add(
             "--policy-metadata-filter-exception",
             help="comma separated key:value string to exclude filtered policies based on Prisma Cloud policy metadata. "
+                 "When used with --policy-metadata-filter, the exceptions override any policies selected as"
+                 "a result of the --policy-metadata-filter flag."
                  "See https://prisma.pan.dev/api/cloud/cspm/policy#operation/get-policy-filters-and-options for "
                  "information on allowed filters. Format: policy.label=test,cloud.type=aws ",
             default=None,

--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -469,6 +469,13 @@ class ExtArgumentParser(configargparse.ArgumentParser):
             default=None,
         )
         self.add(
+            "--policy-metadata-filter-exception",
+            help="comma separated key:value string to exclude filtered policies based on Prisma Cloud policy metadata. "
+                 "See https://prisma.pan.dev/api/cloud/cspm/policy#operation/get-policy-filters-and-options for "
+                 "information on allowed filters. Format: policy.label=test,cloud.type=aws ",
+            default=None,
+        )
+        self.add(
             "--secrets-scan-file-type",
             default=[],
             env_var="CKV_SECRETS_SCAN_FILE_TYPE",

--- a/checkov/docs_generator.py
+++ b/checkov/docs_generator.py
@@ -58,11 +58,13 @@ def get_compare_key(c: list[str] | tuple[str, ...]) -> list[tuple[str, str, int,
 
 
 def print_checks(frameworks: Optional[List[str]] = None, use_bc_ids: bool = False,
-                 include_all_checkov_policies: bool = True, filtered_policy_ids: Optional[List[str]] = None) -> None:
+                 include_all_checkov_policies: bool = True, filtered_policy_ids: Optional[List[str]] = None,
+                 filtered_exception_policy_ids: Optional[List[str]] = None) -> None:
     framework_list = frameworks if frameworks else ["all"]
     printable_checks_list = get_checks(framework_list, use_bc_ids=use_bc_ids,
                                        include_all_checkov_policies=include_all_checkov_policies,
-                                       filtered_policy_ids=filtered_policy_ids or [])
+                                       filtered_policy_ids=filtered_policy_ids or [],
+                                       filtered_exception_policy_ids=filtered_exception_policy_ids or [])
     print(
         tabulate(printable_checks_list, headers=["Id", "Type", "Entity", "Policy", "IaC", "Resource Link"], tablefmt="github",
                  showindex=True))
@@ -83,11 +85,15 @@ def get_check_link(absolute_path: str) -> str:
 
 
 def get_checks(frameworks: Optional[List[str]] = None, use_bc_ids: bool = False,
-               include_all_checkov_policies: bool = True, filtered_policy_ids: Optional[List[str]] = None) -> List[Tuple[str, str, int, int, str, str]]:
+               include_all_checkov_policies: bool = True, filtered_policy_ids: Optional[List[str]] = None,
+               filtered_exception_policy_ids: Optional[List[str]] = None) -> List[Tuple[str, str, int, int, str, str]]:
     framework_list = frameworks if frameworks else ["all"]
     printable_checks_list: list[tuple[str, str, str, str, str, str]] = []
     filtered_policy_ids = filtered_policy_ids or []
-    runner_filter = RunnerFilter(include_all_checkov_policies=include_all_checkov_policies, filtered_policy_ids=filtered_policy_ids)
+    filtered_exception_policy_ids = filtered_exception_policy_ids or []
+    runner_filter = RunnerFilter(include_all_checkov_policies=include_all_checkov_policies,
+                                 filtered_policy_ids=filtered_policy_ids,
+                                 filtered_exception_policy_ids=filtered_exception_policy_ids)
 
     def add_from_repository(registry: Union[BaseCheckRegistry, BaseGraphRegistry], checked_type: str, iac: str,
                             runner_filter: RunnerFilter = runner_filter) -> None:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -493,7 +493,8 @@ class Checkov:
             if self.config.list:
                 print_checks(frameworks=self.config.framework, use_bc_ids=self.config.output_bc_ids,
                              include_all_checkov_policies=self.config.include_all_checkov_policies,
-                             filtered_policy_ids=runner_filter.filtered_policy_ids)
+                             filtered_policy_ids=runner_filter.filtered_policy_ids,
+                             filtered_exception_policy_ids=runner_filter.filtered_exception_policy_ids)
                 return None
 
             baseline = None

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -190,9 +190,9 @@ class Checkov:
         if self.config.bc_api_key and not self.config.repo_id and not self.config.list:
             self.parser.error('--repo-id is required when using a platform API key')
 
-        if self.config.policy_metadata_filter and not (self.config.bc_api_key and self.config.prisma_api_url):
+        if (self.config.policy_metadata_filter or self.config.policy_metadata_filter_exception) and not (self.config.bc_api_key and self.config.prisma_api_url):
             logger.warning(
-                '--policy-metadata-filter flag was used without a Prisma Cloud API key. Policy filtering will be skipped.'
+                '--policy-metadata-filter or --policy-metadata-filter-exception flag was used without a Prisma Cloud API key. Policy filtering will be skipped.'
             )
 
         logging.debug('Normalizing --framework')
@@ -460,7 +460,7 @@ class Checkov:
                     if removed_check_types:
                         logger.warning(f"Following runners won't run as they are not supported for on-premises integrations: {removed_check_types}")
 
-            bc_integration.get_prisma_build_policies(self.config.policy_metadata_filter)
+            bc_integration.get_prisma_build_policies(self.config.policy_metadata_filter, self.config.policy_metadata_filter_exception)
 
             # set config to make it usable inside the integration features
             integration_feature_registry.config = self.config
@@ -476,7 +476,9 @@ class Checkov:
                 runner_filter.run_image_referencer = licensing_integration.should_run_image_referencer()
 
             runner_filter.filtered_policy_ids = policy_metadata_integration.filtered_policy_ids
+            runner_filter.filtered_exception_policy_ids = policy_metadata_integration.filtered_exception_policy_ids
             logger.debug(f"Filtered list of policies: {runner_filter.filtered_policy_ids}")
+            logger.debug(f"Filtered excluded list of policies: {runner_filter.filtered_exception_policy_ids}")
 
             runner_filter.excluded_paths = runner_filter.excluded_paths + list(repo_config_integration.skip_paths)
             policy_level_suppression = suppressions_integration.get_policy_level_suppressions()

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -380,6 +380,7 @@ class RunnerFilter(object):
         if use_enforcement_rules is None:
             use_enforcement_rules = False
         filtered_policy_ids = obj.get('filtered_policy_ids')
+        filtered_exception_policy_ids = obj.get('filtered_exception_policy_ids')
         show_progress_bar = obj.get('show_progress_bar')
         if show_progress_bar is None:
             show_progress_bar = True
@@ -391,8 +392,8 @@ class RunnerFilter(object):
         runner_filter = RunnerFilter(framework, checks, skip_checks, include_all_checkov_policies,
                                      download_external_modules, external_modules_download_path, evaluate_variables,
                                      runners, skip_framework, excluded_paths, all_external, var_files,
-                                     skip_cve_package, use_enforcement_rules, filtered_policy_ids, show_progress_bar,
-                                     run_image_referencer, enable_secret_scan_all_files, block_list_secret_scan)
+                                     skip_cve_package, use_enforcement_rules, filtered_policy_ids, filtered_exception_policy_ids,
+                                     show_progress_bar, run_image_referencer, enable_secret_scan_all_files, block_list_secret_scan)
         return runner_filter
 
     def set_suppressed_policies(self, policy_level_suppressions: List[str]) -> None:

--- a/tests/common/integration_features/test_policy_metadata_integration.py
+++ b/tests/common/integration_features/test_policy_metadata_integration.py
@@ -13,12 +13,14 @@ class TestPolicyMetadataIntegration(unittest.TestCase):
         instance.bc_api_key = '00000000-0000-0000-0000-000000000000::1234=='
         instance.customer_run_config_response = mock_customer_run_config()
         instance.prisma_policies_response = mock_prisma_policies_response()
+        instance.prisma_policies_exception_response = [mock_prisma_policies_response()[0]]
         metadata_integration = PolicyMetadataIntegration(instance)
         metadata_integration.bc_integration = instance
         metadata_integration.pre_scan()
         metadata_integration.pc_to_ckv_id_mapping
         self.assertDictEqual(metadata_integration.pc_to_ckv_id_mapping, {'6960be11-e3a6-46cc-bf66-933c57c2af5d': 'CKV_AWS_212', '3dc2478c-bf25-4383-aaa1-30feb5cda586': '806079891421835264_AZR_1685557908904', 'c11ce08c-b93e-4e11-8d1c-e5a1339139d1': 'CKV_AWS_40', '0e4c576e-c934-4af3-8592-a53920e71ffb': 'CKV_AWS_53'})
         self.assertListEqual(metadata_integration.filtered_policy_ids, ['CKV_AWS_212', '806079891421835264_AZR_1685557908904', 'CKV_AWS_40', 'CKV_AWS_53', 'CKV_AZURE_122'])
+        self.assertListEqual(metadata_integration.filtered_exception_policy_ids, ['CKV_AWS_212'])
 
 
 def mock_customer_run_config():

--- a/tests/common/test_runner_filter.py
+++ b/tests/common/test_runner_filter.py
@@ -445,6 +445,26 @@ class TestRunnerFilter(unittest.TestCase):
                                 filtered_policy_ids=[])
         self.assertTrue(instance.should_run_check(check_id='CKV_AWS_789'))
 
+    def test_should_skip_explicit_run_if_policy_exception(self):
+        instance = RunnerFilter(checks=['CKV_AWS_789'], include_all_checkov_policies=False,
+                                filtered_exception_policy_ids=['CKV_AWS_789'])
+        self.assertFalse(instance.should_run_check(check_id='CKV_AWS_789'))
+
+    def test_should_skip_policy_exception(self):
+        instance = RunnerFilter(skip_checks=['CKV_AWS_789'], include_all_checkov_policies=False,
+                                filtered_exception_policy_ids=["CKV_AWS_789"])
+        self.assertFalse(instance.should_run_check(check_id='CKV_AWS_789'))
+
+    def test_should_run_if_no_policy_exceptions(self):
+        instance = RunnerFilter(checks=['CKV_AWS_789'], include_all_checkov_policies=False,
+                                filtered_exception_policy_ids=[])
+        self.assertTrue(instance.should_run_check(check_id='CKV_AWS_789'))
+
+    def test_should_skip_if_filtered_policy_is_also_policy_exception(self):
+        instance = RunnerFilter(checks=['CKV_AWS_789'], include_all_checkov_policies=False,
+                                filtered_policy_ids=['CKV_AWS_789'], filtered_exception_policy_ids=['CKV_AWS_789'])
+        self.assertFalse(instance.should_run_check(check_id='CKV_AWS_789'))
+
     def test_should_run_check_enforcement_rules(self):
         instance = RunnerFilter(include_all_checkov_policies=True,
                                 filtered_policy_ids=[], use_enforcement_rules=True)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Adds a new `--policy-metadata-filter-exception` flag that can only be used with a Prisma Cloud API key. This adds the ability to *exclude* checks based on [policy metadata filters](https://prisma.pan.dev/api/cloud/cspm/policy#operation/get-policy-filters-and-options).

Filters can be specified in a comma-separated key-value list, for example:
```
checkov -d . --bc-api-key "xxx::xxx" --policy-metadata-filter-exception policy.label=A,cloud.type=aws,policy.mode=custom
```
When you list checks with a filter, checks returned by the filter are excluded.

Some important behaviors:

If a filter is invalid, checkov will continue execution with a warning and will run as though no filters were specified.

If `--policy-metadata-filter` and `--policy-metadata-filter-exception` are simultaneously used, the former is applied first, then the checks returned by the exception flag are removed. For example: 

- Policies P1, P2, P3 have the label `CRITICAL`
- Policies P1, P2 have the label `EXCEPTION`

Running the following command will result in only running policy P3. P1 and P2 will not be executed (*not skipped*).
 
```
checkov -d . --bc-api-key "xxx::xxx" --policy-metadata-filter policy.label=CRITICAL --policy-metadata-filter-exception policy.label=EXCEPTION
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
