### PR TITLE
fix(general): Handle ECS enhanced container insights

### DIFF
--- a/cdk_integration_tests/src/python/ECSClusterContainerInsights/fail__1__.py
+++ b/cdk_integration_tests/src/python/ECSClusterContainerInsights/fail__1__.py
@@ -12,8 +12,24 @@ class MyECSClusterStack(core.Stack):
                       )
 
         cluster = ecs.Cluster(self, "EcsCluster", vpc=vpc, container_insights=False)
-        cluster2 = ecs.Cluster(self, "EcsCluster", vpc=vpc)
-        cluster3 = ecs.Cluster(self, "EcsCluster", vpc=vpc, container_insights_v2=ecs.ContainerInsights.DISABLED)
+        cluster2 = ecs.Cluster(self, "EcsCluster2", vpc=vpc)
+        cluster3 = ecs.Cluster(self, "EcsCluster3", vpc=vpc, container_insights_v2=ecs.ContainerInsights.DISABLED)
+
+        cluster4 = ecs.CfnCluster(
+            self, 'MyECSCluster4',
+            cluster_name='my-ecs-cluster',
+            cluster_settings=[{
+                'name': 'containerInsights',
+                'value': 'disabled'
+            }]
+            # Other properties for your ECS Cluster
+        )
+
+        cluster5 = ecs.CfnCluster(
+            self, 'MyECSCluster5',
+            cluster_name='my-ecs-cluster'
+            # Other properties for your ECS Cluster
+        )
 
 app = core.App()
 MyECSClusterStack(app, "MyECSClusterStack")

--- a/cdk_integration_tests/src/python/ECSClusterContainerInsights/fail__1__.py
+++ b/cdk_integration_tests/src/python/ECSClusterContainerInsights/fail__1__.py
@@ -1,20 +1,19 @@
-from aws_cdk import core
+import aws_cdk as core
+from constructs import Construct
 from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_ec2 as ec2
 
 class MyECSClusterStack(core.Stack):
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
-        # Define ECS Cluster with Cluster Settings
-        cluster = ecs.CfnCluster(
-            self, 'MyECSCluster',
-            cluster_name='my-ecs-cluster',
-            cluster_settings=[{
-                'name': 'containerInsights',
-                'value': 'disabled'
-            }]
-            # Other properties for your ECS Cluster
-        )
+        vpc = ec2.Vpc(self, "Vpc",
+                      ip_protocol=ec2.IpProtocol.DUAL_STACK
+                      )
+
+        cluster = ecs.Cluster(self, "EcsCluster", vpc=vpc, container_insights=False)
+        cluster2 = ecs.Cluster(self, "EcsCluster", vpc=vpc)
+        cluster3 = ecs.Cluster(self, "EcsCluster", vpc=vpc, container_insights_v2=ecs.ContainerInsights.DISABLED)
 
 app = core.App()
 MyECSClusterStack(app, "MyECSClusterStack")

--- a/cdk_integration_tests/src/python/ECSClusterContainerInsights/pass.py
+++ b/cdk_integration_tests/src/python/ECSClusterContainerInsights/pass.py
@@ -15,6 +15,26 @@ class MyECSClusterStack(core.Stack):
         cluster2 = ecs.Cluster(self, "EcsCluster2", vpc=vpc, container_insights_v2=ecs.ContainerInsights.ENHANCED)
         cluster3 = ecs.Cluster(self, "EcsCluster3", vpc=vpc, container_insights_v2=ecs.ContainerInsights.ENABLED)
 
+        cluster4 = ecs.CfnCluster(
+            self, 'MyECSCluster4',
+            cluster_name='my-ecs-cluster',
+            cluster_settings=[{
+                'name': 'containerInsights',
+                'value': 'enabled'
+            }]
+            # Other properties for your ECS Cluster
+        )
+
+        cluster5 = ecs.CfnCluster(
+            self, 'MyECSCluster5',
+            cluster_name='my-ecs-cluster',
+            cluster_settings=[{
+                'name': 'containerInsights',
+                'value': 'enhanced'
+            }]
+            # Other properties for your ECS Cluster
+        )
+
 app = core.App()
 MyECSClusterStack(app, "MyECSClusterStack")
 app.synth()

--- a/cdk_integration_tests/src/python/ECSClusterContainerInsights/pass.py
+++ b/cdk_integration_tests/src/python/ECSClusterContainerInsights/pass.py
@@ -1,20 +1,19 @@
-from aws_cdk import core
+import aws_cdk as core
+from constructs import Construct
 from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_ec2 as ec2
 
 class MyECSClusterStack(core.Stack):
