### PR TITLE
fix(helm): Make Helm template detection less aggressive

### DIFF
--- a/checkov/kubernetes/parser/k8_yaml.py
+++ b/checkov/kubernetes/parser/k8_yaml.py
@@ -37,8 +37,7 @@ def load(filename: Path) -> Tuple[List[Dict[str, Any]], List[Tuple[int, str]]]:
     """
     Load the given YAML file
     """
-    helm_template_patterns = [r"\{\{-?\s*\.Release\.", r"\{\{-?\s*\.Values\.",
-                              r"\{\{-?\s*if\s", r"\{\{-?\s*end\s", r"\{\{-?\s*with\s"]
+    helm_template_patterns = [r"\{\{-?\s*\.Release\.", r"\{\{-?\s*\.Values\."]
 
     content = read_file_with_any_encoding(file_path=filename)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

This change addresses an issue where the Helm parser was too aggressive in its detection of Helm templates, causing it to incorrectly identify and skip valid, rendered Kubernetes manifests that contained other templating languages (like HashiCorp Vault) in their annotations.

### Motivation and Context
When scanning a Helm chart, `checkov` first renders the chart using `helm template` and then scans the resulting Kubernetes YAML. However, a regex-based check was in place to prevent the scanning of un-rendered Helm templates. This check was too broad and was incorrectly triggered by the syntax of other templating languages, such as the `{{- with secret ... }}` syntax used by HashiCorp Vault in annotations.

This resulted in `checkov` producing empty results for Helm charts that used these other templating languages, as it would incorrectly identify the rendered YAML as an un-rendered template and skip it.

### Description of the Change
This PR modifies the `helm_template_patterns` in `checkov/kubernetes/parser/k8_yaml.py` to be more specific to Helm templates. It removes the generic checks for `if`, `end`, and `with` statements, and relies only on the presence of `.Release.` and `.Values.` to identify un-rendered Helm templates.

This change ensures that `checkov` can correctly scan rendered Helm charts that include other templating languages in their annotations, without affecting its ability to handle standard Helm charts.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
