### PR TITLE
feat(arm): add CKV_AZURE_172 to ensure autorotation of Secrets Store CSI Driver secrets for AKS clusters

### DIFF
--- a/checkov/arm/checks/resource/AkSSecretStoreRotation.py
+++ b/checkov/arm/checks/resource/AkSSecretStoreRotation.py
@@ -1,0 +1,17 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+
+
+class AkSSecretStoreRotation(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        name = "Ensure autorotation of Secrets Store CSI Driver secrets for AKS clusters"
+        id = "CKV_AZURE_172"
+        supported_resources = ("Microsoft.ContainerService/managedClusters",)
+        categories = (CheckCategories.GENERAL_SECURITY,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self) -> str:
+        return "properties/addonProfiles/azureKeyvaultSecretsProvider/config/enableSecretRotation"
+
+
+check = AkSSecretStoreRotation()

--- a/tests/arm/checks/resource/example_AkSSecretStoreRotation/fail.json
+++ b/tests/arm/checks/resource/example_AkSSecretStoreRotation/fail.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "aksResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "AKS Cluster Resource ID"
+      }
+    },
+    "aksResourceLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "Location of the AKS resource e.g. \"East US\""
+      }
+    },
+    "aksResourceTagValues": {
+      "type": "object",
+      "metadata": {
+        "description": "Existing all tags on AKS Cluster Resource"
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure Monitor Log Analytics Resource ID"
+      }
+    }
+  },
+  "resources": [
+    {
+      "name": "fail",
+      "type": "Microsoft.ContainerService/managedClusters",
+      "location": "[parameters('aksResourceLocation')]",
+      "tags": "[parameters('aksResourceTagValues')]",
+      "apiVersion": "2018-03-31",
+      "properties": {
+        "mode": "Incremental",
+        "id": "[parameters('aksResourceId')]",
+        "addonProfiles": {
+          "omsagent": {
+            "enabled": true,
+            "config": {
+              "logAnalyticsWorkspaceResourceID": "[parameters('workspaceResourceId')]"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AkSSecretStoreRotation/fail1.json
+++ b/tests/arm/checks/resource/example_AkSSecretStoreRotation/fail1.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "aksResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "AKS Cluster Resource ID"
+      }
+    },
+    "aksResourceLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "Location of the AKS resource e.g. \"East US\""
+      }
+    },
+    "aksResourceTagValues": {
+      "type": "object",
+      "metadata": {
+        "description": "Existing all tags on AKS Cluster Resource"
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure Monitor Log Analytics Resource ID"
+      }
+    }
+  },
+  "resources": [
+    {
+      "name": "fail1",
+      "type": "Microsoft.ContainerService/managedClusters",
+      "location": "[parameters('aksResourceLocation')]",
+      "tags": "[parameters('aksResourceTagValues')]",
+      "apiVersion": "2018-03-31",
+      "properties": {
+        "mode": "Incremental",
+        "id": "[parameters('aksResourceId')]",
+        "addonProfiles": {
+          "omsagent": {
+            "enabled": true,
+            "config": {
+              "logAnalyticsWorkspaceResourceID": "[parameters('workspaceResourceId')]"
+            }
+          },
+          "azureKeyvaultSecretsProvider": {
+         "enabled": true,
+          "config": {
+          "enableSecretRotation": false
+        }
+      }
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AkSSecretStoreRotation/pass.json
+++ b/tests/arm/checks/resource/example_AkSSecretStoreRotation/pass.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "aksResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "AKS Cluster Resource ID"
+      }
+    },
+    "aksResourceLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "Location of the AKS resource e.g. \"East US\""
+      }
+    },
+    "aksResourceTagValues": {
+      "type": "object",
+      "metadata": {
+        "description": "Existing all tags on AKS Cluster Resource"
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure Monitor Log Analytics Resource ID"
+      }
+    }
+  },
+  "resources": [
+    {
+      "name": "pass",
+      "type": "Microsoft.ContainerService/managedClusters",
+      "location": "[parameters('aksResourceLocation')]",
+      "tags": "[parameters('aksResourceTagValues')]",
+      "apiVersion": "2018-03-31",
+      "properties": {
+        "mode": "Incremental",
+        "id": "[parameters('aksResourceId')]",
+        "addonProfiles": {
+          "omsagent": {
+            "enabled": true,
+            "config": {
+              "logAnalyticsWorkspaceResourceID": "[parameters('workspaceResourceId')]"
+            }
+          },
+          "azureKeyvaultSecretsProvider": {
+         "enabled": true,
+          "config": {
+          "enableSecretRotation": true
+        }
+      }
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/test_AkSSecretStoreRotation.py
+++ b/tests/arm/checks/resource/test_AkSSecretStoreRotation.py
@@ -1,0 +1,40 @@
+from checkov.arm.checks.resource.AkSSecretStoreRotation import check
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.arm.runner import Runner
+
+
+class TestAKSSecretStoreRotation(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AkSSecretStoreRotation")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'Microsoft.ContainerService/managedClusters.pass',
+        }
+        failing_resources = {
+            'Microsoft.ContainerService/managedClusters.fail',
+            'Microsoft.ContainerService/managedClusters.fail1',
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
+++ b/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
@@ -38,7 +38,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 16)
+        self.assertEqual(summary['failed'], 20)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
@@ -56,7 +56,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 18)
+        self.assertEqual(summary['failed'], 22)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
@@ -74,7 +74,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 18)
+        self.assertEqual(summary['failed'], 22)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
@@ -92,7 +92,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 20)
+        self.assertEqual(summary['failed'], 24)
         # As skip is not being inserted to result in base check scan
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure autorotation of Secrets Store CSI Driver secrets for AKS clusters
"

## Description

added a new arm policy to ensure autorotation of Secrets Store CSI Driver secrets for AKS clusters

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
