### PR TITLE
feat(general): add support to check all providers

### DIFF
--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -264,9 +264,9 @@ class GraphCheckParser(BaseGraphCheckParser):
             elif "provider" in resource_type and providers:
                 for provider in providers:
                     if provider == 'all':
-                        check.resource_types.append(f"provider.aws")
-                        check.resource_types.append(f"provider.google")
-                        check.resource_types.append(f"provider.azure")
+                        check.resource_types.append("provider.aws")
+                        check.resource_types.append("provider.google")
+                        check.resource_types.append("provider.azure")
                     else:
                         check.resource_types.append(f"provider.{provider.lower()}")
             elif isinstance(resource_type, str):

--- a/checkov/common/checks_infra/checks_parser.py
+++ b/checkov/common/checks_infra/checks_parser.py
@@ -263,7 +263,12 @@ class GraphCheckParser(BaseGraphCheckParser):
 
             elif "provider" in resource_type and providers:
                 for provider in providers:
-                    check.resource_types.append(f"provider.{provider.lower()}")
+                    if provider == 'all':
+                        check.resource_types.append(f"provider.aws")
+                        check.resource_types.append(f"provider.google")
+                        check.resource_types.append(f"provider.azure")
+                    else:
+                        check.resource_types.append(f"provider.{provider.lower()}")
             elif isinstance(resource_type, str):
                 #  for the case the "resource_types" value is a string, which can result in a silent exception
                 check.resource_types = [resource_type]


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

add support to check 
```
resource_types:
    - provider 
```
  to all providers 
```
scope:
  provider: "all"
```
i test with this check:

```
metadata:
  id: "TEST_1"
  name: "test for provider = all"
  category: "GENERAL_SECURITY"
scope:
  provider: "all"
definition:
  cond_type: attribute
  resource_types:
    - provider
  attribute: default_tags
  operator: exists
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Extends the <code>checks_parser.py</code> file to support checking all providers by adding a new condition for the 'all' provider option, which includes AWS, Google, and Azure providers.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6913?tool=ast&topic=All+Providers+Support>All Providers Support</a>
        </td><td>Implements support for checking all providers by adding a new condition in the resource type processing logic<details><summary>Modified files (1)</summary><ul><li>checkov/common/checks_infra/checks_parser.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsmithv11</td><td>feat-general-add-new-C...</td><td>December 02, 2024</td></tr>
<tr><td>dtrouillet</td><td>feat-general-add-sever...</td><td>September 11, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @lirshindalman and the rest of your team on <a href=https://baz.co/changes/bridgecrewio/checkov/6913?tool=ast>(Baz)</a>.
    