### PR TITLE
feat(terraform): Add check for local user in storage

### DIFF
--- a/checkov/terraform/checks/resource/aws/CloudFrontGeoRestrictionDisabled.py
+++ b/checkov/terraform/checks/resource/aws/CloudFrontGeoRestrictionDisabled.py
@@ -4,17 +4,17 @@ from checkov.terraform.checks.resource.base_resource_negative_value_check import
 
 class CloudFrontGeoRestrictionDisabled(BaseResourceNegativeValueCheck):
 
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure AWS CloudFront web distribution has geo restriction enabled"
-        id = "CKV_AWS_799"
-        supported_resources = ['aws_cloudfront_distribution']
+        id = "CKV_AWS_374"
+        supported_resources = ('aws_cloudfront_distribution',)
         categories = [CheckCategories.NETWORKING]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
+    def get_inspected_key(self) -> str:
         return "restrictions/[0]/geo_restriction/[0]/restriction_type"
 
-    def get_forbidden_values(self):
+    def get_forbidden_values(self) -> list:
         return ["none"]
 
 

--- a/checkov/terraform/checks/resource/aws/CloudFrontGeoRestrictionDisabled.py
+++ b/checkov/terraform/checks/resource/aws/CloudFrontGeoRestrictionDisabled.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_negative_value_check import BaseResourceNegativeValueCheck
+
+
+class CloudFrontGeoRestrictionDisabled(BaseResourceNegativeValueCheck):
+
+    def __init__(self):
+        name = "Ensure AWS CloudFront web distribution has geo restriction enabled"
+        id = "CKV_AWS_799"
+        supported_resources = ['aws_cloudfront_distribution']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "restrictions/[0]/geo_restriction/[0]/restriction_type"
+
+    def get_forbidden_values(self):
+        return ["none"]
+
+
+check = CloudFrontGeoRestrictionDisabled()

--- a/checkov/terraform/checks/resource/azure/StorageLocalUsers.py
+++ b/checkov/terraform/checks/resource/azure/StorageLocalUsers.py
@@ -3,17 +3,17 @@ from checkov.terraform.checks.resource.base_resource_value_check import BaseReso
 
 
 class StorageLocalUsers(BaseResourceValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Avoid the use of local users for Azure Storage unless necessary"
-        id = "CKV_AZURE_999"
-        supported_resources = ['azurerm_storage_account']
+        id = "CKV_AZURE_244"
+        supported_resources = ('azurerm_storage_account',)
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
+    def get_inspected_key(self) -> str:
         return 'local_user_enabled'
 
-    def get_expected_value(self):
+    def get_expected_value(self) -> bool:
         return False
 
 

--- a/checkov/terraform/checks/resource/azure/StorageLocalUsers.py
+++ b/checkov/terraform/checks/resource/azure/StorageLocalUsers.py
@@ -1,0 +1,20 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class StorageLocalUsers(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Avoid the use of local users for Azure Storage unless necessary"
+        id = "CKV_AZURE_999"
+        supported_resources = ['azurerm_storage_account']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'local_user_enabled'
+
+    def get_expected_value(self):
+        return False
+
+
+check = StorageLocalUsers()

--- a/tests/terraform/checks/resource/aws/example_CloudFrontGeoRestrictionDisabled/main.tf
+++ b/tests/terraform/checks/resource/aws/example_CloudFrontGeoRestrictionDisabled/main.tf
@@ -1,0 +1,203 @@
+resource "aws_cloudfront_distribution" "pass" {
+  origin {
+    domain_name              = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.default.id
+    origin_id                = local.s3_origin_id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "mylogs.s3.amazonaws.com"
+    prefix          = "myprefix"
+  }
+
+  aliases = ["mysite.example.com", "yoursite.example.com"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  ordered_cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  # Cache behavior with precedence 1
+  ordered_cache_behavior {
+    path_pattern     = "/content/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  tags = {
+    Environment = "production"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+
+resource "aws_cloudfront_distribution" "fail" {
+  origin {
+    domain_name              = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.default.id
+    origin_id                = local.s3_origin_id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "mylogs.s3.amazonaws.com"
+    prefix          = "myprefix"
+  }
+
+  aliases = ["mysite.example.com", "yoursite.example.com"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  ordered_cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  # Cache behavior with precedence 1
+  ordered_cache_behavior {
+    path_pattern     = "/content/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+      locations        = []
+    }
+  }
+
+  tags = {
+    Environment = "production"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/tests/terraform/checks/resource/aws/test_CloudFrontGeoRestrictionDisabled.py
+++ b/tests/terraform/checks/resource/aws/test_CloudFrontGeoRestrictionDisabled.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.CloudFrontGeoRestrictionDisabled import check
+from checkov.terraform.runner import Runner
+
+
+class TestCloudFrontGeoRestrictionDisabled(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_CloudFrontGeoRestrictionDisabled"
+        report = runner.run(
+            root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id])
+        )
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_cloudfront_distribution.pass"
+        }
+        failing_resources = {
+            "aws_cloudfront_distribution.fail"
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/checks/resource/azure/example_StorageLocalUsers/main.tf
+++ b/tests/terraform/checks/resource/azure/example_StorageLocalUsers/main.tf
@@ -1,0 +1,25 @@
+resource "azurerm_storage_account" "pass" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  local_user_enabled       = false
+}
+
+resource "azurerm_storage_account" "fail" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  local_user_enabled       = true
+}
+
+resource "azurerm_storage_account" "fail_missing" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}

--- a/tests/terraform/checks/resource/azure/test_StorageLocalUsers.py
+++ b/tests/terraform/checks/resource/azure/test_StorageLocalUsers.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.azure.StorageLocalUsers import check
+from checkov.terraform.runner import Runner
+
+
+class TestStorageLocalUsers(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_StorageLocalUsers"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "azurerm_storage_account.pass",
+        }
+
+        failing_resources = {
+            "azurerm_storage_account.fail",
+            "azurerm_storage_account.fail_missing",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Local users should only be enabled if necessary

Fixes #6713 

Also added a build policy for `a920a1a2-6856-4eb2-b2db-7aee4ce03f4c`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
