### PR TITLE
fix(general): Skip bc_api_key in output

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -443,9 +443,14 @@ class Report:
 
     @staticmethod
     def create_test_suite_properties_block(config: argparse.Namespace) -> Dict[str, Any]:
-        """Creates a dictionary without 'None' values for the JUnit XML properties block"""
+        """Creates a dictionary without 'None' values and sensitive data for the JUnit XML properties block"""
 
-        properties = {k: v for k, v in config.__dict__.items() if v is not None}
+        # List of sensitive properties that should be excluded from outputs
+        sensitive_properties = ['bc_api_key']
+
+        properties = {k: v for k, v in config.__dict__.items()
+                      if v is not None and k not in sensitive_properties}
+
         return properties
 
     def _create_test_case_failure_output(self, record: Record) -> str:

--- a/tests/common/output/test_junit_report.py
+++ b/tests/common/output/test_junit_report.py
@@ -104,6 +104,42 @@ class TestJunitReport(unittest.TestCase):
             ).toprettyxml()
         )
 
+    def test_sensitive_properties_excluded_from_junit_xml(self):
+        # given
+        test_file = Path(__file__).parent / "fixtures/main.tf"
+        checks = ["CKV_AWS_18"]  # Just need one check for this test
+
+        # Create config with a sensitive property (bc_api_key)
+        config = argparse.Namespace(
+            file="fixtures/main.tf",
+            framework=["terraform"],
+            bc_api_key="secret_api_key_123",  # This should be excluded
+            non_sensitive_prop="regular_value"  # This should be included
+        )
+
+        report = TerrafomrRunner().run(
+            root_folder="", files=[str(test_file)], runner_filter=RunnerFilter(checks=checks)
+        )
+
+        properties = Report.create_test_suite_properties_block(config=config)
+        test_suite = report.get_test_suite(properties=properties)
+        xml_string = Report.get_junit_xml_string([test_suite])
+        root = ET.fromstring(xml_string)
+        testsuite = root.find('testsuite')
+        props = testsuite.find('properties')
+
+        # Check that sensitive properties are not included
+        property_names = [prop.attrib['name'] for prop in props.findall('property')]
+        self.assertIn('file', property_names, "Expected 'file' property to be present")
+        self.assertIn('framework', property_names, "Expected 'framework' property to be present")
+        self.assertIn('non_sensitive_prop', property_names, "Expected 'non_sensitive_prop' property to be present")
+
+        # Most important assertions - check that sensitive properties are excluded
+        self.assertNotIn('bc_api_key', property_names, "Sensitive property 'bc_api_key' should be excluded")
+
+        # Double check the XML string itself doesn't contain the sensitive values
+        self.assertNotIn('secret_api_key_123', xml_string, "API key value should not appear in XML")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Skip bc key in output

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