-    def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
-        # Define ECS Cluster with Cluster Settings
-        cluster = ecs.CfnCluster(
-            self, 'MyECSCluster',
-            cluster_name='my-ecs-cluster',
-            cluster_settings=[{
-                'name': 'containerInsights',
-                'value': 'enabled'
-            }]
-            # Other properties for your ECS Cluster
+        vpc = ec2.Vpc(self, "Vpc",
+            ip_protocol=ec2.IpProtocol.DUAL_STACK
         )
+
+        cluster = ecs.Cluster(self, "EcsCluster", vpc=vpc, container_insights=True)
+        cluster2 = ecs.Cluster(self, "EcsCluster2", vpc=vpc, container_insights_v2=ecs.ContainerInsights.ENHANCED)
+        cluster3 = ecs.Cluster(self, "EcsCluster3", vpc=vpc, container_insights_v2=ecs.ContainerInsights.ENABLED)
 
 app = core.App()
 MyECSClusterStack(app, "MyECSClusterStack")

--- a/cdk_integration_tests/src/typescript/ECSClusterContainerInsights/fail.ts
+++ b/cdk_integration_tests/src/typescript/ECSClusterContainerInsights/fail.ts
@@ -8,6 +8,11 @@ export class exampleStack extends cdk.Stack {
         super(scope, id, props);
         const vpc = new ec2.Vpc(this, 'Vpc', {maxAzs: 1});
         const cluster = new ecs.Cluster(this, 'EcsCluster', {vpc});
+        const cluster2 = new ecs.Cluster(this, 'EcsCluster2', {vpc, containerInsights: false});
+        const cluster3 = new ecs.Cluster(this, 'EcsCluster3', {vpc, containerInsightsV2: ecs.ContainerInsights.DISABLED});
+
+        const cluster4 = new ecs.CfnCluster(this, 'EcsCluster4', {clusterSettings: []});
+        const cluster5 = new ecs.CfnCluster(this, 'EcsCluster5', {clusterSettings: [{name: 'containerInsights', value: 'disabled'}]});
     }
 }
 

--- a/cdk_integration_tests/src/typescript/ECSClusterContainerInsights/pass.ts
+++ b/cdk_integration_tests/src/typescript/ECSClusterContainerInsights/pass.ts
@@ -8,6 +8,11 @@ export class exampleStack extends cdk.Stack {
         super(scope, id, props);
         const vpc = new ec2.Vpc(this, 'Vpc', {maxAzs: 1});
         const cluster = new ecs.Cluster(this, 'EcsCluster', {vpc, containerInsights: true});
+        const cluster2 = new ecs.Cluster(this, 'EcsCluster2', {vpc, containerInsightsV2: ecs.ContainerInsights.ENABLED});
+        const cluster3 = new ecs.Cluster(this, 'EcsCluster6', {vpc, containerInsightsV2: ecs.ContainerInsights.ENHANCED});
+
+        const cluster4 = new ecs.CfnCluster(this, 'EcsCluster4', {clusterSettings: [{name: 'containerInsights', value: 'enabled'}]});
+        const cluster5 = new ecs.CfnCluster(this, 'EcsCluster5', {clusterSettings: [{value: 'enhanced', name: 'containerInsights'}]});
     }
 }
 

--- a/checkov/cdk/checks/python/ECSClusterContainerInsights.yaml
+++ b/checkov/cdk/checks/python/ECSClusterContainerInsights.yaml
@@ -9,9 +9,23 @@ scope:
   languages:
     - python
 definition:
-  pattern: aws_cdk.aws_ecs.CfnCluster(<ANY>)
-  conditions:
-    - not_pattern: |
-        aws_cdk.aws_ecs.CfnCluster(<ANY>, cluster_settings=[<ANY>, {'name': 'containerInsights', 'value': 'enabled'} ,<ANY>], <ANY>)
-    - not_pattern: |
-        aws_cdk.aws_ecs.CfnCluster(<ANY>, cluster_settings=[<ANY>, {'value': 'enabled', 'name': 'containerInsights'} ,<ANY>], <ANY>)
+  patterns:
+    or:
+      - pattern: aws_cdk.aws_ecs.CfnCluster(<ANY>)
+        conditions:
+          - not_pattern: |
+              aws_cdk.aws_ecs.CfnCluster(<ANY>, cluster_settings=[<ANY>, {'name': 'containerInsights', 'value': 'enabled'} ,<ANY>], <ANY>)
+          - not_pattern: |
+              aws_cdk.aws_ecs.CfnCluster(<ANY>, cluster_settings=[<ANY>, {'value': 'enabled', 'name': 'containerInsights'} ,<ANY>], <ANY>)
+          - not_pattern: |
+              aws_cdk.aws_ecs.CfnCluster(<ANY>, cluster_settings=[<ANY>, {'name': 'containerInsights', 'value': 'enhanced'} ,<ANY>], <ANY>)
+          - not_pattern: |
+              aws_cdk.aws_ecs.CfnCluster(<ANY>, cluster_settings=[<ANY>, {'value': 'enhanced', 'name': 'containerInsights'} ,<ANY>], <ANY>)
+      - pattern: aws_cdk.aws_ecs.Cluster(<ANY>)
+        conditions:
+          - not_pattern: |
+              aws_cdk.aws_ecs.Cluster(<ANY>, container_insights=True, <ANY>)
+          - not_pattern: |
+              aws_cdk.aws_ecs.Cluster(<ANY>, container_insights_v2=aws_ecs.ContainerInsights.ENABLED, <ANY>)
+          - not_pattern: |
+              aws_cdk.aws_ecs.Cluster(<ANY>, container_insights_v2=aws_ecs.ContainerInsights.ENHANCED, <ANY>)

