### PR TITLE
fix(terraform): get_resource_tags handles more cases

### DIFF
--- a/checkov/terraform/tag_providers/__init__.py
+++ b/checkov/terraform/tag_providers/__init__.py
@@ -12,11 +12,20 @@ def get_resource_tags(resource_type: str, entity_config: Dict[str, Any]) -> Opti
     if not isinstance(entity_config, dict):
         return None
 
-    if "_" not in resource_type:
-        return None  # probably not a resource block
-    provider = resource_type[: resource_type.index("_")]
-    provider_tag_function = provider_tag_mapping.get(provider)
+    provider_tag = get_provider_tag(resource_type)
+    provider_tag_function = provider_tag_mapping.get(provider_tag) if provider_tag else None
     if provider_tag_function:
         return provider_tag_function(entity_config)
     else:
         return None
+
+
+def get_provider_tag(resource_type: str) -> Optional[str]:
+    provider_tag = None
+    if 'aws' in resource_type:
+        provider_tag = "aws"
+    elif 'azure' in resource_type:
+        provider_tag = "azure"
+    elif 'gcp' in resource_type or 'google' in resource_type:
+        provider_tag = "gcp"
+    return provider_tag

--- a/tests/terraform/test_provider_tags.py
+++ b/tests/terraform/test_provider_tags.py
@@ -1,0 +1,13 @@
+import pytest
+
+from checkov.terraform.tag_providers import get_provider_tag
+
+
+@pytest.mark.parametrize("resource_type, expected", [
+    ("aws_instance.example", "aws"),
+    ("module.test.aws_instance.example", "aws"),
+    ("azure_instance.example", "azure"),
+    ("google_instance.example", "gcp"),
+])
+def test_get_provider_tag(resource_type, expected) -> None:
+    assert get_provider_tag(resource_type) == expected


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

* Fixed `get_resource_tags` function to handle more complex resource_types, like in the case it gets a `module` prefix as shown in the tests.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
