### PR TITLE
feat(terraform_plan): fix handling of resource_id for enrichment in tf_plan

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -562,9 +562,7 @@ class Report:
         skip_records = []
         for record in report.failed_checks:
             resource_raw_id = Report.get_plan_resource_raw_id(record.resource)
-            resource_skips = enriched_resources.get(resource_raw_id, {}).get(
-                "skipped_checks", []
-            )
+            resource_skips = enriched_resources.get(resource_raw_id, {}).get("skipped_checks", [])
             for skip in resource_skips:
                 if record.check_id in skip["id"]:
                     # Mark for removal and add it as a skipped record. It is not safe to remove

--- a/tests/common/runner_registry/plan_with_for_each_for_enrichment/original/main.tf
+++ b/tests/common/runner_registry/plan_with_for_each_for_enrichment/original/main.tf
@@ -1,0 +1,12 @@
+locals {
+  hosted_zone_names = [
+    "example.com",
+    "example2.eu",
+  ]
+}
+
+resource "aws_route53_zone" "example" {
+  for_each = toset(local.hosted_zone_names)
+  # checkov:skip=CKV2_AWS_38
+  name = each.value
+}

--- a/tests/common/runner_registry/plan_with_for_each_for_enrichment/tf_plan.json
+++ b/tests/common/runner_registry/plan_with_for_each_for_enrichment/tf_plan.json
@@ -1,0 +1,55 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.5.7",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_route53_zone.example['example.com']",
+          "mode": "managed",
+          "type": "aws_route53_zone",
+          "name": "example",
+          "index": "example.com",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "comment": "Managed by Terraform",
+            "delegation_set_id": null,
+            "force_destroy": false,
+            "name": "example.com",
+            "tags": null,
+            "vpc": []
+          },
+          "sensitive_values": {
+            "name_servers": [],
+            "tags_all": {},
+            "vpc": []
+          }
+        },
+        {
+          "address": "aws_route53_zone.example['example2.eu']",
+          "mode": "managed",
+          "type": "aws_route53_zone",
+          "name": "example",
+          "index": "example2.eu",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "comment": "Managed by Terraform",
+            "delegation_set_id": null,
+            "force_destroy": false,
+            "name": "example2.eu",
+            "tags": null,
+            "vpc": []
+          },
+          "sensitive_values": {
+            "name_servers": [],
+            "tags_all": {
+            },
+            "vpc": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
+++ b/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
@@ -121,6 +121,24 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
         self.assertEqual(skipped_check_ids, expected_skipped_check_ids)
         self.assertEqual(enriched_data, expected_enriched_data)
 
+    def test_enrichment_of_plan_report_with_for_each(self):
+        allowed_checks = ["CKV2_AWS_38"]
+        runner_registry = RunnerRegistry(
+            banner, RunnerFilter(checks=allowed_checks, framework=["terraform_plan"]), tf_plan_runner()
+        )
+
+        repo_root = Path(__file__).parent / "plan_with_for_each_for_enrichment"
+        valid_plan_path = repo_root / "tf_plan.json"
+
+        report = runner_registry.run(repo_root_for_plan_enrichment=[repo_root], files=[str(valid_plan_path)])[0]
+
+        self.assertEqual(len(report.failed_checks), 0)
+
+        self.assertEqual(len(report.passed_checks), 0)
+
+        self.assertEqual(len(report.skipped_checks), 2)
+
+
     def test_skip_check(self):
         allowed_checks = ["CKV_AWS_20", "CKV_AWS_28"]
         runner_registry = RunnerRegistry(


### PR DESCRIPTION
This PR fixes handling of tf_plan enrichment in the presence of for_each/count when sometimes the computed resource_id would not match the original TF definition.

Solves #7315 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
