### PR TITLE
fix(terraform): correct CKV_AWS_62 documentation URL from bc-aws-iam-45 to bc-aws-iam-47

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py
@@ -9,7 +9,13 @@ class IAMAdminPolicyDocument(BaseResourceCheck):
         id = "CKV_AWS_62"
         supported_resources = ['AWS::IAM::Policy', 'AWS::IAM::Group', 'AWS::IAM::Role', 'AWS::IAM::User']
         categories = [CheckCategories.IAM]
-        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+        super().__init__(
+            name=name,
+            id=id,
+            categories=categories,
+            supported_resources=supported_resources,
+            guideline="https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-iam-policies/bc-aws-iam-47",
+        )
 
     def scan_resource_conf(self, conf):
         my_properties = conf.get("Properties")

--- a/checkov/terraform/checks/resource/aws/IAMAdminPolicyDocument.py
+++ b/checkov/terraform/checks/resource/aws/IAMAdminPolicyDocument.py
@@ -19,7 +19,13 @@ class IAMAdminPolicyDocument(BaseResourceCheck):
             "aws_ssoadmin_permission_set_inline_policy",
         )
         categories = (CheckCategories.IAM,)
-        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+        super().__init__(
+            name=name,
+            id=id,
+            categories=categories,
+            supported_resources=supported_resources,
+            guideline="https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-iam-policies/bc-aws-iam-47",
+        )
 
     def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
         if "policy" in conf.keys():


### PR DESCRIPTION
## Description

Fixes #7447

The check `CKV_AWS_62` ("Ensure IAM policies that allow full '*-*' administrative privileges are not created") was pointing to the wrong Prisma Cloud documentation URL (`bc-aws-iam-45`). 

## Changes

Updated both the Terraform and CloudFormation check definitions to set the correct guideline URL (`bc-aws-iam-47`):

- `checkov/terraform/checks/resource/aws/IAMAdminPolicyDocument.py`
- `checkov/cloudformation/checks/resource/aws/IAMAdminPolicyDocument.py`

The `guideline` parameter is now explicitly passed to the `super().__init__()` call with the correct URL:
`https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-iam-policies/bc-aws-iam-47`

## Testing

- Both existing unit tests pass (`test_IAMAdminPolicyDocument` for Terraform and CloudFormation)
- Full checkov scan against test fixtures confirms all 8 records (3 passed, 5 failed) show the correct `bc-aws-iam-47` guideline URL