### PR TITLE
chore(terraform): VariableRenderer - add caching for _update_end_vertices_indexes

### DIFF
--- a/checkov/common/graph/graph_builder/variable_rendering/renderer.py
+++ b/checkov/common/graph/graph_builder/variable_rendering/renderer.py
@@ -42,10 +42,10 @@ class VariableRenderer(ABC, Generic[_LocalGraph]):
         if self.vertices_index_to_render:
             edges_to_render = self._remove_unrelated_edges(edges_to_render)
 
-        evaluated_edges_cache: list[list[Edge]] = [[], []]
-        duplicates_count = 0
         end_vertices_indexes = set()
         loops = 0
+        evaluated_edges_cache: list[list[Edge]] = [[], []]
+        duplicates_count = 0
 
         while edges_to_render:
             evaluated_edges_two_iter_ago = evaluated_edges_cache[-2]
@@ -57,7 +57,7 @@ class VariableRenderer(ABC, Generic[_LocalGraph]):
                 logging.info(f"Reached too many edge duplications of {self.duplicate_percent}% for {self.duplicate_iter_count} iterations. breaking.")
                 break
             evaluated_edges_cache.append(edges_to_render)
-            logging.debug(f"evaluating {len(edges_to_render)} edges; loops={loops}")
+            logging.debug(f"evaluating {len(edges_to_render)} edges; loop_num={loops}")
 
             edges_groups = self.group_edges_by_origin_and_label(edges_to_render)
 

--- a/checkov/common/graph/graph_builder/variable_rendering/renderer.py
+++ b/checkov/common/graph/graph_builder/variable_rendering/renderer.py
@@ -78,11 +78,12 @@ class VariableRenderer(ABC, Generic[_LocalGraph]):
                 logging.warning("Reached max graph edge evaluation loops, breaking.")
                 break
 
