### PR TITLE
fix(cloudformation): Fixed issue where Ref was not rendered correctly if the parameter name was identical to the default value

### DIFF
--- a/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
@@ -449,7 +449,6 @@ class CloudformationVariableRenderer(VariableRenderer["CloudformationLocalGraph"
         ), None)
 
         if cfn_evaluation_function:
-            original_value = val_to_eval.get(cfn_evaluation_function, None)
 
             evaluated_edges: "list[_EvaluatedEdge]" = []
             for edge in edge_list:

--- a/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
+++ b/checkov/cloudformation/graph_builder/variable_rendering/renderer.py
@@ -461,7 +461,7 @@ class CloudformationVariableRenderer(VariableRenderer["CloudformationLocalGraph"
                     logging.info(f'Failed to evalue cfn function. val_to_eval: {val_to_eval}')
                     continue
 
-                if evaluated_value and evaluated_value != original_value:
+                if evaluated_value:
                     # succeeded to evaluate an edge
                     val_to_eval[cfn_evaluation_function] = evaluated_value
                     evaluated_edges.append({

--- a/tests/cloudformation/graph/graph_runner/external_graph_checks/simple_graph_check.yaml
+++ b/tests/cloudformation/graph/graph_runner/external_graph_checks/simple_graph_check.yaml
@@ -1,0 +1,10 @@
+metadata:
+ name: "simple_graph_check"
+ id: "CKV2_TEST_SIMPLE"
+ category: "GENERAL"
+definition:
+  attribute: "ContainerDefinitions.LogConfiguration.LogDriver"
+  cond_type: "attribute"
+  operator: "exists"
+  resource_types:
+    - "AWS::ECS::TaskDefinition"

--- a/tests/cloudformation/graph/graph_runner/resources/template_with_parameters_names_identical_to_default_values/example.yaml
+++ b/tests/cloudformation/graph/graph_runner/resources/template_with_parameters_names_identical_to_default_values/example.yaml
@@ -1,0 +1,77 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  Foo:
+    Type: String
+    Default: "Foo"
+  Bar:
+    Type: String
+    Default: "Bar"
+
+Conditions:
+  Check: !And
+    - !Equals [!Ref Foo, "Foo"]
+    - !Equals [!Ref Bar, "Bar"]
+  FalseCheck: !And
+    - !Equals [!Ref Foo, "NotFoo"]
+    - !Equals [!Ref Bar, "Bar"]
+
+Resources:
+  Pass:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: my-ecs-task
+      NetworkMode: bridge
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: "256"
+      Memory: "512"
+      ContainerDefinitions:
+        - Name: my-container
+          Image: amazon/amazon-ecs-sample
+          Cpu: 256
+          Memory: 512
+          Essential: true
+          PortMappings:
+            - ContainerPort: 80
+              HostPort: 80
+              Protocol: tcp
+          LogConfiguration: 
+            !If 
+              - Check
+              - 
+                LogDriver: awslogs
+                Options:
+                  awslogs-group: !Sub "/ecs/${AWS::StackName}/my-container-logs"
+                  awslogs-region: !Ref "AWS::Region"
+                  awslogs-stream-prefix: my-container
+              - !Ref AWS::NoValue
+      ExecutionRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/ecsTaskExecutionRole"
+  Fail:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: my-ecs-task
+      NetworkMode: bridge
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: "256"
+      Memory: "512"
+      ContainerDefinitions:
+        - Name: my-container
+          Image: amazon/amazon-ecs-sample
+          Cpu: 256
+          Memory: 512
+          Essential: true
+          PortMappings:
+            - ContainerPort: 80
+              HostPort: 80
+              Protocol: tcp
+          LogConfiguration:
+            !If
+            - FalseCheck
+            - LogDriver: awslogs
+              Options:
+                awslogs-group: !Sub "/ecs/${AWS::StackName}/my-container-logs"
+                awslogs-region: !Ref "AWS::Region"
+                awslogs-stream-prefix: my-container
+            - !Ref AWS::NoValue
+      ExecutionRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/ecsTaskExecutionRole"

--- a/tests/cloudformation/graph/graph_runner/test_running_graph_checks.py
+++ b/tests/cloudformation/graph/graph_runner/test_running_graph_checks.py
@@ -126,6 +126,46 @@ class TestRunningGraphChecks(unittest.TestCase):
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
 
+    def test_template_with_parameters_names_identical_to_default_values(self):
+        test_dir_path = Path(__file__).parent / "resources" / \
+                        "template_with_parameters_names_identical_to_default_values"
+        check_dir = Path(__file__).parent / "external_graph_checks"
+
+        test_check_registry = Registry(
+            checks_dir=f'{check_dir}',
+            parser=GraphCheckParser()
+        )
+
+        # when
+        report = Runner(
+            external_registries=[test_check_registry]).\
+            run(root_folder=str(test_dir_path),
+                runner_filter=RunnerFilter(checks=["CKV2_TEST_SIMPLE"])
+        )
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::ECS::TaskDefinition.Pass",
+        }
+
+        failing_resources = {
+            "AWS::ECS::TaskDefinition.Fail"
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixed issue where Ref was not rendered correctly if the parameter name was identical to the default value

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Resolve an issue in the <code>CloudformationVariableRenderer</code> class where the <code>Ref</code> function was not rendered correctly if the parameter name matched its default value. This fix ensures that the evaluated value is correctly assigned, improving the accuracy of CloudFormation template evaluations. Additionally, new test cases have been added to verify the fix, including a YAML test file <code>simple_graph_check.yaml</code> and a template <code>example.yaml</code> to ensure parameters with identical names and default values are handled correctly. The test suite in <code>test_running_graph_checks.py</code> has been updated to include these scenarios, ensuring robust validation of the changes.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6856?tool=ast&topic=Test+Enhancements>Test Enhancements</a>
        </td><td>Add and update test cases to validate the fix for <code>Ref</code> rendering and ensure parameters with identical names and default values are processed correctly.<details><summary>Modified files (3)</summary><ul><li>tests/cloudformation/graph/graph_runner/test_running_graph_checks.py</li>
<li>tests/cloudformation/graph/graph_runner/external_graph_checks/simple_graph_check.yaml</li>
<li>tests/cloudformation/graph/graph_runner/resources/template_with_parameters_names_identical_to_default_values/example.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bo156</td><td>fix-general-Used-jsonp...</td><td>November 19, 2024</td></tr>
<tr><td>nimrodkor@gmail.com</td><td>Move-test-yamls-for-k8...</td><td>January 24, 2022</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6856?tool=ast&topic=Ref+Rendering+Fix>Ref Rendering Fix</a>
        </td><td>Fix the <code>Ref</code> rendering issue in <code>CloudformationVariableRenderer</code> to handle parameters with identical names and default values correctly.<details><summary>Modified files (1)</summary><ul><li>checkov/cloudformation/graph_builder/variable_rendering/renderer.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bo156</td><td>fix-general-Used-jsonp...</td><td>November 19, 2024</td></tr>
<tr><td>gruebel</td><td>break-general-remove-P...</td><td>October 04, 2023</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @bo156 and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    