### PR TITLE
fix: return distinct exit code 2 on internal errors

### DIFF
--- a/checkov/common/bridgecrew/platform_integration.py
+++ b/checkov/common/bridgecrew/platform_integration.py
@@ -145,6 +145,7 @@ class BcPlatformIntegration:
         self.public_metadata_response = None
         self.use_s3_integration = False
         self.s3_setup_failed = False
+        self.internal_error_occurred = False
         self.platform_integration_configured = False
         self.http: urllib3.PoolManager | urllib3.ProxyManager | None = None
         self.http_timeout = urllib3.Timeout(connect=REQUEST_CONNECT_TIMEOUT, read=REQUEST_READ_TIMEOUT)
@@ -1282,6 +1283,7 @@ class BcPlatformIntegration:
             platform_type = PRISMA_PLATFORM if self.is_prisma_integration() else BRIDGECREW_PLATFORM
             logging.debug(f"Got checkov mappings and guidelines from {platform_type} platform")
         except Exception:
+            self.internal_error_occurred = True
             logging.warning(f"Failed to get the checkov mappings and guidelines from {self.guidelines_api_url}. Skips using BC_* IDs will not work.",
                             exc_info=True)
 

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -143,6 +143,7 @@ class Checkov:
         self.resource_subgraph_maps: dict[str, dict[str, str]] = {}
         self.url: str | None = None
         self.sast_data: SastData = SastData()
+        self._internal_error_occurred: bool = False
 
         self.parse_config(argv=argv)
 
@@ -448,6 +449,7 @@ class Checkov:
             try:
                 bc_integration.get_platform_run_config()
             except Exception:
+                self._internal_error_occurred = True
                 if not self.config.include_all_checkov_policies:
                     # stack trace gets printed in the exception handlers above
                     # include_all_checkov_policies will always be set when there is no API key, so we don't need to worry about it here
@@ -457,6 +459,10 @@ class Checkov:
                           '(but note that this will not include any custom platform configurations or policy metadata).',
                           file=sys.stderr)
                     self.exit_run()
+
+            # check if get_public_run_config or similar had a non-fatal internal error
+            if bc_integration.internal_error_occurred:
+                self._internal_error_occurred = True
 
             # bc_integration.get_runtime_run_config()
             bc_integration.setup_on_prem()
@@ -537,7 +543,7 @@ class Checkov:
                     self.graphs = runner_registry.check_type_to_graph
                     self.resource_subgraph_maps = runner_registry.check_type_to_resource_subgraph_map
                     if runner_registry.is_error_in_reports(self.scan_reports):
-                        self.exit_run()
+                        self._internal_error_occurred = True
                     if baseline:
                         baseline.compare_and_reduce_reports(self.scan_reports)
 
@@ -585,6 +591,9 @@ class Checkov:
                         logger.warning(f"Unable to report contributor metrics due to: {e}")
 
                 exit_code = 1 if 1 in exit_codes else 0
+                if self._internal_error_occurred:
+                    internal_exit = self._get_exit_code_for_internal_error()
+                    exit_code = internal_exit if internal_exit != 0 else exit_code
                 return exit_code
             elif self.config.docker_image:
                 if self.config.bc_api_key is None:
@@ -606,7 +615,7 @@ class Checkov:
                 )
                 self.scan_reports = result if isinstance(result, list) else [result]
                 if runner_registry.is_error_in_reports(self.scan_reports):
-                    self.exit_run()
+                    self._internal_error_occurred = True
                 if len(self.scan_reports) > 1:
                     # this shouldn't happen, but if it happens, then it is intended or something is broke
                     logger.error(f"SCA image runner returned {len(self.scan_reports)} reports; expected 1")
@@ -640,6 +649,9 @@ class Checkov:
                         logger.warning(f"Unable to report contributor metrics due to: {e}")
 
                 exit_code = self.print_results(runner_registry=runner_registry, url=self.url)
+                if self._internal_error_occurred:
+                    internal_exit = self._get_exit_code_for_internal_error()
+                    exit_code = internal_exit if internal_exit != 0 else exit_code
                 return exit_code
             elif self.config.file:
                 bc_integration.scan_file = self.config.file
@@ -652,7 +664,7 @@ class Checkov:
                 self.graphs = runner_registry.check_type_to_graph
                 self.resource_subgraph_maps = runner_registry.check_type_to_resource_subgraph_map
                 if runner_registry.is_error_in_reports(self.scan_reports):
-                    self.exit_run()
+                    self._internal_error_occurred = True
                 if baseline:
                     baseline.compare_and_reduce_reports(self.scan_reports)
                 if self.config.create_baseline:
