### PR TITLE
fix(terraform_plan): Support count in terraform plan files

### DIFF
--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -4,6 +4,7 @@ import itertools
 import json
 import logging
 import os
+import re
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 from checkov.common.graph.graph_builder import CustomAttributes
@@ -20,6 +21,8 @@ TF_PLAN_RESOURCE_CHANGE_ACTIONS = "__change_actions__"
 TF_PLAN_RESOURCE_CHANGE_KEYS = "__change_keys__"
 TF_PLAN_RESOURCE_PROVISIONERS = "provisioners"
 TF_PLAN_RESOURCE_AFTER_UNKNOWN = 'after_unknown'
+
+COUNT_PATTERN = re.compile(r"\[?\d+\]?$")
 
 RESOURCE_TYPES_JSONIFY = {
     "aws_batch_job_definition": "container_properties",
@@ -323,9 +326,19 @@ def _get_module_call_resources(module_address: str, root_module_conf: dict[str, 
         if module_name == "module":
             # module names are always prefixed with 'module.', therefore skip it
             continue
-        root_module_conf = root_module_conf.get("module_calls", {}).get(module_name, {}).get("module", {})
+        sanitized_module_name = _sanitize_count_from_name(module_name)
+        root_module_conf = root_module_conf.get("module_calls", {}).get(sanitized_module_name, {}).get("module", {})
 
     return cast("list[dict[str, Any]]", root_module_conf.get("resources", []))
+
+
+def _sanitize_count_from_name(name: str) -> str:
+    """Sanitize the count from the resource name"""
+    if re.search(COUNT_PATTERN, name):
+        name_parts = re.split(COUNT_PATTERN, name)
+        if len(name_parts) == 2:
+            return name_parts[0]
+    return name
 
 
 def _is_provider_key(key: str) -> bool:

--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -326,8 +326,11 @@ def _get_module_call_resources(module_address: str, root_module_conf: dict[str, 
         if module_name == "module":
             # module names are always prefixed with 'module.', therefore skip it
             continue
-        sanitized_module_name = _sanitize_count_from_name(module_name)
-        root_module_conf = root_module_conf.get("module_calls", {}).get(sanitized_module_name, {}).get("module", {})
+        found_root_module_conf = root_module_conf.get("module_calls", {}).get(module_name, {}).get("module", {})
+        if not found_root_module_conf:
+            sanitized_module_name = _sanitize_count_from_name(module_name)
+            found_root_module_conf = root_module_conf.get("module_calls", {}).get(sanitized_module_name, {}).get("module", {})
+        root_module_conf = found_root_module_conf
 
     return cast("list[dict[str, Any]]", root_module_conf.get("resources", []))
 

--- a/tests/terraform/parser/test_plan_parser.py
+++ b/tests/terraform/parser/test_plan_parser.py
@@ -120,10 +120,6 @@ class TestPlanFileParser(unittest.TestCase):
         result = _sanitize_count_from_name(name)
         self.assertEqual(result, "aws_s3_bucket.bucket")
 
-        name = "aws_s3_bucket.bucket[0].my_bucket"
-        result = _sanitize_count_from_name(name)
-        self.assertEqual(result, "aws_s3_bucket.bucket.my_bucket")
-
 
 def test_large_file(mocker: MockerFixture):
     # given

--- a/tests/terraform/parser/test_plan_parser.py
+++ b/tests/terraform/parser/test_plan_parser.py
@@ -6,7 +6,7 @@ from unittest import mock
 from pytest_mock import MockerFixture
 
 from checkov.common.util.consts import TRUE_AFTER_UNKNOWN
-from checkov.terraform.plan_parser import parse_tf_plan
+from checkov.terraform.plan_parser import parse_tf_plan, _sanitize_count_from_name
 from checkov.common.parsers.node import StrNode
 
 class TestPlanFileParser(unittest.TestCase):
@@ -110,6 +110,20 @@ class TestPlanFileParser(unittest.TestCase):
         resource_definition = next(iter(file_resource_definition.values()))
         resource_attributes = next(iter(resource_definition.values()))
         self.assertEqual(resource_attributes['logging_config'][0]["bucket"], [TRUE_AFTER_UNKNOWN])
+
+    def test___sanitize_count_from_name_with_count(self):
+        name = "aws_s3_bucket.bucket[0]"
+        result = _sanitize_count_from_name(name)
+        self.assertEqual(result, "aws_s3_bucket.bucket")
+
+        name = "aws_s3_bucket.bucket"
+        result = _sanitize_count_from_name(name)
+        self.assertEqual(result, "aws_s3_bucket.bucket")
+
+        name = "aws_s3_bucket.bucket[0].my_bucket"
+        result = _sanitize_count_from_name(name)
+        self.assertEqual(result, "aws_s3_bucket.bucket.my_bucket")
+
 
 def test_large_file(mocker: MockerFixture):
     # given

--- a/tests/terraform_json/test_parser.py
+++ b/tests/terraform_json/test_parser.py
@@ -1,4 +1,3 @@
-from checkov.terraform.plan_parser import _sanitize_count_from_name
 from checkov.terraform_json.parser import hclify, prepare_definition
 
 
@@ -61,25 +60,3 @@ def test_prepare_definition_locals():
             }
         ]
     }
-
-
-def test__sanitize_count_from_name_with_count():
-    # given
-    name = "aws_s3_bucket.bucket[0]"
-
-    # when
-    result = _sanitize_count_from_name(name)
-
-    # then
-    assert result == "aws_s3_bucket.bucket"
-
-
-def test__sanitize_count_from_name_with_no_count():
-    # given
-    name = "aws_s3_bucket.bucket"
-
-    # when
-    result = _sanitize_count_from_name(name)
-
-    # then
-    assert result == "aws_s3_bucket.bucket"

--- a/tests/terraform_json/test_parser.py
+++ b/tests/terraform_json/test_parser.py
@@ -1,3 +1,4 @@
+from checkov.terraform.plan_parser import _sanitize_count_from_name
 from checkov.terraform_json.parser import hclify, prepare_definition
 
 
@@ -60,3 +61,25 @@ def test_prepare_definition_locals():
             }
         ]
     }
+
+
+def test__sanitize_count_from_name_with_count():
+    # given
+    name = "aws_s3_bucket.bucket[0]"
+
+    # when
+    result = _sanitize_count_from_name(name)
+
+    # then
+    assert result == "aws_s3_bucket.bucket"
+
+
+def test__sanitize_count_from_name_with_no_count():
+    # given
+    name = "aws_s3_bucket.bucket"
+
+    # when
+    result = _sanitize_count_from_name(name)
+
+    # then
+    assert result == "aws_s3_bucket.bucket"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

In the case where a module reference has `[0]` (or any other count in its name due to usage of count, Checkov could not find the module reference correctly. 
Therefore, I implemented a sanitization mechanism to remove the index from the module name.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
