### PR TITLE
chore: Upgrade to Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 ENV RUN_IN_DOCKER=True
 

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 ENV RUN_IN_DOCKER=True
 

--- a/tests/dockerfile/checks/example_ReferenceLatestTag/success_multi_stage_platform/Dockerfile
+++ b/tests/dockerfile/checks/example_ReferenceLatestTag/success_multi_stage_platform/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM python:3.11-slim AS build
+FROM --platform=$BUILDPLATFORM python:3.12-slim AS build
 COPY test.sh /test.sh
 
 FROM build as run


### PR DESCRIPTION
Using Python 3.12 as the base for docker images

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Upgrade to Python 3.12

Use Python 3.12 as the base for docker images (upgrading from Python 3.11).

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
