### PR TITLE
feat(arm):AppServiceFTPSState

### DIFF
--- a/checkov/arm/checks/resource/AppServiceFTPSState.py
+++ b/checkov/arm/checks/resource/AppServiceFTPSState.py
@@ -7,7 +7,7 @@ class AppServiceFTPSState(BaseResourceValueCheck):
     def __init__(self) -> None:
         name = "Ensure FTP deployments are disabled"
         id = "CKV_AZURE_78"
-        supported_resources = ('Microsoft.Web/sites', 'azurerm_linux_web_app', 'azurerm_windows_web_app')
+        supported_resources = ('Microsoft.Web/sites',)
         categories = (CheckCategories.APPLICATION_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/checkov/arm/checks/resource/AppServiceFTPSState.py
+++ b/checkov/arm/checks/resource/AppServiceFTPSState.py
@@ -12,7 +12,7 @@ class AppServiceFTPSState(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self) -> str:
-        return "site_config/ftps_state"
+        return "siteConfig/ftpsState"
 
     def get_expected_value(self) -> str:
         return "Disabled"

--- a/checkov/arm/checks/resource/AppServiceFTPSState.py
+++ b/checkov/arm/checks/resource/AppServiceFTPSState.py
@@ -1,0 +1,24 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+from typing import List
+
+
+class AppServiceFTPSState(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure FTP deployments are disabled"
+        id = "CKV_AZURE_78"
+        supported_resources = ('Microsoft.Web/sites', 'azurerm_linux_web_app', 'azurerm_windows_web_app')
+        categories = (CheckCategories.APPLICATION_SECURITY,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "site_config/ftps_state"
+
+    def get_expected_value(self) -> str:
+        return "Disabled"
+
+    def get_expected_values(self) -> List[str]:
+        return ["Disabled", "FtpsOnly"]
+
+
+check = AppServiceFTPSState()

--- a/checkov/arm/checks/resource/AppServiceFTPSState.py
+++ b/checkov/arm/checks/resource/AppServiceFTPSState.py
@@ -1,5 +1,5 @@
-from checkov.common.models.enums import CheckCategories
 from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
 from typing import List
 
 

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -22,5 +22,3 @@ class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
 
 
 check = MSSQLServerMinTLSVersion()
-
-

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -3,7 +3,7 @@ from checkov.arm.base_resource_value_check import BaseResourceValueCheck
 
 
 class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure MSSQL is using the latest version of TLS encryption"
         id = "CKV_AZURE_52"
         supported_resources = ("Microsoft.Sql/servers",)

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -7,19 +7,20 @@ class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
         name = "Ensure MSSQL is using the latest version of TLS encryption"
         id = "CKV_AZURE_52"
         supported_resources = ("Microsoft.Sql/servers",)
-        categories = (CheckCategories.NETWORKING)
+        categories = (CheckCategories.NETWORKING,)
         super().__init__(name=name,
                          id=id,
                          categories=categories,
                          supported_resources=supported_resources,
                          missing_block_result=CheckResult.FAILED,)
 
-    def get_inspected_key(self):
+    def get_inspected_key(self) -> str:
         return "properties/minimalTlsVersion"
 
-    def get_expected_value(self):
+    def get_expected_value(self) -> str:
         return "1.2"
 
 
 check = MSSQLServerMinTLSVersion()
+
 

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -1,0 +1,24 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+
+
+class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure MSSQL is using the latest version of TLS encryption"
+        id = "CKV_AZURE_52"
+        supported_resources = ("Microsoft.Sql/servers",)
+        categories = (CheckCategories.NETWORKING)
+        super().__init__(name=name,
+                         id=id,
+                         categories=categories,
+                         supported_resources=supported_resources,
+                         missing_block_result=CheckResult.FAILED,)
+
+    def get_inspected_key(self):
+        return "properties/minimalTlsVersion"
+
+    def get_expected_value(self):
+        return "1.2"
+
+
+check = MSSQLServerMinTLSVersion()

--- a/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
+++ b/checkov/arm/checks/resource/MSSQLServerMinTLSVersion.py
@@ -22,3 +22,4 @@ class MSSQLServerMinTLSVersion(BaseResourceValueCheck):
 
 
 check = MSSQLServerMinTLSVersion()
+

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/fail.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/fail.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
+    "contentVersion": "1.0.0.1",
     "parameters": {
         "adminEmail": {
             "type": "string",

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/fail.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/fail.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "adminEmail": {
+            "type": "string",
+            "defaultValue": "admin@example.com"
+        },
+        "organizationName": {
+            "type": "string",
+            "defaultValue": "Example Organization"
+        },
+        "customProperties": {
+            "type": "object",
+            "defaultValue": {}
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2021-02-01",
+            "name": "fail",
+            "properties": {
+                "publisherEmail": "[parameters('adminEmail')]",
+                "publisherName": "[parameters('organizationName')]",
+                "customProperties": "[parameters('customProperties')]"
+            },
+            "site_config": {
+                "ftps_state": "Enabled"
+            },
+            "resources": [],
+            "dependsOn": []
+        }
+    ]
+}

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/fail.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/fail.json
@@ -25,8 +25,8 @@
                 "publisherName": "[parameters('organizationName')]",
                 "customProperties": "[parameters('customProperties')]"
             },
-            "site_config": {
-                "ftps_state": "Enabled"
+            "siteConfig": {
+                "ftpsState": "Enabled"
             },
             "resources": [],
             "dependsOn": []

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/fail2.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/fail2.json
@@ -11,8 +11,8 @@
                 "publisherName": "[parameters('organizationName')]",
                 "customProperties": "[parameters('customProperties')]"
             },
-            "site_config": {
-                "ftps_state":
+            "siteConfig": {
+                "ftpsState":
             },
             "resources": [],
             "dependsOn": []

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/fail2.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/fail2.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2021-02-01",
+            "name": "fail2",
+            "properties": {
+                "publisherEmail": "[parameters('adminEmail')]",
+                "publisherName": "[parameters('organizationName')]",
+                "customProperties": "[parameters('customProperties')]"
+            },
+            "site_config": {
+                "ftps_state":
+            },
+            "resources": [],
+            "dependsOn": []
+        }
+    ]
+}

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/fail2.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/fail2.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
+    "contentVersion": "1.0.0.1",
     "resources": [
         {
             "type": "Microsoft.Web/sites",

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/fail3.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/fail3.json
@@ -11,8 +11,8 @@
                 "publisherName": "[parameters('organizationName')]",
                 "customProperties": "[parameters('customProperties')]"
             },
-           "site_config": {
-                "ftps_state":"Enabled",
+           "siteConfig": {
+                "ftpsState":"Enabled",
                         "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/fail3.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/fail3.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2021-02-01",
+            "name": "fail3",
+            "properties": {
+                "publisherEmail": "[parameters('adminEmail')]",
+                "publisherName": "[parameters('organizationName')]",
+                "customProperties": "[parameters('customProperties')]"
+            },
+           "site_config": {
+                "ftps_state":"Enabled",
+                        "appSettings": [
+            {
+              "name": "WEBSITE_NODE_DEFAULT_VERSION",
+              "value": "14.17.0"
+            }
+
+          ],
+          "linuxFxVersion": "NODE|14-lts"
+            },
+            "resources": [],
+            "dependsOn": []
+        }
+    ]
+}

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/fail3.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/fail3.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
+    "contentVersion": "1.0.0.1",
     "resources": [
         {
             "type": "Microsoft.Web/sites",

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/pass.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/pass.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
+    "contentVersion": "1.0.0.1",
     "parameters": {
         "adminEmail": {
             "type": "string",

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/pass.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/pass.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "adminEmail": {
+            "type": "string",
+            "defaultValue": "admin@example.com"
+        },
+        "organizationName": {
+            "type": "string",
+            "defaultValue": "Example Organization"
+        },
+        "customProperties": {
+            "type": "object",
+            "defaultValue": {}
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2021-02-01",
+            "name": "pass",
+            "properties": {
+                "publisherEmail": "[parameters('adminEmail')]",
+                "publisherName": "[parameters('organizationName')]",
+                "customProperties": "[parameters('customProperties')]"
+            },
+            "site_config": {
+                "ftps_state": "Disabled"
+            },
+            "resources": [],
+            "dependsOn": []
+        }
+    ]
+}

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/pass.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/pass.json
@@ -25,8 +25,8 @@
                 "publisherName": "[parameters('organizationName')]",
                 "customProperties": "[parameters('customProperties')]"
             },
-            "site_config": {
-                "ftps_state": "Disabled"
+            "siteConfig": {
+                "ftpsState": "Disabled"
             },
             "resources": [],
             "dependsOn": []

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/pass2.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/pass2.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
+    "contentVersion": "1.0.0.1",
     "resources": [
         {
             "type": "Microsoft.Web/sites",

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/pass2.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/pass2.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2021-02-01",
+            "name": "pass2",
+            "properties": {
+                "publisherEmail": "[parameters('adminEmail')]",
+                "publisherName": "[parameters('organizationName')]",
+                "customProperties": "[parameters('customProperties')]"
+            },
+            "site_config": {
+                "ftps_state": "FtpsOnly"
+            },
+            "resources": [],
+            "dependsOn": []
+        }
+    ]
+}

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/pass2.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/pass2.json
@@ -11,8 +11,8 @@
                 "publisherName": "[parameters('organizationName')]",
                 "customProperties": "[parameters('customProperties')]"
             },
