### PR TITLE
feat(terraform): Add azure DB checks for flexible server private endpoints

### DIFF
--- a/checkov/terraform/checks/graph_checks/azure/AzureMySQLFlexibleServerConfigPrivEndpt.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/AzureMySQLFlexibleServerConfigPrivEndpt.yaml
@@ -1,0 +1,19 @@
+metadata:
+  id: "CKV2_AZURE_56"
+  name: "Ensure Azure MySQL Flexible Server is configured with private endpoint"
+  category: "NETWORKING"
+
+definition:
+  and:
+    - cond_type: "filter"
+      attribute: "resource_type"
+      operator: "within"
+      value:
+        - "azurerm_mysql_flexible_server"
+
+    - cond_type: "connection"
+      resource_types:
+        - "azurerm_mysql_flexible_server"
+      connected_resource_types:
+        - "azurerm_private_endpoint"
+      operator: "exists"

--- a/checkov/terraform/checks/graph_checks/azure/AzurePostgreSQLFlexibleServerConfigPrivEndpt.yaml
+++ b/checkov/terraform/checks/graph_checks/azure/AzurePostgreSQLFlexibleServerConfigPrivEndpt.yaml
@@ -1,0 +1,19 @@
+metadata:
+  id: "CKV2_AZURE_57"
+  name: "Ensure PostgreSQL Flexible Server is configured with private endpoint"
+  category: "GENERAL_SECURITY"
+
+definition:
+  and:
+    - cond_type: "filter"
+      attribute: "resource_type"
+      operator: "within"
+      value:
+        - "azurerm_postgresql_flexible_server"
+
+    - cond_type: "connection"
+      resource_types:
+        - "azurerm_postgresql_flexible_server"
+      connected_resource_types:
+        - "azurerm_private_endpoint"
+      operator: "exists"

--- a/tests/terraform/graph/checks/resources/AzureMySQLFlexibleServerConfigPrivEndpt/expected.yaml
+++ b/tests/terraform/graph/checks/resources/AzureMySQLFlexibleServerConfigPrivEndpt/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "azurerm_mysql_flexible_server.pass"
+fail:
+  - "azurerm_mysql_flexible_server.fail"

--- a/tests/terraform/graph/checks/resources/AzureMySQLFlexibleServerConfigPrivEndpt/main.tf
+++ b/tests/terraform/graph/checks/resources/AzureMySQLFlexibleServerConfigPrivEndpt/main.tf
@@ -1,0 +1,61 @@
+
+variable "resource_group_name" {
+  default = "pud_mysql_rg"
+}
+
+variable "location" {
+  default = "East US 2"
+}
+
+variable "subnet_id" {
+  default = "pud-az-subnet"
+}
+
+# case 1: PASS: azurerm_private_endpoint exists and is connected
+
+resource "azurerm_mysql_flexible_server" "pass" {
+  name                = "pass_mysql_server"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  sku_name   = "GP_Gen5_4"
+  version    = "11"
+
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = true
+
+  public_network_access_enabled    = false
+}
+
+resource "azurerm_private_endpoint" "pass" {
+  name                = "pass_priendpt"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.subnet_id
+
+  private_service_connection {
+    name                           = "dep-privservcon"
+    private_connection_resource_id = azurerm_mysql_flexible_server.pass.id
+    subresource_names              = ["foo"]
+    is_manual_connection           = false
+  }
+}
+
+
+# case 2: FAIL: azurerm_private_endpoint does not exist
+
+resource "azurerm_mysql_flexible_server" "fail" {
+  name                = "fail_mysql_server"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  administrator_login          = "pud"
+
+  sku_name   = "GP_Gen5_4"
+  version    = "11"
+
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = true
+
+  public_network_access_enabled    = false
+}

--- a/tests/terraform/graph/checks/resources/AzurePostgreSQLFlexibleServerConfigPrivEndpt/expected.yaml
+++ b/tests/terraform/graph/checks/resources/AzurePostgreSQLFlexibleServerConfigPrivEndpt/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "azurerm_postgresql_flexible_server.pass"
+fail:
+  - "azurerm_postgresql_flexible_server.fail"

