### PR TITLE
fix(cloudformation): Update TLS policy for ALB listener

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ALBListenerTLS12.py
+++ b/checkov/cloudformation/checks/resource/aws/ALBListenerTLS12.py
@@ -12,7 +12,7 @@ supported_policy_prefixes = {
     'HTTPS': ("ELBSecurityPolicy-FS-1-2", "ELBSecurityPolicy-TLS-1-2", "ELBSecurityPolicy-TLS13-1-2",
               "ELBSecurityPolicy-TLS13-1-3"),
     # NLBs support TLS v1.2 and 1.3
-    'TLS': ("ELBSecurityPolicy-TLS13-1-3-2021-06", "ELBSecurityPolicy-TLS13-1-2", "ELBSecurityPolicy-FS-1-2",
+    'TLS': ("ELBSecurityPolicy-TLS13-1-3", "ELBSecurityPolicy-TLS13-1-2", "ELBSecurityPolicy-FS-1-2",
             "ELBSecurityPolicy-TLS-1-2")
 }
 

--- a/tests/cloudformation/checks/resource/aws/example_ALBListenerTLS12/ALBListenerTLS1.2-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ALBListenerTLS12/ALBListenerTLS1.2-PASSED.yaml
@@ -113,7 +113,7 @@ Resources:
       Protocol: TLS
       Certificates:
         - CertificateArn: test-cert
-      SslPolicy: ELBSecurityPolicy-TLS13-1-3-2021-06
+      SslPolicy: ELBSecurityPolicy-TLS13-1-3-FIPS-2023-04
       DefaultActions:
         - Type: forward
           TargetGroupArn: default-target-group

--- a/tests/cloudformation/checks/resource/aws/example_ALBListenerTLS12/ALBListenerTLS1.3-PASSED.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_ALBListenerTLS12/ALBListenerTLS1.3-PASSED.yaml
@@ -32,7 +32,7 @@ Resources:
       Protocol: HTTPS
       Certificates:
         - CertificateArn: test-cert
-      SslPolicy: ELBSecurityPolicy-TLS13-1-3-2021-06
+      SslPolicy: ELBSecurityPolicy-TLS13-1-3-FIPS-2023-04
       DefaultActions:
         - Type: forward
           TargetGroupArn: default-target-group


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

This PR updates the supported TLS policies for ALB listeners to be less specific, allowing for newer versions of the `ELBSecurityPolicy-TLS13-1-3` policy.

Fixes #7184

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes