### PR TITLE
fix(terraform): CKV_AWS_339 - Update supported EKS versions

### DIFF
--- a/checkov/terraform/checks/resource/aws/EKSPlatformVersion.py
+++ b/checkov/terraform/checks/resource/aws/EKSPlatformVersion.py
@@ -25,7 +25,7 @@ class EKSPlatformVersion(BaseResourceValueCheck):
 
     def get_expected_values(self) -> list[Any]:
         # https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-        return ["1.25", "1.26", "1.27", "1.28", "1.29", "1.30", "1.31", "1.32", "1.33"]
+        return ["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34"]
 
 
 check = EKSPlatformVersion()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

- Removes unsupported versions `1.25`, `1.26`, and `1.27`
- Adds supported version `1.34`

Fixes #7373

## New/Edited policies (Delete if not relevant)

### Description
[docs](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)

Supported AWS EKS versions are out of date.

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
