### PR TITLE
chore: Focus cfn-lint on edited files

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -38,12 +38,21 @@ jobs:
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Get changed CFN test files
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v44
+        with:
+          files: tests/cloudformation/checks/resource/aws/**/*
       - name: Install cfn-lint
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           pip install -U cfn-lint
       - name: Lint Cloudformation templates
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files-specific.outputs.all_changed_files }}
         run: |
-          cfn-lint $(git diff --name-only ${{ github.event.pull_request.base.sha }} | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs) -i W
+          cfn-lint $ALL_CHANGED_FILES -i W
 
   mypy:
     uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -43,7 +43,7 @@ jobs:
           pip install -U cfn-lint
       - name: Lint Cloudformation templates
         run: |
-          cfn-lint $(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs) -i W
+          cfn-lint $(git diff --name-only $GITHUB_BASE_REF $GITHUB_HEAD_REF | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs) -i W
 
   mypy:
     uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -41,9 +41,14 @@ jobs:
       - name: Install cfn-lint
         run: |
           pip install -U cfn-lint
-      - name: Lint Cloudformation templates
+      - name: Find modified CloudFormation templates
+        id: modified_files
         run: |
-          cfn-lint tests/cloudformation/checks/resource/aws/**/* -i W
+          echo "modified_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs)" >> $GITHUB_ENV
+      - name: Lint Cloudformation templates
+        if: env.modified_files != ''
+        run: |
+          cfn-lint ${{ env.modified_files }} -i W
 
   mypy:
     uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Get changed CFN test files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@eaf854ef0c266753e1abec356dcf17d92695b251 # v44
         with:
           files: tests/cloudformation/checks/resource/aws/**/*
       - name: Install cfn-lint

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -43,7 +43,7 @@ jobs:
           pip install -U cfn-lint
       - name: Lint Cloudformation templates
         run: |
-          cfn-lint $(git diff --name-only $GITHUB_BASE_REF | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs) -i W
+          cfn-lint $(git diff --name-only ${{ github.event.pull_request.base.sha }} | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs) -i W
 
   mypy:
     uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -43,7 +43,7 @@ jobs:
           pip install -U cfn-lint
       - name: Lint Cloudformation templates
         run: |
-          cfn-lint $(git diff --name-only $GITHUB_BASE_REF $GITHUB_HEAD_REF | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs) -i W
+          cfn-lint $(git diff --name-only $GITHUB_BASE_REF | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs) -i W
 
   mypy:
     uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files-specific.outputs.all_changed_files }}
         run: |
-          cfn-lint $ALL_CHANGED_FILES -i W
+          cfn-lint "$ALL_CHANGED_FILES" -i W
 
   mypy:
     uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -41,14 +41,9 @@ jobs:
       - name: Install cfn-lint
         run: |
           pip install -U cfn-lint
-      - name: Find modified CloudFormation templates
-        id: modified_files
-        run: |
-          echo "modified_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs)" >> $GITHUB_ENV
       - name: Lint Cloudformation templates
-        if: env.modified_files != ''
         run: |
-          cfn-lint ${{ env.modified_files }} -i W
+          cfn-lint $(git diff --name-only HEAD | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs) -i W
 
   mypy:
     uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -43,7 +43,7 @@ jobs:
           pip install -U cfn-lint
       - name: Lint Cloudformation templates
         run: |
-          cfn-lint $(git diff --name-only HEAD | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs) -i W
+          cfn-lint $(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep 'tests/cloudformation/checks/resource/aws/**/*' | xargs) -i W
 
   mypy:
     uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -52,7 +52,9 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files-specific.outputs.all_changed_files }}
         run: |
-          cfn-lint "$ALL_CHANGED_FILES" -i W
+          for file in $ALL_CHANGED_FILES; do
+            cfn-lint "$file" -i W
+          done
 
   mypy:
     uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMPermissionsManagement/PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMPermissionsManagement/PASSED.yaml
@@ -12,7 +12,7 @@ Resources:
             Action: 
             - 's3:Get*'
             Resource: 
-            - 'foobar'
+            - 'foobar2'
       Roles:
         - example_role
   NotPermissionsWildcard:

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMPermissionsManagement/PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMPermissionsManagement/PASSED.yaml
@@ -12,7 +12,7 @@ Resources:
             Action: 
             - 's3:Get*'
             Resource: 
-            - 'foobar2'
+            - 'foobar'
       Roles:
         - example_role
   NotPermissionsWildcard:

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMPermissionsManagement/PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMPermissionsManagement/PASSED.yaml
@@ -3,6 +3,11 @@ Description: IAM policy
 Resources:
   NotPermissionsScoped:
     Type: 'AWS::IAM::Policy'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3510
     Properties:
       PolicyName: root
       PolicyDocument:
@@ -43,6 +48,11 @@ Resources:
         - example_role
   PermissionsScoped:
     Type: 'AWS::IAM::Policy'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3510
     Properties:
       PolicyName: root
       PolicyDocument:

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMPermissionsManagement/PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_IAMPermissionsManagement/PASSED.yaml
@@ -12,7 +12,7 @@ Resources:
             Action: 
             - 's3:Get*'
             Resource: 
-            - 'foo'
+            - 'foobar'
       Roles:
         - example_role
   NotPermissionsWildcard:

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_ManagedPolicy/PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_ManagedPolicy/PASSED.yaml
@@ -43,6 +43,11 @@ Resources:
         - example_role
   PermissionsScoped:
     Type: 'AWS::IAM::ManagedPolicy'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3510
     Properties:
       ManagedPolicyName: root
       PolicyDocument:

--- a/tests/cloudformation/checks/resource/aws/Cloudsplaining_ManagedPolicy/PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/Cloudsplaining_ManagedPolicy/PASSED.yaml
@@ -3,6 +3,11 @@ Description: IAM policy
 Resources:
   NotPermissionsScoped:
     Type: 'AWS::IAM::ManagedPolicy'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3510
     Properties:
       ManagedPolicyName: root
       PolicyDocument:

--- a/tests/cloudformation/checks/resource/aws/example_AuroraEncryption/AuroraEncryption-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_AuroraEncryption/AuroraEncryption-PASSED.yaml
@@ -1,6 +1,11 @@
 Resources:
   Aurora0:
     Type: 'AWS::RDS::DBCluster'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3690
     Properties:
       DatabaseName: 'mydb2'
       Engine: 'aurora'

--- a/tests/cloudformation/checks/resource/aws/example_AuroraEncryption/AuroraEncryption-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_AuroraEncryption/AuroraEncryption-PASSED.yaml
@@ -2,6 +2,6 @@ Resources:
   Aurora0:
     Type: 'AWS::RDS::DBCluster'
     Properties:
-      DatabaseName: 'mydb'
+      DatabaseName: 'mydb2'
       Engine: 'aurora'
       StorageEncrypted: true


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Make it so cfn-lint only runs on modified files

