### PR TITLE
fix(terraform): Better utilization of managed modules (if enabled)

### DIFF
--- a/checkov/common/util/env_vars_config.py
+++ b/checkov/common/util/env_vars_config.py
@@ -22,6 +22,7 @@ class EnvVarsConfig:
         self.CHECK_FAIL_LEVEL = os.getenv("CHECKOV_CHECK_FAIL_LEVEL", CheckFailLevel.ERROR)
         self.CREATE_COMPLEX_VERTICES = convert_str_to_bool(os.getenv("CREATE_COMPLEX_VERTICES", True))
         self.CHECKOV_ENABLE_DATAS_FOREACH_HANDLING = os.getenv('CHECKOV_ENABLE_DATAS_FOREACH_HANDLING', 'False')
+        self.CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES = convert_str_to_bool(os.getenv('CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES', False))
         self.CREATE_EDGES = convert_str_to_bool(os.getenv("CREATE_EDGES", True))
         self.CREATE_MARKDOWN_HYPERLINKS = convert_str_to_bool(os.getenv("CHECKOV_CREATE_MARKDOWN_HYPERLINKS", False))
         self.CREATE_SCA_IMAGE_REPORTS_FOR_IR = convert_str_to_bool(

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -7,9 +7,9 @@ import re
 from pathlib import Path
 from typing import List, Callable, TYPE_CHECKING
 
+from checkov.common.util.env_vars_config import env_vars_config
 from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.util.file_utils import read_file_with_any_encoding
-from checkov.common.util.type_forcers import convert_str_to_bool
 from checkov.terraform.module_loading.registry import module_loader_registry
 
 if TYPE_CHECKING:
@@ -31,6 +31,29 @@ class ModuleDownload:
 
     def __str__(self) -> str:
         return f"{self.source_dir} -> {self.module_link} ({self.version})"
+
+
+def find_tf_managed_modules(path: str) -> List[ModuleDownload]:
+    """
+    Leverage modules.json to better inform discovery. If we have this,
+    there should be no need to walk and gather modules.
+    """
+    modules_found: list[ModuleDownload] = []
+
+    tf_modules_file = Path(path) / '.terraform' / 'modules' / 'modules.json'
+    if not tf_modules_file.exists():
+        return modules_found
+
+    for mod in json.loads(tf_modules_file.read_bytes())['Modules']:
+        if mod['Key']:
+            md = ModuleDownload(path)
+            md.module_name = mod['Key']
+            md.module_link = mod['Dir']
+            md.version = mod['Version'] if 'Version' in mod else 'latest'
+            md.address = f"{mod['Source']}:{md.version}"
+            md.tf_managed = True
+            modules_found.append(md)
+    return modules_found
 
 
 def find_modules(path: str) -> List[ModuleDownload]:
@@ -107,14 +130,13 @@ def load_tf_modules(
     stop_on_failure: bool = False
 ) -> None:
     module_loader_registry.root_dir = path
+    if not modules_to_load and env_vars_config.CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES:
+        modules_to_load = find_tf_managed_modules(path)
     if not modules_to_load:
         modules_to_load = find_modules(path)
 
-    # load terraform managed modules first, before pulling out distinct modules, as address attribute changes
-    replaced_modules = replace_terraform_managed_modules(path=path, found_modules=modules_to_load)
-
     # To avoid duplicate work, we need to get the distinct module sources
-    distinct_modules = list({m.address: m for m in replaced_modules}.values())
+    distinct_modules = list({m.address: m for m in modules_to_load}.values())
 
     downloadable_modules = [
         (module_loader_registry, m)
@@ -124,7 +146,7 @@ def load_tf_modules(
     if run_parallel:
         list(parallel_runner.run_function(_download_module, downloadable_modules))
     else:
-        logging.info(f"Starting download of modules of length {len(replaced_modules)}")
+        logging.info(f"Starting download of modules of length {len(downloadable_modules)}")
         for m in downloadable_modules:
             success = _download_module(*m)
             if not success and stop_on_failure:
@@ -154,48 +176,3 @@ def _download_module(ml_registry: ModuleLoaderRegistry, module_download: ModuleD
         return False
 
     return True
-
-
-def replace_terraform_managed_modules(path: str, found_modules: list[ModuleDownload]) -> list[ModuleDownload]:
-    """Replaces modules by Terraform managed ones to prevent additional downloading
-
-    It can't handle nested modules yet, ex.
-    {
-      "Key": "parent_module.child_module",
-      "Source": "./child_module",
-      "Dir": "parent_module/child_module"
-    }
-    """
-
-    if not convert_str_to_bool(os.getenv("CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES", False)):
-        return found_modules
-
-    # file used by Terraform internally to map modules to the downloaded path
-    tf_modules_file = Path(path) / ".terraform/modules/modules.json"
-    if not tf_modules_file.exists():
-        return found_modules
-
-    # create Key (module name) to module detail map for faster querying
-    tf_modules = {
-        module["Key"]: module
-        for module in json.loads(tf_modules_file.read_bytes())["Modules"]
-    }
-
-    replaced_modules: list[ModuleDownload] = []
-    for module in found_modules:
-        if module.module_name in tf_modules:
-            tf_module = tf_modules[module.module_name]
-
-            module_new = ModuleDownload(source_dir=path)
-            # if version is 'None' then set it to latest in the address, so it can be mapped properly later on
-            module_new.address = f"{module.module_link}:latest" if module.version is None else module.address
-            module_new.module_link = tf_module["Dir"]
-            module_new.module_name = module.module_name
-            module_new.tf_managed = True
-            module_new.version = module.version
-
-            replaced_modules.append(module_new)
-        else:
-            replaced_modules.append(module)
-
-    return replaced_modules

--- a/tests/terraform/module_loading/data/tf_managed_submodules/.terraform/modules/a.b/main.tf
+++ b/tests/terraform/module_loading/data/tf_managed_submodules/.terraform/modules/a.b/main.tf
@@ -1,0 +1,4 @@
+variable "x" {
+  type    = string
+  default = "xxx"
+}

--- a/tests/terraform/module_loading/data/tf_managed_submodules/.terraform/modules/a/main.tf
+++ b/tests/terraform/module_loading/data/tf_managed_submodules/.terraform/modules/a/main.tf
@@ -1,0 +1,5 @@
+module "b" {
+  source  = "somewhere/b"
+  version = "1"
+}
+

--- a/tests/terraform/module_loading/data/tf_managed_submodules/.terraform/modules/modules.json
+++ b/tests/terraform/module_loading/data/tf_managed_submodules/.terraform/modules/modules.json
@@ -1,0 +1,23 @@
+{
+	"Modules": [
+		{
+			"Key": "",
+			"Source": "",
+			"Dir": "."
+		},
+
+		{
+			"Key": "a",
+			"Source": "somewhere/a",
+			"Version": "0",
+			"Dir": ".terraform/modules/a"
+		},
+
+		{
+			"Key": "a.b",
+			"Source": "somewhere/b",
+			"Version": "1",
+			"Dir": ".terraform/modules/a.b"
+		}
+	]
+}

--- a/tests/terraform/module_loading/data/tf_managed_submodules/main.tf
+++ b/tests/terraform/module_loading/data/tf_managed_submodules/main.tf
@@ -1,0 +1,5 @@
+module "a" {
+  source  = "somewhere/a"
+  version = "0"
+}
+

--- a/tests/terraform/module_loading/test_runner.py
+++ b/tests/terraform/module_loading/test_runner.py
@@ -4,9 +4,9 @@ from unittest import mock
 
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.runner import Runner
+from checkov.common.util.env_vars_config import env_vars_config
 
-
-@mock.patch.dict(os.environ, {"CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES": "True"})
+@mock.patch.object(env_vars_config, 'CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES', True)
 def test_runner_with_tf_managed_modules():
     # given
     root_dir = Path(__file__).parent / "data/tf_managed_modules"
@@ -32,7 +32,7 @@ def test_runner_with_tf_managed_modules():
 
 
 # test can be removed after setting this flow as default
-@mock.patch.dict(os.environ, {"CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES": "False"})
+@mock.patch.object(env_vars_config, 'CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES', False)
 def test_runner_without_tf_managed_modules():
     # given
     root_dir = Path(__file__).parent / "data/tf_managed_modules"

--- a/tests/terraform/module_loading/test_tf_module_finder.py
+++ b/tests/terraform/module_loading/test_tf_module_finder.py
@@ -10,9 +10,9 @@ from checkov.terraform.module_loading.module_finder import (
     ModuleDownload,
     _download_module,
     find_modules,
+    find_tf_managed_modules,
     should_download,
-    load_tf_modules,
-    replace_terraform_managed_modules,
+    load_tf_modules
 )
 from checkov.terraform.module_loading.registry import module_loader_registry
 
@@ -78,21 +78,24 @@ def test_dem_warning(caplog):
     assert 'Failed to download module' not in caplog.text
     assert '--download-external-modules flag' not in caplog.text
 
-@mock.patch.dict(os.environ, {"CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES": "True"})
 def test_tf_managed_and_comment_out_modules():
-    # this test leverages the modules, which Terraform downloads on its own
+    src_path = Path(__file__).parent / 'data' / 'tf_managed_modules'
+    modules = find_tf_managed_modules(str(src_path))
 
-    # given
-    src_path = Path(__file__).parent / "data/tf_managed_modules"
-    modules = find_modules(str(src_path))
+    assert len(modules) == 1
+    assert modules[0].tf_managed is True
+    assert modules[0].address == "registry.terraform.io/terraform-aws-modules/cloudwatch/aws//modules/log-group:4.1.0"
+    assert modules[0].module_link == ".terraform/modules/log_group/modules/log-group"
 
-    # when
-    replaced_modules = replace_terraform_managed_modules(path=str(src_path), found_modules=modules)
+def test_tf_managed_submodules():
+    modules = find_tf_managed_modules(Path(__file__).parent / 'data' / 'tf_managed_submodules')
+    assert len(modules) == 2
+    assert modules[0].tf_managed is True
+    assert modules[0].address == 'somewhere/a:0'
+    assert modules[0].module_name == 'a'
+    assert modules[0].module_link == '.terraform/modules/a'
+    assert modules[1].tf_managed is True
+    assert modules[1].address == 'somewhere/b:1'
+    assert modules[1].module_name == 'a.b'
+    assert modules[1].module_link == '.terraform/modules/a.b'
 
-    tf_managed_modules = [module for module in replaced_modules if module.tf_managed]
-    assert len(replaced_modules) == 2
-    assert len(tf_managed_modules) == 1
-
-    assert tf_managed_modules[0].tf_managed is True
-    assert tf_managed_modules[0].address == "terraform-aws-modules/cloudwatch/aws//modules/log-group:latest"
-    assert tf_managed_modules[0].module_link == ".terraform/modules/log_group/modules/log-group"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

If we have managed modules, the output from terraform should be authoratative. This also allows checkov to scan terraform which only pulls in a module, which pulls in submodules, from the root module.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
