### PR TITLE
fix(terraform): CKV_GCP_79 bump latest postgres to 18

### DIFF
--- a/checkov/terraform/checks/resource/gcp/CloudSqlMajorVersion.py
+++ b/checkov/terraform/checks/resource/gcp/CloudSqlMajorVersion.py
@@ -14,7 +14,7 @@ class CloudSqlMajorVersion(BaseResourceValueCheck):
         return 'database_version'
 
     def get_expected_values(self):
-        return ["POSTGRES_17", "MYSQL_8_0", "MYSQL_8_4", "SQLSERVER_2022_STANDARD", "SQLSERVER_2022_WEB",
+        return ["POSTGRES_18", "MYSQL_8_0", "MYSQL_8_4", "SQLSERVER_2022_STANDARD", "SQLSERVER_2022_WEB",
                 "SQLSERVER_2022_ENTERPRISE", "SQLSERVER_2022_EXPRESS"]
 
 

--- a/tests/terraform/checks/resource/gcp/example_CloudSqlMajorVersion/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_CloudSqlMajorVersion/main.tf
@@ -94,7 +94,7 @@ resource "google_sql_database_instance" "fail2" {
 }
 
 resource "google_sql_database_instance" "pass2" {
-  database_version = "POSTGRES_17"
+  database_version = "POSTGRES_18"
   name             = "general-pos121"
   project          = "gcp-bridgecrew-deployment"
   region           = "us-central1"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Check ID: **CKV_GCP_79**

The latest and default Postgres version now supported by CloudSQL is 18 [(docs)](https://docs.cloud.google.com/sql/docs/postgres/db-versions):
<img width="912" height="220" alt="Image" src="https://github.com/user-attachments/assets/acfdcfd0-35ac-48b6-8466-c3143791f822" />

Currently the check is still looking for 17 as latest.
Changes similar to when this was done last time in https://github.com/bridgecrewio/checkov/pull/7015

Fixes https://github.com/bridgecrewio/checkov/issues/7450

## Checklist:

- [x] I have performed a self-review of my own code
- [x] *(N/A)* I have commented my code, particularly in hard-to-understand areas
- [x] *(N/A)* I have made corresponding changes to the documentation -- N/A
- [x] *(N/A)* I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