--- a/checkov/cdk/checks/typescript/ECSClusterContainerInsights.yaml
+++ b/checkov/cdk/checks/typescript/ECSClusterContainerInsights.yaml
@@ -9,8 +9,23 @@ scope:
   languages:
     - typescript
 definition:
-  pattern: |
-    new ecs.Cluster(<ANY>)
-  conditions:
-    - not_pattern: |
-        new $AWS.Cluster(<ANY>, { <ANY>, containerInsights: true, <ANY>}, <ANY>)
+  patterns:
+    or:
+      - pattern: new ecs.Cluster(<ANY>)
+        conditions:
+          - not_pattern: |
+              new $AWS.Cluster(<ANY>, { <ANY>, containerInsights: true, <ANY>}, <ANY>)
+          - not_pattern: |
+              new $AWS.Cluster(<ANY>, { <ANY>, containerInsightsV2: $AWS.ContainerInsights.ENABLED, <ANY>}, <ANY>)
+          - not_pattern: |
+              new $AWS.Cluster(<ANY>, { <ANY>, containerInsightsV2: $AWS.ContainerInsights.ENHANCED, <ANY>}, <ANY>)
+      - pattern: new ecs.CfnCluster(<ANY>)
+        conditions:
+          - not_pattern: |
+              new $AWS.CfnCluster(<ANY>, { <ANY>, clusterSettings: [<ANY>, {name: 'containerInsights', value: 'enabled'}, <ANY>], <ANY>}, <ANY>)
+          - not_pattern: |
+              new $AWS.CfnCluster(<ANY>, { <ANY>, clusterSettings: [<ANY>, {name: 'containerInsights', value: 'enhanced'}, <ANY>], <ANY>}, <ANY>)
+          - not_pattern: |
+              new $AWS.CfnCluster(<ANY>, { <ANY>, clusterSettings: [<ANY>, {value: 'enabled', name: 'containerInsights'}, <ANY>], <ANY>}, <ANY>)
+          - not_pattern: |
+              new $AWS.CfnCluster(<ANY>, { <ANY>, clusterSettings: [<ANY>, {value: 'enhanced', name: 'containerInsights'}, <ANY>], <ANY>}, <ANY>)

--- a/checkov/cloudformation/checks/resource/aws/ECSClusterContainerInsights.py
+++ b/checkov/cloudformation/checks/resource/aws/ECSClusterContainerInsights.py
@@ -28,7 +28,7 @@ class ECSClusterContainerInsights(BaseResourceCheck):
             if settings and isinstance(settings, list):
                 self.evaluated_keys = ["Properties/ClusterSettings"]
                 for setting in settings:
-                    if setting["Name"] == "containerInsights" and setting["Value"] == "enabled":
+                    if setting["Name"] == "containerInsights" and setting["Value"] in ["enhanced", "enabled"]:
                         return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/checkov/terraform/checks/resource/aws/ECSClusterContainerInsights.py
+++ b/checkov/terraform/checks/resource/aws/ECSClusterContainerInsights.py
@@ -13,10 +13,12 @@ class ECSClusterContainerInsights(BaseResourceCheck):
     def scan_resource_conf(self, conf):
         if 'setting' in conf.keys():
             for idx, setting in enumerate(conf['setting']):
-                if isinstance(setting, dict) and setting['name'] == ['containerInsights'] \
-                        and setting['value'] == ['enabled']:
+                if isinstance(setting, dict) and setting['name'] == ['containerInsights']:
+                    value = setting['value']
+                    if isinstance(value, list):
+                        value = value[0]
                     self.evaluated_keys = [f'setting/[{idx}]/name', f'setting/[{idx}]/value']
-                    return CheckResult.PASSED
+                    return CheckResult.PASSED if value in ['enabled', 'enhanced'] else CheckResult.FAILED
         return CheckResult.FAILED
 
 

