### PR TITLE
feat(arm): add CKV_AZURE_168 to ensure that Azure Kubernetes Cluster (AKS) nodes should use a minimum number of 50 pods

### DIFF
--- a/checkov/arm/checks/resource/AKSMaxPodsMinimum.py
+++ b/checkov/arm/checks/resource/AKSMaxPodsMinimum.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from typing import Any
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.arm.base_resource_check import BaseResourceCheck
+from typing import Optional
+
+
+class AKSMaxPodsMinimum(BaseResourceCheck):
+    def __init__(self) -> None:
+        name = "Ensure Azure Kubernetes Cluster (AKS) nodes should use a minimum number of 50 pods."
+        id = "CKV_AZURE_168"
+        supported_resources = ("Microsoft.ContainerService/managedClusters",
+                               "Microsoft.ContainerService/managedClusters/agentPools", )
+        categories = (CheckCategories.KUBERNETES,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,)
+
+    def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:
+        max_pods: Optional[int] = 30
+
+        properties = conf.get("properties")
+        if properties and isinstance(properties, dict):
+            max_pods = properties.get("maxPods")
+
+        if "agentPoolProfiles" in properties:
+            if "maxPods" in properties["agentPoolProfiles"][0]:
+                max_pods = properties["agentPoolProfiles"][0]["maxPods"]
+
+        if max_pods is None or max_pods < 50:
+            return CheckResult.FAILED
+
+        return CheckResult.PASSED
+
+
+check = AKSMaxPodsMinimum()

