### PR TITLE
fix(terraform): correctly evaluate CKV_AWS_37 when there's a dynamic …

### DIFF
--- a/checkov/terraform/checks/resource/aws/EKSControlPlaneLogging.py
+++ b/checkov/terraform/checks/resource/aws/EKSControlPlaneLogging.py
@@ -20,9 +20,13 @@ class EKSControlPlaneLogging(BaseResourceCheck):
         """
         log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
         if "enabled_cluster_log_types" in conf.keys() and conf["enabled_cluster_log_types"] and \
-                conf["enabled_cluster_log_types"][0] is not None \
-                and all(elem in conf["enabled_cluster_log_types"][0] for elem in log_types):
-            return CheckResult.PASSED
+                conf["enabled_cluster_log_types"][0] is not None:
+                    if type(conf["enabled_cluster_log_types"][0][0]) == str:
+                        if all(elem in conf["enabled_cluster_log_types"][0] for elem in log_types):
+                            return CheckResult.PASSED
+                    elif type(conf["enabled_cluster_log_types"][0][0]) == list:
+                        if all([elem] in conf["enabled_cluster_log_types"][0] for elem in log_types):
+                            return CheckResult.PASSED
         return CheckResult.FAILED
 
     def get_evaluated_keys(self) -> List[str]:

--- a/tests/terraform/checks/resource/aws/example_EKSControlPlaneLogging/main.tf
+++ b/tests/terraform/checks/resource/aws/example_EKSControlPlaneLogging/main.tf
@@ -1,0 +1,55 @@
+# pass
+
+resource "aws_eks_cluster" "fully_enabled" {
+  name     = "example"
+  role_arn = "aws_iam_role.arn"
+
+  enabled_cluster_log_types = [
+    "api",
+    "audit",
+    "authenticator",
+    "controllerManager",
+    "scheduler"
+  ]
+}
+
+resource "aws_eks_cluster" "fully_enabled_with_dynamic_block" {
+  name     = "example"
+  role_arn = "aws_iam_role.arn"
+
+  enabled_cluster_log_types = [
+    "api",
+    "audit",
+    "authenticator",
+    "controllerManager",
+    "scheduler"
+  ]
+
+  dynamic "encryption_config" {
+    for_each = [1]
+
+    content {
+      provider {
+        key_arn = "aws/kms/key"
+      }
+      resources = ["secrets"]
+    }
+  }
+}
+
+# fail
+
+resource "aws_eks_cluster" "partially_enabled" {
+  name     = "example"
+  role_arn = "aws_iam_role.arn"
+
+  enabled_cluster_log_types = [
+    "api",
+    "audit"
+  ]
+}
+
+resource "aws_eks_cluster" "not_configured" {
+  name     = "example"
+  role_arn = "aws_iam_role.arn"
+}

--- a/tests/terraform/checks/resource/aws/test_EKSControlPlaneLogging.py
+++ b/tests/terraform/checks/resource/aws/test_EKSControlPlaneLogging.py
@@ -1,6 +1,9 @@
 import unittest
+from pathlib import Path
 
+from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.EKSControlPlaneLogging import check
+from checkov.terraform.runner import Runner
 from checkov.common.models.enums import CheckResult
 
 
@@ -23,11 +26,42 @@ class TestEKSControlPlaneLogging(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
-    def test_success(self):
+    def test_failure_not_enabled(self):
         resource_conf = {'name': ['testcluster'], 'enabled_cluster_log_types': []}
 
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_file(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_EKSControlPlaneLogging"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_eks_cluster.fully_enabled",
+            "aws_eks_cluster.fully_enabled_with_dynamic_block"
+        }
+        failing_resources = {
+            "aws_eks_cluster.partially_enabled",
+            "aws_eks_cluster.not_configured"
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…block

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

For reasons that are beyond me, `enabled_cluster_log_types` is a list of strings normally, but when there's a dynamic block added to the resource it becomes a list of list of strings. This PR adds tests to confirm that this is indeed an issue (if you run the test file against the check in master then it fails on `aws_eks_cluster.fully_enabled_with_dynamic_block`), and fixes the issue by checking the type before itterating.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
