### PR TITLE
fix(terraform): Handle default for CKV_GCP_76

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleSubnetworkIPV6PrivateGoogleEnabled.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleSubnetworkIPV6PrivateGoogleEnabled.py
@@ -18,7 +18,7 @@ class GoogleSubnetworkLoggingEnabled(BaseResourceValueCheck):
             return CheckResult.UNKNOWN
 
         stack = conf.get("stack_type")
-        if stack and isinstance(stack, list) and stack[0] != "IPV4_IPV6":
+        if not stack or (stack and isinstance(stack, list) and stack[0] != "IPV4_IPV6"):
             return CheckResult.UNKNOWN
 
         return super().scan_resource_conf(conf)

--- a/tests/terraform/checks/resource/gcp/example_GoogleIPV6PrivateGoogleEnabled/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleIPV6PrivateGoogleEnabled/main.tf
@@ -88,7 +88,8 @@ resource "google_compute_subnetwork" "unknown2" {
 resource "google_compute_subnetwork" "unknown2" {
   name             = "log-test-subnetwork"
   ip_cidr_range    = "10.2.0.0/16"
-  # stack_type       = "IPV4_IPV6" # No stack_type defaults to IPV4_ONLY
+  # No stack_type defaults to IPV4_ONLY
+  # stack_type       = "IPV4_IPV6"
   ipv6_access_type = "EXTERNAL"
   region           = "us-central1"
   network          = google_compute_network.custom-test.id

--- a/tests/terraform/checks/resource/gcp/example_GoogleIPV6PrivateGoogleEnabled/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GoogleIPV6PrivateGoogleEnabled/main.tf
@@ -30,7 +30,7 @@ resource "google_compute_subnetwork" "fail2" {
 resource "google_compute_subnetwork" "unknown" {
   name             = "log-test-subnetwork"
   ip_cidr_range    = "10.2.0.0/16"
-  stack_type       = "IPV4"
+  stack_type       = "IPV4_ONLY"
   ipv6_access_type = "EXTERNAL"
   region           = "us-central1"
   network          = google_compute_network.custom-test.id
@@ -76,6 +76,19 @@ resource "google_compute_subnetwork" "unknown2" {
   name             = "log-test-subnetwork"
   ip_cidr_range    = "10.2.0.0/16"
   stack_type       = "IPV4_IPV6"
+  ipv6_access_type = "EXTERNAL"
+  region           = "us-central1"
+  network          = google_compute_network.custom-test.id
+   purpose="INTERNAL_HTTPS_LOAD_BALANCER"
+   log_config {
+     metadata="EXCLUDE_ALL_METADATA"
+   }
+}
+
+resource "google_compute_subnetwork" "unknown2" {
+  name             = "log-test-subnetwork"
+  ip_cidr_range    = "10.2.0.0/16"
+  # stack_type       = "IPV4_IPV6" # No stack_type defaults to IPV4_ONLY
   ipv6_access_type = "EXTERNAL"
   region           = "us-central1"
   network          = google_compute_network.custom-test.id


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Stack type defaults to IPV4_ONLY (https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork#stack_type) so CKV_GCP_76 should treat this as UNKNOWN

Fixes #6425

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