--- a/tests/cloudformation/checks/resource/aws/example_ECSClusterContainerInsights/ECSClusterContainerInsights-PASSED2.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ECSClusterContainerInsights/ECSClusterContainerInsights-PASSED2.yaml
@@ -1,0 +1,8 @@
+Resources:
+  ECSCluster:
+    Type: 'AWS::ECS::Cluster'
+    Properties:
+      ClusterName: 'MyCluster'
+      ClusterSettings:
+        - Name: 'containerInsights'
+          Value: 'enhanced'

--- a/tests/cloudformation/checks/resource/aws/test_ECSClusterContainerInsights.py
+++ b/tests/cloudformation/checks/resource/aws/test_ECSClusterContainerInsights.py
@@ -16,7 +16,7 @@ class TestECSClusterContainerInsights(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/terraform/checks/resource/aws/test_ECSClusterContainerInsights.py
+++ b/tests/terraform/checks/resource/aws/test_ECSClusterContainerInsights.py
@@ -20,6 +20,22 @@ class TestECSClusterContainerInsights(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.FAILED, scan_result)
 
+    def test_failure_explicit_disable(self):
+        hcl_res = hcl2.loads(
+            """
+            resource "aws_ecs_cluster" "my_cluster" {
+                name = "white-hart"
+                setting {
+                    name = "containerInsights"
+                    value = "disabled"
+                }
+            }
+            """
+        )
+        resource_conf = hcl_res['resource'][0]['aws_ecs_cluster']['my_cluster']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
     def test_success(self):
         hcl_res = hcl2.loads(
             """
@@ -28,6 +44,22 @@ class TestECSClusterContainerInsights(unittest.TestCase):
                 setting {
                     name = "containerInsights"
                     value = "enabled"
+                }
+            }
+            """
+        )
+        resource_conf = hcl_res['resource'][0]['aws_ecs_cluster']['my_cluster']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success_enhanced(self):
+        hcl_res = hcl2.loads(
+            """
+            resource "aws_ecs_cluster" "my_cluster" {
+                name = "white-hart"
+                setting {
+                    name = "containerInsights"
+                    value = "enhanced"
                 }
             }
             """


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- Handle containerInsights = `enhanced` in the ECS container insights check
- Update CDK policies to check both L1 and L2 resources correctly

Fixes https://github.com/bridgecrewio/checkov/issues/7000

## New/Edited policies (Delete if not relevant)

`CKV_AWS_65` - allow `enhanced` and `enabled` as the valid values, in all iterations (including CDK L1 and L2 resources)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Updates the ECS container insights check to handle the 'enhanced' setting in addition to 'enabled'. Modifies CDK policies to check both L1 and L2 resources correctly. Implements changes across multiple languages (Python, TypeScript) and frameworks (CDK, CloudFormation, Terraform). Updates test cases to cover new scenarios.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/7001?tool=ast&topic=ECS+Insights+Update>ECS Insights Update</a>
        </td><td>Extends the ECS container insights check to support the 'enhanced' setting alongside 'enabled'<details><summary>Modified files (5)</summary><ul><li>tests/cloudformation/checks/resource/aws/test_ECSClusterContainerInsights.py</li>
<li>tests/terraform/checks/resource/aws/test_ECSClusterContainerInsights.py</li>
<li>tests/cloudformation/checks/resource/aws/example_ECSClusterContainerInsights/ECSClusterContainerInsights-PASSED2.yaml</li>
<li>checkov/cloudformation/checks/resource/aws/ECSClusterContainerInsights.py</li>
<li>checkov/terraform/checks/resource/aws/ECSClusterContainerInsights.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gruebel</td><td>chore-fix-flake8-issue...</td><td>October 11, 2022</td></tr>
<tr><td>YaaraVerner</td><td>Add-evaluated_keys-to-...</td><td>September 30, 2021</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/7001?tool=ast&topic=CDK+Policy+Update>CDK Policy Update</a>
        </td><td>Updates CDK policies to correctly check both L1 and L2 resources for ECS container insights<details><summary>Modified files (6)</summary><ul><li>cdk_integration_tests/src/python/ECSClusterContainerInsights/fail__1__.py</li>
<li>checkov/cdk/checks/python/ECSClusterContainerInsights.yaml</li>
<li>checkov/cdk/checks/typescript/ECSClusterContainerInsights.yaml</li>
<li>cdk_integration_tests/src/typescript/ECSClusterContainerInsights/pass.ts</li>
<li>cdk_integration_tests/src/typescript/ECSClusterContainerInsights/fail.ts</li>
<li>cdk_integration_tests/src/python/ECSClusterContainerInsights/pass.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tronxd@users.noreply.g...</td><td>feat-sast-CDK-TS-polic...</td><td>April 10, 2024</td></tr>
<tr><td>achiar99</td><td>feat-sast-Split-sast-a...</td><td>December 21, 2023</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @mikeurbanski1 and the rest of your team on <a href=https://baz.co/changes/bridgecrewio/checkov/7001?tool=ast>(Baz)</a>.
    