### PR TITLE
feat(secrets): Fix empty supported files not scan in multiline 

### DIFF
--- a/checkov/secrets/plugins/custom_regex_detector.py
+++ b/checkov/secrets/plugins/custom_regex_detector.py
@@ -114,7 +114,7 @@ class CustomRegexDetector(RegexBasedDetector):
             # We want the multiline regex to execute only if current file is supported by them
             for regex in self.multiline_deny_list:
                 regex_supported_files = self.multiline_regex_to_metadata.get(regex.pattern, {}).get("supportedFiles", [])
-                if regex_supported_files and any([filename.endswith(regex_supported_file) for regex_supported_file in regex_supported_files]):
+                if len(regex_supported_files) == 0 or any([filename.endswith(regex_supported_file) for regex_supported_file in regex_supported_files]):
                     current_denylist.add(regex)
         else:
             current_denylist = self.denylist

--- a/checkov/secrets/plugins/custom_regex_detector.py
+++ b/checkov/secrets/plugins/custom_regex_detector.py
@@ -48,14 +48,6 @@ class CustomRegexDetector(RegexBasedDetector):
                     exc_info=True,
                 )
 
-    @property
-    def multiline_regex_supported_file_types(self) -> Set[str]:
-        if self._multiline_regex_supported_file_types:
-            return self._multiline_regex_supported_file_types
-        for regex in self.multiline_regex_to_metadata.values():
-            self._multiline_regex_supported_file_types.update(regex.get("supportedFiles", []))
-        return self._multiline_regex_supported_file_types
-
     def analyze_line(
             self,
             filename: str,
@@ -87,8 +79,6 @@ class CustomRegexDetector(RegexBasedDetector):
             self._analyzed_files.add(filename)
             # We only want to read file if: there is regex supporting it & file size is not over MAX_FILE_SIZE
             if not self.multiline_regex_to_metadata.values() or \
-                    not self.multiline_regex_supported_file_types or \
-                    not any([filename.endswith(str(file_type)) for file_type in self.multiline_regex_supported_file_types]) or \
                     not 0 < get_file_size_safe(filename) < CustomRegexDetector.MAX_FILE_SIZE:
                 return output
             file_content = read_file_safe(filename)

--- a/tests/secrets/test_load_detectors.py
+++ b/tests/secrets/test_load_detectors.py
@@ -801,4 +801,4 @@ class TestLoadDetectors(unittest.TestCase):
                             runner_filter=RunnerFilter(framework=['secrets'],
                                                        enable_secret_scan_all_files=True))
         interesting_failed_checks = _filter_reports_for_incident_ids(report.failed_checks, ["test1", "test2"])
-        self.assertEqual(len(interesting_failed_checks), 1)
+        self.assertEqual(len(interesting_failed_checks), 2)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