-            "site_config": {
-                "ftps_state": "FtpsOnly"
+            "siteConfig": {
+                "ftpsState": "FtpsOnly"
             },
             "resources": [],
             "dependsOn": []

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/pass3.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/pass3.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2021-02-01",
+            "name": "pass3",
+            "properties": {
+                "publisherEmail": "[parameters('adminEmail')]",
+                "publisherName": "[parameters('organizationName')]",
+                "customProperties": "[parameters('customProperties')]"
+            },
+            "site_config": {
+                "ftps_state":"Disabled",
+                        "appSettings": [
+            {
+              "name": "WEBSITE_NODE_DEFAULT_VERSION",
+              "value": "14.17.0"
+            }
+
+          ],
+          "linuxFxVersion": "NODE|14-lts"
+            },
+            "resources": [],
+            "dependsOn": []
+        }
+    ]
+}

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/pass3.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/pass3.json
@@ -11,8 +11,8 @@
                 "publisherName": "[parameters('organizationName')]",
                 "customProperties": "[parameters('customProperties')]"
             },
-            "site_config": {
-                "ftps_state":"Disabled",
+            "siteConfig": {
+                "ftpsState":"Disabled",
                         "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",

--- a/tests/arm/checks/resource/example_AppServiceFTPSState/pass3.json
+++ b/tests/arm/checks/resource/example_AppServiceFTPSState/pass3.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
+    "contentVersion": "1.0.0.1",
     "resources": [
         {
             "type": "Microsoft.Web/sites",

--- a/tests/arm/checks/resource/example_MSSQLServerMinTLSVersion/fail.json
+++ b/tests/arm/checks/resource/example_MSSQLServerMinTLSVersion/fail.json
@@ -1,0 +1,246 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "apiVersion": {
+            "type": "string",
+            "defaultValue": "2021-05-01"
+        },
+        "administratorLogin": {
+            "type": "string"
+        },
+        "administratorLoginPassword": {
+            "type": "securestring"
+        },
+        "location": {
+            "type": "string"
+        },
+        "serverName": {
+            "type": "string"
+        },
+        "serverEdition": {
+            "type": "string"
+        },
+        "vCores": {
+            "type": "int",
+            "defaultValue": 4
+        },
+        "storageSizeGB": {
+            "type": "int"
+        },
+        "haEnabled": {
+            "type": "string",
+            "defaultValue": "Disabled"
+        },
+        "availabilityZone": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "standbyAvailabilityZone": {
+            "type": "string"
+        },
+        "version": {
+            "type": "string"
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "firewallRules": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "backupRetentionDays": {
+            "type": "int"
+        },
+        "geoRedundantBackup": {
+            "type": "string"
+        },
+        "vmName": {
+            "type": "string",
+            "defaultValue": "Standard_B1ms"
+        },
+        "storageIops": {
+            "type": "int"
+        },
+        "storageAutogrow": {
+            "type": "string",
+            "defaultValue": "Enabled"
+        },
+        "autoIoScaling": {
+            "type": "string",
+            "defaultValue": "Disabled"
+        },
+        "identityData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "dataEncryptionData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "serverParameters": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "aadEnabled": {
+            "type": "bool",
+            "defaultValue": false
+        },
+        "aadData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "guid": {
+            "type": "string",
+            "defaultValue": "[newGuid()]"
+        },
+        "network": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "firewallRulesAPIVersion": {
+            "type": "string",
+            "defaultValue": "2022-01-01"
+        }
+    },
+    "variables": {
+        "api": "[parameters('apiVersion')]",
+        "firewallRules": "[parameters('firewallRules').rules]",
+        "serverParameters": "[parameters('serverParameters')]"
+    },
+    "resources": [
+        {
+              "type": "Microsoft.Sql/servers",
+              "apiVersion": "2023-05-01-preview",
+              "name": "fail",
+              "location": "string",
+              "tags": {
+                "tagName1": "tagValue1",
+                "tagName2": "tagValue2"
+              },
+              "identity": {
+                "type": "string",
+                "userAssignedIdentities": {
+                  "{customized property}": {}
+                }
+              },
+              "properties": {
+                "administratorLogin": "string",
+                "administratorLoginPassword": "string",
+                "administrators": {
+                  "administratorType": "ActiveDirectory",
+                  "azureADOnlyAuthentication": "bool",
+                  "login": "string",
+                  "principalType": "string",
+                  "sid": "string",
+                  "tenantId": "string"
+                },
+                "federatedClientId": "string",
+                "isIPv6Enabled": "string",
+                "keyId": "string",
+                "minimalTlsVersion": "1.1",
+                "primaryUserAssignedIdentityId": "string",
+                "publicNetworkAccess": "string",
+                "restrictOutboundNetworkAccess": "string",
+                "version": "string"
+              }
+            },
+        {
+            "condition": "[greater(length(variables('firewallRules')), 0)]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "name": "[concat('firewallRules-', parameters('guid'), '-', copyIndex())]",
+            "copy": {
+                "count": "[if(greater(length(variables('firewallRules')), 0), length(variables('firewallRules')), 1)]",
+                "mode": "Serial",
+                "name": "firewallRulesIterator"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]",
+                "[concat('Microsoft.Resources/deployments/addAdmins-', parameters('guid'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/firewallRules",
+                            "name": "[concat(parameters('serverName'),'/',variables('firewallRules')[copyIndex()].name)]",
+                            "apiVersion": "[parameters('firewallRulesAPIVersion')]",
+                            "properties": {
+                                "StartIpAddress": "[variables('firewallRules')[copyIndex()].startIPAddress]",
+                                "EndIpAddress": "[variables('firewallRules')[copyIndex()].endIPAddress]"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "condition": "[parameters('aadEnabled')]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "name": "[concat('addAdmins-', parameters('guid'))]",
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/administrators",
+                            "name": "[concat(parameters('serverName'),'/ActiveDirectory')]",
+                            "apiVersion": "[variables('api')]",
+                            "properties": {
+                                "administratorType": "[parameters('aadData').administratorType]",
+                                "identityResourceId": "[parameters('aadData').identityResourceId]",
+                                "login": "[parameters('aadData').login]",
+                                "sid": "[parameters('aadData').sid]",
+                                "tenantId": "[parameters('aadData').tenantId]"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "condition": "[and(greater(length(variables('serverParameters')), 0), parameters('aadEnabled'))]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "copy": {
+                "count": "[if(greater(length(variables('serverParameters')), 0), length(variables('serverParameters')), 1)]",
+                "mode": "serial",
+                "name": "serverParametersIterator"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]",
+                "[concat('Microsoft.Resources/deployments/addAdmins-', parameters('guid'))]"
+            ],
+            "name": "[concat('serverParameters-', copyIndex(), '-', parameters('guid'))]",
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/configurations",
+                            "name": "[concat(parameters('serverName'),'/',variables('serverParameters')[copyIndex()].name)]",
+                            "apiVersion": "[variables('api')]",
+                            "properties": {
+                                "value": "[variables('serverParameters')[copyIndex()].value]",
+                                "source": "[variables('serverParameters')[copyIndex()].source]"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/tests/arm/checks/resource/example_MSSQLServerMinTLSVersion/pass.json
+++ b/tests/arm/checks/resource/example_MSSQLServerMinTLSVersion/pass.json
@@ -1,0 +1,246 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "apiVersion": {
+            "type": "string",
+            "defaultValue": "2021-05-01"
+        },
+        "administratorLogin": {
+            "type": "string"
+        },
+        "administratorLoginPassword": {
+            "type": "securestring"
+        },
+        "location": {
+            "type": "string"
+        },
+        "serverName": {
+            "type": "string"
+        },
+        "serverEdition": {
+            "type": "string"
+        },
+        "vCores": {
+            "type": "int",
+            "defaultValue": 4
+        },
+        "storageSizeGB": {
+            "type": "int"
+        },
+        "haEnabled": {
+            "type": "string",
+            "defaultValue": "Disabled"
+        },
+        "availabilityZone": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "standbyAvailabilityZone": {
+            "type": "string"
+        },
+        "version": {
+            "type": "string"
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "firewallRules": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "backupRetentionDays": {
+            "type": "int"
+        },
+        "geoRedundantBackup": {
+            "type": "string"
+        },
+        "vmName": {
+            "type": "string",
+            "defaultValue": "Standard_B1ms"
+        },
+        "storageIops": {
+            "type": "int"
+        },
+        "storageAutogrow": {
+            "type": "string",
+            "defaultValue": "Enabled"
+        },
+        "autoIoScaling": {
+            "type": "string",
+            "defaultValue": "Disabled"
+        },
+        "identityData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "dataEncryptionData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "serverParameters": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "aadEnabled": {
+            "type": "bool",
+            "defaultValue": false
+        },
+        "aadData": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "guid": {
+            "type": "string",
+            "defaultValue": "[newGuid()]"
+        },
+        "network": {
+            "type": "object",
+            "defaultValue": {}
+        },
+        "firewallRulesAPIVersion": {
+            "type": "string",
+            "defaultValue": "2022-01-01"
+        }
+    },
+    "variables": {
+        "api": "[parameters('apiVersion')]",
+        "firewallRules": "[parameters('firewallRules').rules]",
+        "serverParameters": "[parameters('serverParameters')]"
+    },
+    "resources": [
+        {
+              "type": "Microsoft.Sql/servers",
+              "apiVersion": "2023-05-01-preview",
+              "name": "pass",
+              "location": "string",
+              "tags": {
+                "tagName1": "tagValue1",
+                "tagName2": "tagValue2"
+              },
+              "identity": {
+                "type": "string",
+                "userAssignedIdentities": {
+                  "{customized property}": {}
+                }
+              },
+              "properties": {
+                "administratorLogin": "string",
+                "administratorLoginPassword": "string",
+                "administrators": {
+                  "administratorType": "ActiveDirectory",
+                  "azureADOnlyAuthentication": "bool",
+                  "login": "string",
+                  "principalType": "string",
+                  "sid": "string",
+                  "tenantId": "string"
+                },
+                "federatedClientId": "string",
+                "isIPv6Enabled": "string",
+                "keyId": "string",
+                "minimalTlsVersion": "1.2",
+                "primaryUserAssignedIdentityId": "string",
+                "publicNetworkAccess": "string",
+                "restrictOutboundNetworkAccess": "string",
+                "version": "string"
+              }
+            },
+        {
+            "condition": "[greater(length(variables('firewallRules')), 0)]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "name": "[concat('firewallRules-', parameters('guid'), '-', copyIndex())]",
+            "copy": {
+                "count": "[if(greater(length(variables('firewallRules')), 0), length(variables('firewallRules')), 1)]",
+                "mode": "Serial",
+                "name": "firewallRulesIterator"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]",
+                "[concat('Microsoft.Resources/deployments/addAdmins-', parameters('guid'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/firewallRules",
+                            "name": "[concat(parameters('serverName'),'/',variables('firewallRules')[copyIndex()].name)]",
+                            "apiVersion": "[parameters('firewallRulesAPIVersion')]",
+                            "properties": {
+                                "StartIpAddress": "[variables('firewallRules')[copyIndex()].startIPAddress]",
+                                "EndIpAddress": "[variables('firewallRules')[copyIndex()].endIPAddress]"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "condition": "[parameters('aadEnabled')]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "name": "[concat('addAdmins-', parameters('guid'))]",
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/administrators",
+                            "name": "[concat(parameters('serverName'),'/ActiveDirectory')]",
+                            "apiVersion": "[variables('api')]",
+                            "properties": {
+                                "administratorType": "[parameters('aadData').administratorType]",
+                                "identityResourceId": "[parameters('aadData').identityResourceId]",
+                                "login": "[parameters('aadData').login]",
+                                "sid": "[parameters('aadData').sid]",
+                                "tenantId": "[parameters('aadData').tenantId]"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "condition": "[and(greater(length(variables('serverParameters')), 0), parameters('aadEnabled'))]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "copy": {
+                "count": "[if(greater(length(variables('serverParameters')), 0), length(variables('serverParameters')), 1)]",
+                "mode": "serial",
+                "name": "serverParametersIterator"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('serverName'))]",
+                "[concat('Microsoft.Resources/deployments/addAdmins-', parameters('guid'))]"
+            ],
+            "name": "[concat('serverParameters-', copyIndex(), '-', parameters('guid'))]",
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.DBforMySQL/flexibleServers/configurations",
+                            "name": "[concat(parameters('serverName'),'/',variables('serverParameters')[copyIndex()].name)]",
+                            "apiVersion": "[variables('api')]",
+                            "properties": {
+                                "value": "[variables('serverParameters')[copyIndex()].value]",
+                                "source": "[variables('serverParameters')[copyIndex()].source]"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/tests/arm/checks/resource/test_AppServiceFTPSState.py
+++ b/tests/arm/checks/resource/test_AppServiceFTPSState.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.arm.runner import Runner
+from checkov.arm.checks.resource.AppServiceFTPSState import check
+
+
+class TestAppServiceFTPSState(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AppServiceFTPSState")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'Microsoft.Web/sites.pass',
+            'Microsoft.Web/sites.pass2',
+            'Microsoft.Web/sites.pass3',
+        }
+        failing_resources = {
+            'Microsoft.Web/sites.fail',
+            'Microsoft.Web/sites.fail2',
+            'Microsoft.Web/sites.fail3',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/arm/checks/resource/test_AppServiceFTPSState.py
+++ b/tests/arm/checks/resource/test_AppServiceFTPSState.py
@@ -1,5 +1,5 @@
-import os
 import unittest
+import os
 
 from checkov.runner_filter import RunnerFilter
 from checkov.arm.runner import Runner

--- a/tests/arm/checks/resource/test_MSSQLServerMinTLSVersion.py
+++ b/tests/arm/checks/resource/test_MSSQLServerMinTLSVersion.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+
+from checkov.arm.checks.resource.MSSQLServerMinTLSVersion import check
+from checkov.arm.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestMSSQLServerMinTLSVersion(unittest.TestCase):
+
+    def test_summary(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_MSSQLServerMinTLSVersion"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "Microsoft.Sql/servers.pass"
+        }
+
+        failing_resources = {
+            "Microsoft.Sql/servers.fail"
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertSetEqual(passing_resources, passed_check_resources)
+        self.assertSetEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

adds a AppServiceFTPSState





### Description
The function returns the "siteConfig/ftpsState" key, which is used to determine the FTPS state within the Azure Web App resource.
### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
