### PR TITLE
fix(terraform): fix cloning external modules from private regsitries

### DIFF
--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -56,7 +56,7 @@ class GenericGitLoader(ModuleLoader):
                 module_params.module_source = f"{DEFAULT_MODULE_SOURCE_PREFIX}{source}"
             return True
         # https://www.terraform.io/docs/modules/sources.html#generic-git-repository
-        return module_params.module_source.startswith("git::")
+        return module_params.module_source.startswith("git::") and not module_params.module_source.startswith("git::git@github.com")
 
     def _load_module(self, module_params: ModuleParams) -> ModuleContent:
         try:

--- a/checkov/terraform/module_loading/loaders/github_loader.py
+++ b/checkov/terraform/module_loading/loaders/github_loader.py
@@ -21,6 +21,11 @@ class GithubLoader(GenericGitLoader):
             source = module_params.module_source.replace(":", "/")
             module_params.module_source = f"git::ssh://{source}"
             return True
+        if module_params.module_source.startswith(f"git::git@{self.module_source_prefix}"):
+            source = module_params.module_source.replace("git::", "")
+            source = source.replace(":", "/")
+            module_params.module_source = f"git::ssh://{source}"
+            return True
         return False
 
 

--- a/checkov/terraform/module_loading/loaders/github_loader.py
+++ b/checkov/terraform/module_loading/loaders/github_loader.py
@@ -21,6 +21,9 @@ class GithubLoader(GenericGitLoader):
             source = module_params.module_source.replace(":", "/")
             module_params.module_source = f"git::ssh://{source}"
             return True
+        """
+        We should treat git::git@github.com:... the same as git@github.com:...
+        """
         if module_params.module_source.startswith(f"git::git@{self.module_source_prefix}"):
             source = module_params.module_source.replace("git::", "")
             source = source.replace(":", "/")

--- a/checkov/terraform/module_loading/loaders/github_loader.py
+++ b/checkov/terraform/module_loading/loaders/github_loader.py
@@ -21,9 +21,7 @@ class GithubLoader(GenericGitLoader):
             source = module_params.module_source.replace(":", "/")
             module_params.module_source = f"git::ssh://{source}"
             return True
-        """
-        We should treat git::git@github.com:... the same as git@github.com:...
-        """
+        # We should treat git::git@github.com:... the same as git@github.com:...
         if module_params.module_source.startswith(f"git::git@{self.module_source_prefix}"):
             source = module_params.module_source.replace("git::", "")
             source = source.replace(":", "/")

--- a/checkov/terraform/module_loading/registry.py
+++ b/checkov/terraform/module_loading/registry.py
@@ -50,7 +50,7 @@ information, see `loader.ModuleLoader.load`.
         """
         We should treat git::git@github.com:... the same as git@github.com:... for all git based loaders
         """
-        source = source.replace("git::git@", "git@")
+        # source = source.replace("git::git@", "git@")
 
         if module_address is None:
             module_address = f'{source}:{source_version}'

--- a/checkov/terraform/module_loading/registry.py
+++ b/checkov/terraform/module_loading/registry.py
@@ -47,11 +47,6 @@ information, see `loader.ModuleLoader.load`.
         if source is None:
             return None
 
-        """
-        We should treat git::git@github.com:... the same as git@github.com:... for all git based loaders
-        """
-        # source = source.replace("git::git@", "git@")
-
         if module_address is None:
             module_address = f'{source}:{source_version}'
         if module_address in self.module_content_cache:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Private Git registries used RegistryLoader instead of GitLoader.
This fix ensures, the right loader is matched to each source

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
