### PR TITLE
feat(arm): StorageSyncPublicAccessDisabled

### DIFF
--- a/checkov/arm/checks/resource/StorageSyncPublicAccessDisabled.py
+++ b/checkov/arm/checks/resource/StorageSyncPublicAccessDisabled.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+
+
+class NetworkInterfaceEnableIPForwarding(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure that Azure File Sync disables public network access"
+        id = "CKV_AZURE_657"
+        supported_resources = ('Microsoft.StorageSync/storageSyncServices',)
+        categories = (CheckCategories.NETWORKING,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
+                         missing_block_result=CheckResult.FAILED)
+
+    def get_inspected_key(self):
+        return 'properties/incoming_traffic_policy'
+
+    def get_expected_value(self):
+        return 'AllowVirtualNetworksOnly'
+
+
+check = NetworkInterfaceEnableIPForwarding()

--- a/checkov/arm/checks/resource/StorageSyncPublicAccessDisabled.py
+++ b/checkov/arm/checks/resource/StorageSyncPublicAccessDisabled.py
@@ -5,7 +5,7 @@ from checkov.arm.base_resource_value_check import BaseResourceValueCheck
 class NetworkInterfaceEnableIPForwarding(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure that Azure File Sync disables public network access"
-        id = "CKV_AZURE_657"
+        id = "CKV_AZURE_64"
         supported_resources = ('Microsoft.StorageSync/storageSyncServices',)
         categories = (CheckCategories.NETWORKING,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,

--- a/checkov/arm/checks/resource/StorageSyncPublicAccessDisabled.py
+++ b/checkov/arm/checks/resource/StorageSyncPublicAccessDisabled.py
@@ -3,7 +3,7 @@ from checkov.arm.base_resource_value_check import BaseResourceValueCheck
 
 
 class NetworkInterfaceEnableIPForwarding(BaseResourceValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure that Azure File Sync disables public network access"
         id = "CKV_AZURE_64"
         supported_resources = ('Microsoft.StorageSync/storageSyncServices',)
@@ -11,10 +11,10 @@ class NetworkInterfaceEnableIPForwarding(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
                          missing_block_result=CheckResult.FAILED)
 
-    def get_inspected_key(self):
+    def get_inspected_key(self) -> str:
         return 'properties/incomingTrafficPolicy'
 
-    def get_expected_value(self):
+    def get_expected_value(self) -> str:
         return 'AllowVirtualNetworksOnly'
 
 

--- a/checkov/arm/checks/resource/StorageSyncPublicAccessDisabled.py
+++ b/checkov/arm/checks/resource/StorageSyncPublicAccessDisabled.py
@@ -12,7 +12,7 @@ class NetworkInterfaceEnableIPForwarding(BaseResourceValueCheck):
                          missing_block_result=CheckResult.FAILED)
 
     def get_inspected_key(self):
-        return 'properties/incoming_traffic_policy'
+        return 'properties/incomingTrafficPolicy'
 
     def get_expected_value(self):
         return 'AllowVirtualNetworksOnly'

--- a/tests/arm/checks/resource/example_StorageSyncPublicAccessDisabled/fail1.json
+++ b/tests/arm/checks/resource/example_StorageSyncPublicAccessDisabled/fail1.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.StorageSync/storageSyncServices",
+      "apiVersion": "2021-02-01",
+      "name": "fail1",
+      "properties": {
+        "storageSyncServiceStatus": "Registered",
+        "storageSyncServiceProperties": {
+          "trustState": "Enabled",
+          "storageSyncServiceUid": "65fdd65b-ea5d-4a00-bf7f-40c41ba39ae4",
+          "provisioningState": "Succeeded"
+        },
+        "location": "East US",
+        "tags": {
+          "foo": "bar"
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_StorageSyncPublicAccessDisabled/fail2.json
+++ b/tests/arm/checks/resource/example_StorageSyncPublicAccessDisabled/fail2.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.StorageSync/storageSyncServices",
+      "apiVersion": "2021-02-01",
+      "name": "fail2",
+      "properties": {
+        "storageSyncServiceStatus": "Registered",
+        "storageSyncServiceProperties": {
+          "trustState": "Enabled",
+          "storageSyncServiceUid": "65fdd65b-ea5d-4a00-bf7f-40c41ba39ae4",
+          "provisioningState": "Succeeded"
+        },
+        "location": "East US",
+        "incoming_traffic_policy": "AllowAllTraffic",
+        "tags": {
+          "foo": "bar"
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_StorageSyncPublicAccessDisabled/fail2.json
+++ b/tests/arm/checks/resource/example_StorageSyncPublicAccessDisabled/fail2.json
@@ -14,7 +14,7 @@
           "provisioningState": "Succeeded"
         },
         "location": "East US",
-        "incoming_traffic_policy": "AllowAllTraffic",
+        "incomingTrafficPolicy": "AllowAllTraffic",
         "tags": {
           "foo": "bar"
         }

--- a/tests/arm/checks/resource/example_StorageSyncPublicAccessDisabled/pass.json
+++ b/tests/arm/checks/resource/example_StorageSyncPublicAccessDisabled/pass.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "apiVersion": "2021-02-01",
+      "name": "pass",
+      "properties": {
+        "storageSyncServiceStatus": "Registered",
+        "storageSyncServiceProperties": {
+          "trustState": "Enabled",
+          "storageSyncServiceUid": "65fdd65b-ea5d-4a00-bf7f-40c41ba39ae4",
+          "provisioningState": "Succeeded"
+        },
+        "location": "East US",
+        "incoming_traffic_policy": "AllowVirtualNetworksOnly",
+        "tags": {
+          "foo": "bar"
+        }
+      },
+      "type": "Microsoft.StorageSync/storageSyncServices"
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_StorageSyncPublicAccessDisabled/pass.json
+++ b/tests/arm/checks/resource/example_StorageSyncPublicAccessDisabled/pass.json
@@ -13,7 +13,7 @@
           "provisioningState": "Succeeded"
         },
         "location": "East US",
-        "incoming_traffic_policy": "AllowVirtualNetworksOnly",
+        "incomingTrafficPolicy": "AllowVirtualNetworksOnly",
         "tags": {
           "foo": "bar"
         }

--- a/tests/arm/checks/resource/test_StorageSyncPublicAccessDisabled.py
+++ b/tests/arm/checks/resource/test_StorageSyncPublicAccessDisabled.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+from checkov.arm.checks.resource.StorageSyncPublicAccessDisabled import check
+from checkov.arm.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestStorageSyncPublicAccessDisabled(unittest.TestCase):
+    def test_summary(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_StorageSyncPublicAccessDisabled"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "Microsoft.StorageSync/storageSyncServices.pass",
+        }
+        failing_resources = {
+            "Microsoft.StorageSync/storageSyncServices.fail1",
+            "Microsoft.StorageSync/storageSyncServices.fail2",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*We converted the check StorageSyncPublicAccessDisabled from TEerraform language to ARM so that it also works on resources that are defined in ARM.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Ensure that Azure File Sync disables public network access.*

### Fix
*To address the issue, ensure that the Azure File Sync service is
configured to disable public network access. This can typically be done
by adjusting the configuration settings for Azure File Sync either
through the Azure Portal or using Azure CLI/PowerShell commands.
Specifically, you need to set the publicNetworkAccess property to Disabled*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
