### PR TITLE
fix(secrets): Azure Storage Key detector updates in bc-detect-secrets 1.5.7

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,7 +43,7 @@ types-colorama = "<0.5.0,>=0.4.3"
 # REMINDER: Update "install_requires" deps on setup.py when changing
 #
 bc-python-hcl2 = "==0.4.2"
-bc-detect-secrets = "==1.5.6"
+bc-detect-secrets = "==1.5.7"
 bc-jsonpath-ng = "==1.6.1"
 pycep-parser = "==0.4.1"
 tabulate = ">=0.9.0,<0.10.0"

--- a/Pipfile
+++ b/Pipfile
@@ -43,7 +43,7 @@ types-colorama = "<0.5.0,>=0.4.3"
 # REMINDER: Update "install_requires" deps on setup.py when changing
 #
 bc-python-hcl2 = "==0.4.2"
-bc-detect-secrets = "==1.5.5"
+bc-detect-secrets = "==1.5.6"
 bc-jsonpath-ng = "==1.6.1"
 pycep-parser = "==0.4.1"
 tabulate = ">=0.9.0,<0.10.0"

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     },
     install_requires=[
         "bc-python-hcl2==0.4.2",
-        "bc-detect-secrets==1.5.6",
+        "bc-detect-secrets==1.5.7",
         "bc-jsonpath-ng==1.6.1",
         "pycep-parser==0.4.1",
         "tabulate>=0.9.0,<0.10.0",

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     },
     install_requires=[
         "bc-python-hcl2==0.4.2",
-        "bc-detect-secrets==1.5.5",
+        "bc-detect-secrets==1.5.6",
         "bc-jsonpath-ng==1.6.1",
         "pycep-parser==0.4.1",
         "tabulate>=0.9.0,<0.10.0",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Azure Storage Key detector updates

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
