### PR TITLE
fix(terraform_plan): fix CloudStorageSelfLogging for buckets without logging

### DIFF
--- a/checkov/terraform/checks/resource/gcp/CloudStorageSelfLogging.py
+++ b/checkov/terraform/checks/resource/gcp/CloudStorageSelfLogging.py
@@ -23,7 +23,7 @@ class CloudStorageSelfLogging(BaseResourceCheck):
                 if log_bucket_name != bucket_name:
                     return CheckResult.PASSED
                 return CheckResult.FAILED
-            return CheckResult.FAILED
+            return CheckResult.PASSED
         return CheckResult.UNKNOWN
 
 

--- a/tests/terraform/checks/resource/gcp/example_CloudStorageSelfLogging/tfplan.json
+++ b/tests/terraform/checks/resource/gcp/example_CloudStorageSelfLogging/tfplan.json
@@ -1,0 +1,524 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.13.3",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket.plan_pass",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "plan_pass",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 4,
+          "values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "default_event_based_hold": false,
+            "effective_labels": {
+              "goog-terraform-provisioned": "true"
+            },
+            "enable_object_retention": false,
+            "encryption": [],
+            "force_destroy": true,
+            "hierarchical_namespace": [
+              {
+                "enabled": false
+              }
+            ],
+            "id": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+            "ip_filter": [],
+            "labels": {},
+            "lifecycle_rule": [],
+            "location": "EU",
+            "logging": [],
+            "name": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+            "project": "example-project",
+            "project_number": 123456789012,
+            "public_access_prevention": "enforced",
+            "requester_pays": false,
+            "retention_policy": [],
+            "rpo": null,
+            "self_link": "https://www.googleapis.com/storage/v1/b/5bc85a21-7150-48f7-be36-0a8570c6209f",
+            "soft_delete_policy": [
+              {
+                "effective_time": "2025-12-16T18:51:25.798Z",
+                "retention_duration_seconds": 604800
+              }
+            ],
+            "storage_class": "STANDARD",
+            "terraform_labels": {
+              "goog-terraform-provisioned": "true"
+            },
+            "time_created": "2025-12-16T18:51:25.798Z",
+            "timeouts": null,
+            "uniform_bucket_level_access": true,
+            "updated": "2025-12-16T18:51:25.798Z",
+            "url": "gs://5bc85a21-7150-48f7-be36-0a8570c6209f",
+            "versioning": [],
+            "website": []
+          },
+          "sensitive_values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "effective_labels": {},
+            "encryption": [],
+            "hierarchical_namespace": [
+              {}
+            ],
+            "ip_filter": [],
+            "labels": {},
+            "lifecycle_rule": [],
+            "logging": [],
+            "retention_policy": [],
+            "soft_delete_policy": [
+              {}
+            ],
+            "terraform_labels": {},
+            "versioning": [],
+            "website": []
+          }
+        }
+      ]
+    }
+  },
+  "resource_drift": [
+    {
+      "address": "google_storage_bucket.plan_pass",
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "plan_pass",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "default_event_based_hold": false,
+          "effective_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "enable_object_retention": false,
+          "encryption": [],
+          "force_destroy": true,
+          "hierarchical_namespace": [
+            {
+              "enabled": false
+            }
+          ],
+          "id": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "ip_filter": [],
+          "labels": null,
+          "lifecycle_rule": [],
+          "location": "EU",
+          "logging": [],
+          "name": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "project": "example-project",
+          "project_number": 123456789012,
+          "public_access_prevention": "enforced",
+          "requester_pays": false,
+          "retention_policy": [],
+          "rpo": null,
+          "self_link": "https://www.googleapis.com/storage/v1/b/5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "soft_delete_policy": [
+            {
+              "effective_time": "2025-12-16T18:51:25.798Z",
+              "retention_duration_seconds": 604800
+            }
+          ],
+          "storage_class": "STANDARD",
+          "terraform_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "time_created": "2025-12-16T18:51:25.798Z",
+          "timeouts": null,
+          "uniform_bucket_level_access": true,
+          "updated": "2025-12-16T18:51:25.798Z",
+          "url": "gs://5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "versioning": [],
+          "website": []
+        },
+        "after": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "default_event_based_hold": false,
+          "effective_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "enable_object_retention": false,
+          "encryption": [],
+          "force_destroy": true,
+          "hierarchical_namespace": [
+            {
+              "enabled": false
+            }
+          ],
+          "id": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "ip_filter": [],
+          "labels": {},
+          "lifecycle_rule": [],
+          "location": "EU",
+          "logging": [],
+          "name": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "project": "example-project",
+          "project_number": 123456789012,
+          "public_access_prevention": "enforced",
+          "requester_pays": false,
+          "retention_policy": [],
+          "rpo": null,
+          "self_link": "https://www.googleapis.com/storage/v1/b/5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "soft_delete_policy": [
+            {
+              "effective_time": "2025-12-16T18:51:25.798Z",
+              "retention_duration_seconds": 604800
+            }
+          ],
+          "storage_class": "STANDARD",
+          "terraform_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "time_created": "2025-12-16T18:51:25.798Z",
+          "timeouts": null,
+          "uniform_bucket_level_access": true,
+          "updated": "2025-12-16T18:51:25.798Z",
+          "url": "gs://5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "versioning": [],
+          "website": []
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [
+            {}
+          ],
+          "ip_filter": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "retention_policy": [],
+          "soft_delete_policy": [
+            {}
+          ],
+          "terraform_labels": {},
+          "versioning": [],
+          "website": []
+        },
+        "after_sensitive": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [
+            {}
+          ],
+          "ip_filter": [],
+          "labels": {},
+          "lifecycle_rule": [],
+          "logging": [],
+          "retention_policy": [],
+          "soft_delete_policy": [
+            {}
+          ],
+          "terraform_labels": {},
+          "versioning": [],
+          "website": []
+        }
+      }
+    }
+  ],
+  "resource_changes": [
+    {
+      "address": "google_storage_bucket.plan_pass",
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "plan_pass",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "default_event_based_hold": false,
+          "effective_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "enable_object_retention": false,
+          "encryption": [],
+          "force_destroy": true,
+          "hierarchical_namespace": [
+            {
+              "enabled": false
+            }
+          ],
+          "id": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "ip_filter": [],
+          "labels": {},
+          "lifecycle_rule": [],
+          "location": "EU",
+          "logging": [],
+          "name": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "project": "example-project",
+          "project_number": 123456789012,
+          "public_access_prevention": "enforced",
+          "requester_pays": false,
+          "retention_policy": [],
+          "rpo": null,
+          "self_link": "https://www.googleapis.com/storage/v1/b/5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "soft_delete_policy": [
+            {
+              "effective_time": "2025-12-16T18:51:25.798Z",
+              "retention_duration_seconds": 604800
+            }
+          ],
+          "storage_class": "STANDARD",
+          "terraform_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "time_created": "2025-12-16T18:51:25.798Z",
+          "timeouts": null,
+          "uniform_bucket_level_access": true,
+          "updated": "2025-12-16T18:51:25.798Z",
+          "url": "gs://5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "versioning": [],
+          "website": []
+        },
+        "after": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "default_event_based_hold": false,
+          "effective_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "enable_object_retention": false,
+          "encryption": [],
+          "force_destroy": true,
+          "hierarchical_namespace": [
+            {
+              "enabled": false
+            }
+          ],
+          "id": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "ip_filter": [],
+          "labels": {},
+          "lifecycle_rule": [],
+          "location": "EU",
+          "logging": [],
+          "name": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "project": "example-project",
+          "project_number": 123456789012,
+          "public_access_prevention": "enforced",
+          "requester_pays": false,
+          "retention_policy": [],
+          "rpo": null,
+          "self_link": "https://www.googleapis.com/storage/v1/b/5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "soft_delete_policy": [
+            {
+              "effective_time": "2025-12-16T18:51:25.798Z",
+              "retention_duration_seconds": 604800
+            }
+          ],
+          "storage_class": "STANDARD",
+          "terraform_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "time_created": "2025-12-16T18:51:25.798Z",
+          "timeouts": null,
+          "uniform_bucket_level_access": true,
+          "updated": "2025-12-16T18:51:25.798Z",
+          "url": "gs://5bc85a21-7150-48f7-be36-0a8570c6209f",
+          "versioning": [],
+          "website": []
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [
+            {}
+          ],
+          "ip_filter": [],
+          "labels": {},
+          "lifecycle_rule": [],
+          "logging": [],
+          "retention_policy": [],
+          "soft_delete_policy": [
+            {}
+          ],
+          "terraform_labels": {},
+          "versioning": [],
+          "website": []
+        },
+        "after_sensitive": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [
+            {}
+          ],
+          "ip_filter": [],
+          "labels": {},
+          "lifecycle_rule": [],
+          "logging": [],
+          "retention_policy": [],
+          "soft_delete_policy": [
+            {}
+          ],
+          "terraform_labels": {},
+          "versioning": [],
+          "website": []
+        }
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.13.3",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "google_storage_bucket.plan_pass",
+            "mode": "managed",
+            "type": "google_storage_bucket",
+            "name": "plan_pass",
+            "provider_name": "registry.terraform.io/hashicorp/google",
+            "schema_version": 4,
+            "values": {
+              "autoclass": [],
+              "cors": [],
+              "custom_placement_config": [],
+              "default_event_based_hold": false,
+              "effective_labels": {
+                "goog-terraform-provisioned": "true"
+              },
+              "enable_object_retention": false,
+              "encryption": [],
+              "force_destroy": true,
+              "hierarchical_namespace": [
+                {
+                  "enabled": false
+                }
+              ],
+              "id": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+              "ip_filter": [],
+              "labels": {},
+              "lifecycle_rule": [],
+              "location": "EU",
+              "logging": [],
+              "name": "5bc85a21-7150-48f7-be36-0a8570c6209f",
+              "project": "example-project",
+              "project_number": 123456789012,
+              "public_access_prevention": "enforced",
+              "requester_pays": false,
+              "retention_policy": [],
+              "rpo": null,
+              "self_link": "https://www.googleapis.com/storage/v1/b/5bc85a21-7150-48f7-be36-0a8570c6209f",
+              "soft_delete_policy": [
+                {
+                  "effective_time": "2025-12-16T18:51:25.798Z",
+                  "retention_duration_seconds": 604800
+                }
+              ],
+              "storage_class": "STANDARD",
+              "terraform_labels": {
+                "goog-terraform-provisioned": "true"
+              },
+              "time_created": "2025-12-16T18:51:25.798Z",
+              "timeouts": null,
+              "uniform_bucket_level_access": true,
+              "updated": "2025-12-16T18:51:25.798Z",
+              "url": "gs://5bc85a21-7150-48f7-be36-0a8570c6209f",
+              "versioning": [],
+              "website": []
+            },
+            "sensitive_values": {
+              "autoclass": [],
+              "cors": [],
+              "custom_placement_config": [],
+              "effective_labels": {},
+              "encryption": [],
+              "hierarchical_namespace": [
+                {}
+              ],
+              "ip_filter": [],
+              "labels": {},
+              "lifecycle_rule": [],
+              "logging": [],
+              "retention_policy": [],
+              "soft_delete_policy": [
+                {}
+              ],
+              "terraform_labels": {},
+              "versioning": [],
+              "website": []
+            }
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "full_name": "registry.terraform.io/hashicorp/google",
+        "version_constraint": "~> 7.0"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket.plan_pass",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "plan_pass",
+          "provider_config_key": "google",
+          "expressions": {
+            "force_destroy": {
+              "constant_value": true
+            },
+            "location": {
+              "constant_value": "EU"
+            },
+            "name": {
+              "constant_value": "5bc85a21-7150-48f7-be36-0a8570c6209f"
+            },
+            "public_access_prevention": {
+              "constant_value": "enforced"
+            },
+            "storage_class": {
+              "constant_value": "STANDARD"
+            },
+            "uniform_bucket_level_access": {
+              "constant_value": true
+            }
+          },
+          "schema_version": 4
+        }
+      ]
+    }
+  },
+  "timestamp": "2025-12-16T18:51:36Z",
+  "applyable": false,
+  "complete": true,
+  "errored": false
+}

