### PR TITLE
fix(terraform): Parse continue as a string rather as a python object

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
+++ b/checkov/terraform/graph_builder/variable_rendering/safe_eval_functions.py
@@ -280,7 +280,6 @@ def terraform_try(*args: Any) -> Any:
 SAFE_EVAL_FUNCTIONS: List[str] = []
 SAFE_EVAL_DICT = dict([(k, locals().get(k, None)) for k in SAFE_EVAL_FUNCTIONS])
 
-
 # type conversion functions
 TRY_STR_REPLACEMENT = "__terraform_try__"
 SAFE_EVAL_DICT[TRY_STR_REPLACEMENT] = terraform_try
@@ -380,6 +379,8 @@ def evaluate(input_str: str) -> Any:
 
         # Don't use str.replace to make sure we replace just the first occurrence
         input_str = f"{TRY_STR_REPLACEMENT}{input_str[3:]}"
+    if input_str == "continue":
+        return input_str
     asteval = get_asteval()
     log_level = os.getenv("LOG_LEVEL")
     should_log_asteval_errors = log_level == "DEBUG"

--- a/tests/terraform/graph/variable_rendering/test_string_evaluation.py
+++ b/tests/terraform/graph/variable_rendering/test_string_evaluation.py
@@ -537,6 +537,11 @@ class TestTerraformEvaluation(TestCase):
         result = evaluate_terraform(input_str)
         assert result == expected
 
+    def test_continue_stays_the_same(self):
+        expected = "continue"
+        result = evaluate_terraform("continue")
+        self.assertEqual(expected, result)
+
 
 @pytest.mark.parametrize(
     "origin_str,str_to_replace,new_value,expected",


### PR DESCRIPTION
### Description
When parsing "continue" using `asteval` we evaluated as the saved word "continue" in python, however that can be a regular default string in terraform

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
