### PR TITLE
fix(cloudformation): CKV_AWS_91 support CloudWatch Logs access logging for NLB

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/ELBv2AccessLogs.py
+++ b/checkov/cloudformation/checks/resource/aws/ELBv2AccessLogs.py
@@ -18,7 +18,7 @@ class ELBv2AccessLogs(BaseResourceCheck):
                 if isinstance(conf['Properties']['LoadBalancerAttributes'], list):
                     for item in conf['Properties']['LoadBalancerAttributes']:
                         if 'Key' in item.keys() and 'Value' in item.keys():
-                            if item['Key'] == "access_logs.s3.enabled":
+                            if item['Key'] in ("access_logs.s3.enabled", "access_logs.cloudwatch.enabled"):
                                 value = item['Value']
                                 if isinstance(value, bool):
                                     value = str(value).lower()

--- a/tests/cloudformation/checks/resource/aws/example_ELBv2AccessLogs/ELBv2AccessLogs-FAILED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ELBv2AccessLogs/ELBv2AccessLogs-FAILED.yml
@@ -41,3 +41,16 @@ Resources:
       Subnets:
         - SubnetID0
         - SubnetID1
+  CloudWatchLogsDisabled:
+    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Properties:
+      Name: MyNLB
+      Type: network
+      LoadBalancerAttributes:
+        - Key: access_logs.s3.enabled
+          Value: "false"
+        - Key: access_logs.cloudwatch.enabled
+          Value: "false"
+      Subnets:
+        - SubnetID0
+        - SubnetID1

--- a/tests/cloudformation/checks/resource/aws/example_ELBv2AccessLogs/ELBv2AccessLogs-PASSED.yml
+++ b/tests/cloudformation/checks/resource/aws/example_ELBv2AccessLogs/ELBv2AccessLogs-PASSED.yml
@@ -24,3 +24,29 @@ Resources:
       Subnets:
         - SubnetID0
         - SubnetID1
+  CloudWatchLogsEnabled:
+    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Properties:
+      Name: MyNLB
+      Type: network
+      LoadBalancerAttributes:
+        - Key: access_logs.s3.enabled
+          Value: "false"
+        - Key: access_logs.cloudwatch.enabled
+          Value: "true"
+        - Key: access_logs.cloudwatch.log_group_arn
+          Value: arn:aws:logs:us-east-1:123456789012:log-group:/aws/vendedlogs/elasticloadbalancing/loadbalancer/NLB_ACCESS_LOGS/net
+      Subnets:
+        - SubnetID0
+        - SubnetID1
+  CloudWatchLogsEnabledBool:
+    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Properties:
+      Name: MyNLB2
+      Type: network
+      LoadBalancerAttributes:
+        - Key: access_logs.cloudwatch.enabled
+          Value: true
+      Subnets:
+        - SubnetID0
+        - SubnetID1

--- a/tests/cloudformation/checks/resource/aws/test_ELBv2AccessLogs.py
+++ b/tests/cloudformation/checks/resource/aws/test_ELBv2AccessLogs.py
@@ -16,8 +16,8 @@ class TestELBv2AccessLogs(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 2)
-        self.assertEqual(summary['failed'], 4)
+        self.assertEqual(summary['passed'], 4)
+        self.assertEqual(summary['failed'], 5)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

CKV_AWS_91 now passes when `access_logs.cloudwatch.enabled` is set to `true`, in addition to the existing `access_logs.s3.enabled` check.

AWS now supports CloudWatch Logs as an alternative to S3 for Network Load Balancer access logging:
- https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-cloudwatch-logs.html

This addresses the false positive reported in the issue where NLBs using CloudWatch Logs for access logging were incorrectly flagged as non-compliant.

Fixes #7411

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes