### PR TITLE
feat(arm): add CKV_AZURE_169 to ensure that Azure Kubernetes Cluster (AKS) nodes use scale sets

### DIFF
--- a/checkov/arm/checks/resource/AKSPoolTypeIsScaleSet.py
+++ b/checkov/arm/checks/resource/AKSPoolTypeIsScaleSet.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories
+from checkov.arm.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+
+
+class AKSPoolTypeIsScaleSet(BaseResourceNegativeValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure Azure Kubernetes Cluster (AKS) nodes use scale sets"
+        id = "CKV_AZURE_169"
+        supported_resources = ("Microsoft.ContainerService/managedClusters",)
+        categories = (CheckCategories.KUBERNETES,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,)
+
+    def get_inspected_key(self) -> str:
+        return "properties/agentPoolProfiles/[0]/type"
+
+    def get_forbidden_values(self) -> list[Any]:
+        return ["AvailabilitySet"]
+
+
+check = AKSPoolTypeIsScaleSet()

--- a/tests/arm/checks/resource/example_AKSPoolTypeIsScaleSet/fail.json
+++ b/tests/arm/checks/resource/example_AKSPoolTypeIsScaleSet/fail.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.26.170.59819",
+      "templateHash": "14823542069333410776"
+    }
+  },
+  "parameters": {
+    "clusterName": {
+      "type": "string",
+      "defaultValue": "aks101cluster",
+      "metadata": {
+        "description": "The name of the Managed Cluster resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of the Managed Cluster resource."
+      }
+    },
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
+      }
+    },
+    "osDiskSizeGB": {
+      "type": "int",
+      "defaultValue": 0,
+      "minValue": 0,
+      "maxValue": 1023,
+      "metadata": {
+        "description": "Disk size (in GB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
+      }
+    },
+    "agentCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "minValue": 1,
+      "maxValue": 50,
+      "metadata": {
+        "description": "The number of nodes for the cluster."
+      }
+    },
+    "agentVMSize": {
+      "type": "string",
+      "defaultValue": "standard_d2s_v3",
+      "metadata": {
+        "description": "The size of the Virtual Machine."
+      }
+    },
+    "linuxAdminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "User name for the Linux Virtual Machines."
+      }
+    },
+    "sshRSAPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Configure all linux machines with the SSH RSA public key string. Your key should include three parts, for example 'ssh-rsa AAAAB...snip...UcyupgH azureuser@linuxvm'"
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "apiVersion": "2024-02-01",
+      "name": "fail",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+          {
+            "name": "agentpool",
+            "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+            "count": "[parameters('agentCount')]",
+            "type": "AvailabilitySet",
+            "vmSize": "[parameters('agentVMSize')]",
+            "osType": "Linux",
+            "mode": "System"
+          }
+        ],
+        "linuxProfile": {
+          "adminUsername": "[parameters('linuxAdminUsername')]",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "[parameters('sshRSAPublicKey')]"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "controlPlaneFQDN": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName')), '2024-02-01').fqdn]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/example_AKSPoolTypeIsScaleSet/pass.json
+++ b/tests/arm/checks/resource/example_AKSPoolTypeIsScaleSet/pass.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.26.170.59819",
+      "templateHash": "14823542069333410776"
+    }
+  },
+  "parameters": {
+    "clusterName": {
+      "type": "string",
+      "defaultValue": "aks101cluster",
+      "metadata": {
+        "description": "The name of the Managed Cluster resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of the Managed Cluster resource."
+      }
+    },
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
+      }
+    },
+    "osDiskSizeGB": {
+      "type": "int",
+      "defaultValue": 0,
+      "minValue": 0,
+      "maxValue": 1023,
+      "metadata": {
+        "description": "Disk size (in GB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
+      }
+    },
+    "agentCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "minValue": 1,
+      "maxValue": 50,
+      "metadata": {
+        "description": "The number of nodes for the cluster."
+      }
+    },
+    "agentVMSize": {
+      "type": "string",
+      "defaultValue": "standard_d2s_v3",
+      "metadata": {
+        "description": "The size of the Virtual Machine."
+      }
+    },
+    "linuxAdminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "User name for the Linux Virtual Machines."
+      }
+    },
+    "sshRSAPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Configure all linux machines with the SSH RSA public key string. Your key should include three parts, for example 'ssh-rsa AAAAB...snip...UcyupgH azureuser@linuxvm'"
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "apiVersion": "2024-02-01",
+      "name": "pass",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+          {
+            "name": "agentpool",
+            "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+            "count": "[parameters('agentCount')]",
+            "type": "VirtualMachineScaleSets",
+            "vmSize": "[parameters('agentVMSize')]",
+            "osType": "Linux",
+            "mode": "System"
+          }
+        ],
+        "linuxProfile": {
+          "adminUsername": "[parameters('linuxAdminUsername')]",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "[parameters('sshRSAPublicKey')]"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "controlPlaneFQDN": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName')), '2024-02-01').fqdn]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/example_AKSPoolTypeIsScaleSet/pass1.json
+++ b/tests/arm/checks/resource/example_AKSPoolTypeIsScaleSet/pass1.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.26.170.59819",
+      "templateHash": "14823542069333410776"
+    }
+  },
+  "parameters": {
+    "clusterName": {
+      "type": "string",
+      "defaultValue": "aks101cluster",
+      "metadata": {
+        "description": "The name of the Managed Cluster resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of the Managed Cluster resource."
+      }
+    },
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
+      }
+    },
+    "osDiskSizeGB": {
+      "type": "int",
+      "defaultValue": 0,
+      "minValue": 0,
+      "maxValue": 1023,
+      "metadata": {
+        "description": "Disk size (in GB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
+      }
+    },
+    "agentCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "minValue": 1,
+      "maxValue": 50,
+      "metadata": {
+        "description": "The number of nodes for the cluster."
+      }
+    },
+    "agentVMSize": {
+      "type": "string",
+      "defaultValue": "standard_d2s_v3",
+      "metadata": {
+        "description": "The size of the Virtual Machine."
+      }
+    },
+    "linuxAdminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "User name for the Linux Virtual Machines."
+      }
+    },
+    "sshRSAPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Configure all linux machines with the SSH RSA public key string. Your key should include three parts, for example 'ssh-rsa AAAAB...snip...UcyupgH azureuser@linuxvm'"
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "apiVersion": "2024-02-01",
+      "name": "pass1",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+          {
+            "name": "agentpool",
+            "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+            "count": "[parameters('agentCount')]",
+            "vmSize": "[parameters('agentVMSize')]",
+            "osType": "Linux",
+            "mode": "System"
+          }
+        ],
+        "linuxProfile": {
+          "adminUsername": "[parameters('linuxAdminUsername')]",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "[parameters('sshRSAPublicKey')]"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "controlPlaneFQDN": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName')), '2024-02-01').fqdn]"
+    }
+  }
+}

