### PR TITLE
fix(bicep): Add bicep specific for CKV_AZURE_25 since ARM implementation fails

### DIFF
--- a/checkov/bicep/checks/graph_checks/SQLServerThreatDetectionTypes.yaml
+++ b/checkov/bicep/checks/graph_checks/SQLServerThreatDetectionTypes.yaml
@@ -1,0 +1,61 @@
+metadata:
+  id: "CKV_AZURE_25"
+  name: "Azure SQL Server threat detection alerts are enabled for all threat types"
+  category: "LOGGING"
+definition:
+  and:
+    - cond_type: filter
+      attribute: resource_type
+      operator: within
+      value:
+        - Microsoft.Sql/servers
+        - Microsoft.Sql/servers/databases
+    - or:
+        - and:
+            - cond_type: connection
+              resource_types:
+                - Microsoft.Sql/servers
+              connected_resource_types:
+                - Microsoft.Sql/servers/securityAlertPolicies
+              operator: exists
+            - cond_type: attribute
+              resource_types:
+                - Microsoft.Sql/servers/securityAlertPolicies
+              attribute: properties.state
+              operator: equals
+              value: Enabled
+            - or:
+              - cond_type: attribute
+                resource_types:
+                  - Microsoft.Sql/servers/securityAlertPolicies
+                attribute: properties.disabledAlerts
+                operator: is_empty
+              - cond_type: attribute
+                resource_types:
+                  - Microsoft.Sql/servers/securityAlertPolicies
+                attribute: properties.disabledAlerts
+                operator: not_exists
+        - and:
+            - cond_type: connection
+              resource_types:
+                - Microsoft.Sql/servers/databases
+              connected_resource_types:
+                - Microsoft.Sql/servers/databases/securityAlertPolicies
+              operator: exists
+            - cond_type: attribute
+              resource_types:
+                - Microsoft.Sql/servers/databases/securityAlertPolicies
+              attribute: properties.state
+              operator: equals
+              value: Enabled
+            - or:
+                - cond_type: attribute
+                  resource_types:
+                    - Microsoft.Sql/servers/databases/securityAlertPolicies
+                  attribute: properties.disabledAlerts
+                  operator: is_empty
+                - cond_type: attribute
+                  resource_types:
+                    - Microsoft.Sql/servers/databases/securityAlertPolicies
+                  attribute: properties.disabledAlerts
+                  operator: not_exists

--- a/tests/bicep/graph/checks/resources/SQLServerThreatDetectionTypes/expected.yaml
+++ b/tests/bicep/graph/checks/resources/SQLServerThreatDetectionTypes/expected.yaml
@@ -4,9 +4,11 @@ pass:
   - 'Microsoft.Sql/servers/databases.databaseEnabled'
   - 'Microsoft.Sql/servers/databases.databaseEnabledWithoutAlertsAttribute'
 fail:
+  - 'Microsoft.Sql/servers.serverWithoutSecurityPolicy'
   - 'Microsoft.Sql/servers.serverDisabledState'
   - 'Microsoft.Sql/servers.serverDisabledAlerts'
   - 'Microsoft.Sql/servers.serverDisabled'
+  - 'Microsoft.Sql/servers/databases.databaseWithoutSecurityPolicy'
   - 'Microsoft.Sql/servers/databases.databaseDisabledState'
   - 'Microsoft.Sql/servers/databases.databaseDisabledAlerts'
   - 'Microsoft.Sql/servers/databases.databaseDisabled'

--- a/tests/bicep/graph/checks/resources/SQLServerThreatDetectionTypes/expected.yaml
+++ b/tests/bicep/graph/checks/resources/SQLServerThreatDetectionTypes/expected.yaml
@@ -1,0 +1,16 @@
+pass:
+  - 'Microsoft.Sql/servers.serverEnabled'
+  - 'Microsoft.Sql/servers.serverEnabledWithoutAlertsAttribute'
+  - 'Microsoft.Sql/servers/databases.databaseEnabled'
+  - 'Microsoft.Sql/servers/databases.databaseEnabledWithoutAlertsAttribute'
+fail:
+  - 'Microsoft.Sql/servers.serverDisabledState'
+  - 'Microsoft.Sql/servers.serverDisabledAlerts'
+  - 'Microsoft.Sql/servers.serverDisabled'
+  - 'Microsoft.Sql/servers/databases.databaseDisabledState'
+  - 'Microsoft.Sql/servers/databases.databaseDisabledAlerts'
+  - 'Microsoft.Sql/servers/databases.databaseDisabled'
+evaluated_keys:
+  - 'resource_type'
+  - 'properties/state'
+  - 'properties/disabledAlerts'

