### PR TITLE
platform(general): Fix policy.name to use the spaces as specified on CLI.

### DIFF
--- a/checkov/common/util/type_forcers.py
+++ b/checkov/common/util/type_forcers.py
@@ -140,11 +140,10 @@ def convert_prisma_policy_filter_to_dict(filter_string: str) -> Dict[Any, Any]:
     """
     filter_params = {}
     if isinstance(filter_string, str) and filter_string:
-        filter_string = "".join(filter_string.split())
-        try:
-            for f in filter_string.split(','):
+        for f in filter_string.split(','):
+            try:
                 f_name, f_value = f.split('=')
-                filter_params[f_name] = f_value
-        except (IndexError, ValueError) as e:
-            logging.debug(f"Invalid filter format: {e}")
+                filter_params[f_name.strip()] = f_value.strip()
+            except (IndexError, ValueError) as e:
+                logging.debug(f"Invalid filter format: {e}")
     return filter_params

--- a/tests/common/utils/test_type_forcers.py
+++ b/tests/common/utils/test_type_forcers.py
@@ -9,8 +9,13 @@ class TestTypeForcers(unittest.TestCase):
         self.assertDictEqual(convert_prisma_policy_filter_to_dict(''), {})
         self.assertDictEqual(convert_prisma_policy_filter_to_dict(None), {})
         self.assertDictEqual(convert_prisma_policy_filter_to_dict('F1 =   A,   F2= B '), {'F1': 'A', 'F2': 'B'})
-        self.assertDictEqual(convert_prisma_policy_filter_to_dict('F1=A,B,F2=C'), {'F1': 'A'})
+        self.assertDictEqual(convert_prisma_policy_filter_to_dict('F1=A,B,F2=C'), {'F1': 'A', 'F2': 'C'})
         self.assertDictEqual(convert_prisma_policy_filter_to_dict('F1=A,F2=B,C'), {'F1': 'A', 'F2': 'B'})
+
+        policy_string = 'policy.name=AWS S3 bucket ACL grants READ permission to everyone'
+        filter_string = convert_prisma_policy_filter_to_dict(policy_string)
+        self.assertDictEqual(filter_string, {'policy.name': 'AWS S3 bucket ACL grants READ permission to everyone'})
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

 # PR Title
 platform(general): Fix policy.name to use the spaces as specified on CLI.


## Description

When adding the flag policy.name with a valid value of a particular policy, only that policy should run and return in the result. 

checkov -f main.tf --skip-results-upload --repo-id ts/test --policy-metadata-filter policy.name="Data exfiltration allowed without resource constraints"

Instead all the policies are returned (and hence run). This is fixed by handling the spaces in the policy names and leading and trailing whitespaces appropriately.

Fixes # (issue)
When adding the flag policy.name with a valid value of a particular policy, only that policy should run and return in the result. Instead all the policies are returned (and hence run)

### Fix
This is fixed by handling the spaces in the policy names and leading and trailing whitespaces appropriately.

## Checklist:

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] I have added tests that prove my feature, policy, or fix is effective and works
- [ X] New and existing tests pass locally with my changes
- [ X] Any dependent changes have been merged and published in downstream modules
