### PR TITLE
docs(general): Add JAVA_FULL_DT environment variable to CLI reference

### DIFF
--- a/docs/2.Basics/CLI Command Reference.md
+++ b/docs/2.Basics/CLI Command Reference.md
@@ -81,3 +81,4 @@ nav_order: 2
 | `ENABLE_CONFIG_FILE_VALIDATION` | If the conf-file explicitly set using the `--config-file` command does not exist, skip rather than throw an error (default) | `False` |
 | `CHECKOV_MAX_IAC_FILE_SIZE` | Set the max size for CloudFormation file scans. | `50_000_000` or 50MB |
 | `CHECKOV_MAX_FILE_SIZE` | Set the max file size for Secrets scans. | `5000000` or 5MB |
+| `JAVA_FULL_DT` | Enables a deeper SCA scan for Java projects to resolve the full dependency tree, including transitive dependencies. | `False` |


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description
Add JAVA_FULL_DT environment variable to CLI reference docs


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
