### PR TITLE
fix(secrets): Fix test directory tree race

### DIFF
--- a/checkov/secrets/runner.py
+++ b/checkov/secrets/runner.py
@@ -439,16 +439,17 @@ class Runner(BaseRunner[None, None, None]):
 
     @staticmethod
     def _safe_scan(file_path: str, base_path: str) -> tuple[str, list[PotentialSecret]]:
-        full_file_path = os.path.join(base_path, file_path)
-        file_size = os.path.getsize(full_file_path)
-        if file_size > MAX_FILE_SIZE > 0:
-            logging.info(
-                f'Skipping secret scanning on {full_file_path} due to file size. To scan this file for '
-                'secrets, run this command again with the environment variable "CHECKOV_MAX_FILE_SIZE" '
-                f'to 0 or {file_size + 1}'
-            )
-            return file_path, []
         try:
+            full_file_path = os.path.join(base_path, file_path)
+            file_size = os.path.getsize(full_file_path)
+            if file_size > MAX_FILE_SIZE > 0:
+                logging.info(
+                    f'Skipping secret scanning on {full_file_path} due to file size. To scan this file for '
+                    'secrets, run this command again with the environment variable "CHECKOV_MAX_FILE_SIZE" '
+                    f'to 0 or {file_size + 1}'
+                )
+                return file_path, []
+
             start_time = datetime.datetime.now()
             file_results = [*scan.scan_file(full_file_path)]
             logging.debug(f'file {full_file_path} results len {len(file_results)}')

--- a/tests/secrets/test_masking_secrets.py
+++ b/tests/secrets/test_masking_secrets.py
@@ -1,36 +1,31 @@
 import shutil
+import tempfile
 from pathlib import Path
-from distutils.dir_util import copy_tree
 
 from checkov.runner_filter import RunnerFilter
 from checkov.secrets.runner import Runner
 
 
 def test_multiline_keyword_password_in_pod():
-    # given
-    test_file_path = Path(__file__).parent / "masking_secrets"
-    working_test_file_path = test_file_path / "tmp"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        shutil.copytree(Path(__file__).parent / 'masking_secrets', tmpdir, dirs_exist_ok=True)
+        Runner().mask_files(files=None, root_folder=tmpdir,
+                            runner_filter=RunnerFilter(framework=["secrets"]))
 
-    if working_test_file_path.exists():
-        shutil.rmtree(working_test_file_path)
+        f = tmp / 'findings_report_with_pass.json'
+        assert f.is_file()
+        content = f.read_text()
+        assert content.count("AKIAY**********") == 12
+        assert content.count("AKIAYNKRE4OV2LF6TC3N") == 0
+        assert content.count("h4t2TJ**********") == 12
+        assert content.count("h4t2TJheVRR8em5VdNCjrSJdQ+p7OHl33SxrZoUi") == 0
 
-    copy_tree(str(test_file_path), str(working_test_file_path))
-    #  when
-    Runner().mask_files(files=None, root_folder=str(working_test_file_path),
-                        runner_filter=RunnerFilter(framework=["secrets"]))
-
-    #  then
-    content = (working_test_file_path / "findings_report_with_pass.json").read_text()
-    assert content.count("AKIAY**********") == 12
-    assert content.count("AKIAYNKRE4OV2LF6TC3N") == 0
-    assert content.count("h4t2TJ**********") == 12
-    assert content.count("h4t2TJheVRR8em5VdNCjrSJdQ+p7OHl33SxrZoUi") == 0
-
-    content = (working_test_file_path / "assets_report_with_pass.json").read_text()
-    assert content.count("AKIAY**********") == 1
-    assert content.count("AKIAYNKRE4OV2LF6TC3N") == 0
-    assert content.count("h4t2TJ**********") == 1
-    assert content.count("h4t2TJheVRR8em5VdNCjrSJdQ+p7OHl33SxrZoUi") == 0
-
-    shutil.rmtree(working_test_file_path)
+        f = tmp / 'assets_report_with_pass.json'
+        assert f.is_file()
+        content = f.read_text()
+        assert content.count("AKIAY**********") == 1
+        assert content.count("AKIAYNKRE4OV2LF6TC3N") == 0
+        assert content.count("h4t2TJ**********") == 1
+        assert content.count("h4t2TJheVRR8em5VdNCjrSJdQ+p7OHl33SxrZoUi") == 0
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

I've observed a race between two unit tests, as shown below. This seems to be a race between the time the runner enumerates the files in the directory, and the time that ``_safe_scan`` gets called to scan them. The exception is from ``os.path.getsize()``, as the runner assumes that the file exists. The path given in the exception is used by ``tests/secrets/test_masking_secrets.py`` and, just so happens to remove its 'tmp' path, which is under the same path being scanned by ``test_same_resources_in_report_and_coordinator``, hence the race.

Therefore, I've put the ``os.path.getsize()`` call within the try block in ``_safe_scan`` so that a warning can be emitted in this case, versus having an exception bubble up to the runner. Additionally, I've updated the masking test to use ``shutil.copytree()`` since ``distutils.dir_util`` is deprecated, ``tempfile`` to create a proper temporary directory, added a couple of assertions to ensure the files it expects to read are in fact files.

### Failing Test Output

```
FAILED tests/secrets/test_coordinator.py::TestCoordinator::test_same_resources_in_report_and_coordinator - FileNotFoundError: [Errno 2] No such file or directory: '/home/tim/github/checkov/tests/secrets/masking_secrets/tmp/assets_report_with_pass.json'

_____________________________________________________________ TestCoordinator.test_same_resources_in_report_and_coordinator ______________________________________________________________
[gw27] linux -- Python 3.12.9 /home/tim/github/checkov/.venv/bin/python

self = <tests.secrets.test_coordinator.TestCoordinator testMethod=test_same_resources_in_report_and_coordinator>

    def test_same_resources_in_report_and_coordinator(self):
        test_root_folder = f'{Path(__file__).parent}'

        secret_runner = Runner()
>       report = secret_runner.run(
            root_folder=test_root_folder, runner_filter=RunnerFilter(framework=['secrets'])
        )

tests/secrets/test_coordinator.py:14:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
checkov/secrets/runner.py:273: in run
    self._scan_files(files_to_scan, secrets, self.pbar)
checkov/secrets/runner.py:434: in _scan_files
    for filename, secrets_results in results:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>                       raise v.internal_exception.with_traceback(v.internal_exception.__traceback__)
E                       FileNotFoundError: [Errno 2] No such file or directory: '/home/tim/github/checkov/tests/secrets/masking_secrets/tmp/assets_report_with_pass.json'

checkov/common/parallelizer/parallel_runner.py:110: FileNotFoundError
----------------------------------------------------------------------------------- Captured log call ------------------------------------------------------------------------------------
DEBUG    root:runner_filter.py:126 Resultant set of frameworks (removing skipped frameworks): secrets
INFO     root:runner.py:224 Custom detector found at /home/tim/github/checkov/checkov/secrets/plugins/custom_regex_detector.py. Loading...
INFO     root:runner.py:131 Secrets scanning will scan 37 files
DEBUG    root:parallel_runner.py:92 Running function /home/tim/github/checkov/checkov/secrets/runner._safe_scan with parallelization type 'fork'
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
