### PR TITLE
fix(terraform): Fix name of CKV2_AWS_67 to be more clear

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/S3CMKRegularRotation.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/S3CMKRegularRotation.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: "CKV2_AWS_67"
-  name: "Ensure AWS S3 bucket encrypted with Customer Managed Key (CMK) has regular rotation"
+  name: "Ensure AWS S3 bucket is encrypted with a Customer Managed Key (CMK) and the key has regular rotation"
   category: "ENCRYPTION"
 definition:
   and:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Makes title of policy more clear

Fixes #6294
