### PR TITLE
fix(terraform): Handle explicitly-specified tfvars explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,7 +171,8 @@ fabric.properties
 
 # test assets that get created locally (20* refers to the start of a date, so this covers us for 78 years)
 tests/20*
-# vim 
+# vim
+.*.sw?
 .vim/
 .vimspector.json
 !tests/terraform/graph/variable_rendering/test_resources/tfvar_module_variables/modules/instance

--- a/checkov/terraform/graph_builder/variable_rendering/renderer.py
+++ b/checkov/terraform/graph_builder/variable_rendering/renderer.py
@@ -118,11 +118,9 @@ class TerraformVariableRenderer(VariableRenderer["TerraformLocalGraph"]):
                 origin_vertex.block_type == BlockType.VARIABLE
                 and destination_vertex.block_type == BlockType.TF_VARIABLE
             ):
-                # evaluate the last specified variable based on .tfvars precedence
-                destination_vertex = list(filter(lambda v: v.block_type == BlockType.TF_VARIABLE, map(lambda e: self.local_graph.vertices[e.dest], edge_list)))[-1]
                 self.update_evaluated_value(
                     changed_attribute_key=edge.label,
-                    changed_attribute_value=destination_vertex.attributes["default"],
+                    changed_attribute_value=destination_vertex.attributes['default'],
                     vertex=edge.origin,
                     change_origin_id=edge.dest,
                     attribute_at_dest=edge.label,

--- a/tests/terraform/graph/variable_rendering/test_render_scenario.py
+++ b/tests/terraform/graph/variable_rendering/test_render_scenario.py
@@ -183,6 +183,9 @@ class TestRendererScenarios(TestCase):
         }
         self.go("tfvars", vars_files=['other3.tfvars', 'other2.tfvars'], different_expected=different_expected)
 
+    def test_tfvars_outside_dir(self):
+        self.go('tfvars_outside_dir', vars_files=['../tfvars/other1.tfvars'])
+
     def test_account_dirs_and_modules(self):
         self.go("account_dirs_and_modules")
 

--- a/tests/terraform/parser/resources/parser_scenarios/tfvars_outside_dir/expected.json
+++ b/tests/terraform/parser/resources/parser_scenarios/tfvars_outside_dir/expected.json
@@ -1,0 +1,18 @@
+{
+  "{\"file_path\": \"main.tf\", \"tf_source_modules\": null}": {
+    "resource": [
+      {
+        "aws_s3_bucket": {
+          "my_bucket": {
+            "bucket": [
+              "xyz"
+            ],
+            "__start_line__": 5,
+            "__end_line__": 7,
+            "__address__": "aws_s3_bucket.my_bucket"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/terraform/parser/resources/parser_scenarios/tfvars_outside_dir/main.tf
+++ b/tests/terraform/parser/resources/parser_scenarios/tfvars_outside_dir/main.tf
@@ -1,0 +1,7 @@
+variable "other_var_1" {
+  default = "abc"
+}
+
+resource "aws_s3_bucket" "my_bucket" {
+  bucket = "${var.other_var_1}"
+}

--- a/tests/terraform/parser/test_new_parser_modules.py
+++ b/tests/terraform/parser/test_new_parser_modules.py
@@ -110,14 +110,7 @@ class TestParserInternals(unittest.TestCase):
         assert out_definitions[main_key]['module'][1]['mod2']['__resolved__'] == [key_idx_1]
 
         assert parser.external_modules_source_map == {(os.path.join(directory, 'module'), 'latest'): os.path.join(directory, 'module')}
-        assert parser.external_variables_data == [
-            ('versioning', True, 'manual specification'),
-            ('__start_line__', 1, 'manual specification'),
-            ('__end_line__', 4, 'manual specification'),
-            ('versioning', False, 'manual specification'),
-            ('__start_line__', 6, 'manual specification'),
-            ('__end_line__', 9, 'manual specification')
-        ]
+        assert parser.external_vars == {}
         assert parser.keys_to_remove == {TFDefinitionKey(file_path=module_path)}
         assert parser._parsed_directories == {
             directory,


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

* Allow for ``--var-file`` arguments outside of the tf dir to be handled correctly
* Use a dict to enforce tfvars precedence, grouping vars by the directory for which they were defined, reducing the number of tfvar nodes added to the graph for a given directory.
* Create variable -> tfvars edges based on the directory for which the var was defined.
* Have _load_files take a list of str instead of os.DirEntry.
* Changed a usage of printf() to logging.debug()

Fixes #4321

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
