### PR TITLE
fix(sca): fix parsing json with comments

### DIFF
--- a/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
+++ b/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
@@ -17,8 +17,6 @@ def load_json_with_comments(json_str: str) -> dict:
     # Regular expression to remove comments (both single line and multi-line)
     pattern = r'(?<!\\)(["\'])(?:(?=(\\?))\2.)*?\1|//.*?$|/\*[\s\S]*?\*/'
     regex = re.compile(pattern, re.MULTILINE)
-
-    # Replace comments with an empty string, preserving quoted strings
     clean_json_str = regex.sub(lambda match: match.group(0) if match.group(1) else '', json_str)
     return json.loads(clean_json_str)
 

--- a/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
+++ b/checkov/common/sca/reachability/package_alias_mapping/nodejs/utils.py
@@ -13,9 +13,13 @@ MODULE_EXPORTS_PATTERN = r'module\.exports\s*=\s*({.*?});'
 EXPORT_DEFAULT_PATTERN = r'export\s*default\s*({.*?});'
 
 
-def load_json_with_comments(json_str: str) -> Any:
+def load_json_with_comments(json_str: str) -> dict:
     # Regular expression to remove comments (both single line and multi-line)
-    clean_json_str = re.sub(r'//.*?$|/\*.*?\*/', '', json_str, flags=re.MULTILINE | re.DOTALL)
+    pattern = r'(?<!\\)(["\'])(?:(?=(\\?))\2.)*?\1|//.*?$|/\*[\s\S]*?\*/'
+    regex = re.compile(pattern, re.MULTILINE)
+
+    # Replace comments with an empty string, preserving quoted strings
+    clean_json_str = regex.sub(lambda match: match.group(0) if match.group(1) else '', json_str)
     return json.loads(clean_json_str)
 
 

--- a/tests/common/sca/reachability/test_alias_mapping_creator.py
+++ b/tests/common/sca/reachability/test_alias_mapping_creator.py
@@ -32,14 +32,38 @@ def test_alias_mapping_creator():
 def test_load_json_with_no_comments():
     json_data_with_comments = """
     {
+      "compilerOptions": {
+        "paths": {
+          "@modules/*": ["src/modules/*"],
+          "@shared/*": ["src/shared/*"]
+        },
+        "declaration": true,
+        "target": "es2021",
+        "strict": true /* Enable all strict type-checking options. */,
         "noUnusedLocals": false, // off for convenience, enable to enforce cleaner code
         "noUnusedParameters": false, // off for convenience, enable to enforce cleaner code
-        "noImplicitAny": false  // off for convenience, recommended value is true to enforce types and reduce bugs
+        "noImplicitAny": false,  // off for convenience, recommended value is true to enforce types and reduce bugs
+        "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+        "resolveJsonModule": true
+      },
+      "exclude": ["node_modules", "dist"]
     }
     """
     clean_json = load_json_with_comments(json_data_with_comments)
     assert clean_json == {
-        "noUnusedLocals": False,
-        "noUnusedParameters": False,
-        "noImplicitAny": False
+        "compilerOptions": {
+            "paths": {
+                "@modules/*": ["src/modules/*"],
+                "@shared/*": ["src/shared/*"]
+            },
+            "declaration": True,
+            "target": "es2021",
+            "strict": True,
+            "noUnusedLocals": False,
+            "noUnusedParameters": False,
+            "noImplicitAny": False,
+            "forceConsistentCasingInFileNames": True,
+            "resolveJsonModule": True
+        },
+        "exclude": ["node_modules", "dist"]
     }


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
In the reachability mapping, when attempting to load customer JSON files, if they include values such as '@modules/*', the code mistakenly removes the value, thinking it's a comment. This PR fixes this bug

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
