### PR TITLE
Fix(#7239): Add resource_type check for Connect instance storage

### DIFF
--- a/checkov/terraform/checks/resource/aws/ConnectInstanceKinesisVideoStreamStorageConfigUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/ConnectInstanceKinesisVideoStreamStorageConfigUsesCMK.py
@@ -1,20 +1,27 @@
-from checkov.common.models.enums import CheckCategories
+from typing import Any
+
+from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.models.consts import ANY_VALUE
 
 
 class ConnectInstanceKinesisVideoStreamStorageConfigUsesCMK(BaseResourceValueCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         name = "Ensure Connect Instance Kinesis Video Stream Storage Config uses CMK"
         id = "CKV_AWS_269"
-        supported_resources = ['aws_connect_instance_storage_config']
-        categories = [CheckCategories.ENCRYPTION]
+        supported_resources = ("aws_connect_instance_storage_config",)
+        categories = (CheckCategories.ENCRYPTION,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self):
-        return 'storage_config/[0]/kinesis_video_stream_config/[0]/encryption_config/[0]/key_id'
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        if conf.get("resource_type") == ["VIDEO_STREAMS"]:
+            return super().scan_resource_conf(conf)
+        return CheckResult.UNKNOWN
 
-    def get_expected_value(self):
+    def get_inspected_key(self) -> str:
+        return "storage_config/[0]/kinesis_video_stream_config/[0]/encryption_config/[0]/key_id"
+
+    def get_expected_value(self) -> Any:
         return ANY_VALUE
 
 

--- a/checkov/terraform/checks/resource/aws/ConnectInstanceS3StorageConfigUsesCMK.py
+++ b/checkov/terraform/checks/resource/aws/ConnectInstanceS3StorageConfigUsesCMK.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.models.consts import ANY_VALUE
 
@@ -12,6 +12,18 @@ class ConnectInstanceS3StorageConfigUsesCMK(BaseResourceValueCheck):
         supported_resources = ("aws_connect_instance_storage_config",)
         categories = (CheckCategories.ENCRYPTION,)
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        if conf.get("resource_type") and conf.get("resource_type")[0] in (
+            "CHAT_TRANSCRIPTS",
+            "CALL_RECORDINGS",
+            "SCHEDULED_REPORTS",
+            "MEDIA_STREAMS",
+            "CONTACT_TRACE_RECORDS",
+            "AGENT_EVENTS",
+        ):
+            return super().scan_resource_conf(conf)
+        return CheckResult.UNKNOWN
 
     def get_inspected_key(self) -> str:
         return "storage_config/[0]/s3_config/[0]/encryption_config/[0]/key_id"


### PR DESCRIPTION
Closes #7239. This PR fixes an issue where the wrong check was being applied to `aws_connect_instance_storage_config` resources. The checks for Kinesis Video Stream and S3 storage now correctly verify the `resource_type` before running.