### PR TITLE
fix(secrets): multiline matches show the secret and not the first line

### DIFF
--- a/checkov/secrets/plugins/custom_regex_detector.py
+++ b/checkov/secrets/plugins/custom_regex_detector.py
@@ -170,12 +170,12 @@ class CustomRegexDetector(RegexBasedDetector):
                     continue
                 multiline_matches = multiline_regex.findall(file_content)
                 for mm in multiline_matches:
-                    mm = f"'{mm}'"
+                    quoted_mm = f"'{mm}'"
                     ps = PotentialSecret(
                         type=regex_data["Name"],
                         filename=filename,
-                        secret=mm,
-                        line_number=line_number,
+                        secret=quoted_mm,
+                        line_number=find_line_number(file_content, mm, line_number),
                         is_verified=is_verified,
                         is_added=is_added,
                         is_removed=is_removed,
@@ -216,3 +216,12 @@ class CustomRegexDetector(RegexBasedDetector):
                         yield submatch, regex
                 else:
                     yield match, regex
+
+
+def find_line_number(file_string: str, substring: str, default_line_number: int) -> int:
+    lines = file_string.splitlines()
+
+    for line_number, line in enumerate(lines, start=1):
+        if substring in line:
+            return line_number
+    return default_line_number

--- a/tests/secrets/multiline_finding/Dockerfile.mine
+++ b/tests/secrets/multiline_finding/Dockerfile.mine
@@ -1,0 +1,2 @@
+Algolia
+const ADMIN_KEY = 'b782df1739614041699a45f8079a3623';

--- a/tests/secrets/test_multiline_finding_line_number.py
+++ b/tests/secrets/test_multiline_finding_line_number.py
@@ -1,0 +1,53 @@
+import os
+import unittest
+
+
+from checkov.common.bridgecrew.platform_integration import bc_integration
+from checkov.runner_filter import RunnerFilter
+from checkov.secrets.runner import Runner
+from tests.secrets.utils_for_test import _filter_reports_for_incident_ids
+
+
+class TestMultilineFinding(unittest.TestCase):
+
+    def test_multiline_finding(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_dir_path = current_dir + "/multiline_finding"
+        bc_integration.customer_run_config_response = {"secretsPolicies": [
+            {
+                "incidentId": "test1",
+                "category": "Secrets",
+                "severity": "MEDIUM",
+                "incidentType": "Violation",
+                "title": "test1",
+                "guideline": "test",
+                "laceworkViolationId": None,
+                "prowlerCheckId": None,
+                "checkovCheckId": None,
+                "resourceTypes":
+                    [
+                        "aws_instance"
+                    ],
+                "provider": "AWS",
+                "remediationIds":
+                    [],
+                "customerName": "test1",
+                "isCustom": True,
+                "code": "definition:\n  cond_type: secrets\n  multiline: true\n  prerun:\n  - (?i)(?:algolia)\n  value:\n  - (?i)(?:algolia)(?:.|[\\n\\r]){0,80}([A-Za-z0-9]{32})\n",
+                "descriptiveTitle": None,
+                "constructiveTitle": None,
+                "pcPolicyId": None,
+                "additionalPcPolicyIds": None,
+                "pcSeverity": None,
+                "sourceIncidentId": None
+            }
+        ]}
+        runner = Runner()
+        report = runner.run(root_folder=valid_dir_path,
+                            runner_filter=RunnerFilter(framework=['secrets'],
+                                                       enable_secret_scan_all_files=True))
+        interesting_failed_checks = _filter_reports_for_incident_ids(report.failed_checks, ["test1"])
+        self.assertEqual(len(interesting_failed_checks), 1)
+        self.assertEqual(len(interesting_failed_checks[0].code_block), 1)
+        self.assertEqual(len(interesting_failed_checks[0].code_block[0]), 2)
+        self.assertEqual(interesting_failed_checks[0].code_block[0][0], 2)


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Improve the <code>CustomRegexDetector</code> to correctly display multiline secrets by introducing a new function <code>find_line_number</code> to accurately determine the line number of secrets. Enhance test coverage with a new test case <code>TestMultilineFinding</code> to validate the changes.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6854?tool=ast&topic=Multiline+Secret+Fix>Multiline Secret Fix</a>
        </td><td>Fix the multiline secret detection in <code>CustomRegexDetector</code> by quoting the secret and accurately finding its line number using <code>find_line_number</code>.<details><summary>Modified files (1)</summary><ul><li>checkov/secrets/plugins/custom_regex_detector.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>omryMen</td><td>fix-secrets-skip-empty...</td><td>November 18, 2024</td></tr>
<tr><td>RabeaZr</td><td>fix-secrets-add-prerun...</td><td>November 17, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6854?tool=ast&topic=Test+Enhancement>Test Enhancement</a>
        </td><td>Add a new test case <code>TestMultilineFinding</code> to ensure multiline secret detection works correctly, using a sample Dockerfile for testing.<details><summary>Modified files (2)</summary><ul><li>tests/secrets/test_multiline_finding_line_number.py</li>
<li>tests/secrets/multiline_finding/Dockerfile.mine</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @RabeaZr and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    