### PR TITLE
feat(arm): add CKV_AZURE_170 to ensure that AKS use the Paid Sku for its SLA

### DIFF
--- a/checkov/arm/checks/resource/AKSIsPaidSku.py
+++ b/checkov/arm/checks/resource/AKSIsPaidSku.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+
+
+class AKSIsPaidSku(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure that AKS use the Paid Sku for its SLA"
+        id = "CKV_AZURE_170"
+        supported_resources = ("Microsoft.ContainerService/managedClusters",)
+        categories = (CheckCategories.GENERAL_SECURITY,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,)
+
+    def get_inspected_key(self) -> str:
+        return "sku/tier"
+
+    def get_expected_value(self) -> Any:
+        return "Standard"
+
+
+check = AKSIsPaidSku()

--- a/tests/arm/checks/resource/example_AKSIsPaidSku/fail.json
+++ b/tests/arm/checks/resource/example_AKSIsPaidSku/fail.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "aksResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "AKS Cluster Resource ID"
+      }
+    },
+    "aksResourceLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "Location of the AKS resource e.g. \"East US\""
+      }
+    },
+    "aksResourceTagValues": {
+      "type": "object",
+      "metadata": {
+        "description": "Existing all tags on AKS Cluster Resource"
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure Monitor Log Analytics Resource ID"
+      }
+    }
+  },
+  "resources": [
+    {
+      "name": "fail",
+      "type": "Microsoft.ContainerService/managedClusters",
+      "location": "[parameters('aksResourceLocation')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}ManagedIdentity', parameters('aksClusterName'))))]": {}
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": "[parameters('aksResourceTagValues')]",
+      "apiVersion": "2018-03-31",
+      "properties": {
+        "mode": "Incremental",
+        "id": "[parameters('aksResourceId')]",
+        "addonProfiles": {
+          "omsagent": {
+            "enabled": true,
+            "config": {
+              "logAnalyticsWorkspaceResourceID": "[parameters('workspaceResourceId')]"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AKSIsPaidSku/fail1.json
+++ b/tests/arm/checks/resource/example_AKSIsPaidSku/fail1.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "aksResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "AKS Cluster Resource ID"
+      }
+    },
+    "aksResourceLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "Location of the AKS resource e.g. \"East US\""
+      }
+    },
+    "aksResourceTagValues": {
+      "type": "object",
+      "metadata": {
+        "description": "Existing all tags on AKS Cluster Resource"
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure Monitor Log Analytics Resource ID"
+      }
+    }
+  },
+  "resources": [
+    {
+      "name": "fail1",
+      "type": "Microsoft.ContainerService/managedClusters",
+      "location": "[parameters('aksResourceLocation')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}ManagedIdentity', parameters('aksClusterName'))))]": {}
+        }
+      },
+      "tags": "[parameters('aksResourceTagValues')]",
+      "apiVersion": "2018-03-31",
+      "properties": {
+        "mode": "Incremental",
+        "id": "[parameters('aksResourceId')]",
+        "addonProfiles": {
+          "omsagent": {
+            "enabled": true,
+            "config": {
+              "logAnalyticsWorkspaceResourceID": "[parameters('workspaceResourceId')]"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AKSIsPaidSku/pass.json
+++ b/tests/arm/checks/resource/example_AKSIsPaidSku/pass.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "aksResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "AKS Cluster Resource ID"
+      }
+    },
+    "aksResourceLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "Location of the AKS resource e.g. \"East US\""
+      }
+    },
+    "aksResourceTagValues": {
+      "type": "object",
+      "metadata": {
+        "description": "Existing all tags on AKS Cluster Resource"
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure Monitor Log Analytics Resource ID"
+      }
+    }
+  },
+  "resources": [
+    {
+      "name": "pass",
+      "type": "Microsoft.ContainerService/managedClusters",
+      "location": "[parameters('aksResourceLocation')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}ManagedIdentity', parameters('aksClusterName'))))]": {}
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Standard"
+      },
+      "tags": "[parameters('aksResourceTagValues')]",
+      "apiVersion": "2018-03-31",
+      "properties": {
+        "mode": "Incremental",
+        "id": "[parameters('aksResourceId')]",
+        "addonProfiles": {
+          "omsagent": {
+            "enabled": true,
+            "config": {
+              "logAnalyticsWorkspaceResourceID": "[parameters('workspaceResourceId')]"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/test_AKSIsPaidSku.py
+++ b/tests/arm/checks/resource/test_AKSIsPaidSku.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.arm.runner import Runner
+from checkov.arm.checks.resource.AKSIsPaidSku import check
+
+
+class TestAKSIsPaidSku(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AKSIsPaidSku")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'Microsoft.ContainerService/managedClusters.pass',
+        }
+        failing_resources = {
+            'Microsoft.ContainerService/managedClusters.fail',
+            'Microsoft.ContainerService/managedClusters.fail1',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
+++ b/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
@@ -11,7 +11,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_SkipJsonRegex"
+        test_files_dir = os.path.join(current_dir, "example_SkipJsonRegex")
         report = runner.run(
             root_folder=test_files_dir,
             runner_filter=RunnerFilter(skip_checks=["CKV_AZURE_*:.*.json$"])
@@ -21,7 +21,6 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
 
         self.assertEqual(summary['passed'], 0)
         self.assertEqual(summary['failed'], 0)
-        # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -29,7 +28,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_SkipJsonRegex"
+        test_files_dir = os.path.join(current_dir, "example_SkipJsonRegex")
         report = runner.run(
             root_folder=test_files_dir,
             runner_filter=RunnerFilter(skip_checks=["CKV_AZURE_8:.*.json$"])
@@ -38,8 +37,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 20)
-        # As skip is not being inserted to result in base check scan
+        self.assertEqual(summary['failed'], 20)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -47,7 +45,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_SkipJsonRegex"
+        test_files_dir = os.path.join(current_dir, "example_SkipJsonRegex")
         report = runner.run(
             root_folder=test_files_dir,
             runner_filter=RunnerFilter(skip_checks=["CKV_AZURE_8:/skip2.[a-z1-9]*.json$"])
@@ -56,8 +54,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 22)
-        # As skip is not being inserted to result in base check scan
+        self.assertEqual(summary['failed'], 22)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -65,7 +62,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_SkipJsonRegex"
+        test_files_dir = os.path.join(current_dir, "example_SkipJsonRegex")
         report = runner.run(
             root_folder=test_files_dir,
             runner_filter=RunnerFilter(skip_checks=["CKV_AZURE_8:/.*skip1.json$"])
@@ -74,8 +71,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 22)
-        # As skip is not being inserted to result in base check scan
+        self.assertEqual(summary['failed'], 22)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -83,7 +79,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_SkipJsonRegex"
+        test_files_dir = os.path.join(current_dir, "example_SkipJsonRegex")
         report = runner.run(
             root_folder=test_files_dir,
             runner_filter=RunnerFilter(skip_checks=["CKV_AZURE_*:/.*skip555.json$"])
@@ -92,8 +88,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 24)
-        # As skip is not being inserted to result in base check scan
+        self.assertEqual(summary['failed'], 24)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
+++ b/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
@@ -38,7 +38,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 16)
+        self.assertEqual(summary['failed'], 20)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
@@ -56,7 +56,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 18)
+        self.assertEqual(summary['failed'], 22)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
@@ -74,7 +74,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 18)
+        self.assertEqual(summary['failed'], 22)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
@@ -92,7 +92,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 20)
+        self.assertEqual(summary['failed'], 24)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

added a new arm policy to ensure that AKS use the Paid Sku for its SLA

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
