### PR TITLE
feat(terraform): deprecate dotnet v6 and support v9 and v10

### DIFF
--- a/checkov/terraform/checks/resource/azure/AppServiceDotnetFrameworkVersion.py
+++ b/checkov/terraform/checks/resource/azure/AppServiceDotnetFrameworkVersion.py
@@ -12,17 +12,26 @@ class AppServiceDotnetFrameworkVersion(BaseResourceCheck):
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf) -> CheckResult:
+        # Supported .NET versions (LTS and STS currently supported by Microsoft)
+        # v6.0 is EOL as of November 2024
+        # v8.0 is LTS (supported until November 2026)
+        # v9.0 is STS (supported until November 2026)
+        # v10.0 is the latest version
+        supported_versions = {"v8.0", "v9.0", "v10.0"}
+
         if conf.get('site_config') and isinstance(conf.get('site_config'), list):
             site_config = conf.get('site_config')[0]
             if site_config.get('dotnet_framework_version') and isinstance(site_config.get('dotnet_framework_version'), list):
-                if site_config.get('dotnet_framework_version')[0] == "v6.0":
+                version = site_config.get('dotnet_framework_version')[0]
+                if version in supported_versions:
                     return CheckResult.PASSED
                 self.evaluated_keys = ['site_config/[0]/dotnet_framework_version']
                 return CheckResult.FAILED
             if site_config.get('application_stack') and isinstance(site_config.get('application_stack'), list):
                 stack = site_config.get('application_stack')[0]
                 if stack.get('dotnet_version') and isinstance(stack.get('dotnet_version'), list):
-                    if stack.get('dotnet_version')[0] == "v8.0":
+                    version = stack.get('dotnet_version')[0]
+                    if version in supported_versions:
                         return CheckResult.PASSED
                     self.evaluated_keys = ['site_config/[0]/application_stack/[0]/dotnet_version']
                     return CheckResult.FAILED
@@ -30,7 +39,7 @@ class AppServiceDotnetFrameworkVersion(BaseResourceCheck):
         return CheckResult.UNKNOWN
 
     def get_expected_values(self) -> List[str]:
-        return ["v6.0", "v8.0"]
+        return ["v8.0", "v9.0", "v10.0"]
 
 
 check = AppServiceDotnetFrameworkVersion()

--- a/tests/terraform/checks/resource/azure/example_AppServiceDotnetFrameworkVersion/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AppServiceDotnetFrameworkVersion/main.tf
@@ -1,4 +1,4 @@
-
+# FAIL - v5.0 is EOL
 resource "azurerm_app_service" "fail" {
   name                = "example-app-service"
   location            = azurerm_resource_group.example.location
@@ -11,8 +11,8 @@ resource "azurerm_app_service" "fail" {
     }
   }
 
