### PR TITLE
feat(general): update our publishing job SHA to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,7 +400,7 @@ jobs:
         run: |
           pipenv run python setup.py sdist bdist_wheel
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1
       - name: sleep and wait for package to refresh
         run: |
           sleep 2m


### PR DESCRIPTION
This PR updates the publishing job github workflow to latest according to this issue:

https://github.com/pypa/gh-action-pypi-publish/issues/354