### PR TITLE
feat(secrets): Add _prioritise_secrets by 3 levels of severity

### DIFF
--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -73,8 +73,8 @@ SECRET_TYPE_TO_ID = {
     'Hex High Entropy String': 'CKV_SECRET_19'
 }
 
-ENTROPY_CHECK_IDS = ('CKV_SECRET_6', 'CKV_SECRET_19', 'CKV_SECRET_80')
-GENERIC_PRIVATE_KEY_CHECK_IDS = ('CKV_SECRET_10', 'CKV_SECRET_13')
+ENTROPY_CHECK_IDS = {'CKV_SECRET_6', 'CKV_SECRET_19', 'CKV_SECRET_80'}
+GENERIC_PRIVATE_KEY_CHECK_IDS = {'CKV_SECRET_10', 'CKV_SECRET_13'}
 
 CHECK_ID_TO_SECRET_TYPE = {v: k for k, v in SECRET_TYPE_TO_ID.items()}
 
@@ -325,7 +325,7 @@ class Runner(BaseRunner[None, None, None]):
             secret_records.pop(secret_key)
             return True
         if secret_records[secret_key].check_id in GENERIC_PRIVATE_KEY_CHECK_IDS:
-            if check_id not in GENERIC_PRIVATE_KEY_CHECK_IDS + ENTROPY_CHECK_IDS:
+            if check_id not in GENERIC_PRIVATE_KEY_CHECK_IDS | ENTROPY_CHECK_IDS:
                 secret_records.pop(secret_key)
                 return True
         return False

--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -74,6 +74,7 @@ SECRET_TYPE_TO_ID = {
 }
 
 ENTROPY_CHECK_IDS = ('CKV_SECRET_6', 'CKV_SECRET_19', 'CKV_SECRET_80')
+GENERIC_PRIVATE_KEY_CHECK_IDS = ('CKV_SECRET_10', 'CKV_SECRET_13')
 
 CHECK_ID_TO_SECRET_TYPE = {v: k for k, v in SECRET_TYPE_TO_ID.items()}
 
@@ -244,9 +245,8 @@ class Runner(BaseRunner[None, None, None]):
                         f"Removing secret due to UUID filtering: {hashlib.sha256(secret.secret_value.encode('utf-8')).hexdigest()}")
                     continue
                 if secret_key in secret_records.keys():
-                    if secret_records[secret_key].check_id in ENTROPY_CHECK_IDS and check_id not in ENTROPY_CHECK_IDS:
-                        secret_records.pop(secret_key)
-                    else:
+                    is_prioritise = self._prioritise_secrets(secret_records, secret_key, check_id)
+                    if not is_prioritise:
                         continue
                 bc_check_id = metadata_integration.get_bc_id(check_id)
                 if bc_check_id in secret_suppressions_id:
@@ -318,6 +318,17 @@ class Runner(BaseRunner[None, None, None]):
             if runner_filter.skip_invalid_secrets:
                 self._modify_invalid_secrets_check_result_to_skipped(report)
             return report
+
+    @staticmethod
+    def _prioritise_secrets(secret_records: Dict[str, SecretsRecord], secret_key: str, check_id: str) -> bool:
+        if secret_records[secret_key].check_id in ENTROPY_CHECK_IDS and check_id not in ENTROPY_CHECK_IDS:
+            secret_records.pop(secret_key)
+            return True
+        if secret_records[secret_key].check_id in GENERIC_PRIVATE_KEY_CHECK_IDS:
+            if check_id not in GENERIC_PRIVATE_KEY_CHECK_IDS + ENTROPY_CHECK_IDS:
+                secret_records.pop(secret_key)
+                return True
+        return False
 
     def cleanup_plugin_files(
             self,

--- a/tests/secrets/test_prioritise_secrets.py
+++ b/tests/secrets/test_prioritise_secrets.py
@@ -1,0 +1,54 @@
+import unittest
+
+from checkov.common.models.enums import CheckResult
+from checkov.common.output.secrets_record import SecretsRecord
+from checkov.secrets.runner import Runner, ENTROPY_CHECK_IDS, GENERIC_PRIVATE_KEY_CHECK_IDS
+
+
+class TestPrioritiseSecrets(unittest.TestCase):
+    def setUp(self):
+        self.secret_records = {
+            'key1': SecretsRecord(check_id='CKV_SECRET_6', check_name='foo',
+                                  check_result={"result": CheckResult.FAILED}, code_block=[(1, 'baz')],
+                                  file_path='qux', file_line_range=[1, 2], resource='resource', evaluations=None,
+                                  check_class='CheckClass', file_abs_path='abs_path'),
+            'key2': SecretsRecord(check_id='CKV_SECRET_10', check_name='foo',
+                                  check_result={"result": CheckResult.FAILED},
+                                  code_block=[(1, 'baz')], file_path='qux', file_line_range=[1, 2], resource='resource',
+                                  evaluations=None, check_class='CheckClass', file_abs_path='abs_path'),
+            'key3': SecretsRecord(check_id='CKV_SECRET_18', check_name='foo',
+                                  check_result={"result": CheckResult.FAILED}, code_block=[(1, 'baz')],
+                                  file_path='qux', file_line_range=[1, 2], resource='resource', evaluations=None,
+                                  check_class='CheckClass', file_abs_path='abs_path'),
+        }
+        self.ENTROPY_CHECK_IDS = ENTROPY_CHECK_IDS
+        self.GENERIC_PRIVATE_KEY_CHECK_IDS = GENERIC_PRIVATE_KEY_CHECK_IDS
+
+    def test_entropy_check_id_removed(self):
+        result = Runner._prioritise_secrets(self.secret_records, 'key1', 'CKV_SECRET_18')
+        self.assertTrue(result)
+        self.assertNotIn('key1', self.secret_records)
+
+    def test_generic_private_key_check_id_removed(self):
+        result = Runner._prioritise_secrets(self.secret_records, 'key2', 'CKV_SECRET_18')
+        self.assertTrue(result)
+        self.assertNotIn('key2', self.secret_records)
+
+    def test_no_removal_entropy_check_id(self):
+        result = Runner._prioritise_secrets(self.secret_records, 'key1', 'CKV_SECRET_6')
+        self.assertFalse(result)
+        self.assertIn('key1', self.secret_records)
+
+    def test_no_removal_generic_private_key_check_id(self):
+        result = Runner._prioritise_secrets(self.secret_records, 'key2', 'CKV_SECRET_10')
+        self.assertFalse(result)
+        self.assertIn('key2', self.secret_records)
+
+    def test_no_removal_other_check_id(self):
+        result = Runner._prioritise_secrets(self.secret_records, 'key3', 'CKV_SECRET_1000')
+        self.assertFalse(result)
+        self.assertIn('key3', self.secret_records)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Add `_prioritise_secrets` func to prioritise secrets results on the same finding by 3 levels of severity.
1. Private Key.
2. Generic Private Key.
3. Entropy.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
