### PR TITLE
feat(cloudformation): Support Fn::Sub in cases of using a pseudo parameter

### DIFF
--- a/checkov/cloudformation/parser/cfn_keywords.py
+++ b/checkov/cloudformation/parser/cfn_keywords.py
@@ -48,3 +48,14 @@ class TemplateSections(str, Enum):
     TRANSFORM = "Transform"
     OUTPUTS = "Outputs"
     GLOBALS = "Globals"
+
+
+class PseudoParameters(Enum):
+    ACCOUNT_ID = "AWS::AccountId"
+    NOTIFICATION_ARNS = "AWS::NotificationARNs"
+    NO_VALUE = "AWS::NoValue"
+    PARTITION = "AWS::Partition"
+    REGION = "AWS::Region"
+    STACK_ID = "AWS::StackId"
+    STACK_NAME = "AWS::StackName"
+    URL_SUFFIX = "AWS::URLSuffix"

--- a/tests/cloudformation/graph/graph_builder/resources/variable_rendering/render_sub/json/test.json
+++ b/tests/cloudformation/graph/graph_builder/resources/variable_rendering/render_sub/json/test.json
@@ -24,7 +24,7 @@
             "Type": "AWS::RDS::DBInstance",
             "Properties": {
                 "DBName": {
-                    "Fn::Sub": "rds-${AWS::AccountId}-${CompanyName}-${Environment}"
+                    "Fn::Sub": "rds-${CompanyName}-${Environment}"
                 },
                 "DBInstanceClass": "db.m4.large"
             }
@@ -52,7 +52,7 @@
         "DefaultDBName": {
             "Description": "DefaultDB Name",
             "Value": {
-                "Fn::Sub": "rds-${AWS::AccountId}-${CompanyName}-${Environment}"
+                "Fn::Sub": "rds-${CompanyName}-${Environment}"
             }
         }
     }

--- a/tests/cloudformation/graph/graph_builder/resources/variable_rendering/render_sub/yaml/test.yaml
+++ b/tests/cloudformation/graph/graph_builder/resources/variable_rendering/render_sub/yaml/test.yaml
@@ -17,7 +17,7 @@ Resources:
   DefaultDB:
     Type: AWS::RDS::DBInstance
     Properties:
-      DBName: !Sub "rds-${AWS::AccountId}-${CompanyName}-${Environment}"
+      DBName: !Sub "rds-${CompanyName}-${Environment}"
       DBInstanceClass: "db.m4.large"
 Outputs:
   DBEndpoint:
@@ -31,5 +31,5 @@ Outputs:
     Value: !Sub ${WebVPC.CidrBlockAssociations}
   DefaultDBName:
     Description: DefaultDB Name
-    Value: !Sub "rds-${AWS::AccountId}-${CompanyName}-${Environment}"
+    Value: !Sub "rds-${CompanyName}-${Environment}"
 

--- a/tests/cloudformation/graph/graph_builder/test_render.py
+++ b/tests/cloudformation/graph/graph_builder/test_render.py
@@ -140,12 +140,12 @@ class TestRenderer(TestCase):
         environment_expected_attributes = {'Default': None}
         # Resources
         web_vpc_expected_attributes = {'CidrBlock': web_vpc_expected_cidr_block}
-        default_db_expected_attributes = {'DBName': {'Fn::Sub': 'rds-${AWS::AccountId}-${CompanyName}-${Environment}'}}
+        default_db_expected_attributes = {'DBName': {'Fn::Sub': 'rds-${CompanyName}-${Environment}'}}
         # Outputs
         db_endpoint_sg_expected_attributes = {'Value.Fn::Sub': "${DefaultDB.Endpoint.Address}:${DefaultDB.Endpoint.Port}"}
         web_vpc_cidr_block_expected_attributes = {'Value': web_vpc_expected_cidr_block}
         cidr_block_associations_expected_attributes = {'Value.Fn::Sub': "${WebVPC.CidrBlockAssociations}"}