-
-resource "azurerm_app_service" "pass" {
+# FAIL - v6.0 is EOL as of November 2024
+resource "azurerm_app_service" "fail2" {
   name                = "example-app-service"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -24,6 +24,46 @@ resource "azurerm_app_service" "pass" {
     }
   }
 
+# PASS - v8.0 is LTS (supported until November 2026)
+resource "azurerm_app_service" "pass" {
+  name                = "example-app-service"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  app_service_plan_id = azurerm_app_service_plan.example.id
+  https_only          = true
+  site_config {
+    dotnet_framework_version = "v8.0"
+    scm_type                 = "someValue"
+    }
+  }
+
+# PASS - v9.0 is STS (supported until May 2026)
+resource "azurerm_app_service" "pass2" {
+  name                = "example-app-service"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  app_service_plan_id = azurerm_app_service_plan.example.id
+  https_only          = true
+  site_config {
+    dotnet_framework_version = "v9.0"
+    scm_type                 = "someValue"
+    }
+  }
+
+# PASS - v10.0 is the latest version
+resource "azurerm_app_service" "pass3" {
+  name                = "example-app-service"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  app_service_plan_id = azurerm_app_service_plan.example.id
+  https_only          = true
+  site_config {
+    dotnet_framework_version = "v10.0"
+    scm_type                 = "someValue"
+    }
+  }
+
+# IGNORE - uses Java, not .NET
 resource "azurerm_app_service" "ignore" {
   name                = "example-app-service"
   location            = azurerm_resource_group.example.location
@@ -39,7 +79,7 @@ resource "azurerm_app_service" "ignore" {
     }
   }
 
-
+# PASS - v8.0 via application_stack
 resource "azurerm_windows_web_app" "pass" {
   #checkov:skip=CKV_AZURE_16: AD might not be required
   name                = var.name
@@ -90,6 +130,109 @@ resource "azurerm_windows_web_app" "pass" {
   }
 }
 
+# PASS - v9.0 via application_stack
+resource "azurerm_windows_web_app" "pass2" {
+  #checkov:skip=CKV_AZURE_16: AD might not be required
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.rg_name
+  service_plan_id     = var.service_plan_id
+
+  https_only = true
+  logs {
+    detailed_error_messages = true
+    failed_request_tracing  = true
+    http_logs {
+      file_system {
+        retention_in_days = 4
+        retention_in_mb   = 25
+      }
+
+    }
+  }
+
+  storage_account {
+    name         = var.storage.name
+    type         = var.storage.store_type
+    account_name = var.storage.account_name
+    share_name   = var.storage.share_name
+    access_key   = var.storage.access_key
+    mount_path   = var.storage.mount_path
+  }
+
+  site_config {
+    ftps_state        = "FtpsOnly"
+    http2_enabled     = true
+    health_check_path = var.health_check_path
+    application_stack {
+      dotnet_version = "v9.0"
+    }
+  }
+
+
+  client_certificate_enabled = true
+
+  auth_settings {
+    enabled = true
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+# PASS - v10.0 via application_stack
+resource "azurerm_windows_web_app" "pass3" {
+  #checkov:skip=CKV_AZURE_16: AD might not be required
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.rg_name
+  service_plan_id     = var.service_plan_id
+
+  https_only = true
+  logs {
+    detailed_error_messages = true
+    failed_request_tracing  = true
+    http_logs {
+      file_system {
+        retention_in_days = 4
+        retention_in_mb   = 25
+      }
+
+    }
+  }
+
+  storage_account {
+    name         = var.storage.name
+    type         = var.storage.store_type
+    account_name = var.storage.account_name
+    share_name   = var.storage.share_name
+    access_key   = var.storage.access_key
+    mount_path   = var.storage.mount_path
+  }
+
+  site_config {
+    ftps_state        = "FtpsOnly"
+    http2_enabled     = true
+    health_check_path = var.health_check_path
+    application_stack {
+      dotnet_version = "v10.0"
+    }
+  }
+
+
+  client_certificate_enabled = true
+
+  auth_settings {
+    enabled = true
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+# FAIL - v2.0 is EOL
 resource "azurerm_windows_web_app" "fail" {
   #checkov:skip=CKV_AZURE_16: AD might not be required
   name                = var.name
@@ -140,7 +283,58 @@ resource "azurerm_windows_web_app" "fail" {
   }
 }
 
+# FAIL - v6.0 is EOL via application_stack
+resource "azurerm_windows_web_app" "fail2" {
+  #checkov:skip=CKV_AZURE_16: AD might not be required
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.rg_name
+  service_plan_id     = var.service_plan_id
 
+  https_only = true
+  logs {
+    detailed_error_messages = true
+    failed_request_tracing  = true
+    http_logs {
+      file_system {
+        retention_in_days = 4
+        retention_in_mb   = 25
+      }
+
+    }
+  }
+
+  storage_account {
+    name         = var.storage.name
+    type         = var.storage.store_type
+    account_name = var.storage.account_name
+    share_name   = var.storage.share_name
+    access_key   = var.storage.access_key
+    mount_path   = var.storage.mount_path
+  }
+
+  site_config {
+    ftps_state        = "FtpsOnly"
+    http2_enabled     = true
+    health_check_path = var.health_check_path
+    application_stack {
+      dotnet_version = "v6.0"
+    }
+  }
+
+
+  client_certificate_enabled = true
+
+  auth_settings {
+    enabled = true
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+# IGNORE - no dotnet version specified
 resource "azurerm_windows_web_app" "ignore" {
   #checkov:skip=CKV_AZURE_16: AD might not be required
   name                = var.name

--- a/tests/terraform/checks/resource/azure/test_AppServiceDotnetFrameworkVersion.py
+++ b/tests/terraform/checks/resource/azure/test_AppServiceDotnetFrameworkVersion.py
@@ -18,12 +18,18 @@ class TestAppServiceDotnetFrameworkVersion(unittest.TestCase):
         summary = report.get_summary()
 
         passing_resources = {
-            'azurerm_app_service.pass',
-            'azurerm_windows_web_app.pass'
+            'azurerm_app_service.pass',    # v8.0
+            'azurerm_app_service.pass2',   # v9.0
+            'azurerm_app_service.pass3',   # v10.0
+            'azurerm_windows_web_app.pass',   # v8.0
+            'azurerm_windows_web_app.pass2',  # v9.0
+            'azurerm_windows_web_app.pass3',  # v10.0
         }
         failing_resources = {
-            'azurerm_app_service.fail',
-            'azurerm_windows_web_app.fail'
+            'azurerm_app_service.fail',    # v5.0 EOL
+            'azurerm_app_service.fail2',   # v6.0 EOL
+            'azurerm_windows_web_app.fail',   # v2.0 EOL
+            'azurerm_windows_web_app.fail2',  # v6.0 EOL
         }
         skipped_resources = {}
 


### PR DESCRIPTION
This PR adds support for dotnet v9, v10 whilst deprecating support for v6. 
Resolves: #7395

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
