### PR TITLE
fix(terraform_json): support locals block in CDKTF output

### DIFF
--- a/tests/terraform_json/test_parser.py
+++ b/tests/terraform_json/test_parser.py
@@ -1,4 +1,4 @@
-from checkov.terraform_json.parser import hclify
+from checkov.terraform_json.parser import hclify, prepare_definition
 
 
 def test_hclify():
@@ -33,4 +33,30 @@ def test_hclify():
                 "status": ["Enabled"],
             }
         ],
+    }
+
+
+def test_prepare_definition_locals():
+    cdk_definition = {
+        "locals": {
+            "bucket_name": "example",
+            "http_endpoint": "disabled",
+            "__startline__": 1,
+            "__endline__": 2,
+        }
+    }
+
+    # when
+    tf_definition = prepare_definition(cdk_definition)
+
+    # then
+    assert tf_definition == {
+        "locals": [
+            {
+                "bucket_name": ["example"],
+                "http_endpoint": ["disabled"],
+                "__startline__": 1,
+                "__endline__": 2,
+            }
+        ]
     }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- currently `checkov` fails to parse CDKTF json output, which includes a `locals` block
- it was raised  in a closed issue, where I was still tagged, but can't find it anymore 😅 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
