### PR TITLE
feat(terraform): Update CloudArmorWAFACLCVE202144228.py

### DIFF
--- a/checkov/terraform/checks/resource/gcp/CloudArmorWAFACLCVE202144228.py
+++ b/checkov/terraform/checks/resource/gcp/CloudArmorWAFACLCVE202144228.py
@@ -37,8 +37,8 @@ class CloudArmorWAFACLCVE202144228(BaseResourceCheck):
                             return CheckResult.FAILED
                         if rule.get("preview") == [True]:
                             return CheckResult.FAILED
-                        return CheckResult.PASSED
-                    
+                        return CheckResult.PASSED                    
         return CheckResult.FAILED
+
 
 check = CloudArmorWAFACLCVE202144228()

--- a/checkov/terraform/checks/resource/gcp/CloudArmorWAFACLCVE202144228.py
+++ b/checkov/terraform/checks/resource/gcp/CloudArmorWAFACLCVE202144228.py
@@ -25,15 +25,20 @@ class CloudArmorWAFACLCVE202144228(BaseResourceCheck):
             match = rule.get("match")
             if match and isinstance(match, list):
                 expr = match[0].get("expr")
-                if expr and isinstance(expr[0], dict) and expr[0].get("expression") == ["evaluatePreconfiguredExpr('cve-canary')"]:
-                    if rule.get("action") == ["allow"]:
-                        return CheckResult.FAILED
-                    if rule.get("preview") == [True]:
-                        return CheckResult.FAILED
-
-                    return CheckResult.PASSED
-
+                if expr and isinstance(expr[0], dict):
+                    if expr[0].get("expression") == ["evaluatePreconfiguredExpr('cve-canary')"]:
+                        if rule.get("action") == ["allow"]:
+                            return CheckResult.FAILED
+                        if rule.get("preview") == [True]:
+                            return CheckResult.FAILED
+                        return CheckResult.PASSED
+                    elif expr[0].get("expression") == ["evaluatePreconfiguredWaf('cve-canary')"]:
+                        if rule.get("action") == ["allow"]:
+                            return CheckResult.FAILED
+                        if rule.get("preview") == [True]:
+                            return CheckResult.FAILED
+                        return CheckResult.PASSED
+                    
         return CheckResult.FAILED
-
 
 check = CloudArmorWAFACLCVE202144228()

--- a/checkov/terraform/checks/resource/gcp/CloudArmorWAFACLCVE202144228.py
+++ b/checkov/terraform/checks/resource/gcp/CloudArmorWAFACLCVE202144228.py
@@ -37,7 +37,7 @@ class CloudArmorWAFACLCVE202144228(BaseResourceCheck):
                             return CheckResult.FAILED
                         if rule.get("preview") == [True]:
                             return CheckResult.FAILED
-                        return CheckResult.PASSED                    
+                        return CheckResult.PASSED
         return CheckResult.FAILED
 
 

--- a/tests/terraform/checks/resource/gcp/example_CloudArmorWAFACLCVE202144228/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_CloudArmorWAFACLCVE202144228/main.tf
@@ -28,6 +28,21 @@ resource "google_compute_security_policy" "enabled_deny_404" {
   }
 }
 
+resource "google_compute_security_policy" "pass_preconfigwaf" {
+  name = "example"
+
+  rule {
+    action   = "deny(403)"
+    priority = 1
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('cve-canary')"
+        # expression = "evaluatePreconfiguredExpr('cve-canary')"
+      }
+    }
+  }
+}
+
 # fail
 
 resource "google_compute_security_policy" "allow" {
@@ -68,6 +83,21 @@ resource "google_compute_security_policy" "different_expr" {
     match {
       expr {
         expression = "evaluatePreconfiguredExpr('xss-canary')"
+      }
+    }
+  }
+}
+
+resource "google_compute_security_policy" "pass_preconfigwaf" {
+  name = "example"
+
+  rule {
+    action   = "deny(403)"
+    priority = 1
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('xss-canary')"
+        # expression = "evaluatePreconfiguredExpr('xss-canary')"
       }
     }
   }

--- a/tests/terraform/checks/resource/gcp/test_CloudArmorWAFACLCVE202144228.py
+++ b/tests/terraform/checks/resource/gcp/test_CloudArmorWAFACLCVE202144228.py
@@ -20,19 +20,21 @@ class TestCloudArmorWAFACLCVE202144228(unittest.TestCase):
         passing_resources = {
             "google_compute_security_policy.enabled_deny_403",
             "google_compute_security_policy.enabled_deny_404",
+            "google_compute_security_policy.pass_preconfigwaf",
         }
 
         failing_resources = {
             "google_compute_security_policy.allow",
             "google_compute_security_policy.preview",
             "google_compute_security_policy.different_expr",
+            "google_compute_security_policy.pass_preconfigwaf"
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 2)
-        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
Either evaluatePreconfiguredExpr('cve-canary') rule can be used or you can configure a rule by using evaluatePreconfiguredWaf()

https://cloud.google.com/armor/docs/waf-rules#cves_and_other_vulnerabilities

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
