### PR TITLE
fix(terraform): Handled git external module loading with sub-directory but without protocol

### DIFF
--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -12,7 +12,6 @@ import aiohttp
 import asyncio
 from typing import Any, TYPE_CHECKING, cast, Optional, overload
 
-from checkov.common.util import env_vars_config
 from urllib3.response import HTTPResponse
 from urllib3.util import parse_url
 
@@ -213,6 +212,8 @@ async def aiohttp_client_session_wrapper(
         headers: dict[str, Any],
         payload: dict[str, Any] | None = None,
 ) -> ClientResponse:
+    from checkov.common.util import env_vars_config
+
     request_max_tries = int(os.getenv('REQUEST_MAX_TRIES', 3))
     sleep_between_request_tries = float(os.getenv('SLEEP_BETWEEN_REQUEST_TRIES', 1))
 

--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -106,12 +106,15 @@ class GenericGitLoader(ModuleLoader):
 
         if len(module_source_components) < 3:
             if len(module_source_components) == 2 and "git::git" in module_source_components[0]:
+                # Handling the use case of `git::git@github.com:test-inner-module/out-module//inner-module`
                 root_module = module_source_components[-2]
                 inner_module = module_source_components[-1]
             else:
+                # Handling the use case of `git::<any-protocol>@github.com:test-no-inner-module/out-module`
                 root_module = module_source_components[-1]
                 inner_module = ""
         elif len(module_source_components) == 3:
+            # Handling the use case of `git::<any-protocol>://github.com:test-inner-module/out-module//inner-module`
             root_module = module_source_components[1]
             inner_module = module_source_components[2]
         else:

--- a/checkov/terraform/module_loading/loaders/git_loader.py
+++ b/checkov/terraform/module_loading/loaders/git_loader.py
@@ -105,8 +105,12 @@ class GenericGitLoader(ModuleLoader):
             version = "HEAD"
 
         if len(module_source_components) < 3:
-            root_module = module_source_components[-1]
-            inner_module = ""
+            if len(module_source_components) == 2 and "git::git" in module_source_components[0]:
+                root_module = module_source_components[-2]
+                inner_module = module_source_components[-1]
+            else:
+                root_module = module_source_components[-1]
+                inner_module = ""
         elif len(module_source_components) == 3:
             root_module = module_source_components[1]
             inner_module = module_source_components[2]

--- a/tests/terraform/module_loading/loaders/test_git_loader.py
+++ b/tests/terraform/module_loading/loaders/test_git_loader.py
@@ -1,0 +1,36 @@
+import pytest
+
+from checkov.terraform.module_loading.loaders.git_loader import GenericGitLoader
+from checkov.terraform.module_loading.module_params import ModuleParams
+
+
+@pytest.mark.parametrize("source, expected_root_module, expected_inner_module", [
+    ("git::git@github.com:test-inner-module/out-module//inner-module?ref=main",
+     "github.com:test-inner-module/out-module", "inner-module"),
+    ("git::https://github.com:test-inner-module/out-module//inner-module?ref=main",
+     "github.com:test-inner-module/out-module", "inner-module"),
+    ("git::https://github.com:test-only-outer-module/out-module",
+     "github.com:test-only-outer-module/out-module", ""),
+    ("git::ssh://github.com:test-only-outer-module/out-module",
+     "github.com:test-only-outer-module/out-module", ""),
+    ("https://github.com:test-only-outer-module/out-module",
+     "github.com:test-only-outer-module/out-module", ""),
+    ("https://github.com:test-with-inner-module-no-git-prefix/out-module//in-module",
+     "github.com:test-with-inner-module-no-git-prefix/out-module", "in-module")
+]
+                         )
+def test__parse_module_source(source: str, expected_root_module: str, expected_inner_module: str) -> None:
+    git_loader = GenericGitLoader()
+    module_params = ModuleParams(
+        root_dir="test",
+        current_dir="test",
+        source=source,
+        source_version="source_version",
+        dest_dir="test",
+        external_modules_folder_name="test",
+        inner_module="",
+        tf_managed=False
+    )
+    module_source = git_loader._parse_module_source(module_params)
+    assert module_source.root_module == expected_root_module
+    assert module_source.inner_module == expected_inner_module


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
Handled git external module loading with sub-directory but without protocol, specifically when using `git::git` rather than `git::https://...` (or any other protocol instead of https).
This makes sure we correctly parse the sub-directory inside the source url.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
