### PR TITLE
fix(arm): CKV_AZURE_56 just for authsettingsV2 name

### DIFF
--- a/checkov/arm/checks/resource/FunctionAppsEnableAuthentication.py
+++ b/checkov/arm/checks/resource/FunctionAppsEnableAuthentication.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from checkov.arm.base_resource_check import BaseResourceCheck

--- a/checkov/arm/checks/resource/FunctionAppsEnableAuthentication.py
+++ b/checkov/arm/checks/resource/FunctionAppsEnableAuthentication.py
@@ -1,23 +1,30 @@
-from checkov.arm.base_resource_value_check import BaseResourceValueCheck
-from checkov.common.models.enums import CheckCategories
+from typing import Any
+
+from checkov.arm.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckCategories, CheckResult
 
 
-class FunctionAppsEnableAuthentication(BaseResourceValueCheck):
+class FunctionAppsEnableAuthentication(BaseResourceCheck):
 
     def __init__(self) -> None:
         name = "Ensure that function apps enables Authentication"
         id = "CKV_AZURE_56"
         supported_resources = ("Microsoft.Web/sites/config",)
         categories = (CheckCategories.GENERAL_SECURITY,)
-        super().__init__(name=name,
-                         id=id,
-                         categories=categories,
-                         supported_resources=supported_resources,
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,)
 
-                         )
+    def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:
+        if conf.get('name', '') != 'authsettingsV2':
+            return CheckResult.PASSED
 
-    def get_inspected_key(self) -> str:
-        return 'properties/platform/enabled'
+        properties = conf.get('properties', {})
+        if properties and isinstance(properties, dict):
+            platform = properties.get('platform', {})
+            if platform and isinstance(properties, dict):
+                enabled = platform.get('enabled', False)
+                if enabled:
+                    return CheckResult.PASSED
+        return CheckResult.FAILED
 
 
 check = FunctionAppsEnableAuthentication()

--- a/tests/arm/checks/resource/example_FunctionAppsEnableAuthentication/fail.json
+++ b/tests/arm/checks/resource/example_FunctionAppsEnableAuthentication/fail.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2021-02-01",
-      "name": "fail",
+      "name": "authsettingsV2",
       "properties": {
         "httpSettings": {
           "forwardProxy": {

--- a/tests/arm/checks/resource/example_FunctionAppsEnableAuthentication/fail2.json
+++ b/tests/arm/checks/resource/example_FunctionAppsEnableAuthentication/fail2.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2021-02-01",
-      "name": "fail2",
+      "name": "authsettingsV2",
       "properties": {
         "httpSettings": {
           "forwardProxy": {

--- a/tests/arm/checks/resource/example_FunctionAppsEnableAuthentication/pass2.json
+++ b/tests/arm/checks/resource/example_FunctionAppsEnableAuthentication/pass2.json
@@ -5,15 +5,12 @@
     {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2021-02-01",
-      "name": "authsettingsV2",
+      "name": "pass",
       "properties": {
         "httpSettings": {
           "forwardProxy": {
             "convention": "Custom"
           }
-        },
-        "platform": {
-          "enabled": true
         }
       }
     }

--- a/tests/arm/checks/resource/test_FunctionAppsEnableAuthentication.py
+++ b/tests/arm/checks/resource/test_FunctionAppsEnableAuthentication.py
@@ -18,16 +18,17 @@ class TestFunctionAppsEnableAuthentication(unittest.TestCase):
         # then
         summary = report.get_summary()
 
-        passing_resources = {
+        passing_resources = [
             "Microsoft.Web/sites/config.pass",
-        }
-        failing_resources = {
-            "Microsoft.Web/sites/config.fail",
-            "Microsoft.Web/sites/config.fail2",
-        }
+            "Microsoft.Web/sites/config.authsettingsV2"
+        ]
+        failing_resources = [
+            "Microsoft.Web/sites/config.authsettingsV2",
+            "Microsoft.Web/sites/config.authsettingsV2"
+        ]
 
-        passed_check_resources = {c.resource for c in report.passed_checks}
-        failed_check_resources = {c.resource for c in report.failed_checks}
+        passed_check_resources = [c.resource for c in report.passed_checks]
+        failed_check_resources = [c.resource for c in report.failed_checks]
 
         self.assertEqual(summary["passed"], len(passing_resources))
         self.assertEqual(summary["failed"], len(failing_resources))

--- a/tests/arm/checks/resource/test_FunctionAppsEnableAuthentication.py
+++ b/tests/arm/checks/resource/test_FunctionAppsEnableAuthentication.py
@@ -18,20 +18,20 @@ class TestFunctionAppsEnableAuthentication(unittest.TestCase):
         # then
         summary = report.get_summary()
 
-        passing_resources = [
+        passing_resources = {
             "Microsoft.Web/sites/config.pass",
             "Microsoft.Web/sites/config.authsettingsV2"
-        ]
-        failing_resources = [
+        }
+        failing_resources = {
             "Microsoft.Web/sites/config.authsettingsV2",
             "Microsoft.Web/sites/config.authsettingsV2"
-        ]
+        }
 
-        passed_check_resources = [c.resource for c in report.passed_checks]
-        failed_check_resources = [c.resource for c in report.failed_checks]
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], len(passing_resources))
-        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 2)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

fixes: https://github.com/bridgecrewio/checkov/issues/6555

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
