### PR TITLE
feat(arm): add AppServiceJavaVersion

### DIFF
--- a/checkov/arm/checks/resource/AppServiceJavaVersion.py
+++ b/checkov/arm/checks/resource/AppServiceJavaVersion.py
@@ -6,7 +6,7 @@ class AppServiceJavaVersion(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure that 'Java version' is the latest, if used to run the web app"
         id = "CKV_AZURE_83"
-        supported_resources = ['Microsoft.Web/sites']
+        supported_resources = ('Microsoft.Web/sites',)
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
                          missing_block_result=CheckResult.UNKNOWN)
@@ -14,8 +14,9 @@ class AppServiceJavaVersion(BaseResourceValueCheck):
     def get_inspected_key(self):
         return "site_config/java_version"
 
-    def get_expected_value(self):
-        return '11'
+    def get_expected_value(self) -> str:
+        return '17'
 
 
 check = AppServiceJavaVersion()
+

--- a/checkov/arm/checks/resource/AppServiceJavaVersion.py
+++ b/checkov/arm/checks/resource/AppServiceJavaVersion.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+
+
+class AppServiceJavaVersion(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure that 'Java version' is the latest, if used to run the web app"
+        id = "CKV_AZURE_83"
+        supported_resources = ['Microsoft.Web/sites']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
+                         missing_block_result=CheckResult.UNKNOWN)
+
+    def get_inspected_key(self):
+        return "site_config/java_version"
+
+    def get_expected_value(self):
+        return '11'
+
+
+check = AppServiceJavaVersion()

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -14,7 +14,7 @@ class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
                          supported_resources=supported_resources,
                          missing_block_result=CheckResult.FAILED,)
 
-    def get_inspected_key(self) -> str:
+    def get_inspected_key(self):
         return "properties/minimalTlsVersion"
 
     def get_expected_value(self) -> str:

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -17,7 +17,7 @@ class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
     def get_inspected_key(self) -> str:
         return "properties/minimalTlsVersion"
 
-    def get_expected_value(self):
+    def get_expected_value(self) -> str:
         return "1.2"
 
 

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -25,3 +25,4 @@ check = MSSQLServerMinTLSVersion()
 
 
 
+

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -24,3 +24,5 @@ class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
 check = MSSQLServerMinTLSVersion()
 
 
+
+

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -25,4 +25,3 @@ check = MSSQLServerMinTLSVersion()
 
 
 
-

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -17,7 +17,7 @@ class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
     def get_inspected_key(self) -> str:
         return "properties/minimalTlsVersion"
 
-    def get_expected_value(self) -> str:
+    def get_expected_value(self):
         return "1.2"
 
 

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -14,7 +14,7 @@ class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
                          supported_resources=supported_resources,
                          missing_block_result=CheckResult.FAILED,)
 
-    def get_inspected_key(self):
+    def get_inspected_key(self) -> str:
         return "properties/minimalTlsVersion"
 
     def get_expected_value(self) -> str:

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -1,0 +1,24 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+
+
+class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure MSSQL is using the latest version of TLS encryption"
+        id = "CKV_AZURE_52"
+        supported_resources = ("Microsoft.Sql/servers",)
+        categories = (CheckCategories.NETWORKING)
+        super().__init__(name=name,
+                         id=id,
+                         categories=categories,
+                         supported_resources=supported_resources,
+                         missing_block_result=CheckResult.FAILED,)
+
+    def get_inspected_key(self):
+        return "properties/minimalTlsVersion"
+
+    def get_expected_value(self):
+        return "1.2"
+
+
+check = MSSQLServerMinTLSVersion()

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -7,7 +7,7 @@ class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
         name = "Ensure MSSQL is using the latest version of TLS encryption"
         id = "CKV_AZURE_52"
         supported_resources = ("Microsoft.Sql/servers",)
-        categories = (CheckCategories.NETWORKING)
+        categories = (CheckCategories.NETWORKING,)
         super().__init__(name=name,
                          id=id,
                          categories=categories,

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -23,3 +23,4 @@ class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
 
 check = MSSQLServerMinTLSVersion()
 
+

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -14,11 +14,12 @@ class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
                          supported_resources=supported_resources,
                          missing_block_result=CheckResult.FAILED,)
 
-    def get_inspected_key(self):
+    def get_inspected_key(self) -> str:
         return "properties/minimalTlsVersion"
 
-    def get_expected_value(self):
+    def get_expected_value(self) -> str:
         return "1.2"
 
 
 check = MSSQLServerMinTLSVersion()
+