-        default_db_name_expected_attributes = {'Value': {'Fn::Sub': 'rds-${AWS::AccountId}-${CompanyName}-${Environment}'}}
+        default_db_name_expected_attributes = {'Value': {'Fn::Sub': 'rds-${CompanyName}-${Environment}'}}
 
         self.compare_vertex_attributes(local_graph, company_name_expected_attributes, BlockType.PARAMETERS, 'CompanyName')
         self.compare_vertex_attributes(local_graph, environment_expected_attributes, BlockType.PARAMETERS, 'Environment')

--- a/tests/cloudformation/graph/graph_runner/external_graph_checks/jsonpath_policy.yaml
+++ b/tests/cloudformation/graph/graph_runner/external_graph_checks/jsonpath_policy.yaml
@@ -1,0 +1,21 @@
+metadata:
+  id: "CKV2_CFN_JSONPATH_POLICY"
+  name: "Jsonpath policy for cloudformation"
+  severity: "high"
+  guidelines: "Mediastore container and objects must not be accessible anonymously"
+  category: "general"
+scope:
+  provider: "aws"
+definition:
+  and:
+    - cond_type: "attribute"
+      resource_types:
+        - "AWS::MediaStore::Container"
+      attribute: "Policy.Statement[?(@.Effect == 'Allow' & @.Principal == '*')]"
+      operator: "jsonpath_not_exists"
+    - cond_type: "attribute"
+      resource_types:
+        - "AWS::MediaStore::Container"
+      attribute: "Policy.Statement[?(@.Effect == 'Allow')].Principal.AWS[*]"
+      operator: "jsonpath_not_equals"
+      value: "*"

--- a/tests/cloudformation/graph/graph_runner/resources/jsonpath_policy/fail_dict.json
+++ b/tests/cloudformation/graph/graph_runner/resources/jsonpath_policy/fail_dict.json
@@ -1,0 +1,33 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "fail-dict": {
+      "Type": "AWS::MediaStore::Container",
+      "Properties": {
+        "ContainerName": "fail-dict",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "MediaStoredenyAccess",
+              "Effect": "Allow",
+              "Action": [
+                "mediastore:GetObject",
+                "mediastore:DeleteObject",
+                "mediastore:DescribeObject",
+                "mediastore:ListItems"
+              ],
+              "Principal": "*",
+              "Resource": "arn:aws:mediastore:${AWS::Region}:${AWS::AccountId}:container/compmediastorecontainer/*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/cloudformation/graph/graph_runner/resources/jsonpath_policy/fail_str.json
+++ b/tests/cloudformation/graph/graph_runner/resources/jsonpath_policy/fail_str.json
@@ -1,0 +1,14 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+        "fail-str": {
+            "Type": "AWS::MediaStore::Container",
+            "Properties": {
+                "ContainerName": "fail-str",
+                "Policy": {
+                    "Fn::Sub": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"MediaStoredenyAccess\",\"Effect\":\"Allow\",\"Action\":[\"mediastore:GetObject\",\"mediastore:DeleteObject\",\"mediastore:DescribeObject\",\"mediastore:ListItems\"],\"Principal\":\"*\",\"Resource\":\"arn:aws:mediastore:${AWS::Region}:${AWS::AccountId}:container/compmediastorecontainer/*\",\"Condition\":{\"Bool\":{\"aws:SecureTransport\":\"false\"}}}]}"
+                }
+            }
+        }
+    }
+}

