### PR TITLE
fix(terraform): Fix CKV_GCP_93 false positive on multi-key Spanner configuration

### DIFF
--- a/tests/terraform/checks/resource/gcp/example_SpannerDatabaseEncryptedWithCMK/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_SpannerDatabaseEncryptedWithCMK/main.tf
@@ -23,3 +23,16 @@ resource "google_spanner_database" "pass" {
        kms_key_name= google_kms_crypto_key.example.name
      }
 }
+
+resource "google_spanner_database" "multikey_pass" {
+  instance = google_spanner_instance.example.name
+  name     = "my-database"
+  ddl = [
+    "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+    "CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
+  ]
+  deletion_protection = false
+  encryption_config {
+    kms_key_names = [google_kms_crypto_key.example.name]
+  }
+}

--- a/tests/terraform/checks/resource/gcp/test_SpannerDatabaseEncryptedWithCMK.py
+++ b/tests/terraform/checks/resource/gcp/test_SpannerDatabaseEncryptedWithCMK.py
@@ -18,6 +18,7 @@ class TestSpannerDatabaseEncryptedWithCMK(unittest.TestCase):
 
         passing_resources = {
             'google_spanner_database.pass',
+            'google_spanner_database.multikey_pass',
         }
         failing_resources = {
             'google_spanner_database.fail',
@@ -26,13 +27,13 @@ class TestSpannerDatabaseEncryptedWithCMK(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 1)
-        self.assertEqual(summary['skipped'], 0)
-        self.assertEqual(summary['parsing_errors'], 0)
-
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
+
+        self.assertEqual(summary['passed'], len(passing_resources))
+        self.assertEqual(summary['failed'], len(failing_resources))
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

The CKV_GCP_93 check did not check for `kms_key_names` making configurations using multiple keys falsely trigger the check.

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_database#nested_encryption_config

Fixes #7402

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
