### PR TITLE
Fix downloading of the external modules when ref is a shortened Git hash

### DIFF
--- a/checkov/common/goget/github/get_git.py
+++ b/checkov/common/goget/github/get_git.py
@@ -15,7 +15,7 @@ try:
 except ImportError as e:
     git_import_error = e
 
-COMMIT_ID_PATTERN = re.compile(r"\?(ref=)(?P<commit_id>([0-9a-f]{40}))")
+COMMIT_ID_PATTERN = re.compile(r"\?(ref=)(?P<commit_id>([0-9a-f]{5,40}))")
 TAG_PATTERN = re.compile(r'\?(ref=)(?P<tag>(.*))')  # technically should be with ?ref=tags/ but this catches both
 BRANCH_PATTERN = re.compile(r'\?(ref=heads/)(?P<branch>(.*))')
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

When external modules are pulled by using shortened version of the git hash, checkov fails to pull it and outputs:
```
2025-08-06 13:19:38,194 [MainThread  ] [WARNI]  failed to get git::https://github.com/rynkowsg/tf-modules?ref=f6a8868 in git loader because of Cmd('git') failed due to: exit code(128)                                                                      
  cmdline: git clone -v --depth=1 -b f6a8868 -- https://github.com/rynkowsg/tf-modules <my-repo-full-path>/.external_modules/github.com/rynkowsg/tf-modules/f6a8868                                                         
  stderr: 'Cloning into '<my-repo-full-path>/.external_modules/github.com/rynkowsg/tf-modules/f6a8868'...                                                                                                                   
POST git-upload-pack (356 bytes)                                                                                                                                                                                                                             
fatal: Remote branch f6a8868 not found in upstream origin
```

Fixes #7267

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
Change regex to accept shortened version of a commit hash 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
