### PR TITLE
fix(terraform): test dates

### DIFF
--- a/tests/terraform/checks/resource/aws/example_TransferServerLatestPolicy/main.tf
+++ b/tests/terraform/checks/resource/aws/example_TransferServerLatestPolicy/main.tf
@@ -15,7 +15,7 @@ resource "aws_transfer_server" "pass_new" {
   identity_provider_type = "SERVICE_MANAGED"
 
   # Using the latest security policy (as of this example)
-  security_policy_name = "TransferSecurityPolicy-2024-01"
+  security_policy_name = "TransferSecurityPolicy-2034-01"
 
   tags = {
     Name = "LatestTransferServer"
@@ -39,7 +39,7 @@ resource "aws_transfer_server" "pass_fips" {
   identity_provider_type = "SERVICE_MANAGED"
 
   # Using the latest security policy (as of this example)
-  security_policy_name = "TransferSecurityPolicy-FIPS-2024-01"
+  security_policy_name = "TransferSecurityPolicy-FIPS-2034-01"
 
   tags = {
     Name = "LatestTransferServer"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

There is a failing unit test on a policy that validates the policy date is no longer than 2 years.
I changed the test data dates so it won't fail anymore.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
