### PR TITLE
fix(general): base_runner: Properly escape excluded directories that begin with '.'

### DIFF
--- a/checkov/common/runners/base_runner.py
+++ b/checkov/common/runners/base_runner.py
@@ -238,7 +238,7 @@ def filter_ignored_paths(
         compiled = []
         for p in excluded_paths:
             try:
-                compiled.append(re.compile(p.replace(".terraform", r"\.terraform")))
+                compiled.append(re.compile(re.escape(p) if re.match(r'^\.[^\.]', p) else p))
             except re.error:
                 # do not add compiled paths that aren't regexes
                 continue


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

In case the repo has been checked out to a path that inadvertently matches one of the excluded directory patterns (i.e. .git), we should check for it, and escape the pattern via ``re.escape()`` instead of just escaping the leading '.' in '.terraform'.

Otherwise, this causes some tests to fail if the repo is checked out to ``~/git/checkov``, as this would match the '.git' excluded directory by virtue of the leading '.' not being escaped.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
