### PR TITLE
fix(terraform): Fix when apt is in rm statement

### DIFF
--- a/checkov/dockerfile/checks/RunUsingAPT.py
+++ b/checkov/dockerfile/checks/RunUsingAPT.py
@@ -23,9 +23,13 @@ class RunUsingAPT(BaseDockerfileCheck):
     def scan_resource_conf(self, conf: list[_Instruction]) -> tuple[CheckResult, list[_Instruction] | None]:
         for run in conf:
             content = run["content"]
-            # Check if 'apt' is used and 'rm' is not in the same line
-            if " apt " in content and " rm " not in content:
-                return CheckResult.FAILED, [run]
+            # Split the content by '&&' and strip any leading/trailing spaces from each segment
+            commands = [cmd.strip() for cmd in content.split("&&")]
+            for command in commands:
+                command = command.replace('\\\n', '').strip()
+                # Check if 'apt' is used and it's not part of a 'rm' command
+                if "apt " in command and not command.startswith("rm "):
+                    return CheckResult.FAILED, [run]
         return CheckResult.PASSED, None
 
 

--- a/checkov/dockerfile/checks/RunUsingAPT.py
+++ b/checkov/dockerfile/checks/RunUsingAPT.py
@@ -26,9 +26,8 @@ class RunUsingAPT(BaseDockerfileCheck):
             # Split the content by '&&' and strip any leading/trailing spaces from each segment
             commands = [cmd.strip() for cmd in content.split("&&")]
             for command in commands:
-                command = command.replace('\\\n', '').strip()
                 # Check if 'apt' is used and it's not part of a 'rm' command
-                if "apt " in command and not command.startswith("rm "):
+                if "apt " in command and "rm" not in command:
                     return CheckResult.FAILED, [run]
         return CheckResult.PASSED, None
 

--- a/checkov/dockerfile/checks/RunUsingAPT.py
+++ b/checkov/dockerfile/checks/RunUsingAPT.py
@@ -23,7 +23,8 @@ class RunUsingAPT(BaseDockerfileCheck):
     def scan_resource_conf(self, conf: list[_Instruction]) -> tuple[CheckResult, list[_Instruction] | None]:
         for run in conf:
             content = run["content"]
-            if " apt " in content:
+            # Check if 'apt' is used and 'rm' is not in the same line
+            if " apt " in content and " rm " not in content:
                 return CheckResult.FAILED, [run]
         return CheckResult.PASSED, None
 

--- a/tests/dockerfile/checks/example_RunUsingAPT/failure2/Dockerfile
+++ b/tests/dockerfile/checks/example_RunUsingAPT/failure2/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu
+
+RUN apt install curl
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+        git && \
+    apt-get clean autoclean && \
+    apt-get autoremove --yes && \
+    cd /var/lib && \
+    rm -rf apt dpkg cache log

--- a/tests/dockerfile/checks/example_RunUsingAPT/failure3/Dockerfile
+++ b/tests/dockerfile/checks/example_RunUsingAPT/failure3/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu
+
+RUN apt update && \
+    apt-get install --yes --no-install-recommends \
+        git && \
+    apt-get clean autoclean && \
+    apt-get autoremove --yes && \
+    cd /var/lib && \
+    rm -rf apt dpkg cache log

--- a/tests/dockerfile/checks/example_RunUsingAPT/success2/Dockerfile
+++ b/tests/dockerfile/checks/example_RunUsingAPT/success2/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+        git && \
+    apt-get clean autoclean && \
+    apt-get autoremove --yes && \
+    cd /var/lib && \
+    rm -rf apt dpkg cache log

--- a/tests/dockerfile/checks/test_RunUsingAPT.py
+++ b/tests/dockerfile/checks/test_RunUsingAPT.py
@@ -22,6 +22,7 @@ class TestRunUsingAPT(unittest.TestCase):
         failing_resources = {
             "/failure/Dockerfile.RUN",
             "/failure2/Dockerfile.RUN",
+            "/failure3/Dockerfile.RUN",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])

--- a/tests/dockerfile/checks/test_RunUsingAPT.py
+++ b/tests/dockerfile/checks/test_RunUsingAPT.py
@@ -15,14 +15,20 @@ class TestRunUsingAPT(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        passing_resources = {"/success/Dockerfile."}
-        failing_resources = {"/failure/Dockerfile.RUN"}
+        passing_resources = {
+            "/success/Dockerfile.",
+            "/success2/Dockerfile."
+        }
+        failing_resources = {
+            "/failure/Dockerfile.RUN",
+            "/failure2/Dockerfile.RUN",
+        }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 1)
-        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fix when apt is in the rm statement

Fixes #6310

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
