### PR TITLE
Revert "fix(general): using asteval instead of using eval (#7116)"

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -84,7 +84,6 @@ spdx-tools = ">=0.8.0,<0.9.0"
 license-expression = ">=30.1.0,<31.0.0"
 rustworkx = ">=0.13.0,<1.0.0"
 pydantic = ">=2.0.0,<3.0.0"
-asteval = "==1.0.5"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -164,14 +164,13 @@
             "markers": "python_version >= '3.8'",
             "version": "==3.6.2"
         },
-        "asteval": {
+        "async-timeout": {
             "hashes": [
-                "sha256:082b95312578affc8a6d982f7d92b7ac5de05634985c87e7eedd3188d31149fa",
-                "sha256:bac3c8dd6d2b789e959cfec9bb296fb8338eec066feae618c462132701fbc665"
+                "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
+                "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.0.5"
+            "version": "==5.0.1"
         },
         "async-timeout": {
             "hashes": [
@@ -226,11 +225,11 @@
         },
         "beautifulsoup4": {
             "hashes": [
-                "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b",
-                "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195"
+                "sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b",
+                "sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==4.13.4"
+            "version": "==4.13.3"
         },
         "boolean.py": {
             "hashes": [
@@ -1837,11 +1836,11 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4",
-                "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a"
+                "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb",
+                "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.7"
+            "version": "==2.6"
         },
         "spdx-tools": {
             "hashes": [
@@ -2784,19 +2783,19 @@
         },
         "mypy-boto3-s3": {
             "hashes": [
-                "sha256:5cd9449df0ef6cf89e00e6fc9130a0ab641f703a23ab1d2146c394da058e8282",
-                "sha256:f8fe586e45123ffcd305a0c30847128f3931d888649e2b4c5a52f412183c840a"
+                "sha256:4df0975256132ab452896b9d36571866a816157d519cf12c661795b2906e2e9c",
+                "sha256:8afd8d64be352652bc888ed81750788bebabd2b6e8ee6fe9be00ff25228df39b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.0"
+            "version": "==1.37.24"
         },
         "mypy-extensions": {
             "hashes": [
-                "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505",
-                "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.1.0"
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
         },
         "nodeenv": {
             "hashes": [
@@ -3446,11 +3445,11 @@
         },
         "types-s3transfer": {
             "hashes": [
-                "sha256:101bbc5b7f00b71512374df881f480fc6bf63c948b5098ab024bf3370fbfb0e8",
-                "sha256:f8f59201481e904362873bf0be3267f259d60ad946ebdfcb847d092a1fa26f98"
+                "sha256:05fde593c84270f19fd053f0b1e08f5a057d7c5f036b9884e68fb8cd3041ac30",
+                "sha256:2a76d92c07d4a3cb469e5343b2e7560e0b8078b2e03696a65407b8c44c861b61"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.12.0"
+            "version": "==0.11.4"
         },
         "types-tabulate": {
             "hashes": [

--- a/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
@@ -20,7 +20,6 @@ DIRECTIVE_EXPR = re.compile(r"\%\{([^\}]*)\}")
 # exclude "']" one the right side of the compare via (?!']), this can happen with a base64 encoded string
 COMPARE_REGEX = re.compile(r"^(?P<a>.+?)\s*(?P<operator>==|!=|>=|>|<=|<|&&|\|\|)\s*(?P<b>(?!']).+)$")
 COMPARE_OPERATORS = (" == ", " != ", " < ", " <= ", " > ", " >= ", " && ", " || ")
-REMOVE_TRAILING_COMMAS = re.compile(r',(\s*[}\]])')
 
 CHECKOV_RENDER_MAX_LEN = force_int(os.getenv("CHECKOV_RENDER_MAX_LEN", "10000"))
 
@@ -85,10 +84,7 @@ def _eval_merge_as_list(eval_value: Any) -> Any:
 
 def _try_evaluate(input_str: Union[str, bool]) -> Any:
     try:
-        result = evaluate(input_str)  # type:ignore[arg-type]
-        if result is None:
-            raise Exception(f"Can't evaluate {input_str}")
-        return result
+        return evaluate(input_str)  # type:ignore[arg-type]
     except Exception:
         try:
             return evaluate(f'"{input_str}"')
@@ -101,12 +97,7 @@ def _try_evaluate(input_str: Union[str, bool]) -> Any:
                     return json.loads(input_str)
                 return input_str
             except Exception:
-                try:
-                    # Remove trailing commas before } or ]
-                    input_str_no_trailing = REMOVE_TRAILING_COMMAS.sub(r'\1', input_str)  # type:ignore[arg-type]
-                    return json.loads(input_str_no_trailing)
-                except Exception:
-                    return input_str
+                return input_str
 
 
 def replace_string_value(original_str: Any, str_to_replace: str, replaced_value: str, keep_origin: bool = True) -> Any:

--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta
 from functools import reduce
 from math import ceil, floor, log
 from typing import Union, Any, Dict, Callable, List, Optional
-from asteval import Interpreter
 
 from checkov.terraform.parser_functions import tonumber, FUNCTION_FAILED, create_map, tobool, tostring
 
@@ -357,21 +356,13 @@ SAFE_EVAL_DICT["timeadd"] = timeadd
 SAFE_EVAL_DICT["formatdate"] = formatdate
 
 
-def get_asteval() -> Interpreter:
-    # asteval provides a safer environment for evaluating expressions by restricting the operations to a secure subset, significantly reducing the risk of executing malicious code.
-    return Interpreter(
-        symtable=SAFE_EVAL_DICT,
-        use_numpy=False,
-        minimal=True
-    )
-
-
 def evaluate(input_str: str) -> Any:
-    """
-    Safely evaluate a Terraform-like function expression using a predefined function map.
-    Falls back gracefully if evaluation fails.
-    """
-    if not input_str or input_str == "...":
+    count_underscores = input_str.count("__")
+    # We are operating under the assumption that the function name will start and end with "__", ensuring that we have at least two of them
+    if count_underscores >= 2:
+        logging.debug(f"got a substring with double underscore, which is not allowed. origin string: {input_str}")
+        return input_str
+    if input_str == "...":
         # don't create an Ellipsis object
         return input_str
     if input_str.startswith("try"):
@@ -380,19 +371,11 @@ def evaluate(input_str: str) -> Any:
 
         # Don't use str.replace to make sure we replace just the first occurrence
         input_str = f"{TRY_STR_REPLACEMENT}{input_str[3:]}"
-    asteval = get_asteval()
-    log_level = os.getenv("LOG_LEVEL")
-    should_log_asteval_errors = log_level == "DEBUG"
     if RANGE_PATTERN.match(input_str):
-        temp_eval = asteval(input_str, show_errors=should_log_asteval_errors)
+        temp_eval = eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
         evaluated = input_str if temp_eval < 0 else temp_eval
     else:
-        evaluated = asteval(input_str, show_errors=should_log_asteval_errors)
-
-    if asteval.error:
-        error_messages = [err.get_error() for err in asteval.error]
-        raise ValueError(f"Safe evaluation error: {error_messages}")
-
+        evaluated = eval(input_str, {"__builtins__": None}, SAFE_EVAL_DICT)  # nosec
     return evaluated if not isinstance(evaluated, str) else remove_unicode_null(evaluated)
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,6 +19,3 @@ ignore_missing_imports = True
 
 [mypy-checkov.*]
 follow_imports = skip
-
-[mypy-asteval.*]
-ignore_missing_imports = True

--- a/performance_tests/test_checkov_performance.py
+++ b/performance_tests/test_checkov_performance.py
@@ -18,7 +18,7 @@ performance_configurations = {
         'repo_name': 'terraform-aws-components',
         'threshold': {
             "Darwin": 19.0,
-            "Linux": 13.0,
+            "Linux": 11.0,
             "Windows": 15.0,
         }
     },
@@ -114,5 +114,6 @@ def test_k8_performance(benchmark):
         runner_registry = RunnerRegistry(banner, runner_filter, k8_runner())
         reports = runner_registry.run(root_folder=test_files_dir)
         assert len(reports) > 0
+
     benchmark(run_kubernetes_scan)
     assert benchmark.stats.stats.mean <= repo_threshold + (DEVIATION_PERCENT / 100) * repo_threshold

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,6 @@ setup(
         "license-expression<31.0.0,>=30.1.0",
         "rustworkx>=0.13.0,<1.0.0",
         "pydantic<3.0.0,>=2.0.0",
-        "asteval==1.0.5"
     ],
     dependency_links=[],  # keep it empty, needed for pipenv-setup
     license="Apache License 2.0",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

This reverts commit 5ddad08dc712f23a1cd2aafd68895b382ecfd6a3.

If the requisite Python upgrade isn't feasible, it makes sense to revert the asteval change, and go back to ``eval`` until it can be upgraded to a version not vulnerable to CVE-2025-24359; allowing folks an upgrade path who otherwise couldn't due to the CVE. Once everything's in place, the commit herein can be reverted.

Fixes #7194

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
