### PR TITLE
fix(terraform): Add support for 'aws:kms:dsse' in S3 encryption check (CKV_AWS_19)

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/S3Encryption.py
+++ b/checkov/cloudformation/checks/resource/aws/S3Encryption.py
@@ -19,7 +19,7 @@ class S3Encryption(BaseResourceValueCheck):
         return 'AES256'
 
     def get_expected_values(self):
-        return [self.get_expected_value(), 'aws:kms']
+        return [self.get_expected_value(), 'aws:kms', 'aws:kms:dsse']
 
 
 check = S3Encryption()

--- a/checkov/terraform/checks/graph_checks/aws/S3BucketEncryption.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/S3BucketEncryption.yaml
@@ -11,6 +11,7 @@ definition:
       operator: within
       value:
         - "aws:kms"
+        - "aws:kms:dsse"
         - "AES256"
     - and:
       - cond_type: filter
@@ -48,4 +49,5 @@ definition:
         operator: within
         value:
           - "aws:kms"
+          - "aws:kms:dsse"
           - "AES256"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

DSSE was released in 2023 and is another secure encryption method for S3 buckets - it should pass the server-side encryption checks.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration#sse_algorithm-1

https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingDSSEncryption.html

## Edited policies
* CKV_AWS_19 - Add allowed value 'aws:kms:dsse' for the `sse_algorithm` property.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