--- a/tests/arm/checks/resource/test_AKSPoolTypeIsScaleSet.py
+++ b/tests/arm/checks/resource/test_AKSPoolTypeIsScaleSet.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.arm.runner import Runner
+from checkov.arm.checks.resource.AKSPoolTypeIsScaleSet import check
+
+
+class TestAKSPoolTypeIsScaleSet(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AKSPoolTypeIsScaleSet")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'Microsoft.ContainerService/managedClusters.pass',
+            'Microsoft.ContainerService/managedClusters.pass1',
+        }
+        failing_resources = {
+            'Microsoft.ContainerService/managedClusters.fail',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
+++ b/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
@@ -37,7 +37,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
 
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 0)
+        self.assertEqual(summary['passed'], 4)
         self.assertEqual(summary['failed'], 16)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
@@ -55,7 +55,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
 
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 0)
+        self.assertEqual(summary['passed'], 4)
         self.assertEqual(summary['failed'], 18)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
@@ -73,7 +73,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
 
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 0)
+        self.assertEqual(summary['passed'], 4)
         self.assertEqual(summary['failed'], 18)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
@@ -91,7 +91,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
 
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 0)
+        self.assertEqual(summary['passed'], 4)
         self.assertEqual(summary['failed'], 20)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)

--- a/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
+++ b/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
@@ -11,7 +11,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_SkipJsonRegex"
+        test_files_dir = os.path.join(current_dir, "example_SkipJsonRegex")
         report = runner.run(
             root_folder=test_files_dir,
             runner_filter=RunnerFilter(skip_checks=["CKV_AZURE_*:.*.json$"])
@@ -21,7 +21,6 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
 
         self.assertEqual(summary['passed'], 0)
         self.assertEqual(summary['failed'], 0)
-        # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -29,7 +28,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_SkipJsonRegex"
+        test_files_dir = os.path.join(current_dir, "example_SkipJsonRegex")
         report = runner.run(
             root_folder=test_files_dir,
             runner_filter=RunnerFilter(skip_checks=["CKV_AZURE_8:.*.json$"])
@@ -38,8 +37,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 4)
-        self.assertEqual(summary['failed'], 16)
-        # As skip is not being inserted to result in base check scan
+        self.assertEqual(summary['failed'], 16)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -47,7 +45,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_SkipJsonRegex"
+        test_files_dir = os.path.join(current_dir, "example_SkipJsonRegex")
         report = runner.run(
             root_folder=test_files_dir,
             runner_filter=RunnerFilter(skip_checks=["CKV_AZURE_8:/skip2.[a-z1-9]*.json$"])
@@ -56,8 +54,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 4)
-        self.assertEqual(summary['failed'], 18)
-        # As skip is not being inserted to result in base check scan
+        self.assertEqual(summary['failed'], 18)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -65,7 +62,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_SkipJsonRegex"
+        test_files_dir = os.path.join(current_dir, "example_SkipJsonRegex")
         report = runner.run(
             root_folder=test_files_dir,
             runner_filter=RunnerFilter(skip_checks=["CKV_AZURE_8:/.*skip1.json$"])
@@ -74,8 +71,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 4)
-        self.assertEqual(summary['failed'], 18)
-        # As skip is not being inserted to result in base check scan
+        self.assertEqual(summary['failed'], 18)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -83,7 +79,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/example_SkipJsonRegex"
+        test_files_dir = os.path.join(current_dir, "example_SkipJsonRegex")
         report = runner.run(
             root_folder=test_files_dir,
             runner_filter=RunnerFilter(skip_checks=["CKV_AZURE_*:/.*skip555.json$"])
@@ -92,8 +88,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 4)
-        self.assertEqual(summary['failed'], 20)
-        # As skip is not being inserted to result in base check scan
+        self.assertEqual(summary['failed'], 20)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

added a new arm policy to ensure that Azure Kubernetes Cluster (AKS) nodes use scale sets

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
