### PR TITLE
fix(kubernetes): Fix CKV_K8S_31 for CronJobs

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/Seccomp.py
+++ b/checkov/kubernetes/checks/resource/k8s/Seccomp.py
@@ -78,15 +78,17 @@ class Seccomp(BaseK8Check):
         elif conf['kind'] == 'CronJob':
             inner_template = find_in_dict(input_dict=conf, key_path="spec/jobTemplate/spec/template")
             if inner_template and isinstance(inner_template, dict):
-                if "metadata" in inner_template:
-                    metadata = inner_template["metadata"]
-                elif "spec" in inner_template:
+                if "spec" in inner_template:
                     inner_spec = inner_template["spec"]
                     if "metadata" in inner_spec:
                         metadata = inner_spec["metadata"]
                     elif "securityContext" in inner_spec:
                         security_profile = inner_spec["securityContext"].get("seccompProfile", {}).get("type")
-                        return CheckResult.PASSED if security_profile == 'RuntimeDefault' else CheckResult.FAILED
+                        if security_profile == 'RuntimeDefault':
+                            return CheckResult.PASSED
+                if "metadata" in inner_template:
+                    metadata = inner_template["metadata"]
+
         else:
             inner_metadata = find_in_dict(input_dict=conf, key_path="spec/template/metadata")
             metadata = inner_metadata if inner_metadata else metadata

--- a/tests/kubernetes/checks/example_Seccomp/cronjob-seccomp-FAILED.yaml
+++ b/tests/kubernetes/checks/example_Seccomp/cronjob-seccomp-FAILED.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cronjob-failed
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            runAsNonRoot: true
+          containers:
+          - image: "ubuntu"
+            name: image
+  schedule: "0 2 * * *"

--- a/tests/kubernetes/checks/example_Seccomp/cronjob-seccomp-PASSED2.yaml
+++ b/tests/kubernetes/checks/example_Seccomp/cronjob-seccomp-PASSED2.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cronjob-passed2
+spec:
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: new-app
+        spec:
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+          - image: "ubuntu"
+            name: image
+            securityContext:
+              allowPrivilegeEscalation: false
+  schedule: "0 2 * * *"

--- a/tests/kubernetes/checks/example_Seccomp/cronjob-seccomp-PASSED3.yaml
+++ b/tests/kubernetes/checks/example_Seccomp/cronjob-seccomp-PASSED3.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cronjob-passed3
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+          - image: "ubuntu"
+            name: image
+            seccompProfile:
+              type: RuntimeDefault
+  schedule: "0 2 * * *"

--- a/tests/kubernetes/checks/test_Seccomp.py
+++ b/tests/kubernetes/checks/test_Seccomp.py
@@ -19,13 +19,15 @@ class TestSeccomp(unittest.TestCase):
         passed_resources = [check.resource for check in report.passed_checks]
         failed_resources = [check.resource for check in report.failed_checks]
 
-        self.assertEqual(summary["passed"], 10)
-        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["passed"], 12)
+        self.assertEqual(summary["failed"], 4)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 
         expected_passed_resources = [
             "CronJob.default.cronjob-passed",
+            "CronJob.default.cronjob-passed2",
+            "CronJob.default.cronjob-passed3",
             "CronJob.default.cronjob-securityContext-passed",
             "Deployment.default.seccomp-passed-deployment",
             "Deployment.default.seccomp-passed-metadata-annotations",
@@ -37,6 +39,7 @@ class TestSeccomp(unittest.TestCase):
             "Deployment.aws-dev.fdn-svc",
         ]
         expected_failed_resources = [
+            "CronJob.default.cronjob-failed",
             "Deployment.infra.app-cert-manager",
             "Pod.default.seccomp-failed",
             "Pod.default.my-insecure-pod",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixes CronJob check for SeccompProfile under spec instead of metadata

Fixes #2222

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