--- a/tests/arm/checks/resource/example_AppServiceJavaVersion/fail.json
+++ b/tests/arm/checks/resource/example_AppServiceJavaVersion/fail.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2021-02-01",
+            "name": "fail",
+            "properties": {
+                "publisherEmail": "[parameters('adminEmail')]",
+                "publisherName": "[parameters('organizationName')]",
+                "customProperties": "[parameters('customProperties')]"
+            },
+            "site_config": {
+                "java_version": "13"
+            },
+            "resources": [],
+            "dependsOn": []
+        }
+    ]
+}

--- a/tests/arm/checks/resource/example_AppServiceJavaVersion/pass.json
+++ b/tests/arm/checks/resource/example_AppServiceJavaVersion/pass.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2021-02-01",
+            "name": "pass",
+            "properties": {
+                "publisherEmail": "[parameters('adminEmail')]",
+                "publisherName": "[parameters('organizationName')]",
+                "customProperties": "[parameters('customProperties')]"
+            },
+            "site_config": {
+                "java_version": "11"
+            },
+            "resources": [],
+            "dependsOn": []
+        }
+    ]
+}

--- a/tests/arm/checks/resource/example_AppServiceJavaVersion/pass.json
+++ b/tests/arm/checks/resource/example_AppServiceJavaVersion/pass.json
@@ -12,7 +12,7 @@
                 "customProperties": "[parameters('customProperties')]"
             },
             "site_config": {
-                "java_version": "11"
+                "java_version": "17"
             },
             "resources": [],
             "dependsOn": []

