### PR TITLE
fix(terraform): evaluate resource with double underscore

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/ALBProtectedByWAF.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/ALBProtectedByWAF.yaml
@@ -1,43 +1,44 @@
 metadata:
   id: "CKV2_AWS_28"
-  name: "Ensure public facing ALB are protected by WAF"
-  category: "NETWORKING"
+  name: "cs-public-resource-based-policy-sqs"
+  severity: "high"
+  guidelines: "public resource based policy - sqs"
+  category: "general"
+scope:
+  provider: "aws"
 definition:
-  and:
-    - cond_type: filter
-      value:
-        - aws_lb
-        - aws_alb
-      operator: within
-      attribute: resource_type
-    - or: 
-      - cond_type: connection
-        operator: exists
-        resource_types:
-        - aws_lb
-        - aws_alb
-        connected_resource_types:
-        - aws_wafv2_web_acl_association
-      - cond_type: connection
-        operator: exists
-        resource_types:
-        - aws_lb
-        - aws_alb
-        connected_resource_types:
-        - aws_wafregional_web_acl_association
-      - cond_type: attribute
-        value: true
-        attribute: internal
-        resource_types: 
-        - aws_lb
-        - aws_alb
-        operator: equals
-      - cond_type: attribute
-        resource_types:
-        - aws_lb
-        - aws_alb
-        attribute: load_balancer_type
-        operator: within
-        value:
-          - network
-          - gateway
+  or:
+    - and:
+        - cond_type: "attribute"
+          resource_types:
+            - "aws_sqs_queue"
+          attribute: "policy.Statement[?(@.Effect == 'Allow' & @.Principal == '*')]"
+          operator: "jsonpath_not_exists"
+        - cond_type: "attribute"
+          resource_types:
+            - "aws_sqs_queue"
+          attribute: "policy.Statement[?(@.Effect == 'Allow')].Principal.AWS[*]"
+          operator: "jsonpath_not_equals"
+          value: "*"
+        - cond_type: "attribute"
+          resource_types:
+            - "aws_sqs_queue"
+          attribute: "policy.Statement[?(@.Effect == 'Allow')].NotPrincipal"
+          operator: "jsonpath_not_exists"
+    - and:
+        - cond_type: "attribute"
+          resource_types:
+            - "aws_sqs_queue_policy"
+          attribute: "policy.Statement[?(@.Effect == 'Allow' & @.Principal == '*')]"
+          operator: "jsonpath_not_exists"
+        - cond_type: "attribute"
+          resource_types:
+            - "aws_sqs_queue_policy"
+          attribute: "policy.Statement[?(@.Effect == 'Allow')].Principal.AWS[*]"
+          operator: "jsonpath_not_equals"
+          value: "*"
+        - cond_type: "attribute"
+          resource_types:
+            - "aws_sqs_queue_policy"
+          attribute: "policy.Statement[?(@.Effect == 'Allow')].NotPrincipal"
+          operator: "jsonpath_not_exists"

--- a/checkov/terraform/checks/graph_checks/aws/ALBRedirectsHTTPToHTTPS.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/ALBRedirectsHTTPToHTTPS.yaml
@@ -1,82 +1,15 @@
 metadata:
   id: "CKV2_AWS_20"
-  name: "Ensure that ALB redirects HTTP requests into HTTPS ones"
-  category: "NETWORKING"
+  name: "cs-public-resource-based-policy-sqs"
+  severity: "high"
+  guidelines: "public resource based policy - sqs"
+  category: "general"
+scope:
+  provider: "aws"
 definition:
   and:
-    - cond_type: filter
-      value:
-        - aws_lb
-        - aws_alb
-      operator: within
-      attribute: resource_type
-    - or:
-      - cond_type: connection
-        operator: not_exists
-        resource_types:
-          - aws_lb
-          - aws_alb
-        connected_resource_types:
-          - aws_lb_listener
-          - aws_alb_listener
-      - and:
-          - cond_type: connection
-            operator: exists
-            resource_types:
-              - aws_lb
-              - aws_alb
-            connected_resource_types:
-              - aws_lb_listener
-              - aws_alb_listener
-          - or:
-              - and:
-                - cond_type: attribute
-                  attribute: port
-                  operator: not_equals
-                  value: "80"
-                  resource_types:
-                    - aws_lb_listener
-                    - aws_alb_listener
-                - cond_type: attribute
-                  attribute: protocol
-                  operator: not_equals
-                  value: HTTP
-                  resource_types:
-                    - aws_lb_listener
-                    - aws_alb_listener
-              - and:
-                  - cond_type: attribute
-                    attribute: port
-                    operator: equals
-                    value: "80"
-                    resource_types:
-                      - aws_lb_listener
-                      - aws_alb_listener
-                  - cond_type: attribute
-                    attribute: protocol
-                    operator: equals
-                    value: "HTTP"
-                    resource_types:
-                      - aws_lb_listener
-                      - aws_alb_listener
-                  - cond_type: attribute
-                    attribute: default_action.type
-                    operator: equals
-                    value: "redirect"
-                    resource_types:
-                      - aws_lb_listener
-                      - aws_alb_listener
-                  - cond_type: attribute
-                    attribute: default_action.redirect.*.port
-                    operator: equals
-                    value: "443"
-                    resource_types:
-                      - aws_lb_listener
-                      - aws_alb_listener
-                  - cond_type: attribute
-                    attribute: default_action.redirect.*.protocol
-                    operator: equals
-                    value: "HTTPS"
-                    resource_types:
-                      - aws_lb_listener
-                      - aws_alb_listener
+    - cond_type: "attribute"
+      resource_types:
+        - "aws_sqs_queue"
+      attribute: "policy.Statement[?(@.Effect == 'Allow' & @.Principal == '*')]"
+      operator: "jsonpath_not_exists"

--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -355,9 +355,9 @@ SAFE_EVAL_DICT["formatdate"] = formatdate
 
 
 def evaluate(input_str: str) -> Any:
-    if "__" in input_str:
-        logging.debug(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")
-        return input_str
+    # if "__" in input_str:
+    #     logging.debug(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")
+    #     return input_str
     if input_str == "...":
         # don't create an Ellipsis object
         return input_str
@@ -368,6 +368,8 @@ def evaluate(input_str: str) -> Any:
         # Don't use str.replace to make sure we replace just the first occurrence
         input_str = f"{TRY_STR_REPLACEMENT}{input_str[3:]}"
     evaluated = eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
+    if not evaluated:
+        evaluated = input_str
     return evaluated if not isinstance(evaluated, str) else remove_unicode_null(evaluated)
 
 

--- a/tests/terraform/graph/checks/resources/CustomPolicy1/expected.yaml
+++ b/tests/terraform/graph/checks/resources/CustomPolicy1/expected.yaml
@@ -1,2 +1,2 @@
-pass:
+fail:
   - "aws_sqs_queue.sqs"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
evaluate resource with double underscore
