### PR TITLE
fix(terraform): fix issue 7216 module version parsing issue

### DIFF
--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -200,7 +200,7 @@ class K8sKustomizeRunner(K8sRunner):
             directory_prefix_path = k8s_file_dir.parents[amount_of_parents - 1]
 
         directory_prefix = str(directory_prefix_path)
-        resolved_path = str(raw_file_path.resolve())
+        resolved_path = os.path.realpath(str(raw_file_path))
         # Make sure the resolved path starts with the root folder, as pathlib.Path.resolve() might change it
         if directory_prefix in resolved_path and not resolved_path.startswith(directory_prefix):
             resolved_path = K8sKustomizeRunner._remove_extra_path_parts(resolved_path, directory_prefix)

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -200,7 +200,7 @@ class K8sKustomizeRunner(K8sRunner):
             directory_prefix_path = k8s_file_dir.parents[amount_of_parents - 1]
 
         directory_prefix = str(directory_prefix_path)
-        resolved_path = os.path.realpath(str(raw_file_path))
+        resolved_path = str(raw_file_path.resolve())
         # Make sure the resolved path starts with the root folder, as pathlib.Path.resolve() might change it
         if directory_prefix in resolved_path and not resolved_path.startswith(directory_prefix):
             resolved_path = K8sKustomizeRunner._remove_extra_path_parts(resolved_path, directory_prefix)

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -66,7 +66,7 @@ def find_modules(path: str, loaded_files_cache: Optional[Dict[str, Any]] = None,
                 # don't scan the modules folder used by Terraform
                 continue
             file_path = os.path.join(root, file_name)
-            if file_path in excluded_paths:
+            if any(file_path.endswith(excluded_path) for excluded_path in excluded_paths):
                 continue
 
             data = load_or_die_quietly(file_path, parsing_errors)
@@ -100,7 +100,7 @@ def load_tf_modules(
     stop_on_failure: bool = False,
     loaded_files_cache: dict[str, Any] | None = None,
     parsing_errors: dict[str, Exception] | None = None,
-    excluded_paths: dict[str, Exception] | None = None,
+    excluded_paths: List[str] | None = None,
 ) -> None:
     module_loader_registry.root_dir = path
     if not modules_to_load and env_vars_config.CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES:

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import List, Callable, TYPE_CHECKING, Any
+from typing import List, Callable, TYPE_CHECKING, Any, Optional, Dict
 
 from checkov.common.util.env_vars_config import env_vars_config
 from checkov.common.parallelizer.parallel_runner import parallel_runner
@@ -51,8 +51,8 @@ def find_tf_managed_modules(path: str) -> List[ModuleDownload]:
     return modules_found
 
 
-def find_modules(path: str, loaded_files_cache: dict[str, Any] | None = None,
-                 parsing_errors: dict[str, Exception] | None = None) -> list[ModuleDownload]:
+def find_modules(path: str, loaded_files_cache: Optional[Dict[str, Any]] = None,
+                 parsing_errors: Optional[Dict[str, Exception]] = None, excluded_paths: Optional[list[str]] = None) -> list[ModuleDownload]:
     modules_found: list[ModuleDownload] = []
     if loaded_files_cache is None:
         loaded_files_cache = {}
@@ -97,12 +97,13 @@ def load_tf_modules(
     stop_on_failure: bool = False,
     loaded_files_cache: dict[str, Any] | None = None,
     parsing_errors: dict[str, Exception] | None = None,
+    excluded_paths: dict[str, Exception] | None = None,
 ) -> None:
     module_loader_registry.root_dir = path
     if not modules_to_load and env_vars_config.CHECKOV_EXPERIMENTAL_TERRAFORM_MANAGED_MODULES:
         modules_to_load = find_tf_managed_modules(path)
     if not modules_to_load:
-        modules_to_load = find_modules(path, loaded_files_cache=loaded_files_cache, parsing_errors=parsing_errors)
+        modules_to_load = find_modules(path, loaded_files_cache=loaded_files_cache, parsing_errors=parsing_errors, excluded_paths=excluded_paths)
 
     # To avoid duplicate work, we need to get the distinct module sources
     distinct_modules = list({m.address: m for m in modules_to_load}.values())

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -60,7 +60,7 @@ def find_modules(path: str, loaded_files_cache: Optional[Dict[str, Any]] = None,
     if parsing_errors is None:
         parsing_errors = {}
 
-    excluded_paths_regex = re.compile('|'.join(excluded_paths)) if excluded_paths else None
+    excluded_paths_regex = re.compile('|'.join(f"({excluded_paths})")) if excluded_paths else None
     for root, _, full_file_names in os.walk(path):
         for file_name in full_file_names:
             if not file_name.endswith(".tf"):
@@ -69,7 +69,7 @@ def find_modules(path: str, loaded_files_cache: Optional[Dict[str, Any]] = None,
                 # don't scan the modules folder used by Terraform
                 continue
             file_path = os.path.join(root, file_name)
-            if excluded_paths_regex and excluded_paths_regex.match(file_path):
+            if excluded_paths and excluded_paths_regex.search(file_path):
                 continue
 
             data = load_or_die_quietly(file_path, parsing_errors)

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -66,6 +66,9 @@ def find_modules(path: str, loaded_files_cache: Optional[Dict[str, Any]] = None,
                 # don't scan the modules folder used by Terraform
                 continue
             file_path = os.path.join(root, file_name)
+            if file_path in excluded_paths:
+                continue
+
             data = load_or_die_quietly(file_path, parsing_errors)
             if not data:
                 continue

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -8,7 +8,6 @@ from typing import List, Callable, TYPE_CHECKING, Any
 
 from checkov.common.util.env_vars_config import env_vars_config
 from checkov.common.parallelizer.parallel_runner import parallel_runner
-from checkov.common.util.file_utils import read_file_with_any_encoding
 from checkov.terraform.module_loading.registry import module_loader_registry
 from checkov.terraform.parser_utils import load_or_die_quietly
 
@@ -70,7 +69,7 @@ def find_modules(path: str, loaded_files_cache: dict[str, Any] | None = None,
             data = load_or_die_quietly(file_path, parsing_errors)
             if not data:
                 continue
-            
+
             loaded_files_cache[file_path] = data
             if "module" not in data:
                 continue

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from pathlib import Path
 from typing import List, Callable, TYPE_CHECKING, Any, Optional, Dict
 
@@ -58,6 +59,8 @@ def find_modules(path: str, loaded_files_cache: Optional[Dict[str, Any]] = None,
         loaded_files_cache = {}
     if parsing_errors is None:
         parsing_errors = {}
+
+    excluded_paths_regex = re.compile('|'.join(excluded_paths)) if excluded_paths else None
     for root, _, full_file_names in os.walk(path):
         for file_name in full_file_names:
             if not file_name.endswith(".tf"):
@@ -66,7 +69,7 @@ def find_modules(path: str, loaded_files_cache: Optional[Dict[str, Any]] = None,
                 # don't scan the modules folder used by Terraform
                 continue
             file_path = os.path.join(root, file_name)
-            if any(file_path.endswith(excluded_path) for excluded_path in excluded_paths):
+            if excluded_paths_regex and excluded_paths_regex.match(file_path):
                 continue
 
             data = load_or_die_quietly(file_path, parsing_errors)

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -68,25 +68,25 @@ def find_modules(path: str, loaded_files_cache: dict[str, Any] | None = None,
                 continue
             file_path = os.path.join(root, file_name)
             data = load_or_die_quietly(file_path, parsing_errors)
-            if data:
-                loaded_files_cache[file_path] = data
-                if "module" in data:
-                    for module in data["module"]:
-                        for module_name, module_data in module.items():
-                            md = ModuleDownload(os.path.dirname(file_path))
-                            md.module_name = module_name
-                            if "source" in module_data:
-                                md.module_link = module_data["source"][0]
-                            if "version" in module_data:
-                                md.version = module_data["version"][0]
-                            if md.module_link:
-                                md.address = f"{md.module_link}:{md.version}"
-                                modules_found.append(md)
+            if not data:
+                continue
+            
+            loaded_files_cache[file_path] = data
+            if "module" not in data:
+                continue
+            for module in data["module"]:
+                for module_name, module_data in module.items():
+                    md = ModuleDownload(os.path.dirname(file_path))
+                    md.module_name = module_name
+                    md.module_link = module_data.get("source", [None])[0]
+                    md.version = module_data.get("version", [None])[0]
+                    if md.module_link and md.version:
+                        md.address = f"{md.module_link}:{md.version}"
+                        modules_found.append(md)
     return modules_found
 
 
 def should_download(path: str | None) -> bool:
-
     return path is not None and not (path.startswith('./') or path.startswith('../') or path.startswith('/'))
 
 

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -69,7 +69,7 @@ def find_modules(path: str, loaded_files_cache: Optional[Dict[str, Any]] = None,
                 # don't scan the modules folder used by Terraform
                 continue
             file_path = os.path.join(root, file_name)
-            if excluded_paths and excluded_paths_regex.search(file_path):
+            if excluded_paths_regex and excluded_paths_regex.search(file_path):
                 continue
 
             data = load_or_die_quietly(file_path, parsing_errors)

--- a/checkov/terraform/module_loading/module_finder.py
+++ b/checkov/terraform/module_loading/module_finder.py
@@ -79,9 +79,9 @@ def find_modules(path: str, loaded_files_cache: dict[str, Any] | None = None,
                     md.module_name = module_name
                     md.module_link = module_data.get("source", [None])[0]
                     md.version = module_data.get("version", [None])[0]
-                    if md.module_link and md.version:
-                        md.address = f"{md.module_link}:{md.version}"
-                        modules_found.append(md)
+                    if md.module_link:
+                        md.address = f"{md.module_link}:{md.version}" if md.version else md.module_link
+                    modules_found.append(md)
     return modules_found
 
 

--- a/checkov/terraform/parser_utils.py
+++ b/checkov/terraform/parser_utils.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import threading
+from pathlib import Path
+from typing import Any, cast, Optional, TextIO, Type
+
+import hcl2
+
+from checkov.common.util.env_vars_config import env_vars_config
+from checkov.common.util.stopit import ThreadingTimeout, SignalTimeout
+from checkov.common.util.stopit.utils import BaseTimeout
+from checkov.terraform import validate_malformed_definitions, clean_bad_definitions
+from checkov.terraform.modules.module_utils import _Hcl2Payload
+
+
+def load_or_die_quietly(
+    file: str | Path | os.DirEntry[str], parsing_errors: dict[str, Exception], clean_definitions: bool = True
+) -> Optional[_Hcl2Payload]:
+    """
+    Load JSON or HCL, depending on filename.
+    :return: None if the file can't be loaded
+    """
+    file_path = os.fspath(file)
+    file_name = os.path.basename(file_path)
+
+    if file_name.endswith(".tfvars"):
+        clean_definitions = False
+
+    try:
+        logging.debug(f"Parsing {file_path}")
+
+        with open(file_path, "r", encoding="utf-8-sig") as f:
+            if file_name.endswith(".json"):
+                return cast("_Hcl2Payload", json.load(f))
+            else:
+                raw_data = __parse_with_timeout(f)
+                non_malformed_definitions = validate_malformed_definitions(raw_data)
+                if clean_definitions:
+                    return clean_bad_definitions(non_malformed_definitions)
+                else:
+                    return non_malformed_definitions
+    except Exception as e:
+        logging.debug(f"failed while parsing file {file_path}", exc_info=True)
+        parsing_errors[file_path] = e
+        return None
+
+
+# if we are not running in a thread, run the hcl2.load function with a timeout, to prevent from getting stuck in parsing.
+def __parse_with_timeout(f: TextIO) -> dict[str, list[dict[str, Any]]]:
+    # setting up timeout class
+    timeout_class: Optional[Type[BaseTimeout]] = None
+    if platform.system() == "Windows":
+        timeout_class = ThreadingTimeout
+    elif threading.current_thread() is threading.main_thread():
+        timeout_class = SignalTimeout
+
+    # if we're not running on the main thread, don't use timeout
+    parsing_timeout = env_vars_config.HCL_PARSE_TIMEOUT_SEC or 0
+    if not timeout_class or not parsing_timeout:
+        return hcl2.load(f)
+
+    with timeout_class(parsing_timeout) as to_ctx_mgr:
+        raw_data = hcl2.load(f)
+    if to_ctx_mgr.state == to_ctx_mgr.TIMED_OUT:
+        logging.debug(f"reached timeout when parsing file {f} using hcl2")
+        raise Exception(f"file took more than {parsing_timeout} seconds to parse")
+    return raw_data

--- a/checkov/terraform/tf_parser.py
+++ b/checkov/terraform/tf_parser.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 from collections import defaultdict
-from typing import Optional, Dict, Mapping, Set, Tuple, Callable, Any, List, cast, TYPE_CHECKING, overload, TextIO, Type
+from typing import Optional, Dict, Mapping, Set, Tuple, Callable, Any, List, cast, TYPE_CHECKING, overload
 
 from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.runners.base_runner import filter_ignored_paths, IGNORE_HIDDEN_DIRECTORY_ENV

--- a/checkov/terraform/tf_parser.py
+++ b/checkov/terraform/tf_parser.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
-import platform
-import threading
 from collections import defaultdict
 from pathlib import Path
 from typing import Optional, Dict, Mapping, Set, Tuple, Callable, Any, List, cast, TYPE_CHECKING, overload, TextIO, Type

--- a/checkov/terraform/tf_parser.py
+++ b/checkov/terraform/tf_parser.py
@@ -17,15 +17,11 @@ from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR, RESOLVED_MO
 from checkov.common.util.data_structures_utils import pickle_deepcopy
 from checkov.common.util.deep_merge import pickle_deep_merge
 from checkov.common.util.env_vars_config import env_vars_config
-from checkov.common.util.stopit import ThreadingTimeout, SignalTimeout
-from checkov.common.util.stopit.utils import BaseTimeout
 from checkov.common.util.type_forcers import force_list
 from checkov.common.variables.context import EvaluationContext
-from checkov.terraform import validate_malformed_definitions, clean_bad_definitions
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 from checkov.terraform.graph_builder.graph_components.module import Module
 from checkov.terraform.module_loading.content import ModuleContent
-from checkov.terraform.module_loading.module_finder import load_tf_modules
 from checkov.terraform.module_loading.registry import module_loader_registry as default_ml_registry, \
     ModuleLoaderRegistry
 from checkov.common.util.parser_utils import is_acceptable_module_param
@@ -33,6 +29,7 @@ from checkov.terraform.modules.module_utils import safe_index, \
     remove_module_dependency_from_path, \
     clean_parser_types, serialize_definitions, _Hcl2Payload
 from checkov.terraform.modules.module_objects import TFModule, TFDefinitionKey
+from checkov.terraform.parser_utils import load_or_die_quietly
 
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
@@ -105,7 +102,8 @@ class TFParser:
         default_ml_registry.download_external_modules = download_external_modules
         default_ml_registry.external_modules_folder_name = external_modules_download_path
         default_ml_registry.module_content_cache = external_modules_content_cache if external_modules_content_cache else {}
-        load_tf_modules(directory, loaded_files_cache=self.loaded_files_map)
+        from checkov.terraform.module_loading.module_finder import load_tf_modules
+        load_tf_modules(directory, loaded_files_cache=self.loaded_files_map, parsing_errors=self.out_parsing_errors)
         self._parse_directory(dir_filter=lambda d: self._check_process_dir(d), vars_files=vars_files)
         self._update_resolved_modules()
         return self.out_definitions
@@ -699,57 +697,3 @@ def get_tf_definition_object_from_module_dependency(
         return TFDefinitionKey(path.file_path, TFModule(path=module_dependency.file_path, name=module_dependency_name))
     return TFDefinitionKey(path.file_path, TFModule(path=module_dependency.file_path, name=module_dependency_name,
                                                     nested_tf_module=module_dependency.tf_source_modules))
-
-
-def load_or_die_quietly(
-        file: str | Path | os.DirEntry[str], parsing_errors: dict[str, Exception], clean_definitions: bool = True
-) -> Optional[_Hcl2Payload]:
-    """
-    Load JSON or HCL, depending on filename.
-    :return: None if the file can't be loaded
-    """
-    file_path = os.fspath(file)
-    file_name = os.path.basename(file_path)
-
-    if file_name.endswith('.tfvars'):
-        clean_definitions = False
-
-    try:
-        logging.debug(f"Parsing {file_path}")
-
-        with open(file_path, "r", encoding="utf-8-sig") as f:
-            if file_name.endswith(".json"):
-                return cast("_Hcl2Payload", json.load(f))
-            else:
-                raw_data = __parse_with_timeout(f)
-                non_malformed_definitions = validate_malformed_definitions(raw_data)
-                if clean_definitions:
-                    return clean_bad_definitions(non_malformed_definitions)
-                else:
-                    return non_malformed_definitions
-    except Exception as e:
-        logging.debug(f'failed while parsing file {file_path}', exc_info=True)
-        parsing_errors[file_path] = e
-        return None
-
-
-# if we are not running in a thread, run the hcl2.load function with a timeout, to prevent from getting stuck in parsing.
-def __parse_with_timeout(f: TextIO) -> dict[str, list[dict[str, Any]]]:
-    # setting up timeout class
-    timeout_class: Optional[Type[BaseTimeout]] = None
-    if platform.system() == 'Windows':
-        timeout_class = ThreadingTimeout
-    elif threading.current_thread() is threading.main_thread():
-        timeout_class = SignalTimeout
-
-    # if we're not running on the main thread, don't use timeout
-    parsing_timeout = env_vars_config.HCL_PARSE_TIMEOUT_SEC or 0
-    if not timeout_class or not parsing_timeout:
-        return hcl2.load(f)
-
-    with timeout_class(parsing_timeout) as to_ctx_mgr:
-        raw_data = hcl2.load(f)
-    if to_ctx_mgr.state == to_ctx_mgr.TIMED_OUT:
-        logging.debug(f"reached timeout when parsing file {f} using hcl2")
-        raise Exception(f"file took more than {parsing_timeout} seconds to parse")
-    return raw_data

--- a/checkov/terraform/tf_parser.py
+++ b/checkov/terraform/tf_parser.py
@@ -96,7 +96,7 @@ class TFParser:
         default_ml_registry.download_external_modules = download_external_modules
         default_ml_registry.external_modules_folder_name = external_modules_download_path
         default_ml_registry.module_content_cache = external_modules_content_cache if external_modules_content_cache else {}
-        load_tf_modules(directory, loaded_files_cache=self.loaded_files_map, parsing_errors=self.out_parsing_errors)
+        load_tf_modules(directory, loaded_files_cache=self.loaded_files_map, parsing_errors=self.out_parsing_errors, excluded_paths=self.excluded_paths)
         self._parse_directory(dir_filter=lambda d: self._check_process_dir(d), vars_files=vars_files)
         self._update_resolved_modules()
         return self.out_definitions

--- a/checkov/terraform/tf_parser.py
+++ b/checkov/terraform/tf_parser.py
@@ -24,12 +24,14 @@ from checkov.terraform.graph_builder.graph_components.module import Module
 from checkov.terraform.module_loading.content import ModuleContent
 from checkov.terraform.module_loading.registry import module_loader_registry as default_ml_registry, \
     ModuleLoaderRegistry
+from checkov.terraform.module_loading.module_finder import load_tf_modules
 from checkov.common.util.parser_utils import is_acceptable_module_param
 from checkov.terraform.modules.module_utils import safe_index, \
     remove_module_dependency_from_path, \
     clean_parser_types, serialize_definitions, _Hcl2Payload
 from checkov.terraform.modules.module_objects import TFModule, TFDefinitionKey
 from checkov.terraform.parser_utils import load_or_die_quietly
+
 
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
@@ -102,7 +104,6 @@ class TFParser:
         default_ml_registry.download_external_modules = download_external_modules
         default_ml_registry.external_modules_folder_name = external_modules_download_path
         default_ml_registry.module_content_cache = external_modules_content_cache if external_modules_content_cache else {}
-        from checkov.terraform.module_loading.module_finder import load_tf_modules
         load_tf_modules(directory, loaded_files_cache=self.loaded_files_map, parsing_errors=self.out_parsing_errors)
         self._parse_directory(dir_filter=lambda d: self._check_process_dir(d), vars_files=vars_files)
         self._update_resolved_modules()

--- a/checkov/terraform/tf_parser.py
+++ b/checkov/terraform/tf_parser.py
@@ -105,7 +105,7 @@ class TFParser:
         default_ml_registry.download_external_modules = download_external_modules
         default_ml_registry.external_modules_folder_name = external_modules_download_path
         default_ml_registry.module_content_cache = external_modules_content_cache if external_modules_content_cache else {}
-        load_tf_modules(directory)
+        load_tf_modules(directory, loaded_files_cache=self.loaded_files_map)
         self._parse_directory(dir_filter=lambda d: self._check_process_dir(d), vars_files=vars_files)
         self._update_resolved_modules()
         return self.out_definitions

--- a/checkov/terraform/tf_parser.py
+++ b/checkov/terraform/tf_parser.py
@@ -3,17 +3,13 @@ from __future__ import annotations
 import logging
 import os
 from collections import defaultdict
-from pathlib import Path
 from typing import Optional, Dict, Mapping, Set, Tuple, Callable, Any, List, cast, TYPE_CHECKING, overload, TextIO, Type
-
-import hcl2
 
 from checkov.common.parallelizer.parallel_runner import parallel_runner
 from checkov.common.runners.base_runner import filter_ignored_paths, IGNORE_HIDDEN_DIRECTORY_ENV
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR, RESOLVED_MODULE_ENTRY_NAME
 from checkov.common.util.data_structures_utils import pickle_deepcopy
 from checkov.common.util.deep_merge import pickle_deep_merge
-from checkov.common.util.env_vars_config import env_vars_config
 from checkov.common.util.type_forcers import force_list
 from checkov.common.variables.context import EvaluationContext
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
@@ -24,8 +20,7 @@ from checkov.terraform.module_loading.registry import module_loader_registry as 
 from checkov.terraform.module_loading.module_finder import load_tf_modules
 from checkov.common.util.parser_utils import is_acceptable_module_param
 from checkov.terraform.modules.module_utils import safe_index, \
-    remove_module_dependency_from_path, \
-    clean_parser_types, serialize_definitions, _Hcl2Payload
+    remove_module_dependency_from_path, clean_parser_types, serialize_definitions
 from checkov.terraform.modules.module_objects import TFModule, TFDefinitionKey
 from checkov.terraform.parser_utils import load_or_die_quietly
 

--- a/tests/kustomize/test_runner_image_referencer.py
+++ b/tests/kustomize/test_runner_image_referencer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from unittest import mock
 
@@ -21,6 +22,7 @@ RESOURCES_PATH = Path(__file__).parent / "runner/resources"
 
 
 @pytest.mark.xfail(reason="This is probably connected to the OS + kustomize version")
+@pytest.mark.skipif((3, 9) <= sys.version_info < (3, 11), reason="fails on python 3.9 and 3.10 due to path.resolve issues.")
 @pytest.mark.skipif(os.name == "nt" or not kustomize_exists(), reason="kustomize not installed or Windows OS")
 @pytest.mark.parametrize("allow_kustomize_file_edits, code_lines", [
     (True, "18-34"),

--- a/tests/terraform/module_loading/data/nested_modules/main.tf
+++ b/tests/terraform/module_loading/data/nested_modules/main.tf
@@ -1,0 +1,14 @@
+module "example_vm" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.14.0"
+
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  source_image_reference = {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-LTS"
+    version   = "3.15.2"
+  }
+}

--- a/tests/terraform/module_loading/test_tf_module_finder.py
+++ b/tests/terraform/module_loading/test_tf_module_finder.py
@@ -41,6 +41,13 @@ class TestModuleFinder(unittest.TestCase):
             self.assertIn(m, ["terraform-aws-modules/s3-bucket/aws",
                               "../../../../../../../platform/src/stacks/accountStack"])
 
+    def test_module_finder_nested_blocks(self):
+        cur_dir = os.path.abspath(os.path.dirname(__file__))
+        src_dir = os.path.join(cur_dir, 'data', 'nested_modules')
+        modules = find_modules(src_dir)
+        self.assertEqual(1, len(modules))
+        self.assertEqual("3.14.0", modules[0].version)
+
     def test_downloader(self):
         modules = find_modules(self.get_src_dir())
 
@@ -98,4 +105,3 @@ def test_tf_managed_submodules():
     assert modules[1].address == 'somewhere/b:1'
     assert modules[1].module_name == 'a.b'
     assert modules[1].module_link == '.terraform/modules/a.b'
-


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Changed load_modules to use cached hcl2 loaded ast instead of regex for version loading.

Fixes #7216 


### Fix
Fixes how we parse version information so that it is more robust.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
