### PR TITLE
platform(general): handle multiple values for the same metadata filter

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -1186,7 +1186,7 @@ class BcPlatformIntegration:
         return filtered_policies
 
     @staticmethod
-    def add_static_policy_filters(query_params: list[tuple[str, str]]):
+    def add_static_policy_filters(query_params: list[tuple[str, str]]) -> list[tuple[str, str]]:
         """
         Adds policy.enabled = true, policy.subtype = build to the query params, if these are not already present. Modifies the list in place and also returns it.
         """

--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -58,7 +58,7 @@ from checkov.common.util.http_utils import (
     REQUEST_READ_TIMEOUT,
     REQUEST_RETRIES,
 )
-from checkov.common.util.type_forcers import convert_prisma_policy_filter_to_dict, convert_str_to_bool
+from checkov.common.util.type_forcers import convert_prisma_policy_filter_to_params, convert_str_to_bool
 from checkov.version import version as checkov_version
 
 if TYPE_CHECKING:
@@ -1165,16 +1165,17 @@ class BcPlatformIntegration:
                 return filtered_policies
 
             logging.debug(f'Prisma policy URL: {self.prisma_policies_url}')
-            query_params = convert_prisma_policy_filter_to_dict(policy_filter)
+            query_params = convert_prisma_policy_filter_to_params(policy_filter)
             if self.is_valid_policy_filter(query_params, valid_filters=self.get_prisma_policy_filters()):
                 # If enabled and subtype are not explicitly set, use the only acceptable values.
-                query_params['policy.enabled'] = True
-                query_params['policy.subtype'] = 'build'
+                self.add_static_policy_filters(query_params)
+                logging.debug(f'Filter query params: {query_params}')
+
                 request = self.http.request(  # type:ignore[no-untyped-call]
                     "GET",
                     self.prisma_policies_url,
                     headers=headers,
-                    fields=query_params,
+                    fields=tuple(query_params),
                 )
                 logging.debug("Got Prisma build policy metadata")
                 filtered_policies = json.loads(request.data.decode("utf8"))
@@ -1183,6 +1184,17 @@ class BcPlatformIntegration:
             logging.warning(
                 f"Failed to get prisma build policy metadata from {self.prisma_policies_url}{response_message}", exc_info=True)
         return filtered_policies
+
+    @staticmethod
+    def add_static_policy_filters(query_params: list[tuple[str, str]]):
+        """
+        Adds policy.enabled = true, policy.subtype = build to the query params, if these are not already present. Modifies the list in place and also returns it.
+        """
+        if not any(p[0] == 'policy.enabled' for p in query_params):
+            query_params.append(('policy.enabled', 'true'))
+        if not any(p[0] == 'policy.subtype' for p in query_params):
+            query_params.append(('policy.subtype', 'build'))
+        return query_params
 
     def get_prisma_policy_filters(self) -> Dict[str, Dict[str, Any]]:
         request = None
@@ -1211,7 +1223,7 @@ class BcPlatformIntegration:
             return {}
 
     @staticmethod
-    def is_valid_policy_filter(policy_filter: dict[str, str], valid_filters: dict[str, dict[str, Any]] | None = None) -> bool:
+    def is_valid_policy_filter(policy_filter: list[tuple[str, str]], valid_filters: dict[str, dict[str, Any]] | None = None) -> bool:
         """
         Validates only the filter names
         """
@@ -1221,7 +1233,7 @@ class BcPlatformIntegration:
             return False
         if not valid_filters:
             return False
-        for filter_name, filter_value in policy_filter.items():
+        for filter_name, filter_value in policy_filter:
             if filter_name not in valid_filters.keys():
                 logging.warning(f"Invalid filter name: {filter_name}")
                 logging.warning(f"Available filter names: {', '.join(valid_filters.keys())}")

--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -469,7 +469,7 @@ class ExtArgumentParser(configargparse.ArgumentParser):
                  "When used with --policy-metadata-filter-exception, the exceptions override any policies selected as"
                  "a result of the --policy-metadata-filter flag."
                  "See https://prisma.pan.dev/api/cloud/cspm/policy#operation/get-policy-filters-and-options for "
