### PR TITLE
fix(CKV2_K8S_6): accept CiliumNetworkPolicy as valid network policy

### DIFF
--- a/checkov/kubernetes/checks/graph_checks/RequireAllPodsToHaveNetworkPolicy.yaml
+++ b/checkov/kubernetes/checks/graph_checks/RequireAllPodsToHaveNetworkPolicy.yaml
@@ -16,3 +16,4 @@ definition:
         - Deployment
       connected_resource_types:
         - NetworkPolicy
+        - CiliumNetworkPolicy

--- a/checkov/kubernetes/graph_builder/graph_components/edge_builders/NetworkPolicyEdgeBuilder.py
+++ b/checkov/kubernetes/graph_builder/graph_components/edge_builders/NetworkPolicyEdgeBuilder.py
@@ -7,9 +7,11 @@ from checkov.kubernetes.kubernetes_utils import remove_metadata_from_attribute
 
 class NetworkPolicyEdgeBuilder(K8SEdgeBuilder):
 
+    NETWORK_POLICY_KINDS = {"NetworkPolicy", "CiliumNetworkPolicy"}
+
     @staticmethod
     def should_search_for_edges(vertex: KubernetesBlock) -> bool:
-        return bool(vertex.attributes.get("kind") == "NetworkPolicy")
+        return vertex.attributes.get("kind") in NetworkPolicyEdgeBuilder.NETWORK_POLICY_KINDS
 
     @staticmethod
     def find_connections(vertex: KubernetesBlock, vertices: list[KubernetesBlock]) -> list[int]:

--- a/checkov/kubernetes/kubernetes_utils.py
+++ b/checkov/kubernetes/kubernetes_utils.py
@@ -26,7 +26,7 @@ DEFAULT_NESTED_RESOURCE_TYPE = "Pod"
 SUPPORTED_POD_CONTAINERS_TYPES = {"Deployment", "DeploymentConfig", "DaemonSet", "Job", "ReplicaSet", "ReplicationController", "StatefulSet"}
 PARENT_RESOURCE_KEY_NAME = "_parent_resource"
 PARENT_RESOURCE_ID_KEY_NAME = "_parent_resource_id"
-FILTERED_RESOURCES_FOR_EDGE_BUILDERS = ["NetworkPolicy"]
+FILTERED_RESOURCES_FOR_EDGE_BUILDERS = ["NetworkPolicy", "CiliumNetworkPolicy"]
 
 
 def should_include_path(full_path: str, ignore_hidden_dir: bool) -> bool:


### PR DESCRIPTION
Adds CiliumNetworkPolicy to the graph check and edge builder so pods using Cilium network policies don't trigger a false positive.

Fixes #7444