### PR TITLE
fix(terraform): Fixed crash when using variable rendering inside a list of len > 1

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -895,7 +895,7 @@ def update_list_attribute(
         # happens when we can't correctly evaluate something, because of strange defaults or 'for_each' blocks
         return config
 
-    if len(key_parts) == 1:
+    if len(key_parts) == 1 and len(config) == 1:
         idx = force_int(key_parts[0])
         # Avoid changing the config and cause side effects
         inner_config = pickle_deepcopy(config[0])

--- a/tests/terraform/graph/variable_rendering/test_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_renderer.py
@@ -323,6 +323,17 @@ class TestRenderer(TestCase):
             ["10.0.0.0/16", "0.0.0.0/0"],
         )
 
+        multiple_ingress_vertex = (
+            next(v for v in local_graph.vertices if v.id == 'aws_security_group.multiple_ingress_sg'))
+
+        ingress_field = multiple_ingress_vertex.config["aws_security_group"]["multiple_ingress_sg"]["ingress"]
+        self.assertEqual(len(ingress_field), 3)
+
+        # TODO - make var rendering correctly evaluate inner vars in list
+        self.assertEqual(ingress_field[0],[[]])
+        self.assertEqual(ingress_field[1], {'cidr_blocks': ['${var.cidr_sg}'], 'from_port': 23, 'protocol': 'TCP', 'to_port': 23})
+        self.assertEqual(ingress_field[2],'var.empty_ingress')
+
     @mock.patch.dict(os.environ, {"CHECKOV_RENDER_DYNAMIC_MODULES": "False"})
     def test_dynamic_with_env_var_false(self):
         graph_manager = TerraformGraphManager('m', ['m'])

--- a/tests/terraform/graph/variable_rendering/test_resources/list_entry_module_var/module/main.tf
+++ b/tests/terraform/graph/variable_rendering/test_resources/list_entry_module_var/module/main.tf
@@ -24,3 +24,30 @@ resource "aws_security_group" "sg" {
     cidr_blocks     = ["10.0.0.0/16", var.cidr_sg]
   }
 }
+
+variable "empty_ingress" {
+  type = list
+}
+
+resource "aws_security_group" "multiple_ingress_sg" {
+  name            = "example"
+  vpc_id          = var.vpc_id
+
+  ingress = [var.empty_ingress]
+  ingress = [
+    {
+    from_port       = 23
+    to_port         = 23
+    protocol        = "TCP"
+    cidr_blocks     = [var.cidr_sg]
+  },
+    var.empty_ingress
+  ]
+
+  egress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "TCP"
+    cidr_blocks     = ["10.0.0.0/16", var.cidr_sg]
+  }
+}


### PR DESCRIPTION
## Description

There was an inner bug in our variable rendering process for terraform when trying to evaluate a variable inside a list of len > 1. This fixes the crash, but still lacks variable rendering for the inner values of the list, which should be fixed in a future PR.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
