### PR TITLE
feat(terraform): allow module source refs that look like version tags

### DIFF
--- a/checkov/terraform/checks/module/generic/RevisionHash.py
+++ b/checkov/terraform/checks/module/generic/RevisionHash.py
@@ -7,6 +7,7 @@ from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.module.base_module_check import BaseModuleCheck
 
 COMMIT_ID_PATTERN = re.compile(r"\?(ref=)(?P<commit_id>([0-9a-f]{5,40}))")
+VERSION_PATTERN = re.compile(r"\?(ref=).*(\d\.\d).*")
 
 
 class RevisionHash(BaseModuleCheck):
@@ -23,8 +24,8 @@ class RevisionHash(BaseModuleCheck):
             if source_url.startswith(("./", "../")):
                 # local modules can't be pinned to a commit hash
                 return CheckResult.UNKNOWN
-            if "?ref" in source_url and re.search(COMMIT_ID_PATTERN, source_url):
-                # do first a quick lookup, if '?ref' exists in the string before actually searching for the commit hash
+            if "?ref" in source_url and (re.search(COMMIT_ID_PATTERN, source_url) or re.search(VERSION_PATTERN, source_url)):
+                # do first a quick lookup, if '?ref' exists in the string before actually searching for the rev value
                 return CheckResult.PASSED
 
         return CheckResult.FAILED

--- a/tests/terraform/checks/module/generic/example_RevisionHash/main.tf
+++ b/tests/terraform/checks/module/generic/example_RevisionHash/main.tf
@@ -55,6 +55,25 @@ module "tag" {
   }
 }
 
+module "looks_like_a_branch" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=some_branch_name"
+
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  enable_nat_gateway = true
+  enable_vpn_gateway = true
+
+  tags = {
+    Terraform = "true"
+    Environment = "dev"
+  }
+}
+
 # unknown
 
 module "relative" {

--- a/tests/terraform/checks/module/generic/test_RevisionHash.py
+++ b/tests/terraform/checks/module/generic/test_RevisionHash.py
@@ -20,9 +20,10 @@ class TestRevisionHash(unittest.TestCase):
         passing_resources = {
             "hash",
             "sub_dir_hash",
+            "tag"
         }
         failing_resources = {
-            "tag",
+            "looks_like_a_branch",
             "tf_registry",
         }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

CKV_TF_1

### Description
Allow refs with a version number of at least `x.y`, but still disallow things that just look like branches

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
