### PR TITLE
feat(arm): Add check for AzureML workspace not configured with private endpoint

### DIFF
--- a/checkov/arm/checks/resource/AzureMLWorkspacePrivateEndpoint.py
+++ b/checkov/arm/checks/resource/AzureMLWorkspacePrivateEndpoint.py
@@ -2,6 +2,7 @@ from typing import Dict, Any
 
 from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.arm.base_resource_check import BaseResourceCheck
+from checkov.common.util.consts import START_LINE, END_LINE
 
 
 class AzureMLWorkspacePrivateEndpoint(BaseResourceCheck):
@@ -20,7 +21,10 @@ class AzureMLWorkspacePrivateEndpoint(BaseResourceCheck):
                 ob_rules = managed_network.get("outboundRules")
                 if isinstance(ob_rules, dict):
                     # check no outbound rule has private endpoint type
-                    for rule in ob_rules.values():
+                    for key, rule in ob_rules.items():
+                        if key in [START_LINE, END_LINE]:
+                            # Skip inner fields we add
+                            continue
                         if rule.get("type") == "PrivateEndpoint":
                             return CheckResult.FAILED
         return CheckResult.PASSED

--- a/checkov/arm/checks/resource/AzureMLWorkspacePrivateEndpoint.py
+++ b/checkov/arm/checks/resource/AzureMLWorkspacePrivateEndpoint.py
@@ -1,10 +1,10 @@
 from typing import Dict, Any
 
 from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+from checkov.arm.base_resource_check import BaseResourceCheck
 
 
-class AzureMLWorkspacePrivateEndpoint(BaseResourceValueCheck):
+class AzureMLWorkspacePrivateEndpoint(BaseResourceCheck):
     def __init__(self) -> None:
         name = "Ensure Azure Machine learning workspace is not configured with private endpoint"
         id = "CKV_AZURE_239"

--- a/checkov/arm/checks/resource/AzureMLWorkspacePrivateEndpoint.py
+++ b/checkov/arm/checks/resource/AzureMLWorkspacePrivateEndpoint.py
@@ -1,0 +1,29 @@
+from typing import Dict, Any
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+
+
+class AzureMLWorkspacePrivateEndpoint(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure Azure Machine learning workspace is not configured with private endpoint"
+        id = "CKV_AZURE_239"
+        supported_resources = ["Microsoft.MachineLearningServices/workspaces"]
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: Dict[str, Any]) -> CheckResult:
+        properties = conf.get("properties")
+        if isinstance(properties, dict):
+            managed_network = properties.get("managedNetwork")
+            if isinstance(managed_network, dict):
+                ob_rules = managed_network.get("outboundRules")
+                if isinstance(ob_rules, dict):
+                    # check no outbound rule has private endpoint type
+                    for rule in ob_rules.values():
+                        if rule.get("type") == "PrivateEndpoint":
+                            return CheckResult.FAILED
+        return CheckResult.PASSED
+
+
+check = AzureMLWorkspacePrivateEndpoint()

--- a/tests/arm/checks/resource/example_AzureMLWorkspacePrivateEndpoint/fail.json
+++ b/tests/arm/checks/resource/example_AzureMLWorkspacePrivateEndpoint/fail.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+      {
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "apiVersion": "2022-12-01",
+        "name": "fail1",
+        "location": "West US",
+        "properties": {
+          "managedNetwork": {
+            "outboundRules": {
+                "rule1": {
+                    "type": "PrivateEndpoint"
+                }
+            }
+          }
+        }
+      }
+    ]
+  }

--- a/tests/arm/checks/resource/example_AzureMLWorkspacePrivateEndpoint/fail2.json
+++ b/tests/arm/checks/resource/example_AzureMLWorkspacePrivateEndpoint/fail2.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+      {
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "apiVersion": "2022-12-01",
+        "name": "fail2",
+        "location": "West US",
+        "properties": {
+          "managedNetwork": {
+            "outboundRules": {
+                "rule1": {
+                    "type": "ServiceTag"
+                },
+                "rule2": {
+                  "type": "PrivateEndpoint"
+              }
+            }
+          }
+        }
+      }
+    ]
+  }

--- a/tests/arm/checks/resource/example_AzureMLWorkspacePrivateEndpoint/pass.json
+++ b/tests/arm/checks/resource/example_AzureMLWorkspacePrivateEndpoint/pass.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+      {
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "apiVersion": "2022-12-01",
+        "name": "pass1",
+        "location": "West US",
+        "properties": {
+          "managedNetwork": {
+            "outboundRules": {
+                "rule1": {
+                    "type": "ServiceTag"
+                }
+            }
+          }
+        }
+      }
+    ]
+  }

--- a/tests/arm/checks/resource/example_AzureMLWorkspacePrivateEndpoint/pass2.json
+++ b/tests/arm/checks/resource/example_AzureMLWorkspacePrivateEndpoint/pass2.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+      {
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "apiVersion": "2022-12-01",
+        "name": "pass2",
+        "location": "West US",
+        "properties": {
+            "description": "No netowks"
+
+        }
+      }
+    ]
+  }

--- a/tests/arm/checks/resource/test_AzureMLWorkspacePrivateEndpoint.py
+++ b/tests/arm/checks/resource/test_AzureMLWorkspacePrivateEndpoint.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+
+from checkov.arm.checks.resource.AzureMLWorkspacePrivateEndpoint import check
+from checkov.arm.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestAzureMLWorkspacePrivateEndpoint(unittest.TestCase):
+    def test_summary(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_AzureMLWorkspacePrivateEndpoint"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "Microsoft.MachineLearningServices/workspaces.pass1",
+            "Microsoft.MachineLearningServices/workspaces.pass2"
+        }
+        failing_resources = {
+            "Microsoft.MachineLearningServices/workspaces.fail1",
+            "Microsoft.MachineLearningServices/workspaces.fail2",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/arm/checks/resource/test_AzureMLWorkspacePrivateEndpoint.py
+++ b/tests/arm/checks/resource/test_AzureMLWorkspacePrivateEndpoint.py
@@ -29,8 +29,8 @@ class TestAzureMLWorkspacePrivateEndpoint(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
- Add new policy to Ensure Azure Machine learning workspace is not configured with private endpoint

Fixes # (issue)

## New/Edited policies (Delete if not relevant)
- ckv_azure_239

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
