### PR TITLE
fix(general): escape default ignored directories

### DIFF
--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -45,7 +45,8 @@ def strtobool(val: str) -> int:
 
 def re_dir(path: str) -> str:
     """Compile a regex pattern that matches paths containing the given directory at any level."""
-    return rf"(^|.*/){re.escape(path)}($|/.*)"
+    sep = re.escape(os.sep)  # windows compatibility
+    return rf"(^|.*{sep}){re.escape(path)}($|{sep}.*)"
 
 
 IGNORED_DIRECTORIES_ENV = os.getenv(

--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -43,7 +43,15 @@ def strtobool(val: str) -> int:
         raise ValueError("invalid boolean value %r for environment variable CKV_IGNORE_HIDDEN_DIRECTORIES" % (val,))
 
 
-IGNORED_DIRECTORIES_ENV = os.getenv("CKV_IGNORED_DIRECTORIES", "node_modules,.terraform,.serverless")
+def re_dir(path: str) -> str:
+    """Compile a regex pattern that matches paths containing the given directory at any level."""
+    return rf"(^|.*/){re.escape(path)}($|/.*)"
+
+
+IGNORED_DIRECTORIES_ENV = os.getenv(
+    "CKV_IGNORED_DIRECTORIES",
+    ",".join(re_dir(p) for p in ["node_modules", ".terraform", ".serverless"])
+)
 IGNORE_HIDDEN_DIRECTORY_ENV = strtobool(os.getenv("CKV_IGNORE_HIDDEN_DIRECTORIES", "True"))
 
 ignored_directories = IGNORED_DIRECTORIES_ENV.split(",")

--- a/checkov/secrets/utils.py
+++ b/checkov/secrets/utils.py
@@ -9,7 +9,10 @@ from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 
 EXCLUDED_PATHS = [
     *ignored_directories,
-    *(re_dir(p) for p in [DEFAULT_EXTERNAL_MODULES_DIR, ".idea", ".git", "venv"])
+    re_dir(DEFAULT_EXTERNAL_MODULES_DIR),
+    re_dir(".idea"),
+    re_dir(".git"),
+    re_dir("venv"),
 ]
 
 

--- a/checkov/secrets/utils.py
+++ b/checkov/secrets/utils.py
@@ -4,10 +4,13 @@ import os
 import re
 from collections.abc import Iterable
 
-from checkov.common.runners.base_runner import ignored_directories, safe_remove
+from checkov.common.runners.base_runner import ignored_directories, safe_remove, re_dir
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 
-EXCLUDED_PATHS = [*ignored_directories, DEFAULT_EXTERNAL_MODULES_DIR, ".idea", ".git", "venv"]
+EXCLUDED_PATHS = [
+    *ignored_directories,
+    *(re_dir(p) for p in [DEFAULT_EXTERNAL_MODULES_DIR, ".idea", ".git", "venv"])
+]
 
 
 def filter_excluded_paths(

--- a/tests/common/runners/test_base_runner.py
+++ b/tests/common/runners/test_base_runner.py
@@ -3,11 +3,18 @@ import unittest
 from typing import Optional, List
 
 from checkov.common.output.report import Report
-from checkov.common.runners.base_runner import filter_ignored_paths, BaseRunner
+from checkov.common.runners.base_runner import filter_ignored_paths, BaseRunner, re_dir
 from checkov.runner_filter import RunnerFilter
 
 
 class TestBaseRunner(unittest.TestCase):
+
+    def test_re_dir(self):
+        sep = '\\' if os.name == 'nt' else '/'
+        # add regex prefix and suffix to the (unmodified) directory name
+        self.assertEqual(re_dir('dir'), fr'(^|.*{sep})dir($|{sep}.*)')
+        # escape the directory name (but leave the os separator unaltered)
+        self.assertEqual(re_dir('.dir1/.dir2'), fr'(^|.*{sep})\.dir1/\.dir2($|{sep}.*)')
 
     def test_filter_ignored_directories_regex_legacy(self):
         d_names = ['bin', 'integration_tests', 'tests', 'docs', '.github', 'checkov', 'venv', '.git', 'kubernetes', '.idea']


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

See #6737 for more details and context:

> While trying to run checkov's test suit on my local machine I noticed that some files were being (unexpectedly) ignored. After a little digging, I realised that this is because I cloned the repo under a path that looks something like: `~/my_git_forks/checkov`. 
> 
> The reason this is a problem is because the following patterns are treated as regular expressions by checkov:
> 
> https://github.com/bridgecrewio/checkov/blob/42d3178c40cea47a9fc359e0edc4620153fbb446/checkov/secrets/utils.py#L10
> 
> and the `.git` pattern obviously excludes any paths that include the word 'git' (incl. at least one preceding character)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
