### PR TITLE
feat(arm): PubsubSKUSLA

### DIFF
--- a/checkov/arm/checks/resource/PubsubSKUSLA.py
+++ b/checkov/arm/checks/resource/PubsubSKUSLA.py
@@ -1,0 +1,22 @@
+from typing import List
+
+from checkov.arm.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class PubsubSKUSLA(BaseResourceNegativeValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure Web PubSub uses a SKU with an SLA"
+        id = "CKV_AZURE_175"
+        supported_resources = ["Microsoft.SignalRService/webPubSub"]
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "sku/name"
+
+    def get_forbidden_values(self) -> List[str]:
+        return ["Free_F1"]
+
+
+check = PubsubSKUSLA()

--- a/tests/arm/checks/resource/example_PubsubSKUSLA/fail.json
+++ b/tests/arm/checks/resource/example_PubsubSKUSLA/fail.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.SignalRService/webPubSub",
+      "apiVersion": "2021-02-01",
+      "name": "fail",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Free_F1",
+        "capacity": 1
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "liveTraceConfiguration": {
+          "enabled": "true",
+          "categories": [
+            {
+              "name": "MessagingLogs",
+              "enabled": "true"
+            },
+            {
+              "name": "ConnectivityLogs",
+              "enabled": "false"
+            }
+          ]
+        }
+      },
+      "publicNetworkAccess": "Disabled"
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_PubsubSKUSLA/pass.json
+++ b/tests/arm/checks/resource/example_PubsubSKUSLA/pass.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.SignalRService/webPubSub",
+      "apiVersion": "2021-02-01",
+      "name": "pass",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "standard_S1",
+        "capacity": 1
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "liveTraceConfiguration": {
+          "enabled": "true",
+          "categories": [
+            {
+              "name": "MessagingLogs",
+              "enabled": "true"
+            },
+            {
+              "name": "ConnectivityLogs",
+              "enabled": "false"
+            }
+          ]
+        }
+      },
+      "publicNetworkAccess": "Disabled"
+    }
+  ]
+}

--- a/tests/arm/checks/resource/test_PubsubSKUSLA.py
+++ b/tests/arm/checks/resource/test_PubsubSKUSLA.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+from checkov.arm.checks.resource.PubsubSKUSLA import check
+from checkov.arm.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestPubsubSKUSLA(unittest.TestCase):
+
+    def test_summary(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_PubsubSKUSLA"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "Microsoft.SignalRService/webPubSub.pass",
+        }
+
+        failing_resources = {
+            "Microsoft.SignalRService/webPubSub.fail",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertSetEqual(passing_resources, passed_check_resources)
+        self.assertSetEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*We converted the check 'PubsubSKUSLA' from TERRAFORM language to the ARM language so that it also works on resources that are defined in the ARM language.*

Fixes # (issue)

### Description
*Ensure Web PubSub uses a SKU with an SLA.*

### Fix
*To fix the issue in code and/or runtime:
Translated the existing 'PubsubSKUSLA' check from Terraform-specific logic to ARM-specific logic.
Updated any necessary resource mappings, key inspections, and forbidden values definitions to align with ARM resource definitions.*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
