### PR TITLE
fix(terraform): Fix false Positive finding for CKV_GCP_73

### DIFF
--- a/checkov/terraform/checks/resource/gcp/CloudArmorWAFACLCVE202144228.py
+++ b/checkov/terraform/checks/resource/gcp/CloudArmorWAFACLCVE202144228.py
@@ -25,7 +25,7 @@ class CloudArmorWAFACLCVE202144228(BaseResourceCheck):
             match = rule.get("match")
             if match and isinstance(match, list):
                 expr = match[0].get("expr")
-                if expr and isinstance(expr[0], dict) and expr[0].get("expression") == ["evaluatePreconfiguredExpr('cve-canary')"]:
+                if expr and isinstance(expr[0], dict) and expr[0].get("expression") == ["evaluatePreconfiguredWaf('cve-canary')"]:
                     if rule.get("action") == ["allow"]:
                         return CheckResult.FAILED
                     if rule.get("preview") == [True]:

--- a/tests/terraform/checks/resource/gcp/example_CloudArmorWAFACLCVE202144228/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_CloudArmorWAFACLCVE202144228/main.tf
@@ -8,7 +8,7 @@ resource "google_compute_security_policy" "enabled_deny_403" {
     priority = 1
     match {
       expr {
-        expression = "evaluatePreconfiguredExpr('cve-canary')"
+        expression = "evaluatePreconfiguredWaf('cve-canary')"
       }
     }
   }
@@ -22,7 +22,7 @@ resource "google_compute_security_policy" "enabled_deny_404" {
     priority = 1
     match {
       expr {
-        expression = "evaluatePreconfiguredExpr('cve-canary')"
+        expression = "evaluatePreconfiguredWaf('cve-canary')"
       }
     }
   }
@@ -38,7 +38,7 @@ resource "google_compute_security_policy" "allow" {
     priority = 1
     match {
       expr {
-        expression = "evaluatePreconfiguredExpr('cve-canary')"
+        expression = "evaluatePreconfiguredWaf('cve-canary')"
       }
     }
   }
@@ -52,7 +52,7 @@ resource "google_compute_security_policy" "preview" {
     priority = 1
     match {
       expr {
-        expression = "evaluatePreconfiguredExpr('cve-canary')"
+        expression = "evaluatePreconfiguredWaf('cve-canary')"
       }
     }
     preview = true
@@ -67,7 +67,7 @@ resource "google_compute_security_policy" "different_expr" {
     priority = 1
     match {
       expr {
-        expression = "evaluatePreconfiguredExpr('xss-canary')"
+        expression = "evaluatePreconfiguredWaf('xss-canary')"
       }
     }
   }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Updated the matching pattern for this rule.

Fixes #6214

## New/Edited policies (Delete if not relevant)
- CKV_GCP_73

### Description
This was reporting a false positive due to the change in expression pattern

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
