### PR TITLE
platform(general): pass repo ID to runconfig

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -989,7 +989,7 @@ class BcPlatformIntegration:
             self.get_public_run_config()
 
     def _get_run_config_query_params(self) -> str:
-        return f'module={"bc" if self.is_bc_token(self.bc_api_key) else "pc"}&enforcementv2=true'
+        return f'module={"bc" if self.is_bc_token(self.bc_api_key) else "pc"}&enforcementv2=true&repoId={urllib.parse.quote(self.repo_id)}'
 
     def get_run_config_url(self) -> str:
         return f'{self.platform_run_config_url}?{self._get_run_config_query_params()}'

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -989,7 +989,8 @@ class BcPlatformIntegration:
             self.get_public_run_config()
 
     def _get_run_config_query_params(self) -> str:
-        return f'module={"bc" if self.is_bc_token(self.bc_api_key) else "pc"}&enforcementv2=true&repoId={urllib.parse.quote(self.repo_id)}'
+        # ignore mypy warning that this can be null
+        return f'module={"bc" if self.is_bc_token(self.bc_api_key) else "pc"}&enforcementv2=true&repoId={urllib.parse.quote(self.repo_id)}'  # type: ignore
 
     def get_run_config_url(self) -> str:
         return f'{self.platform_run_config_url}?{self._get_run_config_query_params()}'

--- a/tests/common/integration_features/test_repo_config_integration.py
+++ b/tests/common/integration_features/test_repo_config_integration.py
@@ -792,6 +792,27 @@ class TestRepoConfigIntegration(unittest.TestCase):
         repo_config_integration._set_exclusion_paths(vcs_config)
         self.assertEqual(repo_config_integration.skip_paths, set())
 
+    def test_skip_paths_no_repos(self):
+        vcs_config = {
+            "scannedFiles": {
+                "sections": [
+                    {
+                        "repos": [],
+                        "rule": {
+                            "excludePaths": []
+                        },
+                        "isDefault": True
+                    }
+                ]
+            }
+        }
+
+        instance = BcPlatformIntegration()
+        instance.repo_id = 'org/repo'
+        repo_config_integration = RepoConfigIntegration(instance)
+        repo_config_integration._set_exclusion_paths(vcs_config)
+        self.assertEqual(repo_config_integration.skip_paths, set())
+
     def test_skip_paths_multiple_one_match(self):
         vcs_config = {
             "scannedFiles": {

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -139,10 +139,13 @@ class TestBCApiUrl(unittest.TestCase):
 
     def test_run_config_url(self):
         instance = BcPlatformIntegration()
+        instance.repo_id = 'owner/repo'
         instance.bc_api_key = '00000000-0000-0000-0000-000000000000'
-        self.assertTrue(instance.get_run_config_url().endswith('/runConfiguration?module=bc&enforcementv2=true'))
+        self.assertTrue(instance.get_run_config_url().endswith('/runConfiguration?module=bc&enforcementv2=true&repoId=owner/repo'))
         instance.bc_api_key = '00000000-0000-0000-0000-000000000000::1234=='
-        self.assertTrue(instance.get_run_config_url().endswith('/runConfiguration?module=pc&enforcementv2=true'))
+        self.assertTrue(instance.get_run_config_url().endswith('/runConfiguration?module=pc&enforcementv2=true&repoId=owner/repo'))
+        instance.repo_id = 'encode/më'
+        self.assertTrue(instance.get_run_config_url().endswith('/runConfiguration?module=pc&enforcementv2=true&repoId=encode/m%C3%AB'))
 
     def test_is_valid_policy_filter(self):
         instance = BcPlatformIntegration()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
- Passes the repo ID to the platform runConfig endpoint
- Adds a test to handle the new case that is possible in the platform response, where the vcsConfig has no repos or exclude paths

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
