### PR TITLE
feat(general): Add BC_CA_BUNDLE environment variable support for custom CA certificates

### DIFF
--- a/checkov/common/goget/github/get_git.py
+++ b/checkov/common/goget/github/get_git.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import logging
 import re
 import shutil
-import os
 
 from checkov.common.goget.base_getter import BaseGetter
 from checkov.common.resource_code_logger_filter import add_resource_code_filter_to_logger
 from checkov.common.util.contextmanagers import temp_environ
+from checkov.common.util.env_vars_config import env_vars_config
 
 try:
     from git import Repo
@@ -79,14 +79,14 @@ class GitGetter(BaseGetter):
     def _clone(self, git_url: str, clone_dir: str) -> None:
         self.logger.info(f"cloning {git_url} to {clone_dir}")
         with temp_environ(GIT_TERMINAL_PROMPT="0"):  # disables user prompts originating from GIT
-            if os.getenv('PROXY_URL'):
-                self.logger.info(f'Performing clone through proxy - {os.getenv("PROXY_URL")}')
-                with temp_environ(GIT_SSL_CAINFO=os.getenv('PROXY_CA_PATH'),
-                                  https_proxy=os.getenv('PROXY_URL'),
-                                  GIT_CONFIG_PARAMETERS=f"'http.extraHeader={os.getenv('PROXY_HEADER_KEY')}:{os.getenv('PROXY_HEADER_VALUE')}'"):
+            if env_vars_config.PROXY_URL:
+                self.logger.info(f'Performing clone through proxy - {env_vars_config.PROXY_URL}')
+                with temp_environ(GIT_SSL_CAINFO=env_vars_config.PROXY_CA_PATH,
+                                  https_proxy=env_vars_config.PROXY_URL,
+                                  GIT_CONFIG_PARAMETERS=f"'http.extraHeader={env_vars_config.PROXY_HEADER_KEY}:{env_vars_config.PROXY_HEADER_VALUE}'"):
                     self._clone_helper(clone_dir, git_url)
                 return
-            ca_bundle = os.getenv('BC_CA_BUNDLE')
+            ca_bundle = env_vars_config.BC_CA_BUNDLE
             if ca_bundle:
                 self.logger.info(f'Using custom CA bundle from BC_CA_BUNDLE: {ca_bundle}')
                 with temp_environ(GIT_SSL_CAINFO=ca_bundle):


### PR DESCRIPTION
## Description

This PR adds support for the `BC_CA_BUNDLE` environment variable in the `GitGetter._clone()` function. When set, it configures `GIT_SSL_CAINFO` to use the specified CA bundle file, enabling git clone operations to work with on-prem GitLab/GitHub instances that use self-signed or custom CA certificates.

## Changes

- Modified `_clone()` in `checkov/common/goget/github/get_git.py` to check for `BC_CA_BUNDLE` env var
- When `BC_CA_BUNDLE` is set, `GIT_SSL_CAINFO` is configured with its value
- `PROXY_URL` settings take precedence over `BC_CA_BUNDLE`
- Added 3 unit tests for the new functionality

## Usage

```bash
export BC_CA_BUNDLE=/path/to/ca-bundle.crt
checkov -d . --download-external-modules true
```

## Testing

- ✅ All 20 unit tests passed
- ✅ Successfully tested with self-signed certificate GitLab instance
- ✅ Verified the SSL certificate error is resolved when `BC_CA_BUNDLE` is set

## Checklist

- [x] Tests added
- [x] Documentation in commit message
- [x] Tested with real on-prem GitLab instance with self-signed certificate