### PR TITLE
fix(kubernetes): Handle non-sting params in command

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/k8s_check_utils.py
+++ b/checkov/kubernetes/checks/resource/k8s/k8s_check_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 
-def extract_commands(conf: dict[str, Any]) -> tuple[list[str], list[str]]:
+def extract_commands(conf: dict[str, Any]) -> tuple[list[str], list[str|None]]:
     commands = conf.get("command")
     if not commands or not isinstance(commands, list):
         return [], []

--- a/checkov/kubernetes/checks/resource/k8s/k8s_check_utils.py
+++ b/checkov/kubernetes/checks/resource/k8s/k8s_check_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 
-def extract_commands(conf: dict[str, Any]) -> tuple[list[str], list[str|None]]:
+def extract_commands(conf: dict[str, Any]) -> tuple[list[str], list[str]]:
     commands = conf.get("command")
     if not commands or not isinstance(commands, list):
         return [], []
@@ -18,5 +18,5 @@ def extract_commands(conf: dict[str, Any]) -> tuple[list[str], list[str|None]]:
             values.append(value)
         else:
             keys.append(cmd)
-            values.append(None)
+            values.append('')
     return keys, values

--- a/checkov/kubernetes/checks/resource/k8s/k8s_check_utils.py
+++ b/checkov/kubernetes/checks/resource/k8s/k8s_check_utils.py
@@ -12,7 +12,7 @@ def extract_commands(conf: dict[str, Any]) -> tuple[list[str], list[str]]:
     for cmd in commands:
         if cmd is None:
             continue
-        if "=" in cmd:
+        if isinstance(cmd, str) and "=" in cmd:
             key, value = cmd.split("=", maxsplit=1)
             keys.append(key)
             values.append(value)

--- a/tests/kubernetes/checks/test_k8s_check_utils.py
+++ b/tests/kubernetes/checks/test_k8s_check_utils.py
@@ -6,11 +6,12 @@ def test_non_int_extract_commands() -> None:
 
     keys, values = extract_commands(conf)
     assert keys == ['kube-apiserver', '--encryption-provider-config']
-    assert values == [None, 'config.file']
+    assert values == ['', 'config.file']
+
 
 def test_int_extract_commands() -> None:
-    conf = {'command': ['kube-apiserver', '--encryption-provider-config=config.file','-p', 9082]}
+    conf = {'command': ['kube-apiserver', '--encryption-provider-config=config.file', '-p', 9082]}
 
     keys, values = extract_commands(conf)
     assert keys == ['kube-apiserver', '--encryption-provider-config', '-p', 9082]
-    assert values == [None, 'config.file', None, None]
+    assert values == ['', 'config.file', '', '']

--- a/tests/kubernetes/checks/test_k8s_check_utils.py
+++ b/tests/kubernetes/checks/test_k8s_check_utils.py
@@ -1,0 +1,16 @@
+from checkov.kubernetes.checks.resource.k8s.k8s_check_utils import extract_commands
+
+
+def test_non_int_extract_commands() -> None:
+    conf = {'command': ['kube-apiserver', '--encryption-provider-config=config.file']}
+
+    keys, values = extract_commands(conf)
+    assert keys == ['kube-apiserver', '--encryption-provider-config']
+    assert values == [None, 'config.file']
+
+def test_int_extract_commands() -> None:
+    conf = {'command': ['kube-apiserver', '--encryption-provider-config=config.file','-p', 9082]}
+
+    keys, values = extract_commands(conf)
+    assert keys == ['kube-apiserver', '--encryption-provider-config', '-p', 9082]
+    assert values == [None, 'config.file', None, None]


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Checking if a `cmd` is a string before checking if it contains `=` sign, to prevent exceptions.


### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Dear maintainer, below is a concise technical summary of the changes proposed in this PR:
<p>Ensure the <code>extract_commands</code> function in <code>k8s_check_utils.py</code> handles non-string parameters by checking if a command is a string before processing it. This prevents exceptions when commands contain non-string elements. Added tests in <code>test_k8s_check_utils.py</code> to verify the function's behavior with both string and non-string command inputs.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6768?tool=ast&topic=Command+Handling>Command Handling</a>
        </td><td>Ensure <code>extract_commands</code> handles non-string parameters by checking if a command is a string before processing it.<details><summary>Modified files (1)</summary><ul><li>checkov/kubernetes/checks/resource/k8s/k8s_check_utils.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>chore-Enable-mypy-for-...</td><td>October 26, 2022</td></tr>
<tr><td>86768411+YaaraVerner@u...</td><td>Adjust-k8s-checks-file...</td><td>November 15, 2021</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6768?tool=ast&topic=Testing+Enhancements>Testing Enhancements</a>
        </td><td>Verify <code>extract_commands</code> function with both string and non-string command inputs.<details><summary>Modified files (1)</summary><ul><li>tests/kubernetes/checks/test_k8s_check_utils.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @rotemavni and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    