### PR TITLE
Fix(#7227): CKV_AWS_318 not validating correctly

### DIFF
--- a/checkov/terraform/checks/resource/aws/ElasticsearchDomainHA.py
+++ b/checkov/terraform/checks/resource/aws/ElasticsearchDomainHA.py
@@ -21,6 +21,10 @@ class ElasticsearchDomainHA(BaseResourceCheck):
         self.evaluated_keys = ["cluster_config"]
         config = conf.get("cluster_config")
         if config and isinstance(config, list):
+            master_enabled = config[0].get("dedicated_master_enabled")
+            if not master_enabled or not isinstance(master_enabled, list) or not master_enabled[0]:
+                return CheckResult.FAILED
+
             master_count = config[0].get("dedicated_master_count")
             if (
                 master_count

--- a/tests/terraform/checks/resource/aws/example_ElasticsearchDomainHA/opensearch.tf
+++ b/tests/terraform/checks/resource/aws/example_ElasticsearchDomainHA/opensearch.tf
@@ -16,6 +16,7 @@ resource "aws_opensearch_domain" "pass" {
   engine_version = "Elasticsearch_7.10"
 
   cluster_config {
+    dedicated_master_enabled = true
     dedicated_master_count = 3
     instance_type = "r4.large.search"
     zone_awareness_enabled = true
@@ -43,6 +44,18 @@ resource "aws_opensearch_domain" "fail2" {
   cluster_config {
     instance_type = "r4.large.search"
     dedicated_master_count = 3
+  }
+}
+
+resource "aws_opensearch_domain" "fail3" {
+  domain_name    = "example"
+  engine_version = "Elasticsearch_7.10"
+
+  cluster_config {
+    dedicated_master_enabled = false
+    dedicated_master_count   = 3
+    instance_type            = "r4.large.search"
+    zone_awareness_enabled   = true
   }
 
   tags = {

--- a/tests/terraform/checks/resource/aws/test_ElasticsearchDomainHA.py
+++ b/tests/terraform/checks/resource/aws/test_ElasticsearchDomainHA.py
@@ -27,6 +27,7 @@ class TestElasticsearchDomainHA(unittest.TestCase):
             "aws_elasticsearch_domain.fail2",
             "aws_opensearch_domain.fail",
             "aws_opensearch_domain.fail2",
+            "aws_opensearch_domain.fail3",
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}


### PR DESCRIPTION
Closes #7227. This PR fixes an issue where CKV_AWS_318 was not correctly validating the `dedicated_master_enabled` property for OpenSearch domains.