### PR TITLE
fix(terraform): Update CKV_AWS_224 title

### DIFF
--- a/checkov/terraform/checks/resource/aws/ECSClusterLoggingEncryptedWithCMK.py
+++ b/checkov/terraform/checks/resource/aws/ECSClusterLoggingEncryptedWithCMK.py
@@ -8,7 +8,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 
 class ECSClusterLoggingEncryptedWithCMK(BaseResourceCheck):
     def __init__(self) -> None:
-        name = "Ensure ECS Cluster logging uses CMK"
+        name = "Ensure ECS Cluster logging is enabled and client to container communication uses CMK"
         id = "CKV_AWS_224"
         supported_resources = ("aws_ecs_cluster",)
         categories = (CheckCategories.ENCRYPTION,)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fix incorrect name based on docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster#kms_key_id

Fixes #6265
