### PR TITLE
fix(AWS_103): Loosen ALB TLS policy prefix

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ALBListenerTLS12.py
+++ b/checkov/cloudformation/checks/resource/aws/ALBListenerTLS12.py
@@ -12,7 +12,7 @@ supported_policy_prefixes = {
     'HTTPS': ("ELBSecurityPolicy-FS-1-2", "ELBSecurityPolicy-TLS-1-2", "ELBSecurityPolicy-TLS13-1-2",
               "ELBSecurityPolicy-TLS13-1-3"),
     # NLBs support TLS v1.2 and 1.3
-    'TLS': ("ELBSecurityPolicy-TLS13-1-3-2021-06", "ELBSecurityPolicy-TLS13-1-2", "ELBSecurityPolicy-FS-1-2",
+    'TLS': ("ELBSecurityPolicy-TLS13-1-3", "ELBSecurityPolicy-TLS13-1-2", "ELBSecurityPolicy-FS-1-2",
             "ELBSecurityPolicy-TLS-1-2")
 }
 


### PR DESCRIPTION
This PR fixes issue #7184 by updating the TLS policy prefix for the `CKV_AWS_103` check to be less specific. This allows the check to correctly validate newer TLS policies.