### PR TITLE
chore(general): Update rustworkx

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -83,7 +83,7 @@ yarl = ">=1.9.1,<2.0.0"
 openai = "<1.0.0"  # it comes with a couple of changes a different dependencies, needs separate testing
 spdx-tools = ">=0.8.0,<0.9.0"
 license-expression = ">=30.1.0,<31.0.0"
-rustworkx = ">=0.13.0,<0.14.0"
+rustworkx = ">=0.13.0,<0.17.0"
 pydantic = ">=2.0.0,<3.0.0"
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -83,7 +83,7 @@ yarl = ">=1.9.1,<2.0.0"
 openai = "<1.0.0"  # it comes with a couple of changes a different dependencies, needs separate testing
 spdx-tools = ">=0.8.0,<0.9.0"
 license-expression = ">=30.1.0,<31.0.0"
-rustworkx = ">=0.13.0,<0.17.0"
+rustworkx = ">=0.13.0,<1.0.0"
 pydantic = ">=2.0.0,<3.0.0"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4a3ed2f7b11e9bed1134650a3be4bcc206675fafb40f0180827a3b3c46c8b54f"
+            "sha256": "4911c09124afeae8349666470bd7412dda39e171fdc04246c5d5722c86771da8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1537,11 +1537,11 @@
         },
         "rdflib": {
             "hashes": [
-                "sha256:5402310a9f0f3c07d453d73fd0ad6ba35616286fe95d3670db2b725f3f539673",
-                "sha256:f3dcb4c106a8cd9e060d92f43d593d09ebc3d07adc244f4c7315856a12e383ee"
+                "sha256:72f4adb1990fa5241abd22ddaf36d7cafa5d91d9ff2ba13f3086d339b213d997",
+                "sha256:fed46e24f26a788e2ab8e445f7077f00edcf95abb73bcef4b86cefa8b62dd174"
             ],
             "markers": "python_full_version >= '3.8.1' and python_full_version < '4.0.0'",
-            "version": "==7.1.3"
+            "version": "==7.1.4"
         },
         "referencing": {
             "hashes": [
@@ -2192,19 +2192,19 @@
                 "s3"
             ],
             "hashes": [
-                "sha256:6f86cd2a022de2e31187fcbf20851da5c1cc5a137c7a40b11b349d328fb0d9f0",
-                "sha256:b3744db26553ab63995399fe9d0bf2e7d5aeef027c7e4061361db809e235d567"
+                "sha256:05e9b0b19b3f33ee3c3a21f75df3e08f397e93a13bf31255d85a7fa9ed86ad3c",
+                "sha256:0f35c4f04b7e3a1684c83ba6f2fcbf8f022d590c6fc54c36204853e9541a489f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.37.21"
+            "version": "==1.37.23"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:b14b98488c258a16ed693f89f789d8fd6bc1542359f55752b394778cb56125ee",
-                "sha256:bbe702c43312ded6b40b69e0f81d6bbfb80f96e4aa72a77498809c75b614976a"
+                "sha256:13a89baddd3243506d4649999de094faf3e6c1ef2231820e50ac953187940e70",
+                "sha256:3791f463ce9414811c96e29ab6602bc806a98cb46b1d55da13ff945de190e5b6"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.37.21"
+            "version": "==1.37.23"
         },
         "certifi": {
             "hashes": [
@@ -3131,11 +3131,11 @@
         },
         "rich": {
             "hashes": [
-                "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098",
-                "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90"
+                "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0",
+                "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725"
             ],
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==13.9.4"
+            "version": "==14.0.0"
         },
         "rpds-py": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "021ac3187699b933f7fd97b2c3bdd0b1af18587557e8bc2018068cefe14c8e20"
+            "sha256": "4a3ed2f7b11e9bed1134650a3be4bcc206675fafb40f0180827a3b3c46c8b54f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -157,12 +157,12 @@
         },
         "argcomplete": {
             "hashes": [
-                "sha256:2e4e42ec0ba2fff54b0d244d0b1623e86057673e57bafe72dda59c64bd5dee8b",
-                "sha256:4e3e4e10beb20e06444dbac0ac8dda650cb6349caeefe980208d3c548708bedd"
+                "sha256:927531c2fbaa004979f18c2316f6ffadcfc5cc2de15ae2624dfe65deaf60e14f",
+                "sha256:cef54d7f752560570291214f0f1c48c3b8ef09aca63d65de7747612666725dbc"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==3.6.0"
+            "version": "==3.6.1"
         },
         "async-timeout": {
             "hashes": [
@@ -455,11 +455,11 @@
         },
         "click-option-group": {
             "hashes": [
-                "sha256:38a26d963ee3ad93332ddf782f9259c5bdfe405e73408d943ef5e7d0c3767ec7",
-                "sha256:97d06703873518cc5038509443742b25069a3c7562d1ea72ff08bfadde1ce777"
+                "sha256:8dc780be038712fc12c9fecb3db4fe49e0d0723f9c171d7cda85c20369be693c",
+                "sha256:96b9f52f397ef4d916f81929bd6c1f85e89046c7a401a64e72a61ae74ad35c24"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
-            "version": "==0.5.6"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.5.7"
         },
         "cloudsplaining": {
             "hashes": [
@@ -1771,72 +1771,22 @@
         },
         "rustworkx": {
             "hashes": [
-                "sha256:01b26cb2827fda7ad2de35e166fa54ad23b4136080b6cf4f897a18450f2cfb67",
-                "sha256:0276cf0b989211859e8797b67d4c16ed6ac9eb32edb67e0a47e70d7d71e80574",
-                "sha256:0fdf8733323684d4d4d3a37d05ae6f46a13483bee96ac329b841c44216328c9d",
-                "sha256:15cc9d8f684b850aba3e89f9bdbba0f0cf249a17c8eb42ef015adf6a56e29c20",
-                "sha256:1b9b46cc9f89944a5d5e26d6c1602ceeff76b1f4d95790dd7ec47c9f1cc6b95f",
-                "sha256:1ca99cd92c5e969c220a4ae8fa413c6d679e83c0dbce5f86c0fff8874fd5ed9f",
-                "sha256:1f5650813ce4379c5399f1559870ba42f745d01bac05fc0c3b4805128ee03161",
-                "sha256:24a5daf8ef6d7a80c08bc1a00dea1e7b668160cf6264be1e717c1e451b486bd8",
-                "sha256:24bfa0d22db1c0ec34074655f4533fb780db65d87e2189569d47608e5e80c852",
-                "sha256:2a1cf52ed583225960c5f11faa88090f7e871075f29603bead69e67d4a661ad7",
-                "sha256:2f677a13a33a92ce185973d83be4a4621a149924800bacb37d538b617b160981",
-                "sha256:36980ad7a5e831284cc77c9f6f13631429af81010c6692c1d39519919c6901ca",
-                "sha256:371a3f7bdf0e35280bb7d7fc3e2a70aec6d76a564b3878563d5c0f7cf14f2cfa",
-                "sha256:38773f5421c7125339251864fdbad205d9ecaf960000f3a69157ccae0060970e",
-                "sha256:3909942339d7a95a894c3255f8c74ffc7686354a1358e7984abd6059c60f36a6",
-                "sha256:3db0224b41e68b1905814c4817d39a35b0d8174850a265cc3ef129439b39bc6a",
-                "sha256:3f47df1ceda48cf1351fbeefa15fb7704c28c2f6d72c10e15f45f0eb708903bd",
-                "sha256:4731701e661f4fb6f7e1c16441f71a071804ec6c9da7d76d742d7e9a7d19d6e4",
-                "sha256:47b12d3b6aa3196f1f0747f233a8e9eece9b81a5e7eb41e1cae3960db87d18d1",
-                "sha256:51856470f221796be84497aaf933f14964395e0aff41b6d8fd342d9ac43d8f00",
-                "sha256:51fd1c1d9db2aec6f445b9f06a12e8cb579af6f208f6d8909014d00cef03b23f",
-                "sha256:542263b7eb8587e48b1f9ea010c6c9d24102b8082870b11a388dac1e74ab135a",
-                "sha256:546d089917ad9b1ac9c95af2d6295d2b343392a651805b458958347a0e568a82",
-                "sha256:59562edf290ba2d5383ecbac047adc5ab95c9fd8f15f2c1d540562acb4aadf66",
-                "sha256:5961b11ee36fefe2909373ef4551e58588000bf2bc1c177ce190b4bf796a1a73",
-                "sha256:604038ee0fe9b6f72d1c4b0529da1d15b46b757381be569f66540ab5ffb0f9c8",
-                "sha256:60933aea34c014b3dfaa6a8f5d81f6c92cf49d21cab2a3d2989590d477776997",
-                "sha256:69183adf48ab25361ec2ac62b789662de49190b532a03533b2c711a4cbbd7c40",
-                "sha256:6cc15ea8feed0568f7682045e7d7b18974455f910e1fc3e0b6bdcbf526bd6673",
-                "sha256:7014e33d25b3cd7c03004849b685fb7cf934e409c71854fe888bc71f86a26804",
-                "sha256:7207c52417b48e01e11018cb116b53873c67effd528f2696baa1b6d936c00e99",
-                "sha256:76042e30b18735bca37f03182b3e6159977bdd568d85ef7f996e520f64f81061",
-                "sha256:7c06b37d8b1c1d454cde38ebc5ed82eded26db865df79ba46532aef996b3f8ac",
-                "sha256:80e7f20cd3ecbdaa1d5ff149ce2dae0d389c9983c84dec6b95c9db669b6aedd0",
-                "sha256:844d14a37e4ba5b56f791c2d3f23275f26649b1e11685d05cd5009b3cd4100cf",
-                "sha256:88b83dc818bfea1ad743f324d1edc6920ede7345943932453628771ce290d8b2",
-                "sha256:8ef239663d3baf4cbdd7a8a2752f8edf544d853e89024d159bbb742efa83f26a",
-                "sha256:907fa93a377b18ae7360f64a20b1949e06d50faeeaaa5ff4620b697598eb1214",
-                "sha256:915aae559ac9eef1f5fc4f6b8c094d353e2b62df0cd164ac5fb44f2c5ebe19d5",
-                "sha256:9553deb3a834a14192f354d2da80c2bda146523df270c7505501b1800057dc88",
-                "sha256:a1a174674489f416d852ea42b346a59cc4c02e4bd0e11404f94c5e499de05a29",
-                "sha256:a658895541772e76aa895de289e3bedcf1e4676314e4f78d23520b1d5bef2146",
-                "sha256:a66a7fc98a30e7fefd225ee6eed4b8850af9baeaa7ea1df90f4091419dfa3b4b",
-                "sha256:af329d05b4e39bf98cbfb412438dc2dc14f017a53feafec003d1fcf6470f82c8",
-                "sha256:b2fcd805e378eec3fc9ed4338d17d2c6ee517021f9d60187dc9975d2cd761b0e",
-                "sha256:b3cfc0cecb0f400155bedcb7ba1078921f51faf14ad7231d166f2ede42fdba7b",
-                "sha256:bbec49f04dc387a2e22b3d54a9283d4c7dbef0bd7222ee70b7d68f927da7f7fd",
-                "sha256:bdc0745fa448d0a05d92c4c85af3a65d7264a9d2ec714f9e6645272f7e4d1cfc",
-                "sha256:c147a9efca672a4b8dd774a6f2bb78dfbce8efaea52933e3eb520d3618302832",
-                "sha256:c62c99cfad1f8112297e80a9e7a23ca420b4d86a8c49f7ebdf7e1f31d43122f5",
-                "sha256:cbecd5ebd5679909f400e1de990d2a1fdbc2aa6a243faa23699511e4601777c5",
-                "sha256:cc29b6b08d41f06aa8d011bcfc7dba17599231a1c4b172d6007a6eb5ae589124",
-                "sha256:cd10e5654d1ce9c112f344034865a0a94b4da805764485889a723f2da2699cb7",
-                "sha256:cfed0f9ee080d1b16d57ad82559bbdef3cca87b9aa3d573b7108d3ca4ad29388",
-                "sha256:d585d9336b039b3bf5e31daa7a25d6400fe9d2025c1d1ccedcfa757132a2a15d",
-                "sha256:d5b640d5eff6574096a073d9c854d462effb30682aefeb71e5070d0ecd65c700",
-                "sha256:d82e269b5c293e301334e1e7ff10d406767bbfac70bc398496f33cfa4e80fec4",
-                "sha256:d99b6bfae1b2e59c23badaba1317a8fe527f493aa9d037a2d2910060af460852",
-                "sha256:df27694f9822b35902a9e89458f8d37b02e452586dc30fcfeee3d95672846ac7",
-                "sha256:e044469483508b53f2e246b737e49fc04f0f4ab5a6178a8eb9d423e52ebf6ead",
-                "sha256:e96b80a3821d27ce04f4429e3aa1cb29b369b8c09c517512693bacb8a36c0868",
-                "sha256:ec1260a0b81d457858a014646c1aec02d1440d62e7b8f9fb72bd819feae86865"
+                "sha256:0e0cc86599f979285b2ab9c357276f3272f3fcb3b2df5651a6bf9704c570d4c1",
+                "sha256:241c502532e348ba89200823326dba30de4df4b886cb2fd5a140b359ff124bb3",
+                "sha256:308bc76a01bcae9af4602d8b9ed58021df37dd0bb5a7b2e3831ae53c5e234ff0",
+                "sha256:6ac68ae2515ece22ba3ef56f3d16ad6bf707955f650d623190b2e7d706c6dc92",
+                "sha256:6cd4496d3298cd3205c03545e48cc37d21e0455d57752af801d3fb250452d590",
+                "sha256:7834ab34748db6214ec3b3836b996b23882dc83184234e6d346d6bb85fd58ae5",
+                "sha256:7e5f4156f46fa03177c9b0580450eab87786063495d48b457762a5bdd20c55e2",
+                "sha256:89077382633e918d2392772f53b9d6d30eee51eb536f8d38ee195c212b2f0427",
+                "sha256:8b903edec1d803704b499959f9d6f6119cdda63b9b64194a4b4307e506b112f0",
+                "sha256:a2c97a56ff8a0f6c273a83e26e627c72207442b4252aa550acad0bff42caac40",
+                "sha256:cb518f5649e62d753e29ca1e57290c8f58adbebcd154dc3159f4a36ebfa1e2b7",
+                "sha256:ce53f173fed16e1d51d9df9f23475a16c981b03bf1a412d991c75a70db6b1dc1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==0.13.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.15.1"
         },
         "s3transfer": {
             "hashes": [
@@ -1931,12 +1881,12 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
+                "sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b",
+                "sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
+            "version": "==4.13.0"
         },
         "unidiff": {
             "hashes": [
@@ -2242,19 +2192,19 @@
                 "s3"
             ],
             "hashes": [
-                "sha256:4b63c7394bc837cb6e5016d2759dd31ff0e5ec3fc16d1fc63488550b85574f5d",
-                "sha256:c6faf88cf0e5ecf7620197020e003e611e00848a43a5fb7acfad16842520af13"
+                "sha256:6f86cd2a022de2e31187fcbf20851da5c1cc5a137c7a40b11b349d328fb0d9f0",
+                "sha256:b3744db26553ab63995399fe9d0bf2e7d5aeef027c7e4061361db809e235d567"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.37.16"
+            "version": "==1.37.21"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:33973ee0e54ad5bf9f8560b2c36fc532b98540af6b9d4a57ffce5ae62a743a2a",
-                "sha256:532376611ae0c49488b7bdac3674da9ac0de9a6c65198432790b11da41502caf"
+                "sha256:b14b98488c258a16ed693f89f789d8fd6bc1542359f55752b394778cb56125ee",
+                "sha256:bbe702c43312ded6b40b69e0f81d6bbfb80f96e4aa72a77498809c75b614976a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.37.16"
+            "version": "==1.37.21"
         },
         "certifi": {
             "hashes": [
@@ -3530,11 +3480,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
+                "sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b",
+                "sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
+            "version": "==4.13.0"
         },
         "urllib3": {
             "hashes": [

--- a/checkov/common/bridgecrew/wrapper.py
+++ b/checkov/common/bridgecrew/wrapper.py
@@ -10,7 +10,7 @@ from typing import Any, TYPE_CHECKING, Optional, Dict
 from collections import defaultdict
 
 import dpath
-from rustworkx import PyDiGraph, digraph_node_link_json  # type: ignore
+from rustworkx import PyDiGraph, digraph_node_link_json
 
 try:
     from networkx import DiGraph, node_link_data

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
         "openai<1.0.0",
         "spdx-tools>=0.8.0,<0.9.0",
         "license-expression<31.0.0,>=30.1.0",
-        "rustworkx>=0.13.0,<0.17.0",
+        "rustworkx>=0.13.0,<1.0.0",
         "pydantic<3.0.0,>=2.0.0",
     ],
     dependency_links=[],  # keep it empty, needed for pipenv-setup

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
         "openai<1.0.0",
         "spdx-tools>=0.8.0,<0.9.0",
         "license-expression<31.0.0,>=30.1.0",
-        "rustworkx>=0.13.0,<0.14.0",
+        "rustworkx>=0.13.0,<0.17.0",
         "pydantic<3.0.0,>=2.0.0",
     ],
     dependency_links=[],  # keep it empty, needed for pipenv-setup


### PR DESCRIPTION
# User description
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Update the versions of rustworkx to support Python 3.13

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the rustworkx library to a newer version range in dependency files and adjusts its import in the bridgecrew wrapper module. Removes a type ignore comment, potentially improving type checking for the security scan result processing system.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/7072?tool=ast&topic=Type+hint+improve>Type hint improve</a>
        </td><td>Removes the '# type: ignore' comment from the rustworkx import in the bridgecrew wrapper module, potentially improving type checking.<details><summary>Modified files (1)</summary><ul><li>checkov/common/bridgecrew/wrapper.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>omryMen</td><td>chore-secrets-update-d...</td><td>October 15, 2024</td></tr>
<tr><td>mikeurbanski1@users.no...</td><td>platform-general-impro...</td><td>March 08, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bridgecrewio/checkov/7072?tool=ast&topic=Rustworkx+update>Rustworkx update</a>
        </td><td>Updates the rustworkx library version range from '>=0.13.0,<0.14.0' to '>=0.13.0,<0.17.0' in Pipfile and setup.py, with corresponding changes in Pipfile.lock.<details><summary>Modified files (3)</summary><ul><li>Pipfile.lock</li>
<li>Pipfile</li>
<li>setup.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsmithv11</td><td>feat-secrets-Bump-dete...</td><td>March 06, 2025</td></tr>
<tr><td>RabeaZr</td><td>chore-secrets-bump-det...</td><td>February 18, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Join @tsmithv11 and the rest of your team on <a href=https://baz.co/changes/bridgecrewio/checkov/7072?tool=ast>(Baz)</a>.
    