### PR TITLE
fix(sca): Support parsing json with comments

### DIFF
--- a/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
+++ b/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
@@ -13,7 +13,7 @@ MODULE_EXPORTS_PATTERN = r'module\.exports\s*=\s*({.*?});'
 EXPORT_DEFAULT_PATTERN = r'export\s*default\s*({.*?});'
 
 
-def load_json_with_comments(json_str: str):
+def load_json_with_comments(json_str: str) -> str:
     # Regular expression to remove comments (both single line and multi-line)
     clean_json_str = re.sub(r'//.*?$|/\*.*?\*/', '', json_str, flags=re.MULTILINE | re.DOTALL)
     return json.loads(clean_json_str)

--- a/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
+++ b/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
@@ -12,7 +12,8 @@ import os
 MODULE_EXPORTS_PATTERN = r'module\.exports\s*=\s*({.*?});'
 EXPORT_DEFAULT_PATTERN = r'export\s*default\s*({.*?});'
 
-def load_json_with_comments(json_str):
+
+def load_json_with_comments(json_str: str):
     # Regular expression to remove comments (both single line and multi-line)
     clean_json_str = re.sub(r'//.*?$|/\*.*?\*/', '', json_str, flags=re.MULTILINE | re.DOTALL)
     return json.loads(clean_json_str)

--- a/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
+++ b/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
@@ -12,6 +12,11 @@ import os
 MODULE_EXPORTS_PATTERN = r'module\.exports\s*=\s*({.*?});'
 EXPORT_DEFAULT_PATTERN = r'export\s*default\s*({.*?});'
 
+def load_json_with_comments(json_str):
+    # Regular expression to remove comments (both single line and multi-line)
+    clean_json_str = re.sub(r'//.*?$|/\*.*?\*/', '', json_str, flags=re.MULTILINE | re.DOTALL)
+    return json.loads(clean_json_str)
+
 
 def _parse_export(file_content: str, pattern: str) -> Dict[str, Any] | None:
     module_export_match = re.search(pattern, file_content, re.DOTALL)
@@ -40,7 +45,7 @@ def parse_webpack_file(file_content: str, relevant_packages: Set[str]) -> Dict[s
 
 def parse_tsconfig_file(file_content: str, relevant_packages: Set[str]) -> Dict[str, Any]:
     output: Dict[str, Any] = {"packageAliases": {}}
-    tsconfig_json = json.loads(file_content)
+    tsconfig_json = load_json_with_comments(file_content)
     paths = tsconfig_json.get("compilerOptions", {}).get("paths", {})
     for imported_name in paths:
         for package_relative_path in paths[imported_name]:
@@ -52,7 +57,7 @@ def parse_tsconfig_file(file_content: str, relevant_packages: Set[str]) -> Dict[
 
 def parse_babel_file(file_content: str, relevant_packages: Set[str]) -> Dict[str, Any]:
     output: Dict[str, Any] = {"packageAliases": {}}
-    babelrc_json = json.loads(file_content)
+    babelrc_json = load_json_with_comments(file_content)
     plugins = babelrc_json.get("plugins", {})
     for plugin in plugins:
         if len(plugin) > 1:
@@ -91,7 +96,7 @@ def parse_rollup_file(file_content: str, relevant_packages: Set[str]) -> Dict[st
 def parse_package_json_file(file_content: str, relevant_packages: Set[str]) -> Dict[str, Any]:
     output: Dict[str, Any] = {"packageAliases": {}}
     try:
-        package_json = json.loads(file_content)
+        package_json = load_json_with_comments(file_content)
     except JSONDecodeError:
         logging.warning('unable to parse package json file')
         return output

--- a/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
+++ b/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
@@ -13,7 +13,7 @@ MODULE_EXPORTS_PATTERN = r'module\.exports\s*=\s*({.*?});'
 EXPORT_DEFAULT_PATTERN = r'export\s*default\s*({.*?});'
 
 
-def load_json_with_comments(json_str: str) -> str:
+def load_json_with_comments(json_str: str) -> Any:
     # Regular expression to remove comments (both single line and multi-line)
     clean_json_str = re.sub(r'//.*?$|/\*.*?\*/', '', json_str, flags=re.MULTILINE | re.DOTALL)
     return json.loads(clean_json_str)

--- a/tests/common/sca/reachability/test_alias_mapping_creator.py
+++ b/tests/common/sca/reachability/test_alias_mapping_creator.py
@@ -1,5 +1,6 @@
 import os
 from checkov.common.sca.reachability.package_alias_mapping.alias_mapping_creator import AliasMappingCreator
+from checkov.common.sca.reachability.package_alias_mapping.nodejs.utils import load_json_with_comments
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -26,4 +27,19 @@ def test_alias_mapping_creator():
                 }
             }
         }
+    }
+
+def test_load_json_with_no_comments():
+    json_data_with_comments = """
+    {
+        "noUnusedLocals": false, // off for convenience, enable to enforce cleaner code
+        "noUnusedParameters": false, // off for convenience, enable to enforce cleaner code
+        "noImplicitAny": false  // off for convenience, recommended value is true to enforce types and reduce bugs
+    }
+    """
+    clean_json = load_json_with_comments(json_data_with_comments)
+    assert clean_json == {
+        "noUnusedLocals": False,
+        "noUnusedParameters": False,
+        "noImplicitAny": False
     }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

On reachability mapping, there is a step that loads customer JSON files. in case that file contains comments, it will fail.
This PR removes the comments before loading the customer's JSON file.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
