### PR TITLE
feat(terraform): Add new check and update old around cipher suites

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/LBWeakCiphers.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/LBWeakCiphers.yaml
@@ -1,0 +1,28 @@
+metadata:
+  id: "CKV2_AWS_74"
+  name: "Ensure AWS Load Balancers use strong ciphers"
+  category: "NETWORKING"
+definition:
+  and:
+    - cond_type: "attribute"
+      resource_types:
+        - "aws_alb_listener"
+        - "aws_lb_listener"
+      attribute: "ssl_policy"
+      operator: "exists"  # The default is ELBSecurityPolicy-2016-08 which is weak
+    - cond_type: "attribute"
+      resource_types:
+      - "aws_alb_listener"
+      - "aws_lb_listener"
+      attribute: "ssl_policy"
+      operator: "not_within"
+      value:
+        - "ELBSecurityPolicy-2016-08"
+        - "ELBSecurityPolicy-2015-05"
+        - "ELBSecurityPolicy-TLS-1-0-2015-04"
+        - "ELBSecurityPolicy-TLS-1-1-2017-01"
+        - "ELBSecurityPolicy-2015-03"
+        - "ELBSecurityPolicy-2015-02"
+        - "ELBSecurityPolicy-2014-10"
+        - "ELBSecurityPolicy-Default"
+        - "ELBSecurityPolicy-2014-01"

--- a/checkov/terraform/checks/resource/aws/ELBPolicyUsesSecureProtocols.py
+++ b/checkov/terraform/checks/resource/aws/ELBPolicyUsesSecureProtocols.py
@@ -21,7 +21,10 @@ class ELBPolicyUsesSecureProtocols(BaseResourceCheck):
                     return CheckResult.FAILED
             if name == "Reference-Security-Policy":
                 value = policy.get("value")[0]
-                if value in ("ELBSecurityPolicy-2016-08", "ELBSecurityPolicy-TLS-1-1-2017-01", "ELBSecurityPolicy-2015-05", "ELBSecurityPolicy-2015-03", "ELBSecurityPolicy-2015-02"):
+                if value in ("ELBSecurityPolicy-2016-08", "ELBSecurityPolicy-TLS-1-1-2017-01",
+                             "ELBSecurityPolicy-2015-05", "ELBSecurityPolicy-2015-03", "ELBSecurityPolicy-2015-02",
+                             "ELBSecurityPolicy-TLS-1-0-2015-04", "ELBSecurityPolicy-2014-10",
+                             "ELBSecurityPolicy-Default", "ELBSecurityPolicy-2014-01"):
                     return CheckResult.FAILED
         return CheckResult.PASSED
 

--- a/tests/terraform/graph/checks/resources/LBWeakCiphers/expected.yaml
+++ b/tests/terraform/graph/checks/resources/LBWeakCiphers/expected.yaml
@@ -1,0 +1,7 @@
+fail:
+  - "aws_lb_listener.front_end_failing"
+  - "aws_alb_listener.insecure_listener"
+  - "aws_lb_listener.insecure_no_policy"
+pass:
+  - "aws_lb_listener.front_end_passing"
+  - "aws_alb_listener.secure_listener"

--- a/tests/terraform/graph/checks/resources/LBWeakCiphers/main.tf
+++ b/tests/terraform/graph/checks/resources/LBWeakCiphers/main.tf
@@ -1,0 +1,81 @@
+# FAIL
+resource "aws_lb_listener" "front_end_failing" {
+  load_balancer_arn = aws_lb.example_failing.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08" # This policy includes some weak ciphers
+  certificate_arn   = "arn:aws:acm:us-west-2:123456789012:certificate/abcdef-1234-5678-abcd-123456789012"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.example.arn
+  }
+}
+
+resource "aws_alb_listener" "insecure_listener" {
+  load_balancer_arn = aws_lb.insecure_lb.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2015-05" # Weak policy
+
+  certificate_arn = "arn:aws:acm:region:account:certificate/certificate-id"
+
+  default_action {
+    type             = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Insecure"
+      status_code  = "200"
+    }
+  }
+}
+
+resource "aws_lb_listener" "insecure_no_policy" {
+  load_balancer_arn = aws_lb.insecure_lb.arn
+  port              = "443"
+  protocol          = "HTTPS"
+
+  certificate_arn = "arn:aws:acm:region:account:certificate/certificate-id"
+
+  default_action {
+    type             = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Insecure"
+      status_code  = "200"
+    }
+  }
+}
+
+
+# PASS
+resource "aws_lb_listener" "front_end_passing" {
+  load_balancer_arn = aws_lb.example_passing.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01" # This policy includes only strong ciphers
+  certificate_arn   = "arn:aws:acm:us-west-2:123456789012:certificate/abcdef-1234-5678-abcd-123456789012"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.example.arn
+  }
+}
+
+resource "aws_alb_listener" "secure_listener" {
+  load_balancer_arn = aws_lb.secure_lb.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+
+  certificate_arn = "arn:aws:acm:region:account:certificate/certificate-id"
+
+  default_action {
+    type             = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "OK"
+      status_code  = "200"
+    }
+  }
+}

--- a/tests/terraform/graph/checks/test_yaml_policies.py
+++ b/tests/terraform/graph/checks/test_yaml_policies.py
@@ -571,6 +571,9 @@ class TestYamlPolicies(unittest.TestCase):
     def test_Route53ZoneEnableDNSSECSigning(self):
         self.go("Route53ZoneEnableDNSSECSigning")
 
+    def test_LBWeakCiphers(self):
+        self.go("LBWeakCiphers")
+
 
     def test_registry_load(self):
         registry = Registry(parser=GraphCheckParser(), checks_dir=str(


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Check to identify insecure ssl protocols with old cipher suites

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
