### PR TITLE
Created check

### DIFF
--- a/checkov/terraform/checks/resource/azure/KeyVaultEnablesRBAC.py
+++ b/checkov/terraform/checks/resource/azure/KeyVaultEnablesRBAC.py
@@ -1,0 +1,19 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckResult
+
+
+class KeyVaultEnablesRBAC(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure RBAC for Azure Key Vault is enabled"
+        id = "CKV_AZURE_242"
+        supported_resources = ['azurerm_key_vault']
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
+                         missing_block_result=CheckResult.PASSED)
+
+    def get_inspected_key(self):
+        return "enable_rbac_authorization"
+
+
+check = KeyVaultEnablesRBAC()

--- a/tests/terraform/checks/resource/azure/example_KeyVaultEnablesRBAC/main.tf
+++ b/tests/terraform/checks/resource/azure/example_KeyVaultEnablesRBAC/main.tf
@@ -1,0 +1,40 @@
+resource "azurerm_key_vault" "pass" {
+  name                                   = "examplepass1"
+  location                               = azurerm_resource_group.example.location
+  resource_group_name                    = azurerm_resource_group.example.name
+  enabled_for_disk_encryption            = true
+  tenant_id                              = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days             = 90
+  purge_protection_enabled               = enabled
+  public_network_access_enabled          = false
+  sku_name                               = "standard"
+  enable_rbac_authorization              = true
+  
+}
+
+resource "azurerm_key_vault" "fail" {
+  name                                   = "examplepass1"
+  location                               = azurerm_resource_group.example.location
+  resource_group_name                    = azurerm_resource_group.example.name
+  enabled_for_disk_encryption            = true
+  tenant_id                              = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days             = 90
+  purge_protection_enabled               = enabled
+  public_network_access_enabled          = false
+  sku_name                               = "standard"
+  enable_rbac_authorization              = false
+  
+}
+
+resource "azurerm_key_vault" "fail2" {
+  name                                   = "examplepass1"
+  location                               = azurerm_resource_group.example.location
+  resource_group_name                    = azurerm_resource_group.example.name
+  enabled_for_disk_encryption            = true
+  tenant_id                              = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days             = 90
+  purge_protection_enabled               = enabled
+  public_network_access_enabled          = false
+  sku_name                               = "standard"
+
+}

--- a/tests/terraform/checks/resource/azure/test_KeyVaultEnablesRBAC.py
+++ b/tests/terraform/checks/resource/azure/test_KeyVaultEnablesRBAC.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.KeyVaultEnablesRBAC import check
+
+
+class TestKeyVaultEnablesRBAC(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_KeyVaultEnablesRBAC")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_key_vault.pass'
+        }
+        failing_resources = {
+            'azurerm_key_vault.fail',
+            'azurerm_key_vault.fail2'
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fixes #6164

## New/Edited policies (Delete if not relevant)

### Description

Azure Key Vault offers two authorization systems: [Azure role-based access control](https://learn.microsoft.com/en-us/azure/role-based-access-control/overview) (Azure RBAC), which operates on Azure's [control and data planes](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/control-plane-and-data-plane), and the access policy model, which operates on the data plane alone.

Azure RBAC is built on [Azure Resource Manager](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/overview) and provides centralized access management of Azure resources. With Azure RBAC you control access to resources by creating role assignments, which consist of three elements: a security principal, a role definition (predefined set of permissions), and a scope (group of resources or individual resource).

The access policy model is a legacy authorization system, native to Key Vault, which provides access to keys, secrets, and certificates. You can control access by assigning individual permissions to security principals (users, groups, service principals, and managed identities) at Key Vault scope.

Azure RBAC is the recommended authorization system for the Azure Key Vault data plane. It offers several advantages over Key Vault access policies:

Azure RBAC provides a unified access control model for Azure resources — the same APIs are used across all Azure services.
Access management is centralized, providing administrators with a consistent view of access granted to Azure resources.
The right to grant access to keys, secrets, and certificates is better controlled, requiring Owner or User Access Administrator role membership.
Azure RBAC is integrated with [Privileged Identity Management](https://learn.microsoft.com/en-us/azure/active-directory/privileged-identity-management/pim-configure), ensuring that privileged access rights are time-limited and expire automatically.
Security principals' access can be excluded at given scope(s) through the use of [Deny assignments](https://learn.microsoft.com/en-us/azure/role-based-access-control/deny-assignments).

Source: https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-access-policy
### Fix

Change "enable_rbac_authorization" to "true"

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules