### PR TITLE
fix(secrets): skip empty match

### DIFF
--- a/checkov/secrets/plugins/custom_regex_detector.py
+++ b/checkov/secrets/plugins/custom_regex_detector.py
@@ -142,6 +142,9 @@ class CustomRegexDetector(RegexBasedDetector):
         current_regex_to_metadata: dict[str, dict[str, Any]] = self.multiline_regex_to_metadata if is_multiline else self.regex_to_metadata
         kwargs["regex_denylist"] = current_denylist
         for match, regex in self.analyze_string(string_to_analyze, **kwargs):
+            if len(match) == 0:
+                # Skip empty matches
+                continue
             try:
                 verified_result = call_function_with_arguments(self.verify, secret=match, context=context)
                 is_verified = True if verified_result == VerifiedResult.VERIFIED_TRUE else False


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Implement a fix in <code>CustomRegexDetector</code> to skip processing empty matches during regex analysis, enhancing performance and accuracy.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6849?tool=ast&topic=Regex+Match+Optimization>Regex Match Optimization</a>
        </td><td>Enhance the <code>CustomRegexDetector</code> by skipping empty matches during regex analysis to improve performance and accuracy.<details><summary>Modified files (1)</summary><ul><li>checkov/secrets/plugins/custom_regex_detector.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>RabeaZr</td><td>fix-secrets-add-prerun...</td><td>November 17, 2024</td></tr>
<tr><td>ChanochShayner</td><td>feat-secrets-Change-lo...</td><td>September 12, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @omryMen and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    