### PR TITLE
fix(helm): support multiple resources in one template

### DIFF
--- a/tests/helm/runner/resources/multiple/Chart.yaml
+++ b/tests/helm/runner/resources/multiple/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: multiple-resources
+description: A test Helm chart
+version: 0.1.0

--- a/tests/helm/runner/resources/multiple/templates/test.yaml
+++ b/tests/helm/runner/resources/multiple/templates/test.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: one
+data:
+  key: "value"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: two

--- a/tests/helm/test_runner_multiple_resources.py
+++ b/tests/helm/test_runner_multiple_resources.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from checkov.common.output.report import CheckType
+from checkov.helm.runner import Runner
+from tests.helm.utils import helm_exists
+
+RESOURCES_PATH = Path(__file__).parent / "runner" / "resources"
+
+
+@pytest.mark.skipif(not helm_exists(), reason="helm not installed")
+def test_multiple_resources():
+    runner = Runner()
+    report = runner.run(
+        root_folder=str(RESOURCES_PATH / "multiple"),
+    )
+
+    # The helm chart contains one template with two resources.
+    # Neither resource has a namespace.
+
+    assert len(report.failed_checks) == 2
+    assert report.check_type == CheckType.HELM
+
+    assert len(report.resources) == 2
+    for resource in report.resources:
+        assert "templates/test.yaml" in resource


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

The output of the `helm template` command is a multi-document YAML stream. Each document starts with a `---` marker. However, Helm templates can also contain multiple documents.

Currently, this results in a (mostly silent) "error parsing output". The remaining resources are not scanned.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
