### PR TITLE
fix(general): Operator not behaving as expected

### DIFF
--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/resources/main.tf
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/resources/main.tf
@@ -1,3 +1,7 @@
+resource "test" "pass8" {
+  range = ["1-5","2000-3100"]
+}
+
 resource "test" "pass1" {
   range = "*"
 }

--- a/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/test_solver.py
+++ b/tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/test_solver.py
@@ -17,7 +17,8 @@ class TestRangeIncludesSolver(TestBaseSolver):
     def test_range_includes_int_solver(self):
         root_folder = 'resources'
         check_id = "RangeIncludesInt"
-        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7']
+        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7',
+                       'test.pass8']
         should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7',
                        'test.fail8', 'test.fail9']
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
@@ -27,7 +28,8 @@ class TestRangeIncludesSolver(TestBaseSolver):
     def test_range_includes_string_solver(self):
         root_folder = 'resources'
         check_id = "RangeIncludesString"
-        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7']
+        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7',
+                       'test.pass8']
         should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7',
                        'test.fail8', 'test.fail9']
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
@@ -37,7 +39,8 @@ class TestRangeIncludesSolver(TestBaseSolver):
     def test_range_includes_int_jsonpath_solver(self):
         root_folder = 'resources'
         check_id = "JsonPathRangeIncludesInt"
-        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7']
+        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7',
+                       'test.pass8']
         should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7',
                        'test.fail8', 'test.fail9']
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
@@ -47,7 +50,8 @@ class TestRangeIncludesSolver(TestBaseSolver):
     def test_range_includes_string_jsonpath_solver(self):
         root_folder = 'resources'
         check_id = "JsonPathRangeIncludesString"
-        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7']
+        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7',
+                       'test.pass8']
         should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7',
                        'test.fail8', 'test.fail9']
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
@@ -57,7 +61,8 @@ class TestRangeIncludesSolver(TestBaseSolver):
     def test_range_includes_list_solver(self):
         root_folder = 'resources'
         check_id = "RangeIncludesList"
-        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7']
+        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7',
+                       'test.pass8']
         should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7',
                        'test.fail8', 'test.fail9']
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
@@ -67,7 +72,8 @@ class TestRangeIncludesSolver(TestBaseSolver):
     def test_range_includes_list_jsonpath_solver(self):
         root_folder = 'resources'
         check_id = "JsonPathRangeIncludesList"
-        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7']
+        should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7',
+                       'test.pass8']
         should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail4', 'test.fail5', 'test.fail6', 'test.fail7',
                        'test.fail8', 'test.fail9']
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
@@ -78,7 +84,7 @@ class TestRangeIncludesSolver(TestBaseSolver):
         root_folder = 'resources'
         check_id = "RangeIncludesListWRange"
         should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7',
-                       'test.fail4']
+                       'test.fail4', 'test.pass8']
         should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail5', 'test.fail6', 'test.fail7', 'test.fail8',
                        'test.fail9']
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
@@ -89,7 +95,7 @@ class TestRangeIncludesSolver(TestBaseSolver):
         root_folder = 'resources'
         check_id = "JsonPathRangeIncludesListWRange"
         should_pass = ['test.pass1', 'test.pass2', 'test.pass3', 'test.pass4', 'test.pass5', 'test.pass6', 'test.pass7',
-                       'test.fail4']
+                       'test.fail4', 'test.pass8']
         should_fail = ['test.fail1', 'test.fail2', 'test.fail3', 'test.fail5', 'test.fail6', 'test.fail7', 'test.fail8',
                        'test.fail9']
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Adds a new test case <code>test.pass8</code> with a range of ["1-5","2000-3100"] to the <code>main.tf</code> file. Updates all test functions in <code>test_solver.py</code> to include this new test case in the <code>should_pass</code> list. This change expands the test coverage for various range inclusion checks.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/7026?tool=ast&topic=Add+new+test+case>Add new test case</a>
        </td><td>Adds a new test resource <code>test.pass8</code> with a specific range in the Terraform configuration file<details><summary>Modified files (1)</summary><ul><li>tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/resources/main.tf</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsmithv11</td><td>feat-general-Update-ra...</td><td>April 22, 2024</td></tr>
<tr><td>mikeurbanski1@users.no...</td><td>feat-general-add-range...</td><td>November 03, 2022</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/7026?tool=ast&topic=Update+test+cases>Update test cases</a>
        </td><td>Updates all test functions in the Python test file to include the new <code>test.pass8</code> case<details><summary>Modified files (1)</summary><ul><li>tests/terraform/graph/checks_infra/attribute_solvers/range_includes_solver/test_solver.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsmithv11</td><td>feat-general-Update-ra...</td><td>November 27, 2024</td></tr>
<tr><td>lirshindalman</td><td>feat-general-Add-image...</td><td>September 28, 2023</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @tsmithv11 and the rest of your team on <a href=https://baz.co/changes/bridgecrewio/checkov/7026?tool=ast>(Baz)</a>.
    