-                 "information on allowed filters. Format: policy.label=test,cloud.type=aws ",
+                 "information on allowed filters. Example: policy.label=label1,policy.label=label2,cloud.type=aws",
             default=None,
         )
         self.add(
@@ -478,7 +478,7 @@ class ExtArgumentParser(configargparse.ArgumentParser):
                  "When used with --policy-metadata-filter, the exceptions override any policies selected as"
                  "a result of the --policy-metadata-filter flag."
                  "See https://prisma.pan.dev/api/cloud/cspm/policy#operation/get-policy-filters-and-options for "
-                 "information on allowed filters. Format: policy.label=test,cloud.type=aws ",
+                 "information on allowed filters. Example: policy.label=label1,policy.label=label2,cloud.type=aws",
             default=None,
         )
         self.add(

--- a/checkov/common/util/type_forcers.py
+++ b/checkov/common/util/type_forcers.py
@@ -4,7 +4,7 @@ import json
 import logging
 import typing
 from json import JSONDecodeError
-from typing import TypeVar, overload, Any, Dict
+from typing import TypeVar, overload, Any, Tuple, List
 
 import yaml
 
@@ -130,20 +130,26 @@ def convert_csv_string_arg_to_list(csv_string_arg: list[str] | str | None) -> li
         return csv_string_arg
 
 
-def convert_prisma_policy_filter_to_dict(filter_string: str) -> Dict[Any, Any]:
+def convert_prisma_policy_filter_to_params(filter_string: str) -> List[Tuple[str, str]]:
     """
-    Converts the filter string to a dict. For example:
+    Converts the filter string to a list of tuples. For example:
     'policy.label=label,cloud.type=aws' becomes -->
-    {'policy.label': 'label1', 'cloud.type': 'aws'}
-    Note that the API does not accept lists https://prisma.pan.dev/api/cloud/cspm/policy#operation/get-policies-v2
-    This is not allowed: policy.label=label1,label2
+    [('policy.label', 'label1'), ('cloud.type', 'aws')]
+
+    Multiple values for the same attribute, like policy.label, will be separate items in the tuple. For example,
+    'policy.label=label,policy.label=anotherlabel' becomes -->
+    [('policy.label', 'label1'), ('policy.label', 'anotherlabel')]
+
+    Note that the urllib3 library seems to work best with tuples only (not lists), so this result may need to be converted.
+    It is returned as a list so that it can be modified separately, and converted to a tuple only when ready
     """
-    filter_params = {}
+    filter_params: List[Tuple[str, str]] = []
     if isinstance(filter_string, str) and filter_string:
         for f in filter_string.split(','):
             try:
                 f_name, f_value = f.split('=')
-                filter_params[f_name.strip()] = f_value.strip()
+                filter_params.append((f_name.strip(), f_value.strip()))
             except (IndexError, ValueError) as e:
                 logging.debug(f"Invalid filter format: {e}")
+
     return filter_params

--- a/tests/common/test_platform_integration.py
+++ b/tests/common/test_platform_integration.py
@@ -151,15 +151,23 @@ class TestBCApiUrl(unittest.TestCase):
         instance = BcPlatformIntegration()
         instance.bc_api_key = '00000000-0000-0000-0000-000000000000::1234=='
         instance.customer_run_config_response = mock_customer_run_config()
-        self.assertTrue(instance.is_valid_policy_filter(policy_filter={'policy.label': 'CODE'},
+        self.assertTrue(instance.is_valid_policy_filter(policy_filter=[('policy.label', 'CODE')],
                                                         valid_filters=mock_prisma_policy_filter_response()))
-        self.assertFalse(instance.is_valid_policy_filter(policy_filter={'policy.labels': 'CODE'},
+        self.assertFalse(instance.is_valid_policy_filter(policy_filter=[('policy.labels', 'CODE')],
                                                         valid_filters=mock_prisma_policy_filter_response()))
-        self.assertFalse(instance.is_valid_policy_filter(policy_filter={'policy.label': 'CODE', 'not': 'allowed'},
+        self.assertFalse(instance.is_valid_policy_filter(policy_filter=[('policy.label', 'CODE'), ('not', 'allowed')],
                                                         valid_filters=mock_prisma_policy_filter_response()))
-        self.assertFalse(instance.is_valid_policy_filter(policy_filter={},
+        self.assertFalse(instance.is_valid_policy_filter(policy_filter=[],
                                                          valid_filters=mock_prisma_policy_filter_response()))
-        self.assertFalse(instance.is_valid_policy_filter(policy_filter={'policy.label': ['A', 'B']}, valid_filters={}))
+        self.assertFalse(instance.is_valid_policy_filter(policy_filter=[('policy.label', 'A'), ('policy.label', 'B')], valid_filters={}))
+
+    def test_add_static_policy_filters(self):
+        self.assertListEqual(BcPlatformIntegration.add_static_policy_filters([]), [('policy.enabled', 'true'), ('policy.subtype', 'build')])
+        self.assertListEqual(BcPlatformIntegration.add_static_policy_filters([('policy.enabled', 'true')]), [('policy.enabled', 'true'), ('policy.subtype', 'build')])
+        self.assertListEqual(BcPlatformIntegration.add_static_policy_filters([('policy.enabled', 'true'), ('policy.subtype', 'build')]), [('policy.enabled', 'true'), ('policy.subtype', 'build')])
+        self.assertListEqual(BcPlatformIntegration.add_static_policy_filters([('policy.label', 'xyz')]), [('policy.label', 'xyz'), ('policy.enabled', 'true'), ('policy.subtype', 'build')])
+        self.assertListEqual(BcPlatformIntegration.add_static_policy_filters([('policy.label', 'xyz'), ('policy.enabled', 'true')]), [('policy.label', 'xyz'), ('policy.enabled', 'true'), ('policy.subtype', 'build')])
+        self.assertListEqual(BcPlatformIntegration.add_static_policy_filters([('policy.enabled', 'true'), ('policy.label', 'xyz'), ('policy.subtype', 'build')]), [('policy.enabled', 'true'), ('policy.label', 'xyz'), ('policy.subtype', 'build')])
 
     def test_setup_on_prem(self):
         instance = BcPlatformIntegration()

--- a/tests/common/utils/test_type_forcers.py
+++ b/tests/common/utils/test_type_forcers.py
@@ -1,21 +1,22 @@
 import unittest
 
-from checkov.common.util.type_forcers import convert_prisma_policy_filter_to_dict
+from checkov.common.util.type_forcers import convert_prisma_policy_filter_to_params
 
 
 class TestTypeForcers(unittest.TestCase):
     def test_convert_prisma_policy_filter_to_dict(self):
-        self.assertDictEqual(convert_prisma_policy_filter_to_dict('F1=A,F2=B'), {'F1': 'A', 'F2': 'B'})
-        self.assertDictEqual(convert_prisma_policy_filter_to_dict(''), {})
-        self.assertDictEqual(convert_prisma_policy_filter_to_dict(None), {})
-        self.assertDictEqual(convert_prisma_policy_filter_to_dict('F1 =   A,   F2= B '), {'F1': 'A', 'F2': 'B'})
-        self.assertDictEqual(convert_prisma_policy_filter_to_dict('F1=A,B,F2=C'), {'F1': 'A', 'F2': 'C'})
-        self.assertDictEqual(convert_prisma_policy_filter_to_dict('F1=A,F2=B,C'), {'F1': 'A', 'F2': 'B'})
+        self.assertListEqual(convert_prisma_policy_filter_to_params('F1=A,F2=B'), [('F1', 'A'), ('F2', 'B')])
+        self.assertListEqual(convert_prisma_policy_filter_to_params(''), [])
+        self.assertListEqual(convert_prisma_policy_filter_to_params(None), [])
+        self.assertListEqual(convert_prisma_policy_filter_to_params('F1 =   A,   F2= B '), [('F1', 'A'), ('F2', 'B')])
+        self.assertListEqual(convert_prisma_policy_filter_to_params('F1=A,B,F2=C'), [('F1', 'A'), ('F2', 'C')])
+        self.assertListEqual(convert_prisma_policy_filter_to_params('F1=A,F2=B,C'), [('F1', 'A'), ('F2', 'B')])
+        self.assertListEqual(convert_prisma_policy_filter_to_params('F1=A,F2=B,F1=C'), [('F1', 'A'), ('F2', 'B'), ('F1', 'C')])
+        self.assertListEqual(convert_prisma_policy_filter_to_params('F1=A,F2=B,F1=C,F1=DDD'), [('F1', 'A'), ('F2', 'B'), ('F1', 'C'), ('F1', 'DDD')])
 
         policy_string = 'policy.name=AWS S3 bucket ACL grants READ permission to everyone'
-        filter_string = convert_prisma_policy_filter_to_dict(policy_string)
-        self.assertDictEqual(filter_string, {'policy.name': 'AWS S3 bucket ACL grants READ permission to everyone'})
-
+        filter_string = convert_prisma_policy_filter_to_params(policy_string)
+        self.assertListEqual(filter_string, [('policy.name', 'AWS S3 bucket ACL grants READ permission to everyone')])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Allows multiple values for the same metadata filter attribute (e.g., `policy.label`) and passes them to the Prisma APIs.

Example:

`--policy-metadata-filter policy.label=label1,policy.label=label2`

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
