### PR TITLE
fix(ansible): Fix CKV2_ANSIBLE_2

### DIFF
--- a/checkov/ansible/checks/graph_checks/GetUrlHttpsOnly.yaml
+++ b/checkov/ansible/checks/graph_checks/GetUrlHttpsOnly.yaml
@@ -3,10 +3,18 @@ metadata:
   name: "Ensure that HTTPS url is used with get_url"
   category: "NETWORKING"
 definition:
-  cond_type: attribute
-  resource_types:
-    - tasks.ansible.builtin.get_url
-    - tasks.get_url
-  attribute: url
-  operator: starting_with
-  value: "https://"
+  or:
+    - cond_type: attribute
+      resource_types:
+        - tasks.ansible.builtin.get_url
+        - tasks.get_url
+      attribute: url
+      operator: not_starting_with
+      value: "http://"
+    - cond_type: attribute
+      resource_types:
+        - tasks.ansible.builtin.get_url
+        - tasks.get_url
+      attribute: url
+      operator: not_starting_with
+      value: "ftp://"

--- a/checkov/ansible/checks/graph_checks/GetUrlHttpsOnly.yaml
+++ b/checkov/ansible/checks/graph_checks/GetUrlHttpsOnly.yaml
@@ -3,7 +3,7 @@ metadata:
   name: "Ensure that HTTPS url is used with get_url"
   category: "NETWORKING"
 definition:
-  or:
+  and:
     - cond_type: attribute
       resource_types:
         - tasks.ansible.builtin.get_url

--- a/tests/ansible/checks/graph_checks/resources/GetUrlHttpsOnly/expected.yaml
+++ b/tests/ansible/checks/graph_checks/resources/GetUrlHttpsOnly/expected.yaml
@@ -1,5 +1,6 @@
 pass:
   - "tasks.ansible.builtin.get_url.https"
+  - "tasks.get_url.unknown" # update test when variable rendering is supported
 fail:
   - "tasks.get_url.http"
 evaluated_keys:

--- a/tests/ansible/checks/graph_checks/resources/GetUrlHttpsOnly/unknown.yaml
+++ b/tests/ansible/checks/graph_checks/resources/GetUrlHttpsOnly/unknown.yaml
@@ -1,10 +1,11 @@
 ---
 - name: Verify tests
   hosts: all
-  gather_facts: False
+  vars:
+    variable_url: https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
   tasks:
     - name: unknown
       get_url:
-        url: {{ variable_https }}
+        url: "{{ variable_url }}"
         dest: /etc/foo.conf
         force_basic_auth: yes

--- a/tests/ansible/checks/graph_checks/resources/GetUrlHttpsOnly/unknown.yaml
+++ b/tests/ansible/checks/graph_checks/resources/GetUrlHttpsOnly/unknown.yaml
@@ -1,0 +1,10 @@
+---
+- name: Verify tests
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: unknown
+      get_url:
+        url: {{ variable_https }}
+        dest: /etc/foo.conf
+        force_basic_auth: yes


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Variables are flagged by CKV2_ANSIBLE_2, so changed to explicitly flag http and ftp (required prefixes according to the docs: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#parameter-url

Fixes #6556


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
