### PR TITLE
fix(terraform): Always use a timeout when running hcl2.load to avoid being stuck when parsing error occurs

### DIFF
--- a/checkov/common/parallelizer/parallel_runner.py
+++ b/checkov/common/parallelizer/parallel_runner.py
@@ -47,9 +47,10 @@ class ParallelRunner:
         func: Callable[..., _T],
         items: List[Any],
         group_size: Optional[int] = None,
+        timeout: Optional[int] = None
     ) -> Iterable[_T]:
         if self.type == ParallelizationType.THREAD:
-            return self._run_function_multithreaded(func, items)
+            return self._run_function_multithreaded(func, items, timeout)
         elif self.type == ParallelizationType.FORK:
             return self._run_function_multiprocess_fork(func, items, group_size)
         elif self.type == ParallelizationType.SPAWN:
@@ -121,7 +122,8 @@ class ParallelRunner:
 
             return p.map(func, items, chunksize=group_size)
 
-    def _run_function_multithreaded(self, func: Callable[[Any], _T], items: List[Any]) -> Iterator[_T]:
+    def _run_function_multithreaded(self, func: Callable[[Any], _T], items: List[Any], timeout: Optional[int]) \
+            -> Iterator[_T]:
         logging.debug(
             f"Running function {func.__code__.co_filename.replace('.py', '')}.{func.__name__} with parallelization type 'thread'"
         )
@@ -129,7 +131,7 @@ class ParallelRunner:
             if items and isinstance(items[0], tuple):
                 # split a list of tuple into tuples of the positioned values of the tuple
                 return executor.map(func, *list(
-                    zip(*items)))  # noqa[B905]  # no need to set 'strict' otherwise 'mypy' complains
+                    zip(*items)), timeout=timeout)  # noqa[B905]  # no need to set 'strict' otherwise 'mypy' complains
 
             return executor.map(func, items)
 

--- a/checkov/terraform/tf_parser.py
+++ b/checkov/terraform/tf_parser.py
@@ -375,9 +375,11 @@ class TFParser:
 
         definitions_dir_and_source_iterable = [(definitions, source_path, source) for source_path, definitions in
                                                dirs_to_definitions.items()]
+
+        parsing_timeout = env_vars_config.HCL_PARSE_TIMEOUT_SEC or 0
         modules_and_definitions_tuple: list[tuple[Module, list[dict[TFDefinitionKey, dict[str, Any]]]]] = \
             list(parallel_runner.run_function(self.parse_hcl_module_from_multi_tf_definitions,
-                                              definitions_dir_and_source_iterable))
+                                              definitions_dir_and_source_iterable, timeout=parsing_timeout))
 
         return modules_and_definitions_tuple
 


### PR DESCRIPTION
# User description
… parsing error occurs

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Introduce a timeout mechanism in the <code>ParallelRunner</code> class to prevent indefinite blocking during HCL parsing errors. Modify the <code>run_function</code> and <code>_run_function_multithreaded</code> methods to accept a <code>timeout</code> parameter, ensuring that the <code>TFParser</code> class utilizes this feature by setting a parsing timeout from environment variables.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6825?tool=ast&topic=TFParser+Update>TFParser Update</a>
        </td><td>Modify the <code>TFParser</code> class to utilize the new timeout feature by setting a parsing timeout from environment variables.<details><summary>Modified files (1)</summary><ul><li>checkov/terraform/tf_parser.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>52502521+rotemavni@use...</td><td>fix-terraform-Set-time...</td><td>October 13, 2024</td></tr>
<tr><td>57212002+ChanochShayne...</td><td>feat-terraform-Add-pro...</td><td>May 29, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6825?tool=ast&topic=Timeout+Implementation>Timeout Implementation</a>
        </td><td>Implement a timeout mechanism in the <code>ParallelRunner</code> class to prevent indefinite blocking during HCL parsing errors.<details><summary>Modified files (2)</summary><ul><li>checkov/terraform/tf_parser.py</li>
<li>checkov/common/parallelizer/parallel_runner.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>52502521+rotemavni@use...</td><td>fix-terraform-Set-time...</td><td>October 13, 2024</td></tr>
<tr><td>57212002+ChanochShayne...</td><td>feat-terraform-Add-pro...</td><td>May 29, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @bo156 and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    