### PR TITLE
fix(azurerm_redis_cache): Update policy to detect non_ssl_port_enabled

### DIFF
--- a/checkov/terraform/checks/resource/azure/RedisCacheEnableNonSSLPort.py
+++ b/checkov/terraform/checks/resource/azure/RedisCacheEnableNonSSLPort.py
@@ -12,7 +12,7 @@ class RedisCacheEnableNonSSLPort(BaseResourceValueCheck):
                          missing_block_result=CheckResult.PASSED)
 
     def get_inspected_key(self):
-        return "enable_non_ssl_port"
+        return "non_ssl_port_enabled"
 
     def get_expected_value(self):
         return False


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
The current Checkov policy is looking for enable_non_ssl_port, which is no longer valid after the change in version 4.0.0. The correct attribute is now non_ssl_port_enabled. This update modifies RedisCacheEnableNonSSLPort.py to align with the latest attribute name, ensuring proper detection of misconfigurations.

Fixes # (issue)

## New/Edited policies (Delete if not relevant)
https://docs.prismacloud.io/en/enterprise-edition/policy-reference/azure-policies/azure-networking-policies/ensure-that-only-ssl-are-enabled-for-cache-for-redis

### Description

https://registry.terraform.io/providers/hashicorp/azurerm/4.0.0/docs/resources/redis_cache#non_ssl_port_enabled-7

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ x] New and existing tests pass locally with my changes
