### PR TITLE
fix(terraform_plan): Correctly handle complex types for after_unknown

### DIFF
--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -265,12 +265,12 @@ def _handle_complex_after_unknown(k: str, resource_conf: dict[str, Any], v: Any)
         if inner_key not in resource_conf_value and isinstance(resource_conf_value, list):
             for i in range(len(resource_conf_value)):
                 if isinstance(resource_conf_value[i], dict):
-                    _update_after_unkown_in_complex_types(inner_key, resource_conf_value[i])
+                    _update_after_unknown_in_complex_types(inner_key, resource_conf_value[i])
                 elif isinstance(resource_conf_value[i], list) and isinstance(resource_conf_value[i][0], dict):
-                    _update_after_unkown_in_complex_types(inner_key, resource_conf_value[i][0])
+                    _update_after_unknown_in_complex_types(inner_key, resource_conf_value[i][0])
 
 
-def _update_after_unkown_in_complex_types(inner_key: str, value: dict[str, Any]) -> None:
+def _update_after_unknown_in_complex_types(inner_key: str, value: dict[str, Any]) -> None:
     """
     Based on terraform docs, in complex types like list/dict some values might be known while others are not.
     So when trying to update the info shared from the `after_unknown`, we only want to update the specific items in
@@ -306,19 +306,19 @@ def _update_after_unkown_in_complex_types(inner_key: str, value: dict[str, Any])
             if isinstance(v, str) and v.lower() == "true":
                 inner_value[i] = _clean_simple_type_list([TRUE_AFTER_UNKNOWN])
             if isinstance(v, dict):
-                _handle_after_unkown_dict(v)
+                _handle_after_unknown_dict(v)
     if isinstance(inner_value, dict):
         for k, v in inner_value.items():
             if isinstance(v, str) and v.lower() == "true":
                 inner_value[k] = _clean_simple_type_list([TRUE_AFTER_UNKNOWN])
             if isinstance(v, dict):
-                _handle_after_unkown_dict(v)
+                _handle_after_unknown_dict(v)
     return
 
 
-def _handle_after_unkown_dict(v: dict[str, Any]) -> None:
+def _handle_after_unknown_dict(v: dict[str, Any]) -> None:
     for k in v.keys():
-        _update_after_unkown_in_complex_types(k, v)
+        _update_after_unknown_in_complex_types(k, v)
 
 
 def _find_child_modules(

--- a/tests/terraform/parser/test_plan_parser.py
+++ b/tests/terraform/parser/test_plan_parser.py
@@ -10,7 +10,7 @@ from pytest_mock import MockerFixture
 
 from checkov.common.util.consts import TRUE_AFTER_UNKNOWN
 from checkov.terraform.plan_parser import parse_tf_plan, _sanitize_count_from_name, _handle_complex_after_unknown, \
-    _update_after_unkown_in_complex_types
+    _update_after_unknown_in_complex_types
 from checkov.common.parsers.node import StrNode
 
 
@@ -169,7 +169,7 @@ class TestPlanFileParser(unittest.TestCase):
                 {"tag2": "true"},
             ]
         }
-        _update_after_unkown_in_complex_types("tags", original_resource)
+        _update_after_unknown_in_complex_types("tags", original_resource)
         assert original_resource == {
             "tags": [
                 {"tag1": "my_tag"},


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Handled complex types better in after_unknown, this time recursively checking complex types and replacing only the real unknown parts of a key rather than the entire value.
For example, a list can contain 3 values, of which the first 2 are known while the 3rd one isn't.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
