### PR TITLE
fix(python): 🐛 adds support for newly release EKS version 1.32

### DIFF
--- a/checkov/terraform/checks/resource/aws/EKSPlatformVersion.py
+++ b/checkov/terraform/checks/resource/aws/EKSPlatformVersion.py
@@ -25,7 +25,7 @@ class EKSPlatformVersion(BaseResourceValueCheck):
 
     def get_expected_values(self) -> list[Any]:
         # https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-        return ["1.24", "1.25", "1.26", "1.27", "1.28", "1.29", "1.30", "1.31"]
+        return ["1.24", "1.25", "1.26", "1.27", "1.28", "1.29", "1.30", "1.31", "1.32"]
 
 
 check = EKSPlatformVersion()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

EKS recently released version 1.32 (as of 23rd January 2025) - https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
EKS recently released version 1.32 (as of 23rd January 2025)

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
