### PR TITLE
fix(cloudformation): Handle subs in CKV_AWS_384

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ParameterStoreCredentials.py
+++ b/checkov/cloudformation/checks/resource/aws/ParameterStoreCredentials.py
@@ -31,7 +31,7 @@ class ParameterStoreCredentials(BaseResourceCheck):
         properties = conf.get("Properties")
         if isinstance(properties, dict):
             name = properties.get("Name")
-            if name and re.match("(?i).*secret.*|.*api_?key.*", name):
+            if name and re.match("(?i).*secret.*|.*api_?key.*", str(name)):
                 value = properties.get("Value")
                 if value:
                     # If unresolved variable, then pass

--- a/tests/cloudformation/checks/resource/aws/example_ParameterStoreCredentials/no_crash.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ParameterStoreCredentials/no_crash.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template to create an SSM Parameter for holding the DynamoDb Table Name.
+
+Parameters:
+  TableName:
+    Type: String
+    Description: The name of the DynamoDB table
+
+Resources:
+  AccountInfoTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Ref TableName
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
+
+  DynamoDbParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /AccountInfoService/${AWS::StackName}/TableName
+      Type: String
+      Value: !Ref AccountInfoTable
+      Description: SSM Parameter for holding the DynamoDb Table Name.
+
+Outputs:
+  DynamoDbParameterOutput:
+    Description: SSM Parameter for holding the DynamoDb Table Name.
+    Value: !Ref DynamoDbParameter

--- a/tests/cloudformation/checks/resource/aws/test_ParameterStoreCredentials.py
+++ b/tests/cloudformation/checks/resource/aws/test_ParameterStoreCredentials.py
@@ -20,6 +20,7 @@ class TestParameterStoreCredentials(unittest.TestCase):
             "AWS::SSM::Parameter.GoodRef",
             "AWS::SSM::Parameter.PassTestName",
             "AWS::SSM::Parameter.PassTestVALUE",
+            "AWS::SSM::Parameter.DynamoDbParameter",
         }
         failing_resources = {
             "AWS::SSM::Parameter.FailAPIKey",


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixes #7019 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Modifies the <code>ParameterStoreCredentials</code> check in CloudFormation to handle string substitutions in parameter names. Adds a test case for DynamoDB table name storage in SSM Parameter Store. Updates the regex matching to convert the <code>name</code> to a string, preventing potential crashes.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/7022?tool=ast&topic=Regex+fix>Regex fix</a>
        </td><td>Modifies the regex matching in <code>ParameterStoreCredentials</code> check to convert <code>name</code> to string, preventing potential crashes with string substitutions.<details><summary>Modified files (1)</summary><ul><li>checkov/cloudformation/checks/resource/aws/ParameterStoreCredentials.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsmithv11</td><td>feat-cloudformation-Ad...</td><td>December 31, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/7022?tool=ast&topic=Test+updates>Test updates</a>
        </td><td>Adds new test cases for DynamoDB table name storage in SSM Parameter Store and updates the test file for <code>ParameterStoreCredentials</code>.<details><summary>Modified files (2)</summary><ul><li>tests/cloudformation/checks/resource/aws/test_ParameterStoreCredentials.py</li>
<li>tests/cloudformation/checks/resource/aws/example_ParameterStoreCredentials/no_crash.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsmithv11</td><td>feat-cloudformation-Ad...</td><td>December 31, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @tsmithv11 and the rest of your team on <a href=https://baz.co/changes/bridgecrewio/checkov/7022?tool=ast>(Baz)</a>.
    