@@ -698,6 +710,9 @@ class Checkov:
                     created_baseline_path=created_baseline_path,
                     baseline=baseline,
                 )
+                if self._internal_error_occurred:
+                    internal_exit = self._get_exit_code_for_internal_error()
+                    exit_code = internal_exit if internal_exit != 0 else exit_code
                 return exit_code
             elif not self.config.quiet:
                 print(f"{banner}")
@@ -710,16 +725,16 @@ class Checkov:
             # we don't want to print all of these stack traces in normal output, as these could be user error
             # and stack traces look like checkov bugs
             logging.debug("Exception traceback:", exc_info=True)
-            self.exit_run()
-            return None
-        except SystemExit:
-            # calling exit_run from an exception handler causes another exception that is caught here, so we just need to re-exit
-            self.exit_run()
-            return None
+            self._internal_error_occurred = True
+            return self._get_exit_code_for_internal_error()
+        except SystemExit as e:
+            # exit_run() or other code raised SystemExit - propagate the exit code
+            self._internal_error_occurred = True
+            return e.code if isinstance(e.code, int) else self._get_exit_code_for_internal_error()
         except BaseException:  # noqa: B036 # we need to catch any failure and exit properly
             logging.error("Exception traceback:", exc_info=True)
-            self.exit_run()
-            return None
+            self._internal_error_occurred = True
+            return self._get_exit_code_for_internal_error()
 
         finally:
             if bc_integration.support_flag_enabled:
@@ -745,8 +760,21 @@ class Checkov:
                 else:
                     bc_integration.persist_all_logs_streams(logger_streams.get_streams())
 
+    def _get_exit_code_for_internal_error(self) -> int:
+        """Return the appropriate exit code when an internal error has occurred.
+
+        Returns 2 to signal an internal error (distinct from exit code 1 for failed checks),
+        or 0 if --no-fail-on-crash is set.
+        """
+        if self.config.no_fail_on_crash:
+            logging.debug("Internal error occurred but --no-fail-on-crash is set, returning exit code 0")
+            return 0
+        logging.warning("Returning exit code 2 due to an internal error during the scan")
+        return 2
+
     def exit_run(self) -> None:
-        exit(0) if self.config.no_fail_on_crash else exit(2)
+        self._internal_error_occurred = True
+        exit(self._get_exit_code_for_internal_error())
 
     def commit_repository(self) -> str | None:
         try:

