### PR TITLE
feat(serverless): add check for empty resource attributes

### DIFF
--- a/checkov/serverless/graph_builder/definition_context.py
+++ b/checkov/serverless/graph_builder/definition_context.py
@@ -39,18 +39,18 @@ def add_resource_to_definitions_context(definitions_context: dict[str, dict[str,
     if resource_key in LINE_FIELD_NAMES:
         return
 
-    if isinstance(resource_attributes, dict):
-        start_line = resource_attributes[START_LINE] - 1
-        end_line = resource_attributes[END_LINE] - 1
-
-    elif isinstance(resource_attributes, ListNode):
-        start_line = resource_attributes.start_mark.line
-        end_line = resource_attributes.end_mark.line
-
-    elif isinstance(resource_attributes, StrNode):
-        start_line = resource_attributes.start_mark.line + 1
-        end_line = resource_attributes.end_mark.line + 1
-
+    if resource_attributes:
+        if isinstance(resource_attributes, dict):
+            start_line = resource_attributes[START_LINE] - 1
+            end_line = resource_attributes[END_LINE] - 1
+        elif isinstance(resource_attributes, ListNode):
+            start_line = resource_attributes.start_mark.line
+            end_line = resource_attributes.end_mark.line
+        elif isinstance(resource_attributes, StrNode):
+            start_line = resource_attributes.start_mark.line + 1
+            end_line = resource_attributes.end_mark.line + 1
+        else:
+            return
     else:
         return
 

--- a/tests/serverless/checks/aws/example_AWSCredentials/AWSCredentials-FAILED-provider_level/serverless.yml
+++ b/tests/serverless/checks/aws/example_AWSCredentials/AWSCredentials-FAILED-provider_level/serverless.yml
@@ -5,6 +5,7 @@ provider:
   runtime: python3.7
   stackName: lambda-${self:service.name}
   tag: ${opt:tag}
+  stackTags: ${file(${env:STACK_TAGS_FILE, 'dummy.yaml'}), null}
   environment:
     TABLE_NAME: "mytable"
     BUCKET_NAME: "mybucket"


### PR DESCRIPTION
This PR fixes a bug in serverless definitions context building where empty resources were not taken into account. 


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
