### PR TITLE
feat(general): support skips for module for_each and count

### DIFF
--- a/checkov/common/output/report.py
+++ b/checkov/common/output/report.py
@@ -574,6 +574,10 @@ class Report:
 
             if record.resource_address and record.resource_address.startswith("module."):
                 module_path = record.resource_address[module_address_len:record.resource_address.index('.', module_address_len + 1)]
+                # For module with for_each or count, the module path will be module.module_name[(.*)]. We can
+                # ignore the index and the for_each value and just use the module name as it's not possible to
+                # skip checks for a specific instance of a module
+                module_path = module_path.split('[')[0]
                 module_enrichments = enriched_resources.get(module_path, {})
                 for module_skip in module_enrichments.get("skipped_checks", []):
                     if record.check_id in module_skip["id"]:

--- a/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
+++ b/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
@@ -132,12 +132,11 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
 
         report = runner_registry.run(repo_root_for_plan_enrichment=[repo_root], files=[str(valid_plan_path)])[0]
 
-        # TODO: after fixing module enrichment with skipped checks the failed checks will become skipped
-        self.assertEqual(len(report.failed_checks), 3)
+        self.assertEqual(len(report.failed_checks), 0)
 
         self.assertEqual(len(report.passed_checks), 0)
 
-        self.assertEqual(len(report.skipped_checks), 2)
+        self.assertEqual(len(report.skipped_checks), 5)
 
 
     def test_skip_check(self):


### PR DESCRIPTION
This PR adds support for skips out of module for-each and counts.
Previously these skips did not work due to the inability to find the resource in the enriched_resources struct.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
