### PR TITLE
kubernetes fix: do not fail where metadata.name is missing

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/DefaultNamespace.py
+++ b/checkov/kubernetes/checks/resource/k8s/DefaultNamespace.py
@@ -37,11 +37,13 @@ class DefaultNamespace(BaseK8Check):
         if metadata:
             if "namespace" in metadata and metadata["namespace"] != "default":
                 return CheckResult.PASSED
-
-            # If namespace not defined it is default -> Ignore default Service account and kubernetes service
-            if conf["kind"] == "ServiceAccount" and metadata["name"] == "default":
+            name = metadata.get("name")
+            if not name:
                 return CheckResult.PASSED
-            if conf["kind"] == "Service" and metadata["name"] == "kubernetes":
+            # If namespace not defined it is default -> Ignore default Service account and kubernetes service
+            if conf["kind"] == "ServiceAccount" and name == "default":
+                return CheckResult.PASSED
+            if conf["kind"] == "Service" and name == "kubernetes":
                 return CheckResult.PASSED
             return CheckResult.FAILED
         return CheckResult.FAILED


### PR DESCRIPTION
## Description

in cases the name field in not present in the metadata section an exception is thrown

Fixes # (issue)

fix case of uncaught exception, passing the policy instead


## Checklist:

-  I have performed a self-review of my own code
