### PR TITLE
fix(terraform): Graph report tags should be dict

### DIFF
--- a/checkov/terraform/base_runner.py
+++ b/checkov/terraform/base_runner.py
@@ -31,6 +31,7 @@ from checkov.common.graph.graph_builder.graph_components.attribute_names import 
 from checkov.terraform.graph_builder.local_graph import TerraformLocalGraph
 from checkov.terraform.graph_manager import TerraformGraphManager
 from checkov.terraform.image_referencer.manager import TerraformImageReferencerManager
+from checkov.terraform.tag_providers import get_resource_tags
 from checkov.terraform.tf_parser import TFParser
 from checkov.common.util.env_vars_config import env_vars_config
 
@@ -187,7 +188,7 @@ class BaseTerraformRunner(
                             entity_context.get("end_line", 1),
                         ],
                         resource=resource,
-                        entity_tags=entity.get("tags", {}),
+                        entity_tags=get_resource_tags(resource, entity_config),
                         evaluations=None,
                         check_class=check.__class__.__module__,
                         file_abs_path=os.path.abspath(full_file_path),

--- a/checkov/terraform/tag_providers/__init__.py
+++ b/checkov/terraform/tag_providers/__init__.py
@@ -4,7 +4,8 @@ from checkov.terraform.tag_providers import aws
 from checkov.terraform.tag_providers import azure
 from checkov.terraform.tag_providers import gcp
 
-provider_tag_mapping = {"aws": aws.get_resource_tags, "azure": azure.get_resource_tags, "gcp": gcp.get_resource_tags}
+provider_tag_mapping = {"aws": aws.get_resource_tags, "azure": azure.get_resource_tags, "gcp": gcp.get_resource_tags,
+                        "google": gcp.get_resource_tags}
 
 
 def get_resource_tags(resource_type: str, entity_config: Dict[str, Any]) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

* Graph report didn't use the same function to extract tags as the regular report, fixed that.
* The function to generate tags took into account resource names with "gcp" rather than with "google", so I added support for it as well.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
