### PR TITLE
fix(terraform): Skip tsconfig in terraform plan

### DIFF
--- a/checkov/terraform/plan_utils.py
+++ b/checkov/terraform/plan_utils.py
@@ -29,7 +29,7 @@ def create_definitions(
             filter_ignored_paths(root, f_names, runner_filter.excluded_paths)
             for file in f_names:
                 file_ending = os.path.splitext(file)[1]
-                if file_ending == '.json':
+                if file != 'tsconfig.json' and file_ending == '.json':
                     file_path = os.path.join(root, file)
                     try:
                         with open(file_path, "rb") as f:


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Modifies the <code>plan_utils.py</code> file to exclude <code>tsconfig.json</code> from being processed as a Terraform plan file.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6941?tool=ast&topic=Terraform+Plan+Filter>Terraform Plan Filter</a>
        </td><td>Adds a condition to skip processing of <code>tsconfig.json</code> files in Terraform plan parsing<details><summary>Modified files (1)</summary><ul><li>checkov/terraform/plan_utils.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>maxamel</td><td>feat-terraform_plan-ad...</td><td>September 04, 2024</td></tr>
<tr><td>gruebel</td><td>chore-finish-up-type-h...</td><td>September 17, 2023</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @OfekShimko and the rest of your team on <a href=https://baz.co/changes/bridgecrewio/checkov/6941?tool=ast>(Baz)</a>.
    