--- a/tests/arm/checks/resource/example_MSSQLServerMinTLSVersion/fail.json
+++ b/tests/arm/checks/resource/example_MSSQLServerMinTLSVersion/fail.json
@@ -1,0 +1,246 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "apiVersion": {
+            "type": "string",
+            "defaultValue": "2021-05-01"
+        },
+        "administratorLogin": {
+            "type": "string"
+        },
+        "administratorLoginPassword": {
+            "type": "securestring"
+        },
+        "location": {
+            "type": "string"
+        },
+        "serverName": {
+            "type": "string"
+        },
+        "serverEdition": {
+            "type": "string"
+        },
+        "vCores": {
+            "type": "int",
+            "defaultValue": 4
+        },
+        "storageSizeGB": {
+            "type": "int"
+        },
+        "haEnabled": {
+            "type": "string",
+            "defaultValue": "Disabled"
+        },
+        "availabilityZone": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "standbyAvailabilityZone": {
+            "type": "string"
+        },
+        "version": {
+            "type": "string"
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "firewallRules": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "backupRetentionDays": {
+            "type": "int"
+        },
+        "geoRedundantBackup": {
+            "type": "string"
+        },
+        "vmName": {
+            "type": "string",
+            "defaultValue": "Standard_B1ms"
+        },
+        "storageIops": {
+            "type": "int"
+        },
+        "storageAutogrow": {
+            "type": "string",
+            "defaultValue": "Enabled"
+        },
+        "autoIoScaling": {
+            "type": "string",
+            "defaultValue": "Disabled"
+        },
+        "identityData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "dataEncryptionData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "serverParameters": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "aadEnabled": {
+            "type": "bool",
+            "defaultValue": false
+        },
+        "aadData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "guid": {
+            "type": "string",
+            "defaultValue": "[newGuid()]"
+        },
+        "network": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "firewallRulesAPIVersion": {
+            "type": "string",
+            "defaultValue": "2022-01-01"
+        }
+    },
+    "variables": {
+        "api": "[parameters('apiVersion')]",
+        "firewallRules": "[parameters('firewallRules').rules]",
+        "serverParameters": "[parameters('serverParameters')]"
+    },
+    "resources": [
+        {
+              "type": "Microsoft.Sql/servers",
+              "apiVersion": "2023-05-01-preview",
+              "name": "fail",
+              "location": "string",
+              "tags": {
+                "tagName1": "tagValue1",
+                "tagName2": "tagValue2"
+              },
+              "identity": {
+                "type": "string",
+                "userAssignedIdentities": {
+                  "{customized property}": {}
+                }
+              },
+              "properties": {
+                "administratorLogin": "string",
+                "administratorLoginPassword": "string",
+                "administrators": {
+                  "administratorType": "ActiveDirectory",
+                  "azureADOnlyAuthentication": "bool",
+                  "login": "string",
+                  "principalType": "string",
+                  "sid": "string",
+                  "tenantId": "string"
+                },
+                "federatedClientId": "string",
+                "isIPv6Enabled": "string",
+                "keyId": "string",
+                "minimalTlsVersion": "1.1",
+                "primaryUserAssignedIdentityId": "string",
+                "publicNetworkAccess": "string",
+                "restrictOutboundNetworkAccess": "string",
+                "version": "string"
+              }
+            },
+        {
+            "condition": "[greater(length(variables('firewallRules')), 0)]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "name": "[concat('firewallRules-', parameters('guid'), '-', copyIndex())]",
+            "copy": {
+                "count": "[if(greater(length(variables('firewallRules')), 0), length(variables('firewallRules')), 1)]",
+                "mode": "Serial",
+                "name": "firewallRulesIterator"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]",
+                "[concat('Microsoft.Resources/deployments/addAdmins-', parameters('guid'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/firewallRules",
+                            "name": "[concat(parameters('serverName'),'/',variables('firewallRules')[copyIndex()].name)]",
+                            "apiVersion": "[parameters('firewallRulesAPIVersion')]",
+                            "properties": {
+                                "StartIpAddress": "[variables('firewallRules')[copyIndex()].startIPAddress]",
+                                "EndIpAddress": "[variables('firewallRules')[copyIndex()].endIPAddress]"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "condition": "[parameters('aadEnabled')]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "name": "[concat('addAdmins-', parameters('guid'))]",
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/administrators",
+                            "name": "[concat(parameters('serverName'),'/ActiveDirectory')]",
+                            "apiVersion": "[variables('api')]",
+                            "properties": {
+                                "administratorType": "[parameters('aadData').administratorType]",
+                                "identityResourceId": "[parameters('aadData').identityResourceId]",
+                                "login": "[parameters('aadData').login]",
+                                "sid": "[parameters('aadData').sid]",
+                                "tenantId": "[parameters('aadData').tenantId]"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "condition": "[and(greater(length(variables('serverParameters')), 0), parameters('aadEnabled'))]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "copy": {
+                "count": "[if(greater(length(variables('serverParameters')), 0), length(variables('serverParameters')), 1)]",
+                "mode": "serial",
+                "name": "serverParametersIterator"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]",
+                "[concat('Microsoft.Resources/deployments/addAdmins-', parameters('guid'))]"
+            ],
+            "name": "[concat('serverParameters-', copyIndex(), '-', parameters('guid'))]",
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/configurations",
+                            "name": "[concat(parameters('serverName'),'/',variables('serverParameters')[copyIndex()].name)]",
+                            "apiVersion": "[variables('api')]",
+                            "properties": {
+                                "value": "[variables('serverParameters')[copyIndex()].value]",
+                                "source": "[variables('serverParameters')[copyIndex()].source]"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/tests/arm/checks/resource/example_MSSQLServerMinTLSVersion/pass.json
+++ b/tests/arm/checks/resource/example_MSSQLServerMinTLSVersion/pass.json
@@ -1,0 +1,246 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "apiVersion": {
+            "type": "string",
+            "defaultValue": "2021-05-01"
+        },
+        "administratorLogin": {
+            "type": "string"
+        },
+        "administratorLoginPassword": {
+            "type": "securestring"
+        },
+        "location": {
+            "type": "string"
+        },
+        "serverName": {
+            "type": "string"
+        },
+        "serverEdition": {
+            "type": "string"
+        },
+        "vCores": {
+            "type": "int",
+            "defaultValue": 4
+        },
+        "storageSizeGB": {
+            "type": "int"
+        },
+        "haEnabled": {
+            "type": "string",
+            "defaultValue": "Disabled"
+        },
+        "availabilityZone": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "standbyAvailabilityZone": {
+            "type": "string"
+        },
+        "version": {
+            "type": "string"
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "firewallRules": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "backupRetentionDays": {
+            "type": "int"
+        },
+        "geoRedundantBackup": {
+            "type": "string"
+        },
+        "vmName": {
+            "type": "string",
+            "defaultValue": "Standard_B1ms"
+        },
+        "storageIops": {
+            "type": "int"
+        },
+        "storageAutogrow": {
+            "type": "string",
+            "defaultValue": "Enabled"
+        },
+        "autoIoScaling": {
+            "type": "string",
+            "defaultValue": "Disabled"
+        },
+        "identityData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "dataEncryptionData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "serverParameters": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "aadEnabled": {
+            "type": "bool",
+            "defaultValue": false
+        },
+        "aadData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "guid": {
+            "type": "string",
+            "defaultValue": "[newGuid()]"
+        },
+        "network": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "firewallRulesAPIVersion": {
+            "type": "string",
+            "defaultValue": "2022-01-01"
+        }
+    },
+    "variables": {
+        "api": "[parameters('apiVersion')]",
+        "firewallRules": "[parameters('firewallRules').rules]",
+        "serverParameters": "[parameters('serverParameters')]"
+    },
+    "resources": [
+        {
+              "type": "Microsoft.Sql/servers",
+              "apiVersion": "2023-05-01-preview",
+              "name": "pass",
+              "location": "string",
+              "tags": {
+                "tagName1": "tagValue1",
+                "tagName2": "tagValue2"
+              },
+              "identity": {
+                "type": "string",
+                "userAssignedIdentities": {
+                  "{customized property}": {}
+                }
+              },
+              "properties": {
+                "administratorLogin": "string",
+                "administratorLoginPassword": "string",
+                "administrators": {
+                  "administratorType": "ActiveDirectory",
+                  "azureADOnlyAuthentication": "bool",
+                  "login": "string",
+                  "principalType": "string",
+                  "sid": "string",
+                  "tenantId": "string"
+                },
+                "federatedClientId": "string",
+                "isIPv6Enabled": "string",
+                "keyId": "string",
+                "minimalTlsVersion": "1.2",
+                "primaryUserAssignedIdentityId": "string",
+                "publicNetworkAccess": "string",
+                "restrictOutboundNetworkAccess": "string",
+                "version": "string"
+              }
+            },
+        {
+            "condition": "[greater(length(variables('firewallRules')), 0)]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "name": "[concat('firewallRules-', parameters('guid'), '-', copyIndex())]",
+            "copy": {
+                "count": "[if(greater(length(variables('firewallRules')), 0), length(variables('firewallRules')), 1)]",
+                "mode": "Serial",
+                "name": "firewallRulesIterator"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]",
+                "[concat('Microsoft.Resources/deployments/addAdmins-', parameters('guid'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/firewallRules",
+                            "name": "[concat(parameters('serverName'),'/',variables('firewallRules')[copyIndex()].name)]",
+                            "apiVersion": "[parameters('firewallRulesAPIVersion')]",
+                            "properties": {
+                                "StartIpAddress": "[variables('firewallRules')[copyIndex()].startIPAddress]",
+                                "EndIpAddress": "[variables('firewallRules')[copyIndex()].endIPAddress]"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "condition": "[parameters('aadEnabled')]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "name": "[concat('addAdmins-', parameters('guid'))]",
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/administrators",
+                            "name": "[concat(parameters('serverName'),'/ActiveDirectory')]",
+                            "apiVersion": "[variables('api')]",
+                            "properties": {
+                                "administratorType": "[parameters('aadData').administratorType]",
+                                "identityResourceId": "[parameters('aadData').identityResourceId]",
+                                "login": "[parameters('aadData').login]",
+                                "sid": "[parameters('aadData').sid]",
+                                "tenantId": "[parameters('aadData').tenantId]"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "condition": "[and(greater(length(variables('serverParameters')), 0), parameters('aadEnabled'))]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "copy": {
+                "count": "[if(greater(length(variables('serverParameters')), 0), length(variables('serverParameters')), 1)]",
+                "mode": "serial",
+                "name": "serverParametersIterator"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]",
+                "[concat('Microsoft.Resources/deployments/addAdmins-', parameters('guid'))]"
+            ],
+            "name": "[concat('serverParameters-', copyIndex(), '-', parameters('guid'))]",
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/configurations",
+                            "name": "[concat(parameters('serverName'),'/',variables('serverParameters')[copyIndex()].name)]",
+                            "apiVersion": "[variables('api')]",
+                            "properties": {
+                                "value": "[variables('serverParameters')[copyIndex()].value]",
+                                "source": "[variables('serverParameters')[copyIndex()].source]"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/tests/arm/checks/resource/test_AppServiceJavaVersion.py
+++ b/tests/arm/checks/resource/test_AppServiceJavaVersion.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.arm.runner import Runner
+from checkov.arm.checks.resource.AppServiceJavaVersion import check
+
+
+class TestAppServiceJavaVersion(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AppServiceJavaVersion")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'Microsoft.Web/sites.pass',
+        }
+        failing_resources = {
+            'Microsoft.Web/sites.fail',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/arm/checks/resource/test_MSSQLServerMinTLSVersion.py
+++ b/tests/arm/checks/resource/test_MSSQLServerMinTLSVersion.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+
+from checkov.arm.checks.resource.MSSQLServerMinTLSVersion import check
+from checkov.arm.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestMSSQLServerMinTLSVersion(unittest.TestCase):
+
+    def test_summary(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_MSSQLServerMinTLSVersion"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "Microsoft.Sql/servers.pass"
+        }
+
+        failing_resources = {
+            "Microsoft.Sql/servers.fail"
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertSetEqual(passing_resources, passed_check_resources)
+        self.assertSetEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"



## New/Edited policies (Delete if not relevant)

### Description
This code defines a function called AppServiceJavaVersion that performs a check on the Java version configuration in Web Apps (Web Apps) in the Azure service. The function checks if the Java version defined for the application is the latest version (version 11), and returns a test result accordingly. The function uses the Checkov library to perform the check, and imports constants and functions from it.



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
