### PR TITLE
fix(Terraform): Failing checks due to parsing error CKV_GCP_54 & CKV_GCP_57 Issue  7033

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogLockWaits.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogLockWaits.py
@@ -34,7 +34,16 @@ class GoogleCloudPostgreSqlLogLockWaits(BaseResourceCheck):
                         # treating use cases of the following database_flags parsing
                         # (list of dictionaries with arrays): 'database_flags':
                         # [{'name': ['<key>'], 'value': ['<value>']},{'name': ['<key>'], 'value': ['<value>']}]
-                        flags = [{key: flag[key][0] for key in flag} for flag in flags]
+                        new_flag_list = []
+                        for flag in flags:
+                            if "name" and "value" in flag:
+                                new_flag_list.append(
+                                    {
+                                        "name": flag["name"][0],
+                                        "value": flag["value"][0],
+                                    }
+                                )
+                        flags = new_flag_list
                     for flag in flags:
                         if (isinstance(flag, dict) and flag['name'] == 'log_lock_waits') and (flag['value'] == 'on'):  # Must be explicitly set for check to pass
                             self.evaluated_keys = ['database_version/[0]/POSTGRES',

--- a/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogMinDuration.py
+++ b/checkov/terraform/checks/resource/gcp/GoogleCloudPostgreSqlLogMinDuration.py
@@ -35,7 +35,16 @@ class GoogleCloudPostgreSqlLogMinDuration(BaseResourceCheck):
                         # treating use cases of the following database_flags parsing
                         # (list of dictionaries with arrays): 'database_flags':
                         # [{'name': ['<key>'], 'value': ['<value>']},{'name': ['<key>'], 'value': ['<value>']}]
-                        flags = [{key: flag[key][0] for key in flag} for flag in flags]
+                        new_flag_list = []
+                        for flag in flags:
+                            if "name" and "value" in flag:
+                                new_flag_list.append(
+                                    {
+                                        "name": flag["name"][0],
+                                        "value": flag["value"][0],
+                                    }
+                                )
+                        flags = new_flag_list
                     for flag in flags:
                         if (isinstance(flag, dict) and flag['name'] == 'log_min_duration_statement') and (flag['value'] != '-1'):
                             self.evaluated_keys = ['database_version/[0]/POSTGRES',


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
CKV_GCP_54 & CKV_GCP_57 checks are failing with TypeError: 'int' object is not subscriptable on     flags = [{key: flag[key][0] for key in flag} for flag in flags]
failing with a cdk.tf.json file

We are not parsing the `databse_flags` object properly. This just grabs the name and value of each flag and appends to a new array which then we set flags to. This is te format checkov expects. I believe the errors comes from `__startswith` and `__endswith` being part of the flags list in the dict. 

Ran unit tests for both the checks and they still pass and ran locally with a cdk.tf.json file to make sure databse_flags is parsed properly. 

Fixes # 7033

### Fix
*How does someone fix the issue in code and/or in runtime?*
Running checkov on a file that contains google_sql_database_instance leads to these errors I just went to the file where it errored and added the code in the pr. 
## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Modifies the parsing of database flags in Google Cloud PostgreSQL checks to handle different data structures. Updates the <code>GoogleCloudPostgreSqlLogLockWaits</code> and <code>GoogleCloudPostgreSqlLogMinDuration</code> classes to correctly process the <code>database_flags</code> object, addressing a TypeError issue with CDK-generated Terraform JSON files.</p>


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>rotemavni</td><td>fix-terraform-Handle-m...</td><td>September 28, 2022</td></tr>
<tr><td>losisin</td><td>fix-terraform-gcp-post...</td><td>September 05, 2022</td></tr></table></details>
This pull request is reviewed by Baz. Join @andrewkaldani30 and the rest of your team on <a href=https://baz.co/changes/bridgecrewio/checkov/7036?tool=ast>(Baz)</a>.