### PR TITLE
docs: GitLab CI Component for Checkov, SAST JSON Results First When Feature is present, do not fail build for single scanner new findings

### DIFF
--- a/docs/4.Integrations/GitLab CI.md
+++ b/docs/4.Integrations/GitLab CI.md
@@ -7,9 +7,21 @@ nav_order: 4
 
 # Integrate Checkov with GitLab CI
 
-Integrating Checkov into your GitLab CI pipelines provides a simple, automatic way of applying policies to your Terraform code both during merge request review and as part of your build process.
+Since Checkov supports GitLab's SAST JSON format, using it in your GitLab CI pipelines enables integration with GitLab's most advanced security functionality in [Security Dashboard](https://docs.gitlab.com/ee/user/application_security/security_dashboard/), [Merge Request findings display](https://docs.gitlab.com/ee/user/application_security/sast/) and, importantly [Security Policy Merge Approvals](https://docs.gitlab.com/ee/user/application_security/policies/scan-result-policies.html).
 
-## Basic Setup
+## GitLab CI Component Setup
+GitLab CI Components are managed CI dependencies published by GitLab and the GitLab community.
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/guided-explorations/ci-components/checkov-iac-sast/checkov-iac-sast@<VERSION>
+```
+
+Where <VERSION> is the component version from [the Checkov components listing here](https://gitlab.com/explore/catalog/guided-explorations/ci-components/checkov-iac-sast).
+
+See documentation on the [Checkov GitLab CI Component](https://gitlab.com/explore/catalog/guided-explorations/ci-components/checkov-iac-sast)
+
+## Manual Custom Setup
 Add a new job in `.gitlab-ci.yml` in your repository (at whatever stage is appropriate for you).
 
 Here is a basic example:
@@ -18,40 +30,97 @@ Here is a basic example:
 stages:
     - test
     
-checkov:
+checkov-iac-sast:
+checkov-iac-sast-qdjs:
+  variables:
+    CKV_CONTAINER_TAG: 3.2.83
+# Do not set at this level if you wish to also set it at a higher level
+#    CKV_IS_ALLOW_FAILURE:
+#      value: 'true' # defaults to 'true'(by only checking for false)
+#      description: 'Whether Checkov findings should fail the build. It is not a GitLab best practice to fail builds right in scanner jobs.'
+#    CKV_ATTEMPT_COLOR_LOGS:
+#      value: 'false' # defaults to 'false' (by only checking for true)
+#      description: 'Whether to attempt to use the "script" command to show color output in GitLab CI'
   stage: test
-  allow_failure: true  # True for AutoDevOps compatibility
   image:
-    name: bridgecrew/checkov:latest
+    name: bridgecrew/checkov:$CKV_CONTAINER_TAG
     entrypoint:
       - '/usr/bin/env'
       - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
   rules:
     - if: $SAST_DISABLED
       when: never
-    - if: $CI_COMMIT_BRANCH
+    - if: $CI_COMMIT_BRANCH && $CKV_IS_ALLOW_FAILURE == "false"
+      allow_failure: false
       exists:
-        - '**/*.yml'
-        - '**/*.yaml'
-        - '**/*.json'
-        - '**/*.template'
-        - '**/*.tf'      
-        - '**/serverless.yml'
-        - '**/serverless.yaml'
+      - '**/*.yml'
+      - '**/*.yaml'
+      - '**/*.json'
+      - '**/*.template'
+      - '**/*.tf'      
+      - '**/serverless.yml'
+      - '**/serverless.yaml'
+    - if: $CI_COMMIT_BRANCH
+      allow_failure: true
+      exists:
+      - '**/*.yml'
+      - '**/*.yaml'
+      - '**/*.json'
+      - '**/*.template'
+      - '**/*.tf'      
+      - '**/serverless.yml'
+      - '**/serverless.yaml'
   script:
-    - checkov -d . -o junitxml | tee checkov.test.xml
+    - |
+      if [[ "${CI_DEBUG_TRACE,,}" == "true" ]]; then
+        echo "GitLab's global trace (CI_DEBUG_TRACE) has been set, debug logging. More info: https://docs.gitlab.com/ee/ci/variables/#enable-debug-logging"
+        set -xv
+      fi
+      
+      if [[ ! "${CKV_IS_ALLOW_FAILURE}" == "false" ]]; then
+        SOFTFAILARG='--soft-fail'
+      fi
+
+      if [[ "${GITLAB_FEATURES}" == *"security_dashboard"* ]]; then
+        echo "You are licensed for GitLab Security Dashboards, you will find scanning results in Security Dashboard."
+        OUTPUTARG='gitlab_sast'
+        OUTPUTFILEEXT='json'
+      else
+        echo "You will find scanning results in the GitLab Test results visualization panel on your pipeline tabs."
+        OUTPUTARG='junitxml'
+        OUTPUTFILEEXT='xml'
+      fi
+
+      if [[ "${CKV_ATTEMPT_COLOR_LOGS,,}" == "true" && ! -z "$(command -v screen)" ]]; then
+        script -q -c 'checkov ${SOFTFAILARG,,} -d . --output ${OUTPUTARG} | tee checkov-sast.${OUTPUTFILEEXT}' ; CKVEXIT=${PIPESTATUS[0]}
+      else
+        checkov ${SOFTFAILARG} -d . --output ${OUTPUTARG} | tee checkov-sast.${OUTPUTFILEEXT} ; CKVEXIT=${PIPESTATUS[0]}
+      fi
+
+      if [[ ! "${CKV_IS_ALLOW_FAILURE,,}" == "false" ]]; then
+        exit $(cat CKVEXIT)
+      fi
+
   artifacts:
     reports:
-      junit: "checkov.test.xml"
-    paths:
-      - "checkov.test.xml"
+      junit: "checkov-sast.xml"
+      sast: "checkov-sast.json"
 ```
 
 ## Example Results
-When your pipeline executes, it will run this job. If Checkov finds any issues, it will fail the build.
+When your pipeline executes, it will run this job. If Checkov finds any issues, it will report them to GitLab.
 
-### Pipeline Failure
-For example, I have an S3 bucket that does not have versioning enabled. Checkov detects this and fails the job and pipeline.
+### GitLab Security Policy Merge Approvals Instead of Pipeline Failures.
+GitLab has advanced DevSecOps workflow automation. Rather than fail builds, Security Policy Merge Approvals simply prevent merging before code ever progresses to a shared branch or production bound branch. This allows developers to continue working on their code while collaborating on security findings. Once they resolve the offending findings, the approval rule becomes optional without any human intervention or oversight. In the scope of a Merge Request scanning results are only for new vulnerabilities in the code changed in the Merge Request - so this is a very effective way to both retain developer productivity and prevent new vulnerabilities from being merged without external involvement of another team.
+
+Pipeline soft failure also allows all other security scanners to run and have the findings collected - this is helpful when multiple scanner findings help in vulnerability root cause analysis and solutions and for developer productivity in addressing multiple findings at one time.
+
+#### Pipeline Failure
+Pipeline failure might be appropriate when developers are not required to use Merge Requests and approvals to merge to a production bound branch - but this should be an extremely rare configuration if security is a high concern.
+
+Enable this by setting the GitLab CI variable: `CKV_IS_ALLOW_FAILURE: 'false'`
+
+For this example, an S3 bucket that does not have versioning enabled. Checkov detects this and fails the job and pipeline.
 
 [](gitlab_failed_job.png)
 
@@ -59,43 +128,15 @@ This will comment on an associated merge request or fail the build depending on 
 
 GitLab will collect the results into the normal unit testing area of the pipeline and/or the merge request.
 
-### Pipeline Success
+#### Pipeline Success
 Once you correct the configuration, Checkov verifies that no errors have been found.
 
 [](gitlab_results.png)
 
 ## Colored Output
-Note that in the examples above, the output of the test results does not display colors. This is because GitLab Runner runs without an interactive TTY. Although Checkov does not currently support an environment variable to force colored output, the `script` command can be used to emulate `tty` so colors are displayed:
+GitLab Runner runs without an interactive TTY so generally does not display color. The `script` command can be added in the above to emulate `tty` so colors can be displayed. Update the above code with this fragment.
 
-```yaml
-stages:
-    - test
-
-checkov:
-  stage: test
-  allow_failure: true  # True for AutoDevOps compatibility
-  image:
-    name: bridgecrew/checkov:latest
-    entrypoint:
-      - '/usr/bin/env'
-      - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-  rules:
-    - if: $SAST_DISABLED
-      when: never
-    - if: $CI_COMMIT_BRANCH
-      exists:
-        - '**/*.yml'
-        - '**/*.yaml'
-        - '**/*.json'
-        - '**/*.template'
-        - '**/*.tf'      
-        - '**/serverless.yml'
-        - '**/serverless.yaml'
-  script:
-    # Use `script` to emulate `tty` for colored output.
-    - script -q -c 'checkov -d . ; echo $? > CKVEXIT'
-    - exit $(cat CKVEXIT)
-```
+Enable this by setting the GitLab CI variable: `CKV_ATTEMPT_COLOR_LOGS: 'true'`
 
 See the [GitLab CI documentation](https://docs.gitlab.com/ee/ci/) for additional information.
 There is also a working example of using GitLab CI with Checkov [here](https://gitlab.com/guided-explorations/ci-cd-plugin-extensions/checkov-iac-sast).  This example shows how to use the same Checkov YAML file as an includable extension so that all your jobs reuse the same job definition.


### PR DESCRIPTION
Updating docs for Checkov GitLab CI Component and advising not doing build failures to prevent new vulnerabilities from being accepted into production bound code.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

I had previous created the GitLab CI include that I believe some of your code on this page was from (I may have even submitted a PR). I have updated my original code to create a fairly capable GitLab CI Component and bumped those improvements on to your page here.

This code also detects if the CI is running under a context where Security Dashboards are licensed (currently GitLab Ultimate) and outputs json sast automatically as this creates maximum value for your customers. Checkov findings then appear in the MR Widget, Security Dashboard and can be part of Security Policy Merge Approvals. (See the attachment that shows this in action for Amazon CodeGuru SAST Scanning findings.

![image](https://github.com/bridgecrewio/checkov/assets/11597190/82d660cb-f037-4993-a0f9-89af27ecb1a6)

Most notable

Fixes # (issue)

## New
- Points to new GitLab CI Component for Checkov IaC SAST.
- Autoswitches from JUNIT XML to GItLab SAST JSON when GitLab License level is detected
- Promotes not failing builders on single scanner new findings (failure can be configured)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
