### PR TITLE
fix(terraform): use resource address in entity path

### DIFF
--- a/checkov/terraform/checks/resource/base_registry.py
+++ b/checkov/terraform/checks/resource/base_registry.py
@@ -9,4 +9,9 @@ class Registry(BaseCheckRegistry):
         resource_name = list(list(entity.values())[0].keys())[0]
         resource_object = entity[resource_type]
         resource_configuration = resource_object[resource_name]
-        return resource_type, resource_name, resource_configuration
+        full_resource_name = (
+            resource_configuration["__address__"].split(".", 1)[1]
+            if "__address__" in resource_configuration
+            else resource_name
+        )
+        return resource_type, full_resource_name, resource_configuration


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

All terraform checks that rely on Cloudsplaining use the entity_path, and consequently the resource name, to cache parsed policies. This is a problem when dealing with IAM resources managed in a `for_each` block.

The fix is to use the full resource address to infer the resource name, rather than just it's un-indexed form, so that entity paths will result into something like `...:<resouce_type>.<resrouce_name>[<resource_index>]` and the IAM policy caching won't get broken anymore by overlapping keys.

I am not sure if `__address__` is available in all cases when this code is called, I know for sure it is the case when parsing terraform plan outputs, which is where this issue appears the most, so I made the name extraction conditional on the field being present to avoid breaking other input cases.

Fixes #7337

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
