### PR TITLE
add aws_elasticache_serverless_cache to CKV2_AWS_5

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/SGAttachedToResource.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/SGAttachedToResource.yaml
@@ -34,6 +34,7 @@ definition:
         - aws_eks_node_group
         - aws_elasticache_cluster
         - aws_elasticache_replication_group
+        - aws_elasticache_serverless_cache
         - aws_elasticsearch_domain
         - aws_elb
         - aws_emr_cluster

--- a/tests/terraform/graph/checks/resources/SGAttachedToResource/expected.yaml
+++ b/tests/terraform/graph/checks/resources/SGAttachedToResource/expected.yaml
@@ -22,6 +22,7 @@ pass:
   - "aws_security_group.pass_eks"
   - "aws_security_group.pass_eks_node"
   - "aws_security_group.pass_elasticache"
+  - "aws_security_group.pass_elasticache_serverless"
   - "aws_security_group.pass_elasticache_replication_group"
   - "aws_security_group.pass_elb"
   - "aws_security_group.pass_emr"

--- a/tests/terraform/graph/checks/resources/SGAttachedToResource/main.tf
+++ b/tests/terraform/graph/checks/resources/SGAttachedToResource/main.tf
@@ -453,6 +453,15 @@ resource "aws_elasticache_replication_group" "pass_elasticache_replication_group
   security_group_ids            = [aws_security_group.pass_elasticache_replication_group.id]
 }
 
+resource "aws_elasticache_serverless_cache" "pass_elasticache_serverless" {
+  name                 = "elasticache-serverless-cache"
+  security_group_ids   = [aws_security_group.pass_elasticache_serverless.id]
+}
+
+resource "aws_security_group" "pass_elasticache_serverless" {
+  name = "security-group"
+}
+
 # ELB
 
 resource "aws_security_group" "pass_alb" {


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

I found issue CKV2_AWS_5 reported although security group was assigned to elasticache_serverless resource.

## New/Edited policies (Delete if not relevant)

### Description
if security_group is assigned to elasticache_serverless, it is not a CKV2_AWS_5 violation any more.

### Fix
if security_group is assigned to elasticache_serverless, it is not a CKV2_AWS_5 violation any more.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