--- a/tests/cloudformation/graph/graph_runner/resources/jsonpath_policy/pass_str.json
+++ b/tests/cloudformation/graph/graph_runner/resources/jsonpath_policy/pass_str.json
@@ -1,0 +1,14 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+        "pass-str": {
+            "Type": "AWS::MediaStore::Container",
+            "Properties": {
+                "ContainerName": "pass-str",
+                "Policy": {
+                    "Fn::Sub": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"MediaStoredenyAccess\",\"Effect\":\"Deny\",\"Action\":[\"mediastore:GetObject\",\"mediastore:DeleteObject\",\"mediastore:DescribeObject\",\"mediastore:ListItems\"],\"Principal\":\"*\",\"Resource\":\"arn:aws:mediastore:${AWS::Region}:${AWS::AccountId}:container/ncmediastorecontainer/*\",\"Condition\":{\"Bool\":{\"aws:SecureTransport\":\"false\"}}}]}"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Pseudo Parameter in CFN is a parameter which is dynamically available (see reference).
As we do not render it on buildtime, we want to handle this case by keeping the reference itself without the
value, so we can at least build a semi-full resource.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Introduce support for handling <code>Fn::Sub</code> with pseudo parameters in AWS CloudFormation templates. The <code>CloudformationVariableRenderer</code> class now includes a method <code>_handle_sub_with_pseudo_param</code> to manage these cases by retaining the reference without the value, ensuring a semi-complete resource build. The <code>PseudoParameters</code> enum is added to <code>cfn_keywords.py</code> to define available pseudo parameters. Test cases in <code>test_render.py</code> and new JSON/YAML resources validate the changes, ensuring that pseudo parameters are correctly processed and that the <code>Fn::Sub</code> function behaves as expected.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6835?tool=ast&topic=New+Test+Resources>New Test Resources</a>
        </td><td>Introduce new JSON/YAML resources and test cases to validate the <code>Fn::Sub</code> function and pseudo parameter handling in CloudFormation templates.<details><summary>Modified files (5)</summary><ul><li>tests/cloudformation/graph/graph_runner/test_running_graph_checks.py</li>
<li>tests/cloudformation/graph/graph_runner/external_graph_checks/jsonpath_policy.yaml</li>
<li>tests/cloudformation/graph/graph_runner/resources/jsonpath_policy/pass_str.json</li>
<li>tests/cloudformation/graph/graph_runner/resources/jsonpath_policy/fail_dict.json</li>
<li>tests/cloudformation/graph/graph_runner/resources/jsonpath_policy/fail_str.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nimrodkor@gmail.com</td><td>Move-test-yamls-for-k8...</td><td>January 24, 2022</td></tr>
<tr><td>@gruebel</td><td>add-pre-commit-flake8</td><td>December 12, 2021</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6835?tool=ast&topic=PseudoParameters+Enum>PseudoParameters Enum</a>
        </td><td>Add <code>PseudoParameters</code> enum to define available pseudo parameters in CloudFormation templates.<details><summary>Modified files (1)</summary><ul><li>checkov/cloudformation/parser/cfn_keywords.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>@gruebel</td><td>add-AWS-SAM-support-2013</td><td>November 30, 2021</td></tr>
<tr><td>@Saarett</td><td>changed-a-few-enms-to-...</td><td>August 17, 2021</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6835?tool=ast&topic=Renderer+Enhancement>Renderer Enhancement</a>
        </td><td>Enhance the <code>CloudformationVariableRenderer</code> to handle <code>Fn::Sub</code> with pseudo parameters, ensuring references are maintained without values for semi-complete resource builds.<details><summary>Modified files (1)</summary><ul><li>checkov/cloudformation/graph_builder/variable_rendering/renderer.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>@gruebel</td><td>break-general-remove-P...</td><td>October 04, 2023</td></tr>
<tr><td>maxam@post.bgu.ac.il</td><td>add-exception-for-dict...</td><td>June 09, 2022</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6835?tool=ast&topic=Test+Updates>Test Updates</a>
        </td><td>Update test cases to validate the handling of <code>Fn::Sub</code> with pseudo parameters, ensuring correct processing and expected behavior.<details><summary>Modified files (3)</summary><ul><li>tests/cloudformation/graph/graph_builder/test_render.py</li>
<li>tests/cloudformation/graph/graph_builder/resources/variable_rendering/render_sub/yaml/test.yaml</li>
<li>tests/cloudformation/graph/graph_builder/resources/variable_rendering/render_sub/json/test.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>@gruebel</td><td>chore-use-mock.patch-f...</td><td>January 17, 2023</td></tr>
<tr><td>@Saarett</td><td>CFN-Func-is-not-evalua...</td><td>October 07, 2021</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @bo156 and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    