### PR TITLE
fix(general): bitbucket integration test failure

### DIFF
--- a/integration_tests/test_checkov_cli_integration_report.py
+++ b/integration_tests/test_checkov_cli_integration_report.py
@@ -30,21 +30,18 @@ class TestCheckovJsonReport(unittest.TestCase):
 
     def test_bitbucket_pipelines_report_api_key(self):
         report_path = os.path.join(current_dir, '..', 'checkov_report_bitbucket_pipelines_cve.json')
+        # the below condition exist because checkov_report_bitbucket_pipelines_cve.json is
+        # generated only on Linux with Python 3.8 - see prepare_data.sh script
         if sys.version_info[1] == 8 and platform.system() == 'Linux':
             with open(report_path, encoding='utf-8') as f:
-                reports = json.load(f)
-                self.assertGreaterEqual(len(reports), 2,
-                                        "expecting to have 2 reports at least, bitbucket_pipelines and sca_image")
+                report = json.load(f)
+                self.assertGreaterEqual(len(report), 1,
+                                        "expecting to have one report at least - bitbucket_pipelines ")
                 bitbucket_pipelines_actions_report_exists = False
-                sca_image = False
-                for report in reports:
-                    if report["check_type"] == "bitbucket_pipelines":
-                        bitbucket_pipelines_actions_report_exists = True
-                        self.assertGreaterEqual(report['summary']['failed'], 1)
-                    if report["check_type"] == "sca_image":
-                        sca_image = True
-                        self.assertGreaterEqual(report['summary']['failed'], 1)
-                self.assertTrue(sca_image)
+                if report["check_type"] == "bitbucket_pipelines":
+                    bitbucket_pipelines_actions_report_exists = True
+                    self.assertGreaterEqual(report['summary']['failed'], 1)
+
                 self.assertTrue(bitbucket_pipelines_actions_report_exists)
 
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description


As we removed Image Referencer in https://github.com/bridgecrewio/checkov/pull/6386 the `sca_image` report is not longer generated for bitbucket files.
An integration test was expecting this report to exist in `checkov_report_bitbucket_pipelines_cve.json` file and failed.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