--- a/tests/terraform/checks/resource/gcp/test_CloudStorageSelfLogging.py
+++ b/tests/terraform/checks/resource/gcp/test_CloudStorageSelfLogging.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.gcp.CloudStorageSelfLogging import check
 from checkov.terraform.runner import Runner
+from checkov.terraform.plan_runner import Runner as PlanRunner
 
 
 class TestCloudStorageSelfLogging(unittest.TestCase):
@@ -36,6 +37,25 @@ class TestCloudStorageSelfLogging(unittest.TestCase):
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
 
+    def test_terraform_plan(self):
+        runner = PlanRunner()
+
+        test_files_path = Path(__file__).parent / "example_CloudStorageSelfLogging/tfplan.json"
+        report = runner.run(files=[str(test_files_path)], runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "google_storage_bucket.plan_pass",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+
+        self.assertEqual(summary["failed"], 0)
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

When running checkov on a plan for a GCS bucket without logging defined:
```
resource "google_storage_bucket" "bucket" {
  name                        = "5bc85a21-7150-48f7-be36-0a8570c6209f"
  location                    = "us-central1"
  storage_class               = "STANDARD"
  force_destroy               = true
  uniform_bucket_level_access = true
  public_access_prevention    = "enforced"
}
```
checkov complains:
```
Check: CKV_GCP_63: "Bucket should not log to itself"
	FAILED for resource: google_storage_bucket.bucket
	File: /tfplan.json:0-0
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/google-cloud-policies/google-cloud-storage-gcs-policies/bc-gcp-logging-3
```

This is because in the plan, Terraform populates an empty array as the `logging` value (likely refreshed from the live resource):
```json
      "resources": [
        {
          "address": "google_storage_bucket.bucket",
          "values": {
            "logging": [],
          }
        }
```

## New/Edited policies (Delete if not relevant)

* CKV_GCP_63

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] I have performed a self-review of my own code
- [x] ~I have commented my code, particularly in hard-to-understand areas~ n/a
- [x] ~I have made corresponding changes to the documentation~ n/a
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
    - though I didn't run the full suite