### PR TITLE
feat(azure): drop support for dotnet v7.0

### DIFF
--- a/checkov/arm/checks/resource/AppServiceDotnetFrameworkVersion.py
+++ b/checkov/arm/checks/resource/AppServiceDotnetFrameworkVersion.py
@@ -14,7 +14,7 @@ class AppServiceDotnetFrameworkVersion(BaseResourceValueCheck):
         return "properties/netFrameworkVersion"
 
     def get_expected_value(self) -> str:
-        return "v7.0"
+        return "v8.0"
 
 
 check = AppServiceDotnetFrameworkVersion()

--- a/checkov/terraform/checks/resource/azure/AppServiceDotnetFrameworkVersion.py
+++ b/checkov/terraform/checks/resource/azure/AppServiceDotnetFrameworkVersion.py
@@ -21,14 +21,14 @@ class AppServiceDotnetFrameworkVersion(BaseResourceCheck):
             if site_config.get('application_stack') and isinstance(site_config.get('application_stack'), list):
                 stack = site_config.get('application_stack')[0]
                 if stack.get('dotnet_version') and isinstance(stack.get('dotnet_version'), list):
-                    if stack.get('dotnet_version')[0] == "v7.0":
+                    if stack.get('dotnet_version')[0] == "v8.0":
                         return CheckResult.PASSED
                     return CheckResult.FAILED
 
         return CheckResult.UNKNOWN
 
     def get_expected_values(self) -> List[str]:
-        return ["v6.0", "v7.0"]
+        return ["v6.0", "v8.0"]
 
 
 check = AppServiceDotnetFrameworkVersion()

--- a/tests/arm/checks/resource/example_AppServiceDotnetFrameworkVersion/passed.json
+++ b/tests/arm/checks/resource/example_AppServiceDotnetFrameworkVersion/passed.json
@@ -111,7 +111,7 @@
                     "index.php",
                     "hostingstart.html"
                 ],
-                "netFrameworkVersion": "v7.0",
+                "netFrameworkVersion": "v8.0",
                 "phpVersion": "5.6",
                 "requestTracingEnabled": true,
                 "requestTracingExpirationTime": "9999-12-31T23:59:00Z",

--- a/tests/terraform/checks/resource/azure/example_AppServiceDotnetFrameworkVersion/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AppServiceDotnetFrameworkVersion/main.tf
@@ -74,7 +74,7 @@ resource "azurerm_windows_web_app" "pass" {
     http2_enabled     = true
     health_check_path = var.health_check_path
     application_stack {
-      dotnet_version = "v7.0"
+      dotnet_version = "v8.0"
     }
   }
 


### PR DESCRIPTION
This PR drops support for dotnet v7.0 in our azure checks and switches to v8.0.

## Description

Fixes #6343


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