--- a/tests/test_internal_error_exit_code.py
+++ b/tests/test_internal_error_exit_code.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch, MagicMock
+
+from typing_extensions import Literal
+
+from checkov import main
+from checkov.common.models.enums import ErrorStatus
+from checkov.common.output.report import Report
+from checkov.common.runners.base_runner import BaseRunner
+from checkov.common.runners.runner_registry import RunnerRegistry
+from checkov.main import Checkov
+from checkov.runner_filter import RunnerFilter
+
+if TYPE_CHECKING:
+    import argparse
+    from checkov.common.output.baseline import Baseline
+
+
+RESOURCE_DIR = str(Path(__file__).parent / "common/runner_registry/example_multi_iac")
+
+
+class NoOutputRunnerRegistry(RunnerRegistry):
+    """A runner registry that suppresses output for testing."""
+
+    def __init__(self, banner: str, runner_filter: RunnerFilter, *runners: BaseRunner) -> None:
+        super().__init__(banner, runner_filter, *runners)
+
+    def print_reports(
+        self,
+        scan_reports: list[Report],
+        config: argparse.Namespace,
+        url: str | None = None,
+        created_baseline_path: str | None = None,
+        baseline: Baseline | None = None,
+    ) -> Literal[0, 1]:
+        return 0
+
+
+def _make_checkov(extra_argv: list[str] | None = None) -> Checkov:
+    argv = ["-d", RESOURCE_DIR, "--framework", "terraform"]
+    if extra_argv:
+        argv.extend(extra_argv)
+    ckv = Checkov(argv=argv)
+    return ckv
+
+
+def test_normal_run_returns_zero_or_one():
+    """A normal run without internal errors returns 0 (pass) or 1 (failed checks)."""
+    ckv = _make_checkov()
+    # suppress output
+    with patch.dict(os.environ, {"CHECKOV_NO_OUTPUT": "True"}):
+        exit_code = ckv.run()
+    assert exit_code in (0, 1), f"Expected 0 or 1, got {exit_code}"
+    assert not ckv._internal_error_occurred
+
+
+def test_exit_code_2_on_report_error():
+    """When a report has an error status, the exit code should be 2."""
+    ckv = _make_checkov()
+
+    original_run = RunnerRegistry.run
+
+    def patched_run(self, *args, **kwargs):
+        results = original_run(self, *args, **kwargs)
+        # Simulate an internal error in one of the reports
+        if results:
+            results[0].error_status = ErrorStatus.ERROR
+        return results
+
+    with patch.dict(os.environ, {"CHECKOV_NO_OUTPUT": "True"}):
+        with patch.object(RunnerRegistry, "run", patched_run):
+            exit_code = ckv.run()
+
+    assert exit_code == 2, f"Expected exit code 2 for internal error, got {exit_code}"
+    assert ckv._internal_error_occurred
+
+
+def test_exit_code_0_on_report_error_with_no_fail_on_crash():
+    """When --no-fail-on-crash is set, internal errors return exit code 0."""
+    ckv = _make_checkov(extra_argv=["--no-fail-on-crash"])
+
+    original_run = RunnerRegistry.run
+
+    def patched_run(self, *args, **kwargs):
+        results = original_run(self, *args, **kwargs)
+        if results:
+            results[0].error_status = ErrorStatus.ERROR
+        return results
+
+    with patch.dict(os.environ, {"CHECKOV_NO_OUTPUT": "True"}):
+        with patch.object(RunnerRegistry, "run", patched_run):
+            exit_code = ckv.run()
+
+    assert exit_code == 0, f"Expected exit code 0 with --no-fail-on-crash, got {exit_code}"
+    assert ckv._internal_error_occurred
+
+
+def test_exit_code_2_on_unhandled_exception():
+    """When an unhandled exception occurs during the run, exit code should be 2."""
+    ckv = _make_checkov()
+
+    with patch.dict(os.environ, {"CHECKOV_NO_OUTPUT": "True"}):
+        with patch.object(RunnerRegistry, "run", side_effect=RuntimeError("simulated internal error")):
+            exit_code = ckv.run()
+
+    assert exit_code == 2, f"Expected exit code 2 for unhandled exception, got {exit_code}"
+    assert ckv._internal_error_occurred
+
+
+def test_exit_code_0_on_unhandled_exception_with_no_fail_on_crash():
+    """When an unhandled exception occurs with --no-fail-on-crash, exit code should be 0."""
+    ckv = _make_checkov(extra_argv=["--no-fail-on-crash"])
+
+    with patch.dict(os.environ, {"CHECKOV_NO_OUTPUT": "True"}):
+        with patch.object(RunnerRegistry, "run", side_effect=RuntimeError("simulated internal error")):
+            exit_code = ckv.run()
+
+    assert exit_code == 0, f"Expected exit code 0 with --no-fail-on-crash, got {exit_code}"
+    assert ckv._internal_error_occurred
+
+
+def test_internal_error_flag_from_platform_integration():
+    """When bc_integration.internal_error_occurred is set, exit code should be 2."""
+    ckv = _make_checkov()
+
+    from checkov.common.bridgecrew.platform_integration import bc_integration
+
+    # Simulate a platform integration internal error
+    original_value = bc_integration.internal_error_occurred
+    try:
+        bc_integration.internal_error_occurred = True
+        with patch.dict(os.environ, {"CHECKOV_NO_OUTPUT": "True"}):
+            exit_code = ckv.run()
+        assert exit_code == 2, f"Expected exit code 2 for platform integration error, got {exit_code}"
+        assert ckv._internal_error_occurred
+    finally:
+        bc_integration.internal_error_occurred = original_value
+
+
+def test_get_exit_code_for_internal_error():
+    """Test the _get_exit_code_for_internal_error helper method."""
+    ckv = _make_checkov()
+    assert ckv._get_exit_code_for_internal_error() == 2
+
+    ckv_no_fail = _make_checkov(extra_argv=["--no-fail-on-crash"])
+    assert ckv_no_fail._get_exit_code_for_internal_error() == 0


### PR DESCRIPTION
Closes #7393

## Summary

- Internal errors (API failures, JSON decode errors in `get_public_run_config`) now return exit code 2 instead of being silently swallowed
- Added `--no-fail-on-crash` flag support: returns 0 on internal errors when set
- Scan continues after internal errors so partial results are still reported (behavioral improvement over previous immediate termination)

## Exit code semantics

| Code | Meaning |
|------|---------|
| 0 | All checks passed (or soft-fail) |
| 1 | One or more checks failed |
| 2 | Internal error during scan |

When `--no-fail-on-crash` is set, internal errors return 0 instead of 2. Check failures (exit 1) still take precedence over suppressed internal errors.

## Test plan

- [x] 7 new tests covering: normal run, report errors, unhandled exceptions, `--no-fail-on-crash` override, platform integration flag, exit code helper
- [x] All existing exit code tests pass