### PR TITLE
fix: handle required_version in CDKTF terraform_json parser

### DIFF
--- a/checkov/terraform_json/parser.py
+++ b/checkov/terraform_json/parser.py
@@ -112,7 +112,11 @@ def handle_block_type(block_type: str, blocks: dict[str, Any]) -> list[dict[str,
             # a local block is stored as single dict
             return [hclify(obj=blocks)]
         else:
-            result.append({block_name: hclify(obj=config)})
+            if _is_simple_type(config) or _is_list_of_simple_types(config):
+                # simple top-level attributes like terraform.required_version = ">= 1.5.0"
+                result.append({block_name: _clean_simple_type_list([config])})
+            else:
+                result.append({block_name: hclify(obj=config)})
 
     return result
 

--- a/tests/terraform_json/examples/cdk_with_required_version.tf.json
+++ b/tests/terraform_json/examples/cdk_with_required_version.tf.json
@@ -1,0 +1,46 @@
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "MinimalStack",
+      "version": "0.21.0"
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_vpc": {
+      "vpc": {
+        "//": {
+          "metadata": {
+            "path": "MinimalStack/vpc",
+            "uniqueId": "vpc"
+          }
+        },
+        "cidr_block": "10.0.0.0/16",
+        "tags": {
+          "Name": "test-vpc"
+        }
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "local": {
+        "path": "terraform.minimal-stack.tfstate"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "aws",
+        "version": "6.25.0"
+      }
+    },
+    "required_version": ">= 1.5.0"
+  }
+}

--- a/tests/terraform_json/test_parser.py
+++ b/tests/terraform_json/test_parser.py
@@ -1,4 +1,6 @@
-from checkov.terraform_json.parser import hclify, prepare_definition
+from pathlib import Path
+
+from checkov.terraform_json.parser import hclify, loads, prepare_definition
 
 
 def test_hclify():
@@ -34,6 +36,65 @@ def test_hclify():
             }
         ],
     }
+
+
+def test_prepare_definition_terraform_required_version():
+    """CDKTF-generated cdk.tf.json files can have terraform.required_version as a string.
+
+    See https://github.com/bridgecrewio/checkov/issues/7454
+    """
+    cdk_definition = {
+        "terraform": {
+            "backend": {
+                "local": {
+                    "path": "terraform.minimal-stack.tfstate"
+                }
+            },
+            "required_providers": {
+                "aws": {
+                    "source": "aws",
+                    "version": "6.25.0"
+                }
+            },
+            "required_version": ">= 1.5.0"
+        }
+    }
+
+    # when
+    tf_definition = prepare_definition(cdk_definition)
+
+    # then
+    assert "terraform" in tf_definition
+    terraform_blocks = tf_definition["terraform"]
+
+    # required_version should be stored as a list-wrapped simple value
+    required_version_block = next(
+        (b for b in terraform_blocks if "required_version" in b), None
+    )
+    assert required_version_block is not None
+    assert required_version_block["required_version"] == [">= 1.5.0"]
+
+    # backend and required_providers should still be handled as dicts
+    backend_block = next(
+        (b for b in terraform_blocks if "backend" in b), None
+    )
+    assert backend_block is not None
+
+    required_providers_block = next(
+        (b for b in terraform_blocks if "required_providers" in b), None
+    )
+    assert required_providers_block is not None
+
+
+def test_loads_cdktf_with_required_version():
+    """End-to-end test: loads() should not crash on CDKTF JSON with required_version."""
+    file_path = Path(__file__).parent / "examples" / "cdk_with_required_version.tf.json"
+    template, file_lines = loads(file_path=file_path)
+
+    assert template is not None
+    assert file_lines is not None
+    assert "terraform" in template
+    assert "resource" in template
 
 
 def test_prepare_definition_locals():


### PR DESCRIPTION
Closes #7454

## Summary

- Fixed crash in `terraform_json` parser when CDKTF-generated `cdk.tf.json` contains `required_version` as a plain string
- `hclify()` expects a dict, but `required_version` is a string. Added type check to route simple types through `_clean_simple_type_list()` instead
- Also handles int, float, bool, None, and lists of simple types

## Root cause

In `handle_block_type()`, all config values are passed to `hclify()`, which raises `Exception: this method receives only dicts` for non-dict values like `required_version: ">= 1.5.0"`.

## Test plan

- [x] Unit test: `prepare_definition()` with mixed dict/string values in terraform block
- [x] E2E test: full CDKTF fixture file with `required_version` loads without crash
- [x] All 12 existing `terraform_json` tests pass