### PR TITLE
fix(terraform_plan): Don't add values to empty list values in after_unknown

### DIFF
--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -263,9 +263,21 @@ def _handle_complex_after_unknown(k: str, resource_conf: dict[str, Any], v: Any)
             continue
         if inner_key not in resource_conf[k]:
             if isinstance(resource_conf[k][0], dict):
-                resource_conf[k][0][inner_key] = _clean_simple_type_list([TRUE_AFTER_UNKNOWN])
+                if _validate_after_unknown_list_not_empty(inner_key, k, resource_conf):
+                    resource_conf[k][0][inner_key] = _clean_simple_type_list([TRUE_AFTER_UNKNOWN])
             elif isinstance(resource_conf[k][0], list) and isinstance(resource_conf[k][0][0], dict):
-                resource_conf[k][0][0][inner_key] = _clean_simple_type_list([TRUE_AFTER_UNKNOWN])
+                if _validate_after_unknown_list_not_empty(inner_key, k, resource_conf):
+                    resource_conf[k][0][0][inner_key] = _clean_simple_type_list([TRUE_AFTER_UNKNOWN])
+
+
+def _validate_after_unknown_list_not_empty(inner_key: str, k: str, resource_conf: dict[str, Any]) -> bool:
+    """
+    If the inner key is a list - we want to check it's not empty, if not we handle it in the original way.
+    """
+    value = resource_conf[k][0]
+    return ((inner_key not in value) or
+            (inner_key in value and not isinstance(value[inner_key], list)) or
+            (isinstance(value[inner_key], list) and value[inner_key] != [] and value[inner_key][0] != []))
 
 
 def _find_child_modules(

--- a/tests/terraform/parser/test_plan_parser.py
+++ b/tests/terraform/parser/test_plan_parser.py
@@ -146,6 +146,23 @@ class TestPlanFileParser(unittest.TestCase):
         _handle_complex_after_unknown(key, resource, value)
         assert resource == {'tags': [[{'custom_tags': ['true_after_unknown']}]]}
 
+    def test_handle_complex_after_unknown_with_empty_list(self):
+        resource = {"network_configuration": [
+            {
+                "endpoint_configuration": [
+                ]
+            }
+        ]}
+        key: str = 'network_configuration'
+        value: list = [
+            {
+                "endpoint_configuration": [
+                ]
+            }
+        ]
+        _handle_complex_after_unknown(key, resource, value)
+        assert resource == {'network_configuration': [{"endpoint_configuration": []}]}
+
 
 def test_large_file(mocker: MockerFixture):
     # given


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fixes a bug in which empty lists in after_unknown section were inserted a new value, now the value stays an empty list.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