--- a/tests/terraform/graph/checks/resources/AzurePostgreSQLFlexibleServerConfigPrivEndpt/main.tf
+++ b/tests/terraform/graph/checks/resources/AzurePostgreSQLFlexibleServerConfigPrivEndpt/main.tf
@@ -1,0 +1,67 @@
+
+variable "resource_group_name" {
+  default = "pud_pgres_rg"
+}
+
+variable "location" {
+  default = "East US 2"
+}
+
+variable "subnet_id" {
+  default = "pud-az-subnet"
+}
+
+# case 1: PASS: azurerm_private_endpoint exists and is connected
+
+resource "azurerm_postgresql_flexible_server" "pass" {
+  name                = "pass_pgres_server"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  administrator_login          = "pud"
+
+  sku_name   = "GP_Gen5_4"
+  version    = "11"
+  storage_mb = 5120
+
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = true
+  auto_grow_enabled            = false
+
+  public_network_access_enabled    = false
+}
+
+resource "azurerm_private_endpoint" "pass" {
+  name                = "pass_priendpt"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.subnet_id
+
+  private_service_connection {
+    name                           = "dep-privservcon"
+    private_connection_resource_id = azurerm_postgresql_flexible_server.pass.id
+    subresource_names              = ["postgresqlServer"]
+    is_manual_connection           = false
+  }
+}
+
+
+# case 2: FAIL: azurerm_private_endpoint does not exist
+
+resource "azurerm_postgresql_flexible_server" "fail" {
+  name                = "fail_pgres_server"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  administrator_login          = "pud"
+
+  sku_name   = "GP_Gen5_4"
+  version    = "11"
+  storage_mb = 5120
+
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = true
+  auto_grow_enabled            = false
+
+  public_network_access_enabled    = false
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -556,8 +556,11 @@ class TestYamlPolicies(unittest.TestCase):
     def test_GCPComputeGlobalForwardingRuleCheck(self):
         self.go("AzureSpringCloudTLSDisabled")
 
-    def test_AzureMySQLserverConfigPrivEndpt(self):
-        self.go("AzureMySQLserverConfigPrivEndpt")
+    def test_AzureMySQLFlexibleServerConfigPrivEndpt(self):
+        self.go("AzureMySQLFlexibleServerConfigPrivEndpt")
+
+    def test_AzurePostgreSQLFlexibleServerConfigPrivEndpt(self):
+        self.go("AzurePostgreSQLFlexibleServerConfigPrivEndpt")
 
 
     def test_registry_load(self):

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -556,6 +556,9 @@ class TestYamlPolicies(unittest.TestCase):
     def test_GCPComputeGlobalForwardingRuleCheck(self):
         self.go("AzureSpringCloudTLSDisabled")
 
+    def test_AzureMySQLserverConfigPrivEndpt(self):
+        self.go("AzureMySQLserverConfigPrivEndpt")
+
 
     def test_registry_load(self):
         registry = Registry(parser=GraphCheckParser(), checks_dir=str(


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Adds 2 checks for private endpoints for flexible DB servers

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/7030?tool=ast&topic=New+Azure+DB+Checks>New Azure DB Checks</a>
        </td><td>Implements new YAML-based graph checks for Azure MySQL and PostgreSQL Flexible Servers to ensure they are configured with private endpoints<details><summary>Modified files (2)</summary><ul><li>checkov/terraform/checks/graph_checks/azure/AzurePostgreSQLFlexibleServerConfigPrivEndpt.yaml</li>
<li>checkov/terraform/checks/graph_checks/azure/AzureMySQLFlexibleServerConfigPrivEndpt.yaml</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/7030?tool=ast&topic=Test+Implementation>Test Implementation</a>
        </td><td>Adds test cases and resources for the new Azure database server checks<details><summary>Modified files (5)</summary><ul><li>tests/terraform/graph/checks/test_yaml_policies.py</li>
<li>tests/terraform/graph/checks/resources/AzureMySQLFlexibleServerConfigPrivEndpt/expected.yaml</li>
<li>tests/terraform/graph/checks/resources/AzurePostgreSQLFlexibleServerConfigPrivEndpt/expected.yaml</li>
<li>tests/terraform/graph/checks/resources/AzurePostgreSQLFlexibleServerConfigPrivEndpt/main.tf</li>
<li>tests/terraform/graph/checks/resources/AzureMySQLFlexibleServerConfigPrivEndpt/main.tf</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsmithv11</td><td>fix-terraform-Convert-...</td><td>December 03, 2024</td></tr>
<tr><td>bo156</td><td>fix-terraform-Temporar...</td><td>July 08, 2024</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Join @tsmithv11 and the rest of your team on <a href=https://baz.co/changes/bridgecrewio/checkov/7030?tool=ast>(Baz)</a>.
    