### PR TITLE
chore: enable installation on python 3.13 without rustc installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
         "openai<1.0.0",
         "spdx-tools>=0.8.0,<0.9.0",
         "license-expression<31.0.0,>=30.1.0",
-        "rustworkx>=0.13.0,<0.14.0",
+        "rustworkx>=0.13.0,<1.0.0",
         "pydantic<3.0.0,>=2.0.0",
     ],
     dependency_links=[],  # keep it empty, needed for pipenv-setup


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

rustworkx 0.13.x has no working wheel for python 3.13.

This relaxes the version constraint so 0.16.0 can be used, as recommended by rustworkx maintainer here: https://github.com/bridgecrewio/checkov/issues/7025#issuecomment-2726787090

Fixes #7025 (issue)

Testing using:
```
$ which rustc #ensure there is no rust compiler present, exit code 1 expected
$ virtualenv -p python3.13 checkov_patched
...
$ . checkov_patched/bin/activate
...
$ pip install --no-cache-dir $CHECKOV_REPO  # should work
...
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the rustworkx package version constraint in setup.py to enable Checkov installation on Python 3.13 without requiring rustc. Relaxes the upper bound of the rustworkx version from <0.14.0 to <1.0.0.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsmithv11</td><td>feat-secrets-Bump-dete...</td><td>March 06, 2025</td></tr>
<tr><td>RabeaZr</td><td>chore-secrets-bump-det...</td><td>February 18, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @rasarn and the rest of your team on <a href=https://baz.co/changes/bridgecrewio/checkov/7070?tool=ast>(Baz)</a>.