--- a/tests/bicep/graph/checks/resources/SQLServerThreatDetectionTypes/main.bicep
+++ b/tests/bicep/graph/checks/resources/SQLServerThreatDetectionTypes/main.bicep
@@ -1,0 +1,202 @@
+// pass
+resource serverEnabled 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: 'default'
+  location: location
+
+  properties: {
+    administratorLogin: sqlLogicalServer.userName
+    administratorLoginPassword: password
+    version: '12.0'
+    minimalTlsVersion: sqlLogicalServer.minimalTlsVersion
+    publicNetworkAccess: sqlLogicalServer.publicNetworkAccess
+  }
+
+  resource securityAlertPolicyEnabled 'securityAlertPolicies' = {
+    name: 'default'
+    properties: {
+      state: 'Enabled'
+      disabledAlerts: [
+      ]
+    }
+  }
+}
+
+resource serverEnabledWithoutAlertsAttribute 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: 'default'
+  location: location
+
+  properties: {
+    administratorLogin: sqlLogicalServer.userName
+    administratorLoginPassword: password
+    version: '12.0'
+    minimalTlsVersion: sqlLogicalServer.minimalTlsVersion
+    publicNetworkAccess: sqlLogicalServer.publicNetworkAccess
+  }
+
+  resource securityAlertPolicyEnabled 'securityAlertPolicies' = {
+    name: 'default'
+    properties: {
+      state: 'Enabled'
+    }
+  }
+}
+
+resource databaseEnabled 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  name: '${server.name}/${sqlDBName}'
+  location: location
+  sku: {
+    name: 'GP_S_Gen5_2'
+    tier: 'GeneralPurpose'
+  }
+
+  resource securityAlertPolicyEnabled 'securityAlertPolicies' = {
+    name: 'default'
+    properties: {
+      state: 'Enabled'
+      disabledAlerts: [
+      ]
+    }
+  }
+}
+
+resource databaseEnabledWithoutAlertsAttribute 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  name: '${server.name}/${sqlDBName}'
+  location: location
+  sku: {
+    name: 'GP_S_Gen5_2'
+    tier: 'GeneralPurpose'
+  }
+
+  resource securityAlertPolicyEnabled 'securityAlertPolicies' = {
+    name: 'default'
+    properties: {
+      state: 'Enabled'
+    }
+  }
+}
+
+// fail
+resource serverDisabledState 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: 'default'
+  location: location
+
+  properties: {
+    administratorLogin: sqlLogicalServer.userName
+    administratorLoginPassword: password
+    version: '12.0'
+    minimalTlsVersion: sqlLogicalServer.minimalTlsVersion
+    publicNetworkAccess: sqlLogicalServer.publicNetworkAccess
+  }
+
+  resource securityAlertPolicyEnabled 'securityAlertPolicies' = {
+    name: 'default'
+    properties: {
+      state: 'Disabled'
+      disabledAlerts: [
+      ]
+    }
+  }
+}
+
+resource serverDisabledAlerts 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: 'default'
+  location: location
+
+  properties: {
+    administratorLogin: sqlLogicalServer.userName
+    administratorLoginPassword: password
+    version: '12.0'
+    minimalTlsVersion: sqlLogicalServer.minimalTlsVersion
+    publicNetworkAccess: sqlLogicalServer.publicNetworkAccess
+  }
+
+  resource securityAlertPolicyEnabled 'securityAlertPolicies' = {
+    name: 'default'
+    properties: {
+      state: 'Enabled'
+      disabledAlerts: [
+        'disabledAlert'
+      ]
+    }
+  }
+}
+
+resource serverDisabled 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: 'default'
+  location: location
+
+  properties: {
+    administratorLogin: sqlLogicalServer.userName
+    administratorLoginPassword: password
+    version: '12.0'
+    minimalTlsVersion: sqlLogicalServer.minimalTlsVersion
+    publicNetworkAccess: sqlLogicalServer.publicNetworkAccess
+  }
+
+  resource securityAlertPolicyEnabled 'securityAlertPolicies' = {
+    name: 'default'
+    properties: {
+      state: 'Disabled'
+      disabledAlerts: [
+        'disabledAlert'
+      ]
+    }
+  }
+}
+
+resource databaseDisabledState 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  name: '${server.name}/${sqlDBName}'
+  location: location
+  sku: {
+    name: 'GP_S_Gen5_2'
+    tier: 'GeneralPurpose'
+  }
+
+  resource securityAlertPolicyDisabledAlerts 'securityAlertPolicies' = {
+    name: 'default'
+    properties: {
+      state: 'Disabled'
+      disabledAlerts: [
+      ]
+    }
+  }
+}
+
+resource databaseDisabledAlerts 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  name: '${server.name}/${sqlDBName}'
+  location: location
+  sku: {
+    name: 'GP_S_Gen5_2'
+    tier: 'GeneralPurpose'
+  }
+
+  resource securityAlertPolicyDisabledAlerts 'securityAlertPolicies' = {
+    name: 'default'
+    properties: {
+      state: 'Enabled'
+      disabledAlerts: [
+        'disabledAlert'
+      ]
+    }
+  }
+}
+
+resource databaseDisabled 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  name: '${server.name}/${sqlDBName}'
+  location: location
+  sku: {
+    name: 'GP_S_Gen5_2'
+    tier: 'GeneralPurpose'
+  }
+
+  resource securityAlertPolicy 'securityAlertPolicies' = {
+    name: 'default'
+    properties: {
+      state: 'Disabled'
+      disabledAlerts: [
+        'disabledAlert'
+      ]
+    }
+  }
+}
+