--- a/tests/arm/checks/resource/example_AKSMaxPodsMinimum/agentPoolProfiles_with_maxPods_fail4.json
+++ b/tests/arm/checks/resource/example_AKSMaxPodsMinimum/agentPoolProfiles_with_maxPods_fail4.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.5.6.12127",
+      "templateHash": "12705365244308198684"
+    }
+  },
+  "parameters": {
+    "aksClusterName": {
+      "type": "string",
+      "defaultValue": "aks101cluster-vmss",
+      "metadata": {
+        "description": "The name of the Managed Cluster resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of AKS resource."
+      }
+    },
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
+      }
+    },
+    "osDiskSizeGB": {
+      "type": "int",
+      "defaultValue": 0,
+      "maxValue": 1023,
+      "minValue": 0,
+      "metadata": {
+        "description": "Disk size (in GiB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
+      }
+    },
+    "agentCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "maxValue": 100,
+      "minValue": 1,
+      "metadata": {
+        "description": "The number of nodes for the cluster. 1 Node is enough for Dev/Test and minimum 3 nodes, is recommended for Production"
+      }
+    },
+    "agentVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2s_v3",
+      "metadata": {
+        "description": "The size of the Virtual Machine."
+      }
+    },
+    "osType": {
+      "type": "string",
+      "defaultValue": "Linux",
+      "allowedValues": [
+        "Linux",
+        "Windows"
+      ],
+      "metadata": {
+        "description": "The type of operating system."
+      }
+    }
+  },
+  "resources": [
+             {
+            "type": "Microsoft.ContainerService/managedClusters",
+            "apiVersion": "2020-03-01",
+            "name": "agentPoolProfiles_with_maxPods_fail4",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "Basic",
+                "tier": "Free"
+            },
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "kubernetesVersion": "[parameters('kubernetesVersion')]",
+                "dnsPrefix": "[variables('dnsPrefix')]",
+                "agentPoolProfiles":[
+                    {
+                        "name": "agentpool",
+                        "count": 3,
+                        "vmSize": "[parameters('agentVMSize')]",
+                        "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+                        "maxPods": 28,
+                        "type": "VirtualMachineScaleSets",
+                        "orchestratorVersion": "[parameters('kubernetesVersion')]",
+                        "mode": "System",
+                        "osType": "Linux"
+                    }
+                  ]
+                ,
+                "linuxProfile": {
+                    "adminUsername": "[parameters('linuxAdminUsername')]",
+                    "ssh": {
+                        "publicKeys": [
+                            {
+                                "keyData": "[parameters('sshRSAPublicKey')]"
+                            }
+                        ]
+                    }
+                },
+                "servicePrincipalProfile": {
+                    "clientId": "msi"
+                },
+                "nodeResourceGroup": "[concat('MC_', resourceGroup().name,'_', parameters('clusterName'), '_',parameters('location'))]",
+                "enableRBAC": true,
+                "networkProfile": {
+                    "networkPlugin": "kubenet",
+                    "loadBalancerSku": "Basic",
+                    "podCidr": "[parameters('podCidr')]",
+                    "serviceCidr": "[parameters('serviceCidr')]",
+                    "dnsServiceIP": "[parameters('dnsServiceIP')]",
+                    "dockerBridgeCidr": "[parameters('dockerBridgeCidr')]",
+                    "outboundType": "loadBalancer"
+                }
+            }
+        }
+
+
+  ],
+  "outputs": {
+    "controlPlaneFQDN": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName'))).fqdn]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/example_AKSMaxPodsMinimum/agentPoolProfiles_with_maxPods_pass.json
+++ b/tests/arm/checks/resource/example_AKSMaxPodsMinimum/agentPoolProfiles_with_maxPods_pass.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.5.6.12127",
+      "templateHash": "12705365244308198684"
+    }
+  },
+  "parameters": {
+    "aksClusterName": {
+      "type": "string",
+      "defaultValue": "aks101cluster-vmss",
+      "metadata": {
+        "description": "The name of the Managed Cluster resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of AKS resource."
+      }
+    },
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
+      }
+    },
+    "osDiskSizeGB": {
+      "type": "int",
+      "defaultValue": 0,
+      "maxValue": 1023,
+      "minValue": 0,
+      "metadata": {
+        "description": "Disk size (in GiB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
+      }
+    },
+    "agentCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "maxValue": 100,
+      "minValue": 1,
+      "metadata": {
+        "description": "The number of nodes for the cluster. 1 Node is enough for Dev/Test and minimum 3 nodes, is recommended for Production"
+      }
+    },
+    "agentVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2s_v3",
+      "metadata": {
+        "description": "The size of the Virtual Machine."
+      }
+    },
+    "osType": {
+      "type": "string",
+      "defaultValue": "Linux",
+      "allowedValues": [
+        "Linux",
+        "Windows"
+      ],
+      "metadata": {
+        "description": "The type of operating system."
+      }
+    }
+  },
+  "resources": [
+
+              {
+            "type": "Microsoft.ContainerService/managedClusters",
+            "apiVersion": "2020-03-01",
+            "name": "agentPoolProfiles_with_maxPods_pass",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "Basic",
+                "tier": "Free"
+            },
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "kubernetesVersion": "[parameters('kubernetesVersion')]",
+                "dnsPrefix": "[variables('dnsPrefix')]",
+                "agentPoolProfiles":[
+                    {
+                        "name": "agentpool",
+                        "count": 3,
+                        "vmSize": "[parameters('agentVMSize')]",
+                        "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+                        "maxPods": 51,
+                        "type": "VirtualMachineScaleSets",
+                        "orchestratorVersion": "[parameters('kubernetesVersion')]",
+                        "mode": "System",
+                        "osType": "Linux"
+                    }
+                  ],
+                "linuxProfile": {
+                    "adminUsername": "[parameters('linuxAdminUsername')]",
+                    "ssh": {
+                        "publicKeys": [
+                            {
+                                "keyData": "[parameters('sshRSAPublicKey')]"
+                            }
+                        ]
+                    }
+                },
+                "servicePrincipalProfile": {
+                    "clientId": "msi"
+                },
+                "nodeResourceGroup": "[concat('MC_', resourceGroup().name,'_', parameters('clusterName'), '_',parameters('location'))]",
+                "enableRBAC": true,
+                "networkProfile": {
+                    "networkPlugin": "kubenet",
+                    "loadBalancerSku": "Basic",
+                    "podCidr": "[parameters('podCidr')]",
+                    "serviceCidr": "[parameters('serviceCidr')]",
+                    "dnsServiceIP": "[parameters('dnsServiceIP')]",
+                    "dockerBridgeCidr": "[parameters('dockerBridgeCidr')]",
+                    "outboundType": "loadBalancer"
+                }
+            }
+        }
+  ],
+  "outputs": {
+    "controlPlaneFQDN": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName'))).fqdn]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/example_AKSMaxPodsMinimum/agentPoolProfiles_without_maxPods_fail3.json
+++ b/tests/arm/checks/resource/example_AKSMaxPodsMinimum/agentPoolProfiles_without_maxPods_fail3.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.5.6.12127",
+      "templateHash": "12705365244308198684"
+    }
+  },
+  "parameters": {
+    "aksClusterName": {
+      "type": "string",
+      "defaultValue": "aks101cluster-vmss",
+      "metadata": {
+        "description": "The name of the Managed Cluster resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of AKS resource."
+      }
+    },
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
+      }
+    },
+    "osDiskSizeGB": {
+      "type": "int",
+      "defaultValue": 0,
+      "maxValue": 1023,
+      "minValue": 0,
+      "metadata": {
+        "description": "Disk size (in GiB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
+      }
+    },
+    "agentCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "maxValue": 100,
+      "minValue": 1,
+      "metadata": {
+        "description": "The number of nodes for the cluster. 1 Node is enough for Dev/Test and minimum 3 nodes, is recommended for Production"
+      }
+    },
+    "agentVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2s_v3",
+      "metadata": {
+        "description": "The size of the Virtual Machine."
+      }
+    },
+    "osType": {
+      "type": "string",
+      "defaultValue": "Linux",
+      "allowedValues": [
+        "Linux",
+        "Windows"
+      ],
+      "metadata": {
+        "description": "The type of operating system."
+      }
+    }
+  },
+  "resources": [
+              {
+            "type": "Microsoft.ContainerService/managedClusters",
+            "apiVersion": "2020-03-01",
+            "name": "agentPoolProfiles_without_maxPods_fail3",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "Basic",
+                "tier": "Free"
+            },
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "kubernetesVersion": "[parameters('kubernetesVersion')]",
+                "dnsPrefix": "[variables('dnsPrefix')]",
+                "agentPoolProfiles":[
+                    {
+                        "name": "agentpool",
+                        "count": 3,
+                        "vmSize": "[parameters('agentVMSize')]",
+                        "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+                        "type": "VirtualMachineScaleSets",
+                        "orchestratorVersion": "[parameters('kubernetesVersion')]",
+                        "mode": "System",
+                        "osType": "Linux"
+                    }
+                  ]
+                ,
+                "linuxProfile": {
+                    "adminUsername": "[parameters('linuxAdminUsername')]",
+                    "ssh": {
+                        "publicKeys": [
+                            {
+                                "keyData": "[parameters('sshRSAPublicKey')]"
+                            }
+                        ]
+                    }
+                },
+                "servicePrincipalProfile": {
+                    "clientId": "msi"
+                },
+                "nodeResourceGroup": "[concat('MC_', resourceGroup().name,'_', parameters('clusterName'), '_',parameters('location'))]",
+                "enableRBAC": true,
+                "networkProfile": {
+                    "networkPlugin": "kubenet",
+                    "loadBalancerSku": "Basic",
+                    "podCidr": "[parameters('podCidr')]",
+                    "serviceCidr": "[parameters('serviceCidr')]",
+                    "dnsServiceIP": "[parameters('dnsServiceIP')]",
+                    "dockerBridgeCidr": "[parameters('dockerBridgeCidr')]",
+                    "outboundType": "loadBalancer"
+                }
+            }
+        }
+
+
+  ],
+  "outputs": {
+    "controlPlaneFQDN": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName'))).fqdn]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/example_AKSMaxPodsMinimum/properties_with_maxPods_fail2.json
+++ b/tests/arm/checks/resource/example_AKSMaxPodsMinimum/properties_with_maxPods_fail2.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.5.6.12127",
+      "templateHash": "12705365244308198684"
+    }
+  },
+  "parameters": {
+    "aksClusterName": {
+      "type": "string",
+      "defaultValue": "aks101cluster-vmss",
+      "metadata": {
+        "description": "The name of the Managed Cluster resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of AKS resource."
+      }
+    },
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
+      }
+    },
+    "osDiskSizeGB": {
+      "type": "int",
+      "defaultValue": 0,
+      "maxValue": 1023,
+      "minValue": 0,
+      "metadata": {
+        "description": "Disk size (in GiB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
+      }
+    },
+    "agentCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "maxValue": 100,
+      "minValue": 1,
+      "metadata": {
+        "description": "The number of nodes for the cluster. 1 Node is enough for Dev/Test and minimum 3 nodes, is recommended for Production"
+      }
+    },
+    "agentVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2s_v3",
+      "metadata": {
+        "description": "The size of the Virtual Machine."
+      }
+    },
+    "osType": {
+      "type": "string",
+      "defaultValue": "Linux",
+      "allowedValues": [
+        "Linux",
+        "Windows"
+      ],
+      "metadata": {
+        "description": "The type of operating system."
+      }
+    }
+  },
+  "resources": [
+      {
+            "type": "Microsoft.ContainerService/managedClusters/agentPools",
+            "apiVersion": "2020-03-01",
+            "name": "properties_with_maxPods_fail2",
+            "dependsOn": [
+                "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName'))]"
+            ],
+            "properties": {
+                "count": "[parameters('agentCount')]",
+                "vmSize": "[parameters('agentVMSize')]",
+                "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+                "maxPods": 33,
+                "type": "VirtualMachineScaleSets",
+                "orchestratorVersion": "[parameters('kubernetesVersion')]",
+                "mode": "System",
+                "osType": "Linux"
+            }
+        }
+
+
+  ],
+  "outputs": {
+    "controlPlaneFQDN": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName'))).fqdn]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/example_AKSMaxPodsMinimum/properties_with_maxPods_pass1.json
+++ b/tests/arm/checks/resource/example_AKSMaxPodsMinimum/properties_with_maxPods_pass1.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.5.6.12127",
+      "templateHash": "12705365244308198684"
+    }
+  },
+  "parameters": {
+    "aksClusterName": {
+      "type": "string",
+      "defaultValue": "aks101cluster-vmss",
+      "metadata": {
+        "description": "The name of the Managed Cluster resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of AKS resource."
+      }
+    },
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
+      }
+    },
+    "osDiskSizeGB": {
+      "type": "int",
+      "defaultValue": 0,
+      "maxValue": 1023,
+      "minValue": 0,
+      "metadata": {
+        "description": "Disk size (in GiB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
+      }
+    },
+    "agentCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "maxValue": 100,
+      "minValue": 1,
+      "metadata": {
+        "description": "The number of nodes for the cluster. 1 Node is enough for Dev/Test and minimum 3 nodes, is recommended for Production"
+      }
+    },
+    "agentVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2s_v3",
+      "metadata": {
+        "description": "The size of the Virtual Machine."
+      }
+    },
+    "osType": {
+      "type": "string",
+      "defaultValue": "Linux",
+      "allowedValues": [
+        "Linux",
+        "Windows"
+      ],
+      "metadata": {
+        "description": "The type of operating system."
+      }
+    }
+  },
+  "resources": [
+    {
+            "type": "Microsoft.ContainerService/managedClusters/agentPools",
+            "apiVersion": "2020-03-01",
+            "name": "properties_with_maxPods_pass1",
+            "dependsOn": [
+                "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName'))]"
+            ],
+            "properties": {
+                "count": "[parameters('agentCount')]",
+                "vmSize": "[parameters('agentVMSize')]",
+                "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+                "type": "VirtualMachineScaleSets",
+                "orchestratorVersion": "[parameters('kubernetesVersion')]",
+                "mode": "System",
+                "osType": "Linux",
+                "maxPods": 51
+            }
+        }
+
+  ],
+  "outputs": {
+    "controlPlaneFQDN": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName'))).fqdn]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/example_AKSMaxPodsMinimum/properties_without_maxPods_fail.json
+++ b/tests/arm/checks/resource/example_AKSMaxPodsMinimum/properties_without_maxPods_fail.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.5.6.12127",
+      "templateHash": "12705365244308198684"
+    }
+  },
+  "parameters": {
+    "aksClusterName": {
+      "type": "string",
+      "defaultValue": "aks101cluster-vmss",
+      "metadata": {
+        "description": "The name of the Managed Cluster resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of AKS resource."
+      }
+    },
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
+      }
+    },
+    "osDiskSizeGB": {
+      "type": "int",
+      "defaultValue": 0,
+      "maxValue": 1023,
+      "minValue": 0,
+      "metadata": {
+        "description": "Disk size (in GiB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
+      }
+    },
+    "agentCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "maxValue": 100,
+      "minValue": 1,
+      "metadata": {
+        "description": "The number of nodes for the cluster. 1 Node is enough for Dev/Test and minimum 3 nodes, is recommended for Production"
+      }
+    },
+    "agentVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2s_v3",
+      "metadata": {
+        "description": "The size of the Virtual Machine."
+      }
+    },
+    "osType": {
+      "type": "string",
+      "defaultValue": "Linux",
+      "allowedValues": [
+        "Linux",
+        "Windows"
+      ],
+      "metadata": {
+        "description": "The type of operating system."
+      }
+    }
+  },
+  "resources": [
+        {
+            "type": "Microsoft.ContainerService/managedClusters/agentPools",
+            "apiVersion": "2020-03-01",
+            "name": "properties_without_maxPods_fail",
+            "dependsOn": [
+                "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName'))]"
+            ],
+            "properties": {
+                "count": "[parameters('agentCount')]",
+                "vmSize": "[parameters('agentVMSize')]",
+                "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+                "type": "VirtualMachineScaleSets",
+                "orchestratorVersion": "[parameters('kubernetesVersion')]",
+                "mode": "System",
+                "osType": "Linux"
+            }
+        }
+
+
+  ],
+  "outputs": {
+    "controlPlaneFQDN": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName'))).fqdn]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/test_AKSMaxPodsMinimum.py
+++ b/tests/arm/checks/resource/test_AKSMaxPodsMinimum.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+from checkov.runner_filter import RunnerFilter
+from checkov.arm.runner import Runner
+from checkov.arm.checks.resource.AKSMaxPodsMinimum import check
+
+
+class TestAKSMaxPodsMinimum(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_AKSMaxPodsMinimum"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "Microsoft.ContainerService/managedClusters.agentPoolProfiles_with_maxPods_pass",
+            "Microsoft.ContainerService/managedClusters/agentPools.properties_with_maxPods_pass1"
+        }
+        failing_resources = {
+            "Microsoft.ContainerService/managedClusters.agentPoolProfiles_with_maxPods_fail4",
+            "Microsoft.ContainerService/managedClusters.agentPoolProfiles_without_maxPods_fail3",
+            "Microsoft.ContainerService/managedClusters/agentPools.properties_with_maxPods_fail2",
+            "Microsoft.ContainerService/managedClusters/agentPools.properties_without_maxPods_fail",
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

added a new arm policy to ensure that Azure Kubernetes Cluster (AKS) nodes should use a minimum number of 50 pods

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
