### PR TITLE
feat(terraform): fix foreach module handling

### DIFF
--- a/checkov/terraform/graph_builder/foreach/module_handler.py
+++ b/checkov/terraform/graph_builder/foreach/module_handler.py
@@ -299,17 +299,18 @@ class ForeachModuleHandler(ForeachAbstractHandler):
         if isinstance(config, dict):
             resolved_module_name = config.get(RESOLVED_MODULE_ENTRY_NAME)
             if resolved_module_name is not None and len(resolved_module_name) > 0:
-                original_definition_key = config[RESOLVED_MODULE_ENTRY_NAME][0]
-                if isinstance(original_definition_key, str):
-                    original_definition_key = TFDefinitionKey.from_json(json.loads(original_definition_key))
-                resolved_tf_source_module = TFDefinitionKey.from_json(json.loads(resolved_module_name[0])) if isinstance(resolved_module_name[0], str) else resolved_module_name[0]
-                tf_source_modules = ForeachModuleHandler._get_module_with_only_relevant_foreach_idx(
-                    original_foreach_or_count_key,
-                    original_module_key,
-                    resolved_tf_source_module.tf_source_modules,
-                )
-                config[RESOLVED_MODULE_ENTRY_NAME][0] = TFDefinitionKey(file_path=original_definition_key.file_path,
-                                                                        tf_source_modules=tf_source_modules)
+                # iterate over each item in the resolved list and override it with updated data
+                for idx, original_definition_key in enumerate(resolved_module_name):
+                    if isinstance(original_definition_key, str):
+                        original_definition_key = TFDefinitionKey.from_json(json.loads(original_definition_key))
+                    resolved_tf_source_module = TFDefinitionKey.from_json(json.loads(resolved_module_name[idx])) if isinstance(resolved_module_name[idx], str) else resolved_module_name[idx]
+                    tf_source_modules = ForeachModuleHandler._get_module_with_only_relevant_foreach_idx(
+                        original_foreach_or_count_key,
+                        original_module_key,
+                        resolved_tf_source_module.tf_source_modules,
+                    )
+                    resolved_module_name[idx] = TFDefinitionKey(file_path=original_definition_key.file_path,
+                                                                tf_source_modules=tf_source_modules)
 
     @staticmethod
     def _get_module_with_only_relevant_foreach_idx(original_foreach_or_count_key: int | str,

--- a/tests/terraform/runner/resources/for_each/main.tf
+++ b/tests/terraform/runner/resources/for_each/main.tf
@@ -1,8 +1,8 @@
 
 module "simple" {
-  source   = "./simple"
+  source = "./simple"
   bucket = "my_bucket"
-  key = "my_key"
-  count = 2
-  # checkov:skip=CKV_AWS_21:Testing
+  key    = "my_key"
+  count  = 2
+  # checkov:skip=CKV_AWS_88:Testing
 }

--- a/tests/terraform/runner/resources/for_each/main.tf
+++ b/tests/terraform/runner/resources/for_each/main.tf
@@ -1,5 +1,8 @@
 
 module "simple" {
   source   = "./simple"
+  bucket = "my_bucket"
+  key = "my_key"
   count = 2
+  # checkov:skip=CKV_AWS_21:Testing
 }

--- a/tests/terraform/runner/resources/for_each/simple/alerts.tf
+++ b/tests/terraform/runner/resources/for_each/simple/alerts.tf
@@ -1,0 +1,3 @@
+locals {
+  alerts = 0
+}

--- a/tests/terraform/runner/resources/for_each/simple/main.tf
+++ b/tests/terraform/runner/resources/for_each/simple/main.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket_object" "this_file" {
-  bucket   = "your_bucket_name"
-  key      = "readme.md"
   source   = "readme.md"
+}
+
+resource "aws_s3_bucket" "my_bucket" {
 }

--- a/tests/terraform/runner/resources/for_each/simple/main.tf
+++ b/tests/terraform/runner/resources/for_each/simple/main.tf
@@ -2,5 +2,8 @@ resource "aws_s3_bucket_object" "this_file" {
   source   = "readme.md"
 }
 
-resource "aws_s3_bucket" "my_bucket" {
+resource "aws_instance" "public_server" {
+  ami           = "ami-0abcdef1234567890"
+  instance_type = "t2.micro"
+  associate_public_ip_address = true
 }

--- a/tests/terraform/runner/resources/for_each/simple/outputs.tf
+++ b/tests/terraform/runner/resources/for_each/simple/outputs.tf
@@ -1,0 +1,6 @@
+output "account_id" {
+  description = "Storage account resource ID."
+  value       = azurerm_storage_account.id
+}
+
+

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -160,7 +160,7 @@ class TestRunnerValid(unittest.TestCase):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         valid_dir_path = current_dir + "/resources/for_each"
         runner = Runner(db_connector=self.db_connector())
-        checks_allowlist = ['CKV_AWS_186', 'CKV_AWS_21']
+        checks_allowlist = ['CKV_AWS_186', 'CKV_AWS_88']
         report = runner.run(root_folder=valid_dir_path, runner_filter=RunnerFilter(framework=["terraform"], checks=checks_allowlist))
         report_json = report.get_json()
         self.assertIsInstance(report_json, str)

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -160,13 +160,14 @@ class TestRunnerValid(unittest.TestCase):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         valid_dir_path = current_dir + "/resources/for_each"
         runner = Runner(db_connector=self.db_connector())
-        checks_allowlist = ['CKV_AWS_186']
+        checks_allowlist = ['CKV_AWS_186', 'CKV_AWS_21']
         report = runner.run(root_folder=valid_dir_path, runner_filter=RunnerFilter(framework=["terraform"], checks=checks_allowlist))
         report_json = report.get_json()
         self.assertIsInstance(report_json, str)
         self.assertIsNotNone(report_json)
         self.assertIsNotNone(report.get_test_suite())
         assert len(report.failed_checks) == 2
+        assert len(report.skipped_checks) == 2
         assert len(report.passed_checks) == 0
         failed_resources = [c.resource for c in report.failed_checks]
         assert 'module.simple[0].aws_s3_bucket_object.this_file' in failed_resources


### PR DESCRIPTION
This PR fixes handling of for_each modules where only the first instance used to be populated with the updated for_each attributes. Now we iterate over the entire list.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
