### PR TITLE
feat(terraform): Add check - ensure AWS CodeGuru resource contains CMK

### DIFF
--- a/checkov/terraform/checks/resource/aws/AWSCodeGuruHasCMK.py
+++ b/checkov/terraform/checks/resource/aws/AWSCodeGuruHasCMK.py
@@ -1,0 +1,33 @@
+from typing import Dict, List, Any
+
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class AWSCodeGuruHasCMK(BaseResourceCheck):
+    def __init__(self):
+        # This is the full description of your check
+        description = "Make sure that aws_codegurureviewer_repository_association has a CMK"
+
+        # This is the Unique ID for your check
+        id = "CKV_AWS_381"
+
+        # These are the terraform objects supported by this check (ex: aws_iam_policy_document)
+        supported_resources = ['aws_codegurureviewer_repository_association']
+
+        # Valid CheckCategories are defined in checkov/common/models/enums.py
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=description, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
+        if 'kms_key_details' in conf:
+            kms_key_details = conf['kms_key_details'][0]
+            if 'encryption_option' in kms_key_details:
+                encryption_option = kms_key_details['encryption_option'][0]
+                if encryption_option == 'CUSTOMER_MANAGED_CMK':
+                    return CheckResult.PASSED
+
+        return CheckResult.FAILED
+
+
+check = AWSCodeGuruHasCMK()

--- a/tests/terraform/checks/resource/aws/example_AWSCodeGuruHasCMK/AWSCodeGuruHasCMK.tf
+++ b/tests/terraform/checks/resource/aws/example_AWSCodeGuruHasCMK/AWSCodeGuruHasCMK.tf
@@ -1,0 +1,44 @@
+
+resource "aws_codegurureviewer_repository_association" "pass" {
+  repository {
+    codecommit {
+      name = "repository_name"
+    }
+  }
+  kms_key_details {
+    encryption_option = "CUSTOMER_MANAGED_CMK"
+    kms_key_id        = "aws_kms_key.example.key_id"
+  }
+}
+
+resource "aws_codegurureviewer_repository_association" "ckv_unittest_fail_no_encryption_option" {
+  repository {
+    codecommit {
+      name = "repository_name"
+    }
+  }
+  kms_key_details {
+    kms_key_id        = "aws_kms_key.example.key_id"
+  }
+}
+
+
+resource "aws_codegurureviewer_repository_association" "ckv_unittest_fail_no_kms_key_details" {
+  repository {
+    codecommit {
+      name = "repository_name"
+    }
+  }
+}
+
+resource "aws_codegurureviewer_repository_association" "ckv_unittest_fail_encryption_option_OWNED" {
+  repository {
+    codecommit {
+      name = "repository_name"
+    }
+  }
+  kms_key_details {
+    encryption_option = "AWS_OWNED_CMK"
+    kms_key_id        = "aws_kms_key.example.key_id"
+  }
+}

--- a/tests/terraform/checks/resource/aws/test_AWSCodeGuruHasCMK.py
+++ b/tests/terraform/checks/resource/aws/test_AWSCodeGuruHasCMK.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+from checkov.terraform.checks.resource.aws.AWSCodeGuruHasCMK import check
+
+
+class TestAWSCodeGuruHasCMK(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = os.path.join(current_dir, "example_AWSCodeGuruHasCMK")
+        report = runner.run(root_folder=test_files_dir,
+                            runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'aws_codegurureviewer_repository_association.pass'
+        }
+        failing_resources = {
+            'aws_codegurureviewer_repository_association.ckv_unittest_fail_no_encryption_option',
+            'aws_codegurureviewer_repository_association.ckv_unittest_fail_no_kms_key_details',
+            'aws_codegurureviewer_repository_association.ckv_unittest_fail_encryption_option_OWNED',
+        }
+        skipped_resources = {}
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], len(skipped_resources))
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

 feat(terraform): Add CKV_AWS_381 to ensure that AWS CloudGuru has CMK
## New/Edited policies (Delete if not relevant)
CKV_AWS_381


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Introduce a new Terraform check <code>CKV_AWS_381</code> to ensure that AWS CodeGuru resources are configured with a Customer Managed Key (CMK) for encryption. The <code>AWSCodeGuruHasCMK</code> class implements this check by verifying the presence of <code>kms_key_details</code> with <code>encryption_option</code> set to <code>CUSTOMER_MANAGED_CMK</code>. This change enhances security by enforcing encryption standards. Additionally, test cases are added to validate the functionality of this check, ensuring it correctly identifies compliant and non-compliant configurations.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6850?tool=ast&topic=CMK+Encryption+Check>CMK Encryption Check</a>
        </td><td>Implement a new Terraform check <code>AWSCodeGuruHasCMK</code> to ensure AWS CodeGuru resources use CMK for encryption.<details><summary>Modified files (1)</summary><ul><li>checkov/terraform/checks/resource/aws/AWSCodeGuruHasCMK.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6850?tool=ast&topic=Test+Cases+for+CMK+Check>Test Cases for CMK Check</a>
        </td><td>Add test cases to validate the <code>AWSCodeGuruHasCMK</code> check functionality.<details><summary>Modified files (2)</summary><ul><li>tests/terraform/checks/resource/aws/test_AWSCodeGuruHasCMK.py</li>
<li>tests/terraform/checks/resource/aws/example_AWSCodeGuruHasCMK/AWSCodeGuruHasCMK.tf</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @talazuri and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    