### PR TITLE
fix(dockerfile): Handle heredoc

### DIFF
--- a/checkov/dockerfile/parser.py
+++ b/checkov/dockerfile/parser.py
@@ -44,11 +44,11 @@ def collect_skipped_checks(parse_result: dict[str, list[_Instruction]]) -> list[
     return skipped_checks
 
 
-def convert_multiline_commands(dockerfile_content):
+def convert_multiline_commands(dockerfile_content: str) -> str:
     lines = dockerfile_content.splitlines()
     converted_lines = []
     in_multiline = False
-    multiline_command = []
+    multiline_command: list[str] = []
 
     for line in lines:
         if line.strip().startswith('RUN <<EOF'):

--- a/tests/dockerfile/resources/multiline_command/Dockerfile
+++ b/tests/dockerfile/resources/multiline_command/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.4
+FROM docker.io/library/ubuntu:22.04
+
+RUN <<EOF
+echo "Hello"
+echo "World"
+mkdir -p /hello/world
+# not detected by checkov:
+apt update
+EOF
+
+# detected by checkov:
+RUN apt update

--- a/tests/dockerfile/test_runner.py
+++ b/tests/dockerfile/test_runner.py
@@ -339,6 +339,30 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(extra_resource.file_abs_path, str(test_file))
         self.assertTrue(extra_resource.file_path.endswith("Dockerfile.prod"))
 
+    def test_runner_multi_line(self):
+        # given
+        test_file = RESOURCES_DIR / "multiline_command/"
+
+        # when
+        report = Runner(db_connector=self.db_connector()).run(
+            files=[str(test_file)],
+            runner_filter=RunnerFilter(framework=['dockerfile'], checks=["CKV_DOCKER_9"])  # chose a check, which will find nothing
+        )
+
+        # then
+        summary = report.get_summary()
+
+        self.assertEqual(summary["passed"], 0)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+        self.assertEqual(summary["resource_count"], 1)
+
+        self.assertEqual(len(report.extra_resources), 1)
+        extra_resource = next(iter(report.extra_resources))
+        self.assertEqual(extra_resource.file_abs_path, str(test_file))
+        self.assertTrue(extra_resource.file_path.endswith("Dockerfile"))
+
 
     def tearDown(self) -> None:
         registry.checks = self.orig_checks

--- a/tests/dockerfile/test_runner.py
+++ b/tests/dockerfile/test_runner.py
@@ -339,29 +339,16 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(extra_resource.file_abs_path, str(test_file))
         self.assertTrue(extra_resource.file_path.endswith("Dockerfile.prod"))
 
-    def test_runner_multi_line(self):
-        # given
-        test_file = RESOURCES_DIR / "multiline_command/"
-
-        # when
-        report = Runner(db_connector=self.db_connector()).run(
-            files=[str(test_file)],
-            runner_filter=RunnerFilter(framework=['dockerfile'], checks=["CKV_DOCKER_9"])  # chose a check, which will find nothing
-        )
-
-        # then
-        summary = report.get_summary()
-
-        self.assertEqual(summary["passed"], 0)
-        self.assertEqual(summary["failed"], 1)
-        self.assertEqual(summary["skipped"], 0)
-        self.assertEqual(summary["parsing_errors"], 0)
-        self.assertEqual(summary["resource_count"], 1)
-
-        self.assertEqual(len(report.extra_resources), 1)
-        extra_resource = next(iter(report.extra_resources))
-        self.assertEqual(extra_resource.file_abs_path, str(test_file))
-        self.assertTrue(extra_resource.file_path.endswith("Dockerfile"))
+    def test_runner_multiline(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/resources/multiline_command"
+        runner = Runner(db_connector=self.db_connector())
+        report = runner.run(root_folder=valid_dir_path, external_checks_dir=None,
+                            runner_filter=RunnerFilter(framework='dockerfile', checks=['CKV_DOCKER_9']))
+        self.assertEqual(len(report.failed_checks), 1)
+        self.assertEqual(report.parsing_errors, [])
+        self.assertEqual(report.passed_checks, [])
+        self.assertEqual(report.skipped_checks, [])
 
 
     def tearDown(self) -> None:


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Handle heredoc in Dockerfile

Fixes #5090 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Implement handling of heredoc syntax in Dockerfiles by introducing a new function <code>convert_multiline_commands</code> in <code>parser.py</code>. This function processes Dockerfile content to convert heredoc-style commands into single-line commands. Update tests to verify the new functionality, including a new test case <code>test_runner_multiline</code> in <code>test_runner.py</code> and a sample Dockerfile in <code>resources/multiline_command</code>.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6828?tool=ast&topic=Heredoc+Handling>Heredoc Handling</a>
        </td><td>Handle heredoc syntax in Dockerfiles by converting multiline commands into single-line commands using the <code>convert_multiline_commands</code> function.<details><summary>Modified files (1)</summary><ul><li>checkov/dockerfile/parser.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>feat-dockerfile-add-Im...</td><td>October 06, 2022</td></tr>
<tr><td>mikeurbanski1@users.no...</td><td>Use-new-runconfig-endp...</td><td>February 21, 2022</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6828?tool=ast&topic=Testing+Enhancements>Testing Enhancements</a>
        </td><td>Add test cases to verify the handling of heredoc syntax in Dockerfiles, ensuring the new functionality works as expected.<details><summary>Modified files (2)</summary><ul><li>tests/dockerfile/test_runner.py</li>
<li>tests/dockerfile/resources/multiline_command/Dockerfile</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>49649760+lirshindalman...</td><td>platform-general-remov...</td><td>January 28, 2024</td></tr>
<tr><td>ravni@paloaltonetworks...</td><td>fixing-more-tests</td><td>October 19, 2023</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @tsmithv11 and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    