### PR TITLE
feat(arm): KeyVaultDisablesPublicNetworkAccess

### DIFF
--- a/checkov/arm/checks/resource/KeyVaultDisablesPublicNetworkAccess.py
+++ b/checkov/arm/checks/resource/KeyVaultDisablesPublicNetworkAccess.py
@@ -1,5 +1,6 @@
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+from typing import Dict, Any
 
 
 class KeyVaultDisablesPublicNetworkAccess(BaseResourceValueCheck):
@@ -14,9 +15,9 @@ class KeyVaultDisablesPublicNetworkAccess(BaseResourceValueCheck):
         return "publicNetworkAccess"
 
     def get_expected_value(self) -> str:
-        return "Disabled"
+        return "disabled"
 
-    def scan_resource_conf(self, conf) -> CheckResult:
+    def scan_resource_conf(self, conf: Dict[str, Any]) -> CheckResult:
         properties = conf.get("properties", {})
         if self.get_inspected_key() in properties:
             conf_value = conf["properties"][self.get_inspected_key()]

--- a/checkov/arm/checks/resource/KeyVaultDisablesPublicNetworkAccess.py
+++ b/checkov/arm/checks/resource/KeyVaultDisablesPublicNetworkAccess.py
@@ -1,0 +1,36 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+
+
+class KeyVaultDisablesPublicNetworkAccess(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that Azure Key Vault disables public network access"
+        id = "CKV_AZURE_189"
+        supported_resources = ("Microsoft.KeyVault/vaults",)
+        categories = (CheckCategories.NETWORKING,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "publicNetworkAccess"
+
+    def get_expected_value(self) -> str:
+        return "Disabled"
+
+    def scan_resource_conf(self, conf) -> CheckResult:
+        properties = conf.get("properties", {})
+        if self.get_inspected_key() in properties:
+            conf_value = conf["properties"][self.get_inspected_key()]
+            if conf_value and conf_value == self.get_expected_value():
+                return CheckResult.PASSED
+
+        if properties and "networkAcls" in properties:
+            network_acls = conf["properties"]["networkAcls"]
+            if isinstance(network_acls, dict) and "ipRules" in network_acls:
+                ip_rules = network_acls["ipRules"]
+                ip_rules = ip_rules[0] if ip_rules and isinstance(ip_rules, list) else ip_rules
+                if ip_rules:
+                    return CheckResult.PASSED
+        return CheckResult.FAILED
+
+
+check = KeyVaultDisablesPublicNetworkAccess()

--- a/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/fail1.json
+++ b/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/fail1.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "fail1",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "enabledForDiskEncryption": true,
+        "tenantId": "[subscription().tenantId]",
+        "softDeleteRetentionInDays": 90,
+        "purgeProtectionEnabled": true,
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "publicNetworkAccess": "Enabled",
+        "accessPolicies": [
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[parameters('objectId')]",
+            "permissions": {
+              "keys": ["get"],
+              "secrets": ["get"],
+              "storage": ["get"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/fail2.json
+++ b/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/fail2.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "fail2",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "enabledForDiskEncryption": true,
+        "tenantId": "[subscription().tenantId]",
+        "softDeleteRetentionInDays": 90,
+        "purgeProtectionEnabled": true,
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "accessPolicies": [
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[parameters('objectId')]",
+            "permissions": {
+              "keys": ["get"],
+              "secrets": ["get"],
+              "storage": ["get"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/fail3.json
+++ b/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/fail3.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "fail3",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "enabledForDiskEncryption": true,
+        "tenantId": "[subscription().tenantId]",
+        "softDeleteRetentionInDays": 90,
+        "purgeProtectionEnabled": true,
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "networkAcls": {
+          "defaultAction" : "Allow",
+          "bypass" : "AzureServices",
+          "ipRules" : []
+        },
+        "accessPolicies": [
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[parameters('objectId')]",
+            "permissions": {
+              "keys": ["get"],
+              "secrets": ["get"],
+              "storage": ["get"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/fail4.json
+++ b/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/fail4.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "fail4",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "enabledForDiskEncryption": true,
+        "tenantId": "[subscription().tenantId]",
+        "softDeleteRetentionInDays": 90,
+        "purgeProtectionEnabled": true,
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "networkAcls": {
+          "defaultAction" : "Allow",
+          "bypass" : "AzureServices"
+        },
+        "accessPolicies": [
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[parameters('objectId')]",
+            "permissions": {
+              "keys": ["get"],
+              "secrets": ["get"],
+              "storage": ["get"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/fail5.json
+++ b/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/fail5.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "fail5",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "enabledForDiskEncryption": true,
+        "tenantId": "[subscription().tenantId]",
+        "softDeleteRetentionInDays": 90,
+        "purgeProtectionEnabled": true,
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "bypass": "AzureServices",
+          "ipRules": [],
+          "virtualNetworkRules": [
+            {
+              "id": "[if(parameters('naclsEnabled'),concat(subscription().id, '/resourceGroups/', parameters('resourceGroupName'), '/providers/Microsoft.Network/virtualNetworks/<yourVirtualNetworkName>/subnets/<yourSubnetName>'),json('null'))]"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass1.json
+++ b/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass1.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "pass1",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "enabledForDiskEncryption": true,
+        "tenantId": "[subscription().tenantId]",
+        "softDeleteRetentionInDays": 90,
+        "purgeProtectionEnabled": true,
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "publicNetworkAccess": "Disabled",
+        "accessPolicies": [
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[parameters('objectId')]",
+            "permissions": {
+              "keys": ["get"],
+              "secrets": ["get"],
+              "storage": ["get"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass1.json
+++ b/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass1.json
@@ -16,7 +16,7 @@
           "family": "A",
           "name": "standard"
         },
-        "publicNetworkAccess": "Disabled",
+        "publicNetworkAccess": "disabled",
         "accessPolicies": [
           {
             "tenantId": "[subscription().tenantId]",

--- a/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass2.json
+++ b/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass2.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "pass2",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "enabledForDiskEncryption": true,
+        "tenantId": "[subscription().tenantId]",
+        "softDeleteRetentionInDays": 90,
+        "purgeProtectionEnabled": true,
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "networkAcls" : {
+          "defaultAction" : "Allow",
+          "bypass" : "AzureServices"
+        },
+        "publicNetworkAccess": "Disabled",
+        "accessPolicies": [
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[parameters('objectId')]",
+            "permissions": {
+              "keys": ["get"],
+              "secrets": ["get"],
+              "storage": ["get"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass2.json
+++ b/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass2.json
@@ -20,7 +20,7 @@
           "defaultAction" : "Allow",
           "bypass" : "AzureServices"
         },
-        "publicNetworkAccess": "Disabled",
+        "publicNetworkAccess": "disabled",
         "accessPolicies": [
           {
             "tenantId": "[subscription().tenantId]",

--- a/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass3.json
+++ b/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass3.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "pass3",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "enabledForDiskEncryption": true,
+        "tenantId": "[subscription().tenantId]",
+        "softDeleteRetentionInDays": 90,
+        "purgeProtectionEnabled": true,
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "bypass": "AzureServices",
+          "ipRules": ["127.0.0.1"]
+        },
+        "publicNetworkAccess": "Enabled",
+        "accessPolicies": [
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[parameters('objectId')]",
+            "permissions": {
+              "keys": ["get"],
+              "secrets": ["get"],
+              "storage": ["get"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass4.json
+++ b/tests/arm/checks/resource/example_KeyVaultDisablesPublicNetworkAccess/pass4.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "pass4",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "enabledForDiskEncryption": true,
+        "tenantId": "[subscription().tenantId]",
+        "softDeleteRetentionInDays": 90,
+        "purgeProtectionEnabled": true,
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "bypass": "AzureServices",
+          "ipRules": ["127.0.0.1"]
+        },
+        "accessPolicies": [
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[parameters('objectId')]",
+            "permissions": {
+              "keys": ["get"],
+              "secrets": ["get"],
+              "storage": ["get"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/test_KeyVaultDisablesPublicNetworkAccess.py
+++ b/tests/arm/checks/resource/test_KeyVaultDisablesPublicNetworkAccess.py
@@ -1,0 +1,47 @@
+import unittest
+from pathlib import Path
+from checkov.arm.checks.resource.KeyVaultDisablesPublicNetworkAccess import check
+from checkov.arm.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestKeyVaultDisablesPublicNetworkAccess(unittest.TestCase):
+    def test_summary(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_KeyVaultDisablesPublicNetworkAccess"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+        print(f'\n{summary}')
+
+        passing_resources = {
+            "Microsoft.KeyVault/vaults.pass1",
+            "Microsoft.KeyVault/vaults.pass2",
+            "Microsoft.KeyVault/vaults.pass3",
+            "Microsoft.KeyVault/vaults.pass4",
+        }
+        failing_resources = {
+            "Microsoft.KeyVault/vaults.fail1",
+            "Microsoft.KeyVault/vaults.fail2",
+            "Microsoft.KeyVault/vaults.fail3",
+            "Microsoft.KeyVault/vaults.fail4",
+            "Microsoft.KeyVault/vaults.fail5",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/arm/checks/resource/test_KeyVaultDisablesPublicNetworkAccess.py
+++ b/tests/arm/checks/resource/test_KeyVaultDisablesPublicNetworkAccess.py
@@ -45,3 +45,4 @@ class TestKeyVaultDisablesPublicNetworkAccess(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+    


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*We converted the check KeyVaultDisablesPublicNetworkAccess from TEerraform language to ARM so that it also works on resources that are defined in ARM.*

Fixes # (issue)

### Description
*Ensure that Azure Key Vault disables public network accessEnsure that Azure Key Vault disables public network access.*

### Fix
*Update the NetworkInterfaceEnableIPForwarding class to include missing return type annotations for its methods.*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
