### PR TITLE
feat(arm): AKSEncryptionAtHostEnable

### DIFF
--- a/checkov/arm/checks/resource/AKSEncryptionAtHostEnabled.py
+++ b/checkov/arm/checks/resource/AKSEncryptionAtHostEnabled.py
@@ -1,0 +1,38 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.arm.base_resource_value_check import BaseResourceValueCheck
+
+
+class AKSEncryptionAtHostEnabled(BaseResourceValueCheck):
+    def __init__(self) -> None:
+        """
+        With host-based encryption, the data stored on the VM host of
+        your AKS agent nodes' VMs is encrypted at rest and flows encrypted to the Storage service.
+        This means the temp disks are encrypted at rest with platform-managed keys.
+        The cache of OS and data disks is encrypted at rest with either platform-managed keys
+        or customer-managed keys depending on the encryption type set on those disks.
+        """
+        name = "Ensure that the AKS cluster encrypt temp disks, caches, and data flows "
+        name += "between Compute and Storage resources"
+        id = "CKV_AZURE_227"
+        supported_resources = ["Microsoft.ContainerService/managedClusters",
+                               "Microsoft.ContainerService/managedClusters/agentPools"]
+        categories = [CheckCategories.KUBERNETES, ]
+        super().__init__(
+            name=name,
+            id=id,
+            categories=categories,
+            supported_resources=supported_resources,
+            missing_block_result=CheckResult.FAILED,
+        )
+
+    def get_inspected_key(self) -> str:
+        if self.entity_type == "Microsoft.ContainerService/managedClusters":
+            return "properties/agentPoolProfiles/[0]/enableEncryptionAtHost"
+        else:
+            return "properties/enableEncryptionAtHost"
+
+    def get_expected_value(self) -> bool:
+        return True
+
+
+check = AKSEncryptionAtHostEnabled()

--- a/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/fail1.json
+++ b/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/fail1.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "apiVersion": "2024-03-02",
+      "name": "fail1",
+      "location": "East US",
+      "properties": {
+        "vmSize": "Standard_DS2_v2",
+        "count": 1,
+        "tags": {
+          "Enviroment": "Production"
+        },
+        "agentPoolProfiles": [
+          {
+            "name": "default",
+            "enableEncryptionAtHost": false,
+            "vmSize": "Standard_E4ads_v5",
+            "osDiskType": "Ephemeral",
+            "availabilityZones": [1, 2, 3],
+            "type": "VirtualMachineScaleSets",
+            "maxCount": 6,
+            "minCount": 2,
+            "enableAutoScaling": true,
+            "orchestratorVersion": "[parameters('kubernetesVersion')]",
+            "vnetSubnetID": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/fail2.json
+++ b/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/fail2.json
@@ -1,0 +1,32 @@
+
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "apiVersion": "2024-03-02",
+      "name": "fail2",
+      "location": "East US",
+      "properties": {
+        "vmSize": "Standard_DS2_v2",
+        "count": 1,
+        "agentPoolProfiles": [
+          {
+            "name": "default",
+            "vmSize": "Standard_E4ads_v5",
+            "osDiskType": "Ephemeral",
+            "availabilityZones": [1, 2, 3],
+            "onlyCriticalAddonsEnabled": true,
+            "type": "VirtualMachineScaleSets",
+            "vnetSubnetID": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}",
+            "enableAutoScaling": true,
+            "maxCount": 6,
+            "minCount": 2,
+            "orchestratorVersion": "[parameters('kubernetesVersion')]"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/failA1.json
+++ b/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/failA1.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.ContainerService/managedClusters/agentPools",
+      "apiVersion": "2014-04-01",
+      "name": "failA1",
+      "properties": {
+        "count": 1,
+        "enableEncryptionAtHost": false,
+        "vmSize": "Standard_DS2_v2",
+        "tags": {
+          "Environment": "Production"
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/failA2.json
+++ b/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/failA2.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.ContainerService/managedClusters/agentPools",
+      "apiVersion": "2014-04-01",
+      "name": "failA2",
+      "properties": {
+        "nodeCount": 1,
+        "vmSize": "Standard_DS2_v2",
+        "tags": {
+          "Environment": "Production"
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/pass.json
+++ b/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/pass.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "apiVersion": "2024-03-02",
+      "name": "pass",
+      "location": "East US",
+      "properties": {
+        "vmSize": "Standard_DS2_v2",
+        "nodeCount": 1,
+        "agentPoolProfiles": [
+          {
+            "name": "default",
+            "enableEncryptionAtHost": true,
+            "vmSize": "Standard_E4ads_v5",
+            "osDiskType": "Ephemeral",
+            "availabilityZones": [
+              1,
+              2,
+              3
+            ],
+            "onlyCriticalAddOns": true,
+            "type": "VirtualMachineScaleSets",
+            "maxCount": 6,
+            "minCount": 2,
+            "orchestratorVersion": "[parameters('kubernetesVersion')]",
+            "vnetSubnetID": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/passA.json
+++ b/tests/arm/checks/resource/example_AKSEncryptionAtHostEnabled/passA.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.ContainerService/managedClusters/agentPools",
+      "apiVersion": "2014-04-01",
+      "name": "passA",
+      "properties": {
+        "count": 1,
+        "enableEncryptionAtHost": true,
+        "orchestratorVersion": "[parameters('kubernetesVersion')]",
+        "vmSize": "Standard_DS2_v2",
+        "tags": {
+          "Environment": "Production"
+        }
+      }
+    }
+  ]
+}

--- a/tests/arm/checks/resource/test_AKSEncryptionAtHostEnabled.py
+++ b/tests/arm/checks/resource/test_AKSEncryptionAtHostEnabled.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.arm.runner import Runner
+from checkov.arm.checks.resource.AKSEncryptionAtHostEnabled import check
+
+
+class TestAKSEncryptionAtHostEnabled(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AKSEncryptionAtHostEnabled")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'Microsoft.ContainerService/managedClusters.pass',
+            'Microsoft.ContainerService/managedClusters/agentPools.passA'
+        }
+        failing_resources = {
+            'Microsoft.ContainerService/managedClusters.fail1',
+            'Microsoft.ContainerService/managedClusters.fail2',
+            'Microsoft.ContainerService/managedClusters/agentPools.failA1',
+            'Microsoft.ContainerService/managedClusters/agentPools.failA2',
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
+++ b/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
@@ -37,7 +37,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 32)  # Updated expected value
+        self.assertEqual(summary['failed'], 36)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -54,7 +54,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 34)  # Updated expected value
+        self.assertEqual(summary['failed'], 38)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -71,7 +71,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 34)  # Updated expected value
+        self.assertEqual(summary['failed'], 38)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -88,7 +88,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 0)
-        self.assertEqual(summary['failed'], 36)  # Updated expected value
+        self.assertEqual(summary['failed'], 40)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*We converted the check 'AKSEncryptionAtHostEnabled' from TERRAFORM language to the ARM language so that it also works on resources that are defined in the ARM language.*

Fixes # (issue)

### Description
*Ensure that the AKS cluster encrypt temp disks, caches, and data flows between Compute and Storage resources*

### Fix
*To fix the issue, ensure that the 'enableEncryptionAtHost' property is set to true for both Microsoft.ContainerService/managedClusters and Microsoft.ContainerService/managedClusters/agentPools resources. This enables encryption at host for the VM host of AKS agent nodes, ensuring data stored on the VM host is encrypted at rest and flows encrypted to the Storage service.*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
