### PR TITLE
fix(terraform): Fix resource type for CKV_AZURE_242

### DIFF
--- a/checkov/arm/checks/resource/AzureMLWorkspacePrivateEndpoint.py
+++ b/checkov/arm/checks/resource/AzureMLWorkspacePrivateEndpoint.py
@@ -7,7 +7,7 @@ from checkov.common.util.consts import START_LINE, END_LINE
 
 class AzureMLWorkspacePrivateEndpoint(BaseResourceCheck):
     def __init__(self) -> None:
-        name = "Ensure Azure Machine learning workspace is not configured with private endpoint"
+        name = "Ensure Azure Machine learning workspace is configured with private endpoint"
         id = "CKV_AZURE_243"
         supported_resources = ["Microsoft.MachineLearningServices/workspaces"]
         categories = [CheckCategories.NETWORKING]

--- a/checkov/terraform/checks/resource/azure/AzureSparkPoolIsolatedComputeEnabled.py
+++ b/checkov/terraform/checks/resource/azure/AzureSparkPoolIsolatedComputeEnabled.py
@@ -6,7 +6,7 @@ class AzureSparkPoolIsolatedComputeEnabled(BaseResourceValueCheck):
     def __init__(self) -> None:
         name = "Ensure isolated compute is enabled for Synapse Spark pools"
         id = "CKV_AZURE_242"
-        supported_resources = ("synapse_spark_pool",)
+        supported_resources = ("azurerm_synapse_spark_pool",)
         categories = (CheckCategories.GENERAL_SECURITY,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 

--- a/tests/terraform/checks/resource/azure/example_AzureSparkPoolIsolatedComputeEnabled/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AzureSparkPoolIsolatedComputeEnabled/main.tf
@@ -1,5 +1,5 @@
 ## SHOULD PASS: Explicit true
-resource "synapse_spark_pool" "pass" {
+resource "azurerm_synapse_spark_pool" "pass" {
   name                = "sparkPool1"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
@@ -7,14 +7,14 @@ resource "synapse_spark_pool" "pass" {
 }
 
 ## SHOULD FAIL: Default false
-resource "synapse_spark_pool" "fail" {
+resource "azurerm_synapse_spark_pool" "fail" {
   name                = "sparkPool1"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
 }
 
 ## SHOULD FAIL: Explicit false
-resource "synapse_spark_pool" "fail2" {
+resource "azurerm_synapse_spark_pool" "fail2" {
   name                = "sparkPool1"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location

--- a/tests/terraform/checks/resource/azure/test_AzureSparkPoolIsolatedComputeEnabled.py
+++ b/tests/terraform/checks/resource/azure/test_AzureSparkPoolIsolatedComputeEnabled.py
@@ -19,11 +19,11 @@ class TestAzureSparkPoolIsolatedComputeEnabled(unittest.TestCase):
         logging.warning(f"summary: {summary}")
 
         passing_resources = {
-            'synapse_spark_pool.pass'
+            'azurerm_synapse_spark_pool.pass'
         }
         failing_resources = {
-            'synapse_spark_pool.fail',
-            'synapse_spark_pool.fail2'
+            'azurerm_synapse_spark_pool.fail',
+            'azurerm_synapse_spark_pool.fail2'
         }
         skipped_resources = {}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Resource type was wrong for CKV_AZURE_242

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
