### PR TITLE
fix(terraform): Added support in restricting to a specific GitHub organization for GithubActionsOIDCTrustPolicy

### DIFF
--- a/checkov/common/util/oidc_utils.py
+++ b/checkov/common/util/oidc_utils.py
@@ -11,3 +11,4 @@ Constants:
 """
 gh_repo_regex = re.compile(r"(\$\{)?[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*(\})?/[^/]+")
 gh_abusable_claims = ["workflow", "environment", "ref", "context", "head_ref", "base_ref"]
+gh_sub_condition = re.compile(r"^token\.actions\.githubusercontent\.com(?:/[a-zA-Z0-9_-]+)?:sub$")

--- a/checkov/terraform/checks/data/aws/GithubActionsOIDCTrustPolicy.py
+++ b/checkov/terraform/checks/data/aws/GithubActionsOIDCTrustPolicy.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Any
 from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.common.util.type_forcers import force_list
 from checkov.terraform.checks.data.base_check import BaseDataCheck
-from checkov.common.util.oidc_utils import gh_abusable_claims, gh_repo_regex
+from checkov.common.util.oidc_utils import gh_abusable_claims, gh_repo_regex, gh_sub_condition
 
 
 class GithubActionsOIDCTrustPolicy(BaseDataCheck):
@@ -56,7 +56,7 @@ class GithubActionsOIDCTrustPolicy(BaseDataCheck):
                     condition_values = condition.get("values")
                     if isinstance(condition_variables, list):
                         for condition_variable in condition_variables:
-                            if condition_variable == "token.actions.githubusercontent.com:sub":
+                            if gh_sub_condition.match(condition_variable):
                                 found_sub_condition_variable = True
                                 break
 

--- a/tests/terraform/checks/data/aws/example_GithubActionsOIDCTrustPolicy/main.tf
+++ b/tests/terraform/checks/data/aws/example_GithubActionsOIDCTrustPolicy/main.tf
@@ -235,3 +235,30 @@ data "aws_iam_policy_document" "pass-org-only" {
     }
   }
 }
+
+#pass github org
+data "aws_iam_policy_document" "pass-gh-org" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    action = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+    principals {
+      identifiers = ["arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"]
+      type        = "Federated"
+    }
+    condition {
+      test     = "StringEquals"
+      values   = ["repo:myOrg/myRepo:ref:refs/heads/MyBranch"]
+      variable = "token.actions.githubusercontent.com/github-org:sub"
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["sts.amazonaws.com"]
+      variable = "token.actions.githubusercontent.com:aud"
+    }
+  }
+}

--- a/tests/terraform/checks/data/aws/test_GithubActionsOIDCTrustPolicy.py
+++ b/tests/terraform/checks/data/aws/test_GithubActionsOIDCTrustPolicy.py
@@ -21,6 +21,7 @@ class TestGithubActionsOIDCTrustPolicy(unittest.TestCase):
             "aws_iam_policy_document.pass3",
             "aws_iam_policy_document.pass-org-only",
             "aws_iam_policy_document.pass_aud_first",
+            "aws_iam_policy_document.pass-gh-org",
         }
         failing_resources = {
             "aws_iam_policy_document.fail1",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Added support for sub condition variables which includes a specific GitHub org:
`token.actions.githubusercontent.com/github-org:sub`



## Edited policies
https://github.com/bridgecrewio/checkov/blob/main/checkov/terraform/checks/data/aws/GithubActionsOIDCTrustPolicy.py


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