--- a/tests/bicep/graph/checks/resources/SQLServerThreatDetectionTypes/main.bicep
+++ b/tests/bicep/graph/checks/resources/SQLServerThreatDetectionTypes/main.bicep
@@ -76,6 +76,19 @@ resource databaseEnabledWithoutAlertsAttribute 'Microsoft.Sql/servers/databases@
 }
 
 // fail
+resource serverWithoutSecurityPolicy 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: 'default'
+  location: location
+
+  properties: {
+    administratorLogin: sqlLogicalServer.userName
+    administratorLoginPassword: password
+    version: '12.0'
+    minimalTlsVersion: sqlLogicalServer.minimalTlsVersion
+    publicNetworkAccess: sqlLogicalServer.publicNetworkAccess
+  }
+}
+
 resource serverDisabledState 'Microsoft.Sql/servers@2021-02-01-preview' = {
   name: 'default'
   location: location
@@ -141,6 +154,15 @@ resource serverDisabled 'Microsoft.Sql/servers@2021-02-01-preview' = {
         'disabledAlert'
       ]
     }
+  }
+}
+
+resource databaseWithoutSecurityPolicy 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  name: '${server.name}/${sqlDBName}'
+  location: location
+  sku: {
+    name: 'GP_S_Gen5_2'
+    tier: 'GeneralPurpose'
   }
 }
 

--- a/tests/bicep/graph/checks/test_yaml_policies.py
+++ b/tests/bicep/graph/checks/test_yaml_policies.py
@@ -39,6 +39,9 @@ class TestYamlPolicies(TestYamlPoliciesBase):
     def test_SQLServerAuditingRetention90Days(self):
         self.go("SQLServerAuditingRetention90Days")
 
+    def test_SQLServerThreatDetectionTypes(self):
+        self.go("SQLServerThreatDetectionTypes")
+
     def test_registry_load(self):
         registry = self.get_checks_registry()
         self.assertGreater(len(registry.checks), 0)


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
The change uses the graph to properly check for the 'state' and 'disabledAlerts' attributes in the required securityAlertPolicies for Azure SQL servers and databases. As of now, checkov uses the ARM implementation for this check, which fails for bicep scripts.

Fixes #6963 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Implements a new graph-based check for Azure SQL Server threat detection alerts in Bicep scripts. Adds a YAML configuration file for the check, creates test cases to verify the implementation, and updates the test suite to include the new check. The change addresses an issue where the existing ARM implementation fails for Bicep scripts, ensuring that all threat types are properly enabled for Azure SQL servers and databases.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6996?tool=ast&topic=Test+Cases>Test Cases</a>
        </td><td>Adds test cases and resources to verify the new graph-based check implementation<details><summary>Modified files (3)</summary><ul><li>tests/bicep/graph/checks/resources/SQLServerThreatDetectionTypes/main.bicep</li>
<li>tests/bicep/graph/checks/resources/SQLServerThreatDetectionTypes/expected.yaml</li>
<li>tests/bicep/graph/checks/test_yaml_policies.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsmithv11</td><td>feat-bicep-Add-bicep-v...</td><td>April 19, 2024</td></tr>
<tr><td>lirshindalman</td><td>feat-general-Add-image...</td><td>September 28, 2023</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/6996?tool=ast&topic=Graph+Check+Impl>Graph Check Impl</a>
        </td><td>Implements a new graph-based check for Azure SQL Server threat detection alerts in Bicep scripts<details><summary>Modified files (1)</summary><ul><li>checkov/bicep/checks/graph_checks/SQLServerThreatDetectionTypes.yaml</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @mLe110 and the rest of your team on <a href=https://baz.co/changes/bridgecrewio/checkov/6996?tool=ast>(Baz)</a>.
    