### PR TITLE
fix(terraform_plan): Fix parsing other types of provisioners

### DIFF
--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -439,10 +439,6 @@ def _clean_simple_type_list(value_list: List[Any]) -> List[Any]:
     return value_list
 
 
-from typing import List, Any, Dict
-
-from typing import List, Any, Dict
-
 def _get_provisioner(input_data: List[Dict[str, Any]]) -> List[Dict[str, Dict[str, Any]]]:
     result = []
     for item in input_data:

--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -439,13 +439,31 @@ def _clean_simple_type_list(value_list: List[Any]) -> List[Any]:
     return value_list
 
 
-def _get_provisioner(input_data: List[Any]) -> List[Any]:
+from typing import List, Any, Dict
+
+from typing import List, Any, Dict
+
+def _get_provisioner(input_data: List[Dict[str, Any]]) -> List[Dict[str, Dict[str, Any]]]:
     result = []
     for item in input_data:
-        key = item['type']
-        command_value = item['expressions']['command']
-        if not isinstance(command_value, list):
-            command_value = [command_value]
-        transformed_item = {key: {'command': command_value}}
-        result.append(transformed_item)
+        if 'type' in item and 'expressions' in item:
+            key = item['type']
+            expressions = item['expressions']
+            transformed_expressions = {}
+
+            if key == 'local-exec':
+                if 'command' in expressions:
+                    command_value = expressions['command']
+                    if not isinstance(command_value, list):
+                        command_value = [command_value]
+                    transformed_expressions['command'] = command_value
+
+                for field, value in expressions.items():
+                    if field != 'command':
+                        transformed_expressions[field] = value
+            else:
+                transformed_expressions = expressions
+
+            transformed_item = {key: transformed_expressions}
+            result.append(transformed_item)
     return result

--- a/tests/terraform/parser/resources/plan_provisioners/tfplan2.json
+++ b/tests/terraform/parser/resources/plan_provisioners/tfplan2.json
@@ -199,15 +199,23 @@
           "provider_config_key": "aws",
           "provisioners": [
             {
-              "type": "local-exec",
+              "type": "file",
               "expressions": {
-                "command": {
-                  "constant_value": "open WFH, '>completed.txt' and print WFH scalar localtime"
+                "destination": {
+                  "constant_value": "/tmp/script.sh"
                 },
-                "interpreter": {
+                "source": {
+                  "constant_value": "script.sh"
+                }
+              }
+            },
+            {
+              "type": "remote-exec",
+              "expressions": {
+                "inline": {
                   "constant_value": [
-                    "perl",
-                    "-e"
+                    "chmod +x /tmp/script.sh",
+                    "/tmp/script.sh args"
                   ]
                 }
               }
@@ -231,5 +239,5 @@
       ]
     }
   },
-  "timestamp": "2024-07-26T05:47:45Z"
+  "timestamp": "2024-07-26T05:10:57Z"
 }

--- a/tests/terraform/parser/test_plan_parser.py
+++ b/tests/terraform/parser/test_plan_parser.py
@@ -61,12 +61,15 @@ class TestPlanFileParser(unittest.TestCase):
 
     def test_provisioners(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
-        valid_plan_path = current_dir + "/resources/plan_provisioners/tfplan.json"
-        tf_definition, _ = parse_tf_plan(valid_plan_path, {})
-        file_resource_definition = tf_definition['resource'][1]
-        resource_definition = next(iter(file_resource_definition.values()))
-        resource_attributes = next(iter(resource_definition.values()))
-        self.assertTrue(resource_attributes['provisioner'])
+        plan_files = ['tfplan.json','tfplan2.json']
+
+        for file in plan_files:
+            valid_plan_path = current_dir + "/resources/plan_provisioners/" + file
+            tf_definition, _ = parse_tf_plan(valid_plan_path, {})
+            file_resource_definition = tf_definition['resource'][0]
+            resource_definition = next(iter(file_resource_definition.values()))
+            resource_attributes = next(iter(resource_definition.values()))
+            self.assertTrue(resource_attributes['provisioner'])
 
     def test_module_with_connected_resources(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

The parser was causing errors for provisioners that weren't local-exec. This fixes: https://github.com/bridgecrewio/checkov/pull/5622#issuecomment-2251799676

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
