### PR TITLE
fix(general): fix lazy loading custom policies into check registry

### DIFF
--- a/checkov/common/checks_infra/registry.py
+++ b/checkov/common/checks_infra/registry.py
@@ -41,6 +41,11 @@ class Registry(BaseRegistry):
     def load_checks(self) -> None:
         if not self.checks:
             self._load_checks_from_dir(self.checks_dir, False)
+
+        # the first time this runs, custom_policies_checks will not have been set yet, so we don't want to prematurely mark
+        # custom policies as loaded.
+        # this does mean that for a registry that has no custom policies to load, this condition will never be skipped (but it will also have no effect)
+        # maybe there is a better way to do it
         if not self.custom_policies_loaded and self.custom_policies_checks:
             self.checks += self.custom_policies_checks
             self.custom_policies_loaded = True

--- a/checkov/common/checks_infra/registry.py
+++ b/checkov/common/checks_infra/registry.py
@@ -33,17 +33,17 @@ class Registry(BaseRegistry):
         super().__init__(parser)
         self.checks: list[BaseGraphCheck] = []
         self.custom_policies_checks: list[BaseGraphCheck] = []
+        self.custom_policies_loaded: bool = False
         self.checks_dir = checks_dir
         self.logger = logging.getLogger(__name__)
         add_resource_code_filter_to_logger(self.logger)
 
     def load_checks(self) -> None:
-        if self.checks:
-            # checks were previously loaded
-            return
-
-        self._load_checks_from_dir(self.checks_dir, False)
-        self.checks += self.custom_policies_checks
+        if not self.checks:
+            self._load_checks_from_dir(self.checks_dir, False)
+        if not self.custom_policies_loaded and self.custom_policies_checks:
+            self.checks += self.custom_policies_checks
+            self.custom_policies_loaded = True
 
     def _load_checks_from_dir(self, directory: str, external_check: bool) -> None:
         dir = os.path.expanduser(directory)


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixes an issue preventing custom policies from running.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Dear maintainer, below is a concise technical summary of the changes proposed in this PR:
<p>Fix an issue in the <code>Registry</code> class that prevents custom policies from being loaded into the check registry. Modify the <code>load_checks</code> method to ensure custom policies are added only once and introduce a flag <code>custom_policies_loaded</code> to track the loading status.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6662?tool=ast&topic=Custom+Policy+Loading>Custom Policy Loading</a>
        </td><td>Fix the lazy loading mechanism for custom policies in the <code>Registry</code> class.<details><summary>Modified files (1)</summary><ul><li>checkov/common/checks_infra/registry.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>iifrach@paloaltonetwor...</td><td>feat-general-Support-m...</td><td>August 18, 2024</td></tr>
<tr><td>123508988+taviassaf@us...</td><td>feat-general-support-m...</td><td>August 05, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @mikeurbanski1 and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    