### PR TITLE
feat(arm): AzureDefenderDisabledForResManager

### DIFF
--- a/checkov/arm/checks/resource/AzureDefenderDisabledForResManager.py
+++ b/checkov/arm/checks/resource/AzureDefenderDisabledForResManager.py
@@ -16,9 +16,9 @@ class AzureDefenderDisabledForResManager(BaseResourceCheck):
 
     def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
 
-        properties = conf.get("properties", {})
-        resource_type = properties["subPlan"].lower()
-        pricing_tier = properties["pricingTier"].lower()
+        properties: Dict[str, Any] = conf.get("properties", {})
+        resource_type = properties.get("subPlan", "").lower()
+        pricing_tier = properties.get("pricingTier","").lower()
 
         if resource_type == "arm" and pricing_tier != "standard":
             return CheckResult.FAILED

--- a/checkov/arm/checks/resource/AzureDefenderDisabledForResManager.py
+++ b/checkov/arm/checks/resource/AzureDefenderDisabledForResManager.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.arm.base_resource_check import BaseResourceCheck
+
+
+class AzureDefenderDisabledForResManager(BaseResourceCheck):
+    def __init__(self) -> None:
+        name = "Ensure that Azure Defender for cloud is set to On for Resource Manager"
+        id = "CKV_AZURE_234"
+        supported_resources = ("Microsoft.Security/pricings",)
+        categories = (CheckCategories.GENERAL_SECURITY,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+
+        properties = conf.get("properties", {})
+        resource_type = properties["subPlan"].lower()
+        pricing_tier = properties["pricingTier"].lower()
+
+        if resource_type == "arm" and pricing_tier != "standard":
+            return CheckResult.FAILED
+        else:
+            return CheckResult.PASSED
+
+    def get_evaluated_keys(self) -> list[str]:
+        return ["subPlan", "pricingTier"]
+
+
+check = AzureDefenderDisabledForResManager()

--- a/tests/arm/checks/resource/example_AzureDefenderDisabledForResManager/fail1.json
+++ b/tests/arm/checks/resource/example_AzureDefenderDisabledForResManager/fail1.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.Security/pricings",
+      "apiVersion": "2020-01-01",
+      "name": "fail1",
+      "properties": {
+        "pricingTier": "Free",
+        "subPlan": "arm"
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AzureDefenderDisabledForResManager/pass1.json
+++ b/tests/arm/checks/resource/example_AzureDefenderDisabledForResManager/pass1.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.Security/pricings",
+      "apiVersion": "2020-01-01",
+      "name": "pass1",
+      "properties": {
+        "pricingTier": "Standard",
+        "subPlan": "Arm"
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AzureDefenderDisabledForResManager/pass2.json
+++ b/tests/arm/checks/resource/example_AzureDefenderDisabledForResManager/pass2.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.Security/pricings",
+      "apiVersion": "2020-01-01",
+      "name": "pass2",
+      "properties": {
+        "pricingTier": "Free",
+        "subPlan": "Dns"
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AzureDefenderDisabledForResManager/pass3.json
+++ b/tests/arm/checks/resource/example_AzureDefenderDisabledForResManager/pass3.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.Security/pricings",
+      "apiVersion": "2020-01-01",
+      "name": "pass3",
+      "properties": {
+        "pricingTier": "Free",
+        "subPlan": "VirtualMachine"
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/test_AzureDefenderDisabledForResManager.py
+++ b/tests/arm/checks/resource/test_AzureDefenderDisabledForResManager.py
@@ -1,0 +1,44 @@
+import unittest
+from pathlib import Path
+
+from checkov.arm.checks.resource.AzureDefenderDisabledForResManager import check
+from checkov.arm.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestAzureDefenderDisabledForResManager(unittest.TestCase):
+    def test_summary(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_AzureDefenderDisabledForResManager"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "Microsoft.Security/pricings.pass1",
+            "Microsoft.Security/pricings.pass2",
+            "Microsoft.Security/pricings.pass3",
+        }
+        failing_resources = {
+            "Microsoft.Security/pricings.fail1",
+
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+        print('/n', passed_check_resources)
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*We converted the check AzureDefenderDisabledForResManagerL from TERRAFORM language to the ARM language so that it also works on resources that are defined in the ARM language.*


### Description
*Ensure that Azure Defender for cloud is set to On for Resource Manager*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
