### PR TITLE
chore(secrets): filter out more obvious variables for base64

### DIFF
--- a/checkov/secrets/plugins/detector_utils.py
+++ b/checkov/secrets/plugins/detector_utils.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 MAX_KEYWORD_LIMIT = 500
 
-B64_FP_REGEX = re.compile(r'\b[A-Za-z]+_+[A-Za-z_]*[A-Za-z]\b')
+B64_FP_REGEX = re.compile(r'\b[A-Za-z]+_+[A-Za-z_]*[A-Za-z]\b|\b([a-z0-9]+-)+[a-z0-9]+\b')
 
 DENY_LIST_REGEX = r'|'.join(DENYLIST)
 # Support for suffix after keyword i.e. password_secure = "value"

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -13,6 +13,7 @@ class TestSecrets(unittest.TestCase):
             '-----BEGIN RSA PRIVATE KEY-----\n',  # checkov:skip=CKV_SECRET_13 test secret
             'Hello from Bridgecrew',
             'cert-manager.io/secret: org/repo',
+            'S3ApiKeyParamKey: s3-cache-api-key-dev',
         ]
 
         # check that no category checks all


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Filter out more obvious FPs

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