-        if not self.vertices_index_to_render:
-            self.local_graph.update_vertices_configs()
-            logging.debug("done evaluating edges")
-            self.evaluate_non_rendered_values()
-            logging.debug("Done evaluating non-rendered values")
+        if self.vertices_index_to_render:
+            return
+        self.local_graph.update_vertices_configs()
+        logging.debug("done evaluating edges")
+        self.evaluate_non_rendered_values()
+        logging.debug("done evaluate_non_rendered_values")
 
     def _get_initial_end_vertices(self) -> set[int]:
         return self.local_graph.get_vertices_with_degrees_conditions(

--- a/checkov/common/graph/graph_builder/variable_rendering/renderer.py
+++ b/checkov/common/graph/graph_builder/variable_rendering/renderer.py
@@ -75,7 +75,7 @@ class VariableRenderer(ABC, Generic[_LocalGraph]):
 
             loops += 1
             if loops >= self.MAX_NUMBER_OF_LOOPS:
-                logging.warning("Reached max graph edge evaluation loops, breaking.")
+                logging.warning(f"Reached max ({self.MAX_NUMBER_OF_LOOPS}) graph edge evaluation loops, breaking.")
                 break
 
         if self.vertices_index_to_render:

--- a/checkov/common/graph/graph_builder/variable_rendering/renderer.py
+++ b/checkov/common/graph/graph_builder/variable_rendering/renderer.py
@@ -37,20 +37,16 @@ class VariableRenderer(ABC, Generic[_LocalGraph]):
         self._render_variables_from_vertices()
 
     def _render_variables_from_edges(self) -> None:
-        # find vertices with out-degree = 0 and in-degree > 0
-        end_vertices_indexes = self.local_graph.get_vertices_with_degrees_conditions(
-            out_degree_cond=lambda degree: degree == 0, in_degree_cond=lambda degree: degree > 0
-        )
-
-        # all the edges entering `end_vertices`
+        end_vertices_indexes = self._get_initial_end_vertices()
         edges_to_render = self.local_graph.get_in_edges(end_vertices_indexes)
         if self.vertices_index_to_render:
             edges_to_render = self._remove_unrelated_edges(edges_to_render)
 
-        end_vertices_indexes = set()
-        loops = 0
         evaluated_edges_cache: list[list[Edge]] = [[], []]
         duplicates_count = 0
+        end_vertices_indexes = set()
+        loops = 0
+
         while edges_to_render:
             evaluated_edges_two_iter_ago = evaluated_edges_cache[-2]
             intersection_edges = set(edges_to_render).intersection(evaluated_edges_two_iter_ago)
@@ -61,46 +57,72 @@ class VariableRenderer(ABC, Generic[_LocalGraph]):
                 logging.info(f"Reached too many edge duplications of {self.duplicate_percent}% for {self.duplicate_iter_count} iterations. breaking.")
                 break
             evaluated_edges_cache.append(edges_to_render)
+            logging.debug(f"evaluating {len(edges_to_render)} edges; loops={loops}")
 
-            logging.debug(f"evaluating {len(edges_to_render)} edges")
-            # group edges that have the same origin and label together
             edges_groups = self.group_edges_by_origin_and_label(edges_to_render)
-            if self.run_async:
-                run_function_multithreaded(
-                    func=self._edge_evaluation_task,
-                    data=edges_groups,
-                    max_group_size=1,
-                    num_of_workers=self.max_workers,
-                )
-            else:
-                for edge_group in edges_groups:
-                    self._edge_evaluation_task([edge_group])
-            for edge in edges_to_render:
-                origin = edge.origin
-                self.done_edges_by_origin_vertex.setdefault(origin, []).append(edge)
 
-            for edge in edges_to_render:
-                origin_vertex_index = edge.origin
-                out_edges = set(self.local_graph.out_edges.get(origin_vertex_index, []))
-                done_edges_for_origin = self.done_edges_by_origin_vertex.get(origin_vertex_index, [])
-                if out_edges.issubset(done_edges_for_origin):
-                    end_vertices_indexes.add(origin_vertex_index)
+            self._evaluate_edge_groups(edges_groups)
+
+            self._update_done_edges_by_origin_vertex(edges_to_render)
+
+            self._update_end_vertices_indexes(edges_to_render, end_vertices_indexes)
+
             new_edges_to_render = self.local_graph.get_in_edges_deduped(end_vertices_indexes)
+
             edges_to_render = self.local_graph.sort_edged_by_dest_out_degree(
                 new_edges_to_render - set(edges_to_render)
             )
 
             loops += 1
             if loops >= self.MAX_NUMBER_OF_LOOPS:
-                logging.warning("Reached 50 graph edge iterations, breaking.")
+                logging.warning("Reached max graph edge evaluation loops, breaking.")
                 break
 
-        if self.vertices_index_to_render:
-            return
-        self.local_graph.update_vertices_configs()
-        logging.debug("done evaluating edges")
-        self.evaluate_non_rendered_values()
-        logging.debug("done evaluate_non_rendered_values")
+        if not self.vertices_index_to_render:
+            self.local_graph.update_vertices_configs()
+            logging.debug("done evaluating edges")
+            self.evaluate_non_rendered_values()
+            logging.debug("Done evaluating non-rendered values")
+
+    def _get_initial_end_vertices(self) -> set[int]:
+        return self.local_graph.get_vertices_with_degrees_conditions(
+            out_degree_cond=lambda d: d == 0,
+            in_degree_cond=lambda d: d > 0,
+        )
+
+    def _evaluate_edge_groups(self, edges_groups: list[list[Edge]]) -> None:
+        if self.run_async:
+            run_function_multithreaded(
+                func=self._edge_evaluation_task,
+                data=edges_groups,
+                max_group_size=1,
+                num_of_workers=self.max_workers,
+            )
+        else:
+            for edge_group in edges_groups:
+                self._edge_evaluation_task([edge_group])
+
+    def _update_done_edges_by_origin_vertex(self, edges_to_render: list[Edge]) -> None:
+        for edge in edges_to_render:
+            origin = edge.origin
+            self.done_edges_by_origin_vertex.setdefault(origin, []).append(edge)
+
+    def _update_end_vertices_indexes(self, edges_to_render: list[Edge], end_vertices_indexes: set[int]) -> None:
+        already_checked: set[int] = set()
+
+        for edge in edges_to_render:
+            origin_vertex_index = edge.origin
+
+            # Only check each origin once
+            if origin_vertex_index in already_checked:
+                continue
+            already_checked.add(origin_vertex_index)
+
+            out_edges = set(self.local_graph.out_edges.get(origin_vertex_index, []))
+            done_edges_for_origin = set(self.done_edges_by_origin_vertex.get(origin_vertex_index, []))
+
+            if out_edges.issubset(done_edges_for_origin):
+                end_vertices_indexes.add(origin_vertex_index)
 
     @abstractmethod
     def _render_variables_from_vertices(self) -> None:


### PR DESCRIPTION
this method perf can be optimized by introducing caching: `for edge in edges_to_render` can go over the same edge multiple times.
also - refactor the entire render_variables_from_edges method - split to multiple private methods.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
