### PR TITLE
feat(arm): add CKV_AZURE_137 Ensure ACR admin account is disabled

### DIFF
--- a/checkov/arm/checks/resource/ACRAdminAccountDisabled.py
+++ b/checkov/arm/checks/resource/ACRAdminAccountDisabled.py
@@ -5,7 +5,7 @@ from checkov.arm.base_resource_negative_value_check import BaseResourceNegativeV
 
 
 class ACRAdminAccountDisabled(BaseResourceNegativeValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure ACR admin account is disabled"
         id = "CKV_AZURE_137"
         supported_resources = ("Microsoft.ContainerRegistry/registries",)
@@ -19,4 +19,5 @@ class ACRAdminAccountDisabled(BaseResourceNegativeValueCheck):
         return [True]
 
 
-check = ACRAdminAccountDisabled()
+check: ACRAdminAccountDisabled = ACRAdminAccountDisabled()
+

--- a/checkov/arm/checks/resource/ACRAdminAccountDisabled.py
+++ b/checkov/arm/checks/resource/ACRAdminAccountDisabled.py
@@ -19,6 +19,4 @@ class ACRAdminAccountDisabled(BaseResourceNegativeValueCheck):
         return [True]
 
 
-check: ACRAdminAccountDisabled = ACRAdminAccountDisabled()
-
-
+check = ACRAdminAccountDisabled()

--- a/checkov/arm/checks/resource/ACRAdminAccountDisabled.py
+++ b/checkov/arm/checks/resource/ACRAdminAccountDisabled.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from typing import Any, List
+from checkov.common.models.enums import CheckCategories
+from checkov.arm.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+
+
+class ACRAdminAccountDisabled(BaseResourceNegativeValueCheck):
+    def __init__(self):
+        name = "Ensure ACR admin account is disabled"
+        id = "CKV_AZURE_137"
+        supported_resources = ("Microsoft.ContainerRegistry/registries",)
+        categories = [CheckCategories.IAM]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "properties/adminUserEnabled"
+
+    def get_forbidden_values(self) -> List[Any]:
+        return [True]
+
+
+check = ACRAdminAccountDisabled()

--- a/checkov/arm/checks/resource/ACRAdminAccountDisabled.py
+++ b/checkov/arm/checks/resource/ACRAdminAccountDisabled.py
@@ -21,3 +21,4 @@ class ACRAdminAccountDisabled(BaseResourceNegativeValueCheck):
 
 check: ACRAdminAccountDisabled = ACRAdminAccountDisabled()
 
+

--- a/tests/arm/checks/resource/example_ACRAdminAccountDisabled/fail.json
+++ b/tests/arm/checks/resource/example_ACRAdminAccountDisabled/fail.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.1",
+  "resources": [
+    {
+      "apiVersion": "2019-05-01",
+      "type": "Microsoft.ContainerRegistry/registries",
+      "name": "fail",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "Basic"
+      },
+      "properties": {
+        "adminUserEnabled": true,
+        "anonymousPullEnabled": true,
+        "dataEndpointEnabled": true,
+        "encryption": {
+          "keyVaultProperties": {
+            "identity": "someIdentity",
+            "keyIdentifier": "someKeyIdentifier"
+          },
+          "status": "enabled"
+        },
+        "networkRuleBypassOptions": "AzureServices",
+        "networkRuleSet": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "value": "127.0.0.1"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_ACRAdminAccountDisabled/pass.json
+++ b/tests/arm/checks/resource/example_ACRAdminAccountDisabled/pass.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.1",
+  "resources": [
+    {
+      "apiVersion": "2019-05-01",
+      "type": "Microsoft.ContainerRegistry/registries",
+      "name": "pass",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "Standard"
+      },
+      "properties": {
+        "adminUserEnabled":  false,
+        "anonymousPullEnabled": true,
+        "dataEndpointEnabled": true,
+        "encryption": {
+          "keyVaultProperties": {
+            "identity": "someIdentity",
+            "keyIdentifier": "someKeyIdentifier"
+          },
+          "status": "enabled"
+        },
+        "networkRuleBypassOptions": "AzureServices",
+        "networkRuleSet": {
+          "defaultAction": "Deny",
+          "ipRules": [
+            {
+              "action": "Allow",
+              "value": "127.0.0.1"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/test_ACRAdminAccountDisabled.py
+++ b/tests/arm/checks/resource/test_ACRAdminAccountDisabled.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+
+from checkov.arm.checks.resource.ACRAdminAccountDisabled import check
+from checkov.arm.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestACRAdminAccountDisabled(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ACRAdminAccountDisabled"
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'Microsoft.ContainerRegistry/registries.pass',
+        }
+        failing_resources = {
+            'Microsoft.ContainerRegistry/registries.fail'
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

We converted the policy CKV_AWS_137  from  TERRAFORM language to the ARM language so that it also works on resources that are defined in the ARM language



## Description on the check

Ensure ACR admin account is disabled

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
-  [x] I have added tests that prove my feature, policy, or fix is effective and works
-  [x] New and existing tests pass locally with my changes
-  [x] Any dependent changes have been merged and published in downstream modules
