### PR TITLE
fix(aws): Loosen TLS policy prefix for CKV_AWS_103

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ALBListenerTLS12.py
+++ b/checkov/cloudformation/checks/resource/aws/ALBListenerTLS12.py
@@ -12,7 +12,7 @@ supported_policy_prefixes = {
     'HTTPS': ("ELBSecurityPolicy-FS-1-2", "ELBSecurityPolicy-TLS-1-2", "ELBSecurityPolicy-TLS13-1-2",
               "ELBSecurityPolicy-TLS13-1-3"),
     # NLBs support TLS v1.2 and 1.3
-    'TLS': ("ELBSecurityPolicy-TLS13-1-3-2021-06", "ELBSecurityPolicy-TLS13-1-2", "ELBSecurityPolicy-FS-1-2",
+    'TLS': ("ELBSecurityPolicy-TLS13-1-3", "ELBSecurityPolicy-TLS13-1-2", "ELBSecurityPolicy-FS-1-2",
             "ELBSecurityPolicy-TLS-1-2")
 }
 

--- a/tests/cloudformation/checks/resource/aws/example_ALBListenerTLS12/ALBListenerTLS1.3-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ALBListenerTLS12/ALBListenerTLS1.3-PASSED.yaml
@@ -36,3 +36,15 @@ Resources:
       DefaultActions:
         - Type: forward
           TargetGroupArn: default-target-group
+  ListenerHTTPSPASS14:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ApplicationLoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: test-cert
+      SslPolicy: ELBSecurityPolicy-TLS13-1-3-FIPS-2023-04
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: default-target-group

--- a/tests/cloudformation/checks/resource/aws/test_ALBListenerTLS12.py
+++ b/tests/cloudformation/checks/resource/aws/test_ALBListenerTLS12.py
@@ -23,7 +23,8 @@ class TestALBListenerTLS12(unittest.TestCase):
             'AWS::ElasticLoadBalancingV2::Listener.ListenerTLSPASSED2',
             'AWS::ElasticLoadBalancingV2::Listener.ListenerTLSPASSED3',
             'AWS::ElasticLoadBalancingV2::Listener.ListenerTCPPASSED4',
-            'AWS::ElasticLoadBalancingV2::Listener.ListenerHTTPSPASS13'
+            'AWS::ElasticLoadBalancingV2::Listener.ListenerHTTPSPASS13',
+            'AWS::ElasticLoadBalancingV2::Listener.ListenerHTTPSPASS14'
         }
 
         failing_resources = {


### PR DESCRIPTION
Fixes #7184

- The check for ALB/NLB TLS policies was too specific and failed for valid policies with additional suffixes like '-FIPS-'.
- This change makes the prefix check less strict to support a wider range of valid policy names.