### PR TITLE
fix(aws): Correct check for Connect Instance Storage Config

### DIFF
--- a/checkov/terraform/checks/resource/aws/ConnectInstanceKinesisVideoStreamStorageConfigUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/ConnectInstanceKinesisVideoStreamStorageConfigUsesCMK.py
@@ -1,4 +1,6 @@
-from checkov.common.models.enums import CheckCategories
+from typing import Dict, List, Any
+
+from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.models.consts import ANY_VALUE
 
@@ -16,6 +18,16 @@ class ConnectInstanceKinesisVideoStreamStorageConfigUsesCMK(BaseResourceValueChe
 
     def get_expected_value(self):
         return ANY_VALUE
+
+    def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
+        """
+        Looks for encryption key_id in kinesis_video_stream_config
+        """
+        storage_config = conf.get("storage_config")
+        if storage_config and isinstance(storage_config, list):
+            if "kinesis_video_stream_config" in storage_config[0]:
+                return super().scan_resource_conf(conf)
+        return CheckResult.UNKNOWN
 
 
 check = ConnectInstanceKinesisVideoStreamStorageConfigUsesCMK()

--- a/checkov/terraform/checks/resource/aws/ConnectInstanceS3StorageConfigUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/ConnectInstanceS3StorageConfigUsesCMK.py
@@ -1,6 +1,6 @@
-from typing import Any
+from typing import Any, Dict, List
 
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.models.consts import ANY_VALUE
 
@@ -18,6 +18,16 @@ class ConnectInstanceS3StorageConfigUsesCMK(BaseResourceValueCheck):
 
     def get_expected_value(self) -> Any:
         return ANY_VALUE
+
+    def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
+        """
+        Looks for encryption key_id in s3_config
+        """
+        storage_config = conf.get("storage_config")
+        if storage_config and isinstance(storage_config, list):
+            if "s3_config" in storage_config[0]:
+                return super().scan_resource_conf(conf)
+        return CheckResult.UNKNOWN
 
 
 check = ConnectInstanceS3StorageConfigUsesCMK()


### PR DESCRIPTION
Fixes #7239. The checks for aws_connect_instance_storage_config were using resource_type to determine which check to run. This was unreliable. This PR changes the logic to check for the presence of s3_config or kinesis_video_stream_config blocks, which is more robust.