### PR TITLE
feat(terraform): Ensure App configuration has at least one replica configured

### DIFF
--- a/checkov/terraform/checks/resource/azure/AppConfigReplicaEnabled.py
+++ b/checkov/terraform/checks/resource/azure/AppConfigReplicaEnabled.py
@@ -1,0 +1,23 @@
+from checkov.common.models.consts import ANY_VALUE
+
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from typing import Any
+
+
+class AppConfigReplicaEnabled(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure App configuration has at least one replica configured."
+        id = "CKV_AZURE_242"
+        supported_resources = ("azurerm_app_configuration",)
+        categories = (CheckCategories.BACKUP_AND_RECOVERY,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "replica/[0]/name"
+
+    def get_expected_value(self) -> Any:
+        return ANY_VALUE
+
+
+check = AppConfigReplicaEnabled()

--- a/tests/terraform/checks/resource/azure/example_AppConfigReplicaEnabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AppConfigReplicaEnabled/main.tf
@@ -1,0 +1,28 @@
+resource "azurerm_app_configuration" "fail" {
+  name                       = "appConf2"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
+  sku                        = "standard"
+  local_auth_enabled         = true
+  public_network_access      = "Enabled"
+  purge_protection_enabled   = true
+  soft_delete_retention_days = 1
+
+}
+
+resource "azurerm_app_configuration" "pass" {
+  name                       = "appConf2"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
+  sku                        = "standard"
+  local_auth_enabled         = true
+  public_network_access      = "Enabled"
+  purge_protection_enabled   = false
+  soft_delete_retention_days = 1
+
+  replica {
+    name     = "replica1"
+    location = "West US"
+  }
+
+}

--- a/tests/terraform/checks/resource/azure/test_AppConfigReplicaEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_AppConfigReplicaEnabled.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.azure.AppConfigReplicaEnabled import check
+
+
+class TestAppConfigReplicaEnabled(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AppConfigReplicaEnabled")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'azurerm_app_configuration.pass'
+        }
+        failing_resources = {
+            'azurerm_app_configuration.fail'
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
## Description


Fixes #6136 

## New/Edited policies (Delete if not relevant)

### Description

For application developers and IT engineers, a common goal is to build and run resilient applications. Resiliency is defined as the ability of your application to react to failure and still remain functional. To achieve resilience in the face of regional failures in the cloud, the first step is to build in redundancy to avoid a single point of failure. This redundancy can be achieved with geo-replication.

The App Configuration geo-replication feature allows you to replicate your configuration store at-will to the regions of your choice. Each new replica will be in a different region and creates a new endpoint for your applications to send requests to. The original endpoint of your configuration store is called the Origin. The origin can't be removed, but otherwise behaves like any replica.

Source: https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-geo-replication

### Fix

Create another App Configuration and mention it in the "replica" block.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
