### PR TITLE
fix(terraform): Exclude String in CKV_AWS_337

### DIFF
--- a/checkov/terraform/checks/resource/aws/SSMParameterUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/SSMParameterUsesCMK.py
@@ -14,7 +14,7 @@ class SSMParameterUsesCMK(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        if conf.get("type")[0] == "String":
+        if conf.get("type")[0] != "SecureString":
             return CheckResult.PASSED
         return super().scan_resource_conf(conf)
 

--- a/checkov/terraform/checks/resource/aws/SSMParameterUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/SSMParameterUsesCMK.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.models.consts import ANY_VALUE
 
@@ -12,6 +12,11 @@ class SSMParameterUsesCMK(BaseResourceValueCheck):
         supported_resources = ("aws_ssm_parameter",)
         categories = (CheckCategories.ENCRYPTION,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if conf.get("type")[0] == "String":
+            return CheckResult.PASSED
+        return super().scan_resource_conf(conf)
 
     def get_inspected_key(self) -> str:
         return "key_id"

--- a/tests/terraform/checks/resource/aws/example_SSMParameterUsesCMK/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SSMParameterUsesCMK/main.tf
@@ -20,3 +20,14 @@ resource "aws_ssm_parameter" "pass" {
     environment = "production"
   }
 }
+
+resource "aws_ssm_parameter" "pass2" {
+  name        = "/production/database/password/master"
+  description = "The parameter description"
+  type        = "String"
+  value       = var.database_master_password
+
+  tags = {
+    environment = "production"
+  }
+}

--- a/tests/terraform/checks/resource/aws/test_SSMParameterUsesCMK.py
+++ b/tests/terraform/checks/resource/aws/test_SSMParameterUsesCMK.py
@@ -17,6 +17,7 @@ class TestSSMParameterUsesCMK(unittest.TestCase):
 
         passing_resources = {
             "aws_ssm_parameter.pass",
+            "aws_ssm_parameter.pass2",
         }
 
         failing_resources = {


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

While technically possible to encrypt String parameters with KMS, no sensitive information should be stored as a string (there is another check for that) and thus encryption with KMS is not required.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
