### PR TITLE
fix(terraform): evaluate for expressions in module for_each

### DIFF
--- a/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
+++ b/checkov/terraform/graph_builder/variable_rendering/evaluate_terraform.py
@@ -349,13 +349,15 @@ def _handle_for_loop_in_dict(object_to_run_on: str, statement: str, start_expres
         return None
     k_expression, v_expression = split_expression
     obj_key = statement.split(' ')[1]
+    use_obj_as_key = k_expression == obj_key
     if k_expression.startswith(f'{obj_key}.'):
         k_expression = k_expression.replace(f'{obj_key}.', '')
     rendered_result = {}
     for obj in evaluated_object_to_run_on:
         val_to_assign = obj if statement.startswith(f'{renderer.LEFT_CURLY}{renderer.FOR_LOOP} {v_expression}') else evaluate_terraform(v_expression)
         try:
-            rendered_result[obj[k_expression]] = val_to_assign
+            key = obj if use_obj_as_key else obj[k_expression]
+            rendered_result[key] = val_to_assign
         except (TypeError, KeyError):
             return None
     return json.dumps(rendered_result)

--- a/tests/terraform/graph/variable_rendering/resources/foreach_module_for_expression/main.tf
+++ b/tests/terraform/graph/variable_rendering/resources/foreach_module_for_expression/main.tf
@@ -1,0 +1,10 @@
+variable "items" {
+  type    = list(string)
+  default = ["a", "b"]
+}
+
+module "child" {
+  source   = "./module"
+  for_each = { for v in var.items : v => v }
+  val      = each.value
+}

--- a/tests/terraform/graph/variable_rendering/resources/foreach_module_for_expression/module/main.tf
+++ b/tests/terraform/graph/variable_rendering/resources/foreach_module_for_expression/module/main.tf
@@ -1,0 +1,7 @@
+variable "val" {
+  type = string
+}
+
+resource "terraform_data" "test" {
+  input = var.val
+}

--- a/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
+++ b/tests/terraform/graph/variable_rendering/test_foreach_renderer.py
@@ -439,6 +439,21 @@ def test_foreach_module_with_more_than_two_resources(checkov_source_path):
     assert len(tf_definitions.keys()) == 17
 
 
+@mock.patch.dict(os.environ, {"CHECKOV_ENABLE_MODULES_FOREACH_HANDLING": "True"})
+def test_foreach_module_with_for_expression(checkov_source_path):
+    dir_name = 'foreach_module_for_expression'
+    graph, _ = build_and_get_graph_by_path(dir_name, render_var=True)
+
+    module_vertices = [b for b in graph.vertices if b.block_type == 'module']
+    assert len(module_vertices) == 2
+
+    module_names = sorted([v.name for v in module_vertices])
+    assert module_names == ['child["a"]', 'child["b"]']
+
+    resource_vertices = [b for b in graph.vertices if b.block_type == 'resource']
+    assert len(resource_vertices) == 2
+
+
 @pytest.mark.parametrize(
     "statement,expected",
     [

--- a/tests/terraform/graph/variable_rendering/test_string_evaluation.py
+++ b/tests/terraform/graph/variable_rendering/test_string_evaluation.py
@@ -489,6 +489,11 @@ class TestTerraformEvaluation(TestCase):
         expected = {'key3': 'true', 'key4': 'true'}
         self.assertEqual(expected, evaluate_terraform(input_str))
 
+    def test_handle_for_loop_in_dict_with_simple_iterable(self):
+        input_str = "{for v in ['a', 'b'] : v => v}"
+        expected = {'a': 'a', 'b': 'b'}
+        self.assertEqual(expected, evaluate_terraform(input_str))
+
     def test_handle_for_loop_in_list(self):
         input_str = "[for val in ['k', 'v'] : val]"
         expected = ['k', 'v']


### PR DESCRIPTION
## Summary

Fixes #7503

When a module's `for_each` uses a `for` expression with a simple identity mapping (e.g. `{ for v in var.items : v => v }`), `_handle_for_loop_in_dict()` assumed iterable items are always dicts and tried `obj[k_expression]`, which raises `TypeError` on string items. The module was silently skipped.

- Handle the case where the key expression equals the loop variable by using the item directly as the dict key
- Add unit test for the for-expression evaluation
- Add integration test verifying module expansion with a for expression in `for_each`

## Test plan

- [x] New unit test: `test_handle_for_loop_in_dict_with_simple_iterable` -- `{for v in ['a', 'b'] : v => v}` evaluates to `{'a': 'a', 'b': 'b'}`
- [x] New integration test: `test_foreach_module_with_for_expression` -- module with `for_each = { for v in var.items : v => v }` expands to `child["a"]` and `child["b"]`
- [x] Full `tests/terraform/graph/variable_rendering/` suite passes (207 passed, 0 failed)