### PR TITLE
feat(arm): AzureSearchSQLQueryUpdates

### DIFF
--- a/checkov/arm/checks/resource/AzureSearchSLAQueryUpdates.py
+++ b/checkov/arm/checks/resource/AzureSearchSLAQueryUpdates.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.arm.base_resource_check import BaseResourceCheck
+
+
+class AzureSearchSQLQueryUpdates(BaseResourceCheck):
+    def __init__(self) -> None:
+        # Cognitive Search services support indexing and querying. Indexing is the process of loading content
+        # into the service to make it searchable. Querying is the process where a client searches for content
+        # by sending queries to the index.
+        # Cognitive Search supports a configurable number of replicas.
+        # Having multiple replicas allows queries and index updates to load balance across multiple replicas.
+        # To receive a Service Level Agreement (SLA) for Search index queries a minimum of 2 replicas is required.
+        name = "Ensure that Azure Cognitive Search maintains SLA for search index queries"
+        id = "CKV_AZURE_209"
+        supported_resources = ["Microsoft.Search/searchServices", ]
+        categories = [CheckCategories.GENERAL_SECURITY, ]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:
+        self.evaluated_keys = ["properties/replicaCount"]
+
+        properties = conf.get("properties", {})
+        if not isinstance(properties, dict):
+            return CheckResult.FAILED
+        replica_count = properties.get("replicaCount")
+        if replica_count:
+            if not isinstance(replica_count, int):
+                return CheckResult.UNKNOWN
+            if replica_count >= 2:
+                return CheckResult.PASSED
+
+        return CheckResult.FAILED
+
+
+check = AzureSearchSQLQueryUpdates()

--- a/tests/arm/checks/resource/example_AzureSearchSLAQueryUpdates/fail.json
+++ b/tests/arm/checks/resource/example_AzureSearchSLAQueryUpdates/fail.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.Search/searchServices",
+      "apiVersion": "2024-03-01-preview",
+      "name": "fail",
+      "location": "string",
+      "sku": {
+        "name": "standard"
+      },
+      "properties": {
+        "publicNetworkAccess": "Enabled"
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AzureSearchSLAQueryUpdates/fail2.json
+++ b/tests/arm/checks/resource/example_AzureSearchSLAQueryUpdates/fail2.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.Search/searchServices",
+      "apiVersion": "2024-03-01-preview",
+      "name": "fail2",
+      "location": "string",
+      "sku": {
+        "name": "standard"
+      },
+      "properties": {
+        "replicaCount": 1
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AzureSearchSLAQueryUpdates/pass.json
+++ b/tests/arm/checks/resource/example_AzureSearchSLAQueryUpdates/pass.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.Search/searchServices",
+      "apiVersion": "2024-03-01-preview",
+      "name": "pass",
+      "location": "string",
+      "sku": {
+        "name": "standard"
+      },
+      "properties": {
+        "publicNetworkAccess": "Disabled",
+        "replicaCount": 2
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/test_AzureSearchSLAQueryUpdates.py
+++ b/tests/arm/checks/resource/test_AzureSearchSLAQueryUpdates.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.arm.runner import Runner
+from checkov.arm.checks.resource.AzureSearchSLAQueryUpdates import check
+
+
+class TestAzureSearchSLAQueryUpdates(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AzureSearchSLAQueryUpdates")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'Microsoft.Search/searchServices.pass'
+        }
+        failing_resources = {
+            'Microsoft.Search/searchServices.fail',
+            'Microsoft.Search/searchServices.fail2'
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*We converted the check 'AzureSearchSQLQueryUpdates' from TERRAFORM language to the ARM language so that it also works on resources that are defined in the ARM language.*

Fixes # (issue)

### Description
*Ensure that Azure Cognitive Search maintains SLA for search index queries.*

### Fix
*Implemented the check in ARM language to verify the `replicaCount` of Azure Cognitive Search services (`Microsoft.Search/searchServices`) defined in ARM templates. The check ensures that the `replicaCount` is at least 2 to meet SLA requirements for search index queries.*

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
