### PR TITLE
fix(terraform): add condition for CKV_AWS_353

### DIFF
--- a/checkov/terraform/checks/resource/aws/RDSInstancePerformanceInsights.py
+++ b/checkov/terraform/checks/resource/aws/RDSInstancePerformanceInsights.py
@@ -11,7 +11,7 @@ class RDSInstancePerformanceInsights(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        # Performance Insights is not available  for MariaDB and MySQL using certain classes: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.Engines.html
+        # Performance Insights is not available  for MariaDB and MySQL using certain classes: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.Engines.html 
         if conf.get("engine") in (["mariadb"], ["mysql"], ["aws_rds_cluster.default.engine"]):
             if conf.get("instance_class") in (["db.t2.micro"], ["db.t2.small"], ["db.t3.micro"], ["db.t3.small"],
                                               ["db.t4g.micro"], ["db.t4g.small"]):

--- a/checkov/terraform/checks/resource/aws/RDSInstancePerformanceInsights.py
+++ b/checkov/terraform/checks/resource/aws/RDSInstancePerformanceInsights.py
@@ -1,5 +1,5 @@
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class RDSInstancePerformanceInsights(BaseResourceValueCheck):
@@ -9,6 +9,17 @@ class RDSInstancePerformanceInsights(BaseResourceValueCheck):
         supported_resources = ('aws_rds_cluster_instance', 'aws_db_instance')
         categories = (CheckCategories.LOGGING,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        # Performance Insights is not available  for MariaDB and MySQL using certain classes: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.Engines.html
+        if conf.get("engine") in (["mariadb"], ["mysql"], ["aws_rds_cluster.default.engine"]):
+            if conf.get("instance_class") in (["db.t2.micro"], ["db.t2.small"], ["db.t3.micro"], ["db.t3.small"],
+                                              ["db.t4g.micro"], ["db.t4g.small"]):
+                return CheckResult.UNKNOWN
+        # Performance Insights is not supported for DB2: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RDS_Fea_Regions_DB-eng.Feature.PerformanceInsights.html
+        if conf.get("engine") in (["db2-se"], ["db2-ae"]):
+            return CheckResult.UNKNOWN
+        return super().scan_resource_conf(conf)
 
     def get_inspected_key(self) -> str:
         return 'performance_insights_enabled'

--- a/checkov/terraform/checks/resource/aws/RDSInstancePerformanceInsights.py
+++ b/checkov/terraform/checks/resource/aws/RDSInstancePerformanceInsights.py
@@ -11,7 +11,7 @@ class RDSInstancePerformanceInsights(BaseResourceValueCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf):
-        # Performance Insights is not available  for MariaDB and MySQL using certain classes: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.Engines.html 
+        # Performance Insights is not available  for MariaDB and MySQL using certain classes: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.Engines.html
         if conf.get("engine") in (["mariadb"], ["mysql"], ["aws_rds_cluster.default.engine"]):
             if conf.get("instance_class") in (["db.t2.micro"], ["db.t2.small"], ["db.t3.micro"], ["db.t3.small"],
                                               ["db.t4g.micro"], ["db.t4g.small"]):

--- a/tests/terraform/checks/resource/aws/example_RDSInstancePerformanceInsights/main.tf
+++ b/tests/terraform/checks/resource/aws/example_RDSInstancePerformanceInsights/main.tf
@@ -61,3 +61,36 @@ resource "aws_rds_cluster_instance" "pass" {
   engine_version               = aws_rds_cluster.default.engine_version
   performance_insights_enabled = true
 }
+
+resource "aws_db_instance" "unknown_engine_class_combo" {
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  engine               = "mariadb"
+  engine_version       = "10.5"
+  instance_class       = "db.t3.micro"
+  name                 = "mydatabase"
+  username             = "admin"
+  password             = "yourpassword" # Use a more secure method for production
+  parameter_group_name = "default.mariadb10.5"
+  skip_final_snapshot  = true
+
+  tags = {
+    Name = "MyMariaDBInstance"
+  }
+}
+
+resource "aws_rds_cluster_instance" "unknown_engine_defaultclass_combo" {
+  identifier         = "aurora-cluster-demo-${count.index}"
+  cluster_identifier = aws_rds_cluster.default.id
+  instance_class     = "db.t2.small"
+  engine             = aws_rds_cluster.default.engine
+  engine_version     = aws_rds_cluster.default.engine_version
+}
+
+resource "aws_rds_cluster_instance" "unknown_engine_class_combo" {
+  identifier         = "aurora-cluster-demo-${count.index}"
+  cluster_identifier = aws_rds_cluster.default.id
+  instance_class     = "db.t2.small"
+  engine             = "mysql"
+  engine_version     = aws_rds_cluster.default.engine_version
+}

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -276,7 +276,7 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.get_exit_code({'soft_fail': False, 'soft_fail_checks': [], 'soft_fail_threshold': None, 'hard_fail_checks': [], 'hard_fail_threshold': None}), 1)
         self.assertEqual(report.get_exit_code({'soft_fail': True, 'soft_fail_checks': [], 'soft_fail_threshold': None, 'hard_fail_checks': [], 'hard_fail_threshold': None}), 0)
 
-        self.assertEqual(report.get_summary()["failed"], 106)
+        self.assertEqual(report.get_summary()["failed"], 105)
 
     def test_runner_child_modules(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

According to the docs, MariaDB and MySQL using certain classes and all DB2 RDS DBs can't use Performance Insights. Adding an exception for these cases.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
