### PR TITLE
fix(terraform): Lambda images don't have code signing

### DIFF
--- a/checkov/terraform/checks/resource/aws/LambdaCodeSigningConfigured.py
+++ b/checkov/terraform/checks/resource/aws/LambdaCodeSigningConfigured.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
+from typing import Any
 from checkov.common.models.consts import ANY_VALUE
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 
 
 class LambdaCodeSigningConfigured(BaseResourceValueCheck):
@@ -10,6 +13,12 @@ class LambdaCodeSigningConfigured(BaseResourceValueCheck):
         supported_resources = ['aws_lambda_function']
         categories = [CheckCategories.SUPPLY_CHAIN]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: dict[str, Any], entity_type: str = None):
+        # Code signing only applies to Zip package type, not Image (container)
+        if conf.get("package_type") == "Image":
+            return CheckResult.PASSED
+        return super().scan_resource_conf(conf, entity_type)
 
     def get_inspected_key(self):
         return "code_signing_config_arn"

--- a/tests/terraform/checks/resource/aws/example_LambdaCodeSigningConfigured/main.tf
+++ b/tests/terraform/checks/resource/aws/example_LambdaCodeSigningConfigured/main.tf
@@ -14,3 +14,12 @@ resource "aws_lambda_function" "fail" {
   role          = ""
   runtime       = "python3.9"
 }
+
+# pass (Image package type - code signing not applicable)
+
+resource "aws_lambda_function" "image_pass" {
+  function_name = "test-image"
+  role          = ""
+  package_type  = "Image"
+  image_uri     = "123456789012.dkr.ecr.us-east-1.amazonaws.com/myimage:latest"
+}

--- a/tests/terraform/checks/resource/aws/test_LambdaCodeSigningConfigured.py
+++ b/tests/terraform/checks/resource/aws/test_LambdaCodeSigningConfigured.py
@@ -6,7 +6,7 @@ from checkov.terraform.checks.resource.aws.LambdaCodeSigningConfigured import ch
 from checkov.terraform.runner import Runner
 
 
-class TestWafHasAnyRules(unittest.TestCase):
+class TestLambdaCodeSigningConfigured(unittest.TestCase):
     def test(self):
         # given
         test_files_dir = Path(__file__).parent / "example_LambdaCodeSigningConfigured"
@@ -17,10 +17,13 @@ class TestWafHasAnyRules(unittest.TestCase):
         # then
         summary = report.get_summary()
 
+        # pass: has code_signing_config_arn; image_pass: package_type=Image (check skipped, passes)
         passing_resources = {
-            "aws_lambda_function.pass"
+            "aws_lambda_function.pass",
+            "aws_lambda_function.image_pass",
         }
 
+        # fail: Zip package type (default) without code_signing_config_arn
         failing_resources = {
             "aws_lambda_function.fail"
         }
@@ -28,7 +31,7 @@ class TestWafHasAnyRules(unittest.TestCase):
         passed_check_resources = {c.resource for c in report.passed_checks}
         failed_check_resources = {c.resource for c in report.failed_checks}
 
-        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["passed"], 2)
         self.assertEqual(summary["failed"], 1)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Lambdas support both zip and container images for the runtime however code signing is not available for container images.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
