### PR TITLE
fix(terraform_plan): use provider name not resource address to fix supported_provider matching

### DIFF
--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -345,7 +345,7 @@ def _get_providers(template: dict[str, dict[str, Any]]) -> list[dict[str, dict[s
     #         }
     #     },
     #     {
-    #         "aws.west": {
+    #         "aws": {
     #             "region": ["us-west-1"],
     #             "alias": ["west"],
     #             . . .
@@ -360,10 +360,11 @@ def _get_providers(template: dict[str, dict[str, Any]]) -> list[dict[str, dict[s
             if _is_provider_key(key=provider_key):
                 # Not a provider, skip
                 continue
+            provider_name = provider_data.get("name")
             provider_alias = provider_data.get("alias", "default")
             provider_map: dict[str, dict[str, Any]] = {}
-            provider_map[provider_key] = {}
-            provider_map_entry = provider_map[provider_key]
+            provider_map[provider_name] = {}
+            provider_map_entry = provider_map[provider_name]
             for field, value in provider_data.get('expressions', {}).items():
                 if field in LINE_FIELD_NAMES or not isinstance(value, dict):
                     continue  # don't care about line #s or non dicts
@@ -377,11 +378,7 @@ def _get_providers(template: dict[str, dict[str, Any]]) -> list[dict[str, dict[s
             provider_map_entry[start_line] = [provider_data.get(START_LINE, 1) - 1]
             provider_map_entry[end_line] = [provider_data.get(END_LINE, 1)]
             provider_map_entry['alias'] = [provider_alias]
-            # provider_key already contains the alias (ie "aws.east") for non-default providers
-            if provider_alias == "default":
-                provider_map_entry[TF_PLAN_RESOURCE_ADDRESS] = f"{provider_key}.{provider_alias}"
-            else:
-                provider_map_entry[TF_PLAN_RESOURCE_ADDRESS] = provider_key
+            provider_map_entry[TF_PLAN_RESOURCE_ADDRESS] = f"{provider_name}.{provider_alias}"
             providers.append(provider_map)
 
     return providers

--- a/tests/terraform/parser/test_plan_parser.py
+++ b/tests/terraform/parser/test_plan_parser.py
@@ -37,16 +37,16 @@ class TestPlanFileParser(unittest.TestCase):
         tf_definition, _ = parse_tf_plan(valid_plan_path, {})
         providers = tf_definition['provider']
         self.assertEqual( len(providers), 3)
-        provider_keys = []
+        provider_names = []
         provider_aliases = []
         provider_addresses = []
         for provider in providers:
             key = next(iter(provider))
-            provider_keys.append(key)
+            provider_names.append(key)
             provider_aliases.append( provider[key]['alias'][0] )
             provider_addresses.append( provider[key]['__address__'] )
         
-        self.assertEqual(provider_keys, ["aws", "aws.ohio", "aws.oregon"])
+        self.assertEqual(provider_names, ["aws", "aws", "aws"])
         self.assertEqual(provider_aliases, ["default", "ohio", "oregon"])
         self.assertEqual(provider_addresses, ["aws.default", "aws.ohio", "aws.oregon"])
 

--- a/tests/terraform/runner/resources/plan_with_providers/main.tf
+++ b/tests/terraform/runner/resources/plan_with_providers/main.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+    region = "us-east-1"
+}
+
+provider "aws" {
+    region = "us-east-2"
+    alias = "ohio"
+    access_key = "AKIAIOSFODNN7EXAMPLE"
+}
+provider "aws" {
+    region = "us-west-2"
+    alias = "oregon"
+}

--- a/tests/terraform/runner/resources/plan_with_providers/tfplan.json
+++ b/tests/terraform/runner/resources/plan_with_providers/tfplan.json
@@ -1,0 +1,48 @@
+{
+    "format_version": "1.2",
+    "terraform_version": "1.11.4",
+    "planned_values": {
+        "root_module": {}
+    },
+    "configuration": {
+        "provider_config": {
+            "aws": {
+                "name": "aws",
+                "full_name": "registry.terraform.io/hashicorp/aws",
+                "expressions": {
+                    "region": {
+                        "constant_value": "us-east-1"
+                    }
+                }
+            },
+            "aws.ohio": {
+                "name": "aws",
+                "full_name": "registry.terraform.io/hashicorp/aws",
+                "alias": "ohio",
+                "expressions": {
+                    "access_key": {
+                        "constant_value": "AKIAIOSFODNN7EXAMPLE"
+                    },
+                    "region": {
+                        "constant_value": "us-east-2"
+                    }
+                }
+            },
+            "aws.oregon": {
+                "name": "aws",
+                "full_name": "registry.terraform.io/hashicorp/aws",
+                "alias": "oregon",
+                "expressions": {
+                    "region": {
+                        "constant_value": "us-west-2"
+                    }
+                }
+            }
+        },
+        "root_module": {}
+    },
+    "timestamp": "2025-05-05T16:11:28Z",
+    "applyable": false,
+    "complete": true,
+    "errored": false
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fix matching of `supported_provider` values.

Use the provider name (not the key from the plan which can contain the provider alias) in the provider_map data structure, since this is what `supported_provider` is compared against. Otherwise, some provider checks will only run against providers without an alias.

Fixes #7118 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
