### PR TITLE
fix(general): fix the right numbers in TestSkipJsonRegexPattern

### DIFF
--- a/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
+++ b/tests/arm/checks/resource/test_SkipJsonRegexPattern.py
@@ -37,7 +37,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 4)
-        self.assertEqual(summary['failed'], 36)  # Updated expected value
+        self.assertEqual(summary['failed'], 40)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -54,7 +54,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 4)
-        self.assertEqual(summary['failed'], 38)  # Updated expected value
+        self.assertEqual(summary['failed'], 42)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -71,7 +71,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 4)
-        self.assertEqual(summary['failed'], 38)  # Updated expected value
+        self.assertEqual(summary['failed'], 42)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
@@ -88,7 +88,7 @@ class TestSkipJsonRegexPattern(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 4)
-        self.assertEqual(summary['failed'], 40)  # Updated expected value
+        self.assertEqual(summary['failed'], 44)  # Updated expected value
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

### Fix
*fix the right numbers in TestSkipJsonRegexPattern

## Checklist:

- [x] New and existing tests pass locally with my changes
