### PR TITLE
fix(general): make version cache init lazy

### DIFF
--- a/checkov/common/util/update_checker/update_checker.py
+++ b/checkov/common/util/update_checker/update_checker.py
@@ -101,9 +101,6 @@ def cache_results(
     def _ensure_initialized() -> None:
         """Lazily initialize the cache directory and load the permacache on first use.
 
-        This avoids calling os.makedirs() at import time, which would crash
-        on read-only filesystems even when the update check is disabled via
-        ``CKV_SKIP_PACKAGE_UPDATE_CHECK``.
         """
         if _state["initialized"]:
             return

--- a/checkov/common/util/update_checker/update_checker.py
+++ b/checkov/common/util/update_checker/update_checker.py
@@ -98,22 +98,39 @@ def cache_results(
 ) -> Callable[[UpdateChecker, str, str], UpdateResult | None]:
     """Return decorated function that caches the results."""
 
+    def _ensure_initialized() -> None:
+        """Lazily initialize the cache directory and load the permacache on first use.
+
+        This avoids calling os.makedirs() at import time, which would crash
+        on read-only filesystems even when the update check is disabled via
+        ``CKV_SKIP_PACKAGE_UPDATE_CHECK``.
+        """
+        if _state["initialized"]:
+            return
+        _state["initialized"] = True
+        try:
+            _remove_legacy_cache()
+            _state["filename"] = os.path.join(_get_cache_dir(), CACHE_FILENAME)
+            update_from_permacache()
+        except (NotImplementedError, OSError):
+            _state["filename"] = None
+
     def save_to_permacache() -> None:
         """Merge in-memory cache into the on-disk permacache."""
         update_from_permacache()
         try:
-            if filename is None:
+            if _state["filename"] is None:
                 return
-            _write_json_atomic(filename, _serialize_cache(cache))
+            _write_json_atomic(_state["filename"], _serialize_cache(cache))
         except IOError:
             pass
 
     def update_from_permacache() -> None:
         """Load newer entries from the on-disk permacache into memory."""
         try:
-            if filename is None:
+            if _state["filename"] is None:
                 return
-            with open(filename, "r") as fp:
+            with open(_state["filename"], "r") as fp:
                 permacache = _deserialize_cache(json.load(fp))
         except Exception:
             return
@@ -122,16 +139,12 @@ def cache_results(
                 cache[key] = value
 
     cache: dict[tuple[str, str], tuple[float, UpdateResult | None]] = {}
-    try:
-        _remove_legacy_cache()
-        filename = os.path.join(_get_cache_dir(), CACHE_FILENAME)
-        update_from_permacache()
-    except NotImplementedError:
-        filename = None
+    _state: dict[str, Any] = {"initialized": False, "filename": None}
 
     @wraps(function)
     def wrapped(obj: UpdateChecker, package_name: str, package_version: str, **extra_data: Any) -> UpdateResult | None:
         """Return cached results if available."""
+        _ensure_initialized()
         now = time.time()
         key = (package_name, package_version)
         if not obj._bypass_cache and key in cache:
@@ -140,7 +153,7 @@ def cache_results(
                 return retval
         retval = function(obj, package_name, package_version, **extra_data)
         cache[key] = now, retval
-        if filename:
+        if _state["filename"]:
             save_to_permacache()
         return retval
 

--- a/tests/common/utils/test_update_checker.py
+++ b/tests/common/utils/test_update_checker.py
@@ -1,13 +1,14 @@
 """Tests for checkov.common.util.update_checker.update_checker."""
 from __future__ import annotations
 
+import errno
 import json
 import os
 import pickle
 import time
 from tempfile import gettempdir
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -16,7 +17,9 @@ from checkov.common.util.update_checker.update_checker import (
     DATE_FORMAT,
     KEY_SEPARATOR,
     LEGACY_CACHE_FILENAME,
+    UpdateChecker,
     UpdateResult,
+    cache_results,
     _deserialize_cache,
     _deserialize_result,
     _get_cache_dir,
@@ -212,6 +215,178 @@ class TestReadOnlyFilesystem:
             result = check_for_update("checkov", "3.0.0", skip_check=True)
 
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# PermissionError / OSError graceful degradation
+# ---------------------------------------------------------------------------
+
+class TestCacheGracefulDegradation:
+    """Verify that every cache code path handles PermissionError and OSError
+    without crashing, so checkov works on read-only volumes, permission-
+    restricted home dirs, full disks, and network-mounted filesystems."""
+
+    # -- _get_cache_dir: PermissionError (e.g. non-writable home) ----------
+
+    def test_permission_error_on_makedirs(self) -> None:
+        """PermissionError in _get_cache_dir degrades to in-memory cache."""
+        @cache_results
+        def dummy(self: UpdateChecker, pkg: str, ver: str) -> UpdateResult | None:
+            return UpdateResult(package=pkg, running=ver, available="9.0", release_date=None)
+
+        with patch(
+            "checkov.common.util.update_checker.update_checker._get_cache_dir",
+            side_effect=PermissionError(errno.EACCES, "Permission denied", "/home/locked/.cache"),
+        ):
+            checker = UpdateChecker()
+            result = dummy(checker, "checkov", "1.0")
+
+        assert result is not None
+        assert result.available_version == "9.0"
+
+    # -- _get_cache_dir: OSError EROFS (read-only filesystem) ---------------
+
+    def test_readonly_fs_erofs(self) -> None:
+        """OSError with errno 30 (EROFS) degrades to in-memory cache."""
+        @cache_results
+        def dummy(self: UpdateChecker, pkg: str, ver: str) -> UpdateResult | None:
+            return UpdateResult(package=pkg, running=ver, available="8.0", release_date=None)
+
+        with patch(
+            "checkov.common.util.update_checker.update_checker._get_cache_dir",
+            side_effect=OSError(errno.EROFS, "Read-only file system", "/home/nonroot/.cache"),
+        ):
+            checker = UpdateChecker()
+            result = dummy(checker, "checkov", "2.0")
+
+        assert result is not None
+        assert result.available_version == "8.0"
+
+    # -- save_to_permacache: IOError on write (disk full, etc.) -------------
+
+    def test_disk_full_on_cache_write(self, tmp_path: Any) -> None:
+        """IOError during save_to_permacache must not crash the check."""
+        cache_dir = str(tmp_path / "checkov_cache")
+        os.makedirs(cache_dir)
+        cache_file = os.path.join(cache_dir, CACHE_FILENAME)
+
+        @cache_results
+        def dummy(self: UpdateChecker, pkg: str, ver: str) -> UpdateResult | None:
+            return UpdateResult(package=pkg, running=ver, available="7.0", release_date=None)
+
+        # Let init succeed (writable dir), but make writes fail
+        with patch(
+            "checkov.common.util.update_checker.update_checker._get_cache_dir",
+            return_value=cache_dir,
+        ):
+            with patch(
+                "checkov.common.util.update_checker.update_checker._write_json_atomic",
+                side_effect=IOError(errno.ENOSPC, "No space left on device"),
+            ):
+                checker = UpdateChecker()
+                result = dummy(checker, "checkov", "3.0")
+
+        # Function must still return the result despite write failure
+        assert result is not None
+        assert result.available_version == "7.0"
+
+    # -- update_from_permacache: corrupt cache file -------------------------
+
+    def test_corrupt_cache_file_does_not_crash(self, tmp_path: Any) -> None:
+        """A corrupt (non-JSON) cache file must not crash the check."""
+        cache_dir = str(tmp_path / "checkov_cache")
+        os.makedirs(cache_dir)
+        cache_file = os.path.join(cache_dir, CACHE_FILENAME)
+
+        # Write garbage to the cache file
+        with open(cache_file, "w") as f:
+            f.write("NOT VALID JSON {{{")
+
+        @cache_results
+        def dummy(self: UpdateChecker, pkg: str, ver: str) -> UpdateResult | None:
+            return UpdateResult(package=pkg, running=ver, available="6.0", release_date=None)
+
+        with patch(
+            "checkov.common.util.update_checker.update_checker._get_cache_dir",
+            return_value=cache_dir,
+        ):
+            checker = UpdateChecker()
+            result = dummy(checker, "checkov", "4.0")
+
+        assert result is not None
+        assert result.available_version == "6.0"
+
+    # -- update_from_permacache: PermissionError reading cache file ---------
+
+    def test_permission_denied_reading_cache_file(self, tmp_path: Any) -> None:
+        """PermissionError reading the cache file degrades gracefully."""
+        cache_dir = str(tmp_path / "checkov_cache")
+        os.makedirs(cache_dir)
+        cache_file = os.path.join(cache_dir, CACHE_FILENAME)
+
+        # Create a valid cache file, then make it unreadable
+        _write_json_atomic(cache_file, {})
+        os.chmod(cache_file, 0o000)
+
+        @cache_results
+        def dummy(self: UpdateChecker, pkg: str, ver: str) -> UpdateResult | None:
+            return UpdateResult(package=pkg, running=ver, available="5.0", release_date=None)
+
+        try:
+            with patch(
+                "checkov.common.util.update_checker.update_checker._get_cache_dir",
+                return_value=cache_dir,
+            ):
+                checker = UpdateChecker()
+                result = dummy(checker, "checkov", "5.0")
+
+            assert result is not None
+            assert result.available_version == "5.0"
+        finally:
+            # Restore permissions so tmp_path cleanup works
+            os.chmod(cache_file, 0o644)
+
+    # -- Multiple calls: in-memory cache works when disk is unavailable -----
+
+    def test_in_memory_cache_works_without_disk(self) -> None:
+        """When disk cache is unavailable, in-memory caching still prevents
+        redundant calls to the wrapped function."""
+        call_count = 0
+
+        @cache_results
+        def dummy(self: UpdateChecker, pkg: str, ver: str) -> UpdateResult | None:
+            nonlocal call_count
+            call_count += 1
+            return UpdateResult(package=pkg, running=ver, available="4.0", release_date=None)
+
+        with patch(
+            "checkov.common.util.update_checker.update_checker._get_cache_dir",
+            side_effect=OSError("Read-only file system"),
+        ):
+            checker = UpdateChecker()
+            result1 = dummy(checker, "checkov", "1.0")
+            result2 = dummy(checker, "checkov", "1.0")
+
+        assert call_count == 1, "Second call should use in-memory cache"
+        assert result1 is not None
+        assert result2 is not None
+        assert result1.available_version == result2.available_version == "4.0"
+
+    # -- _remove_legacy_cache: PermissionError on temp dir ------------------
+
+    def test_legacy_cache_removal_permission_error(self, tmp_path: Any) -> None:
+        """PermissionError removing legacy cache must not crash."""
+        with patch(
+            "checkov.common.util.update_checker.update_checker.gettempdir",
+            return_value=str(tmp_path),
+        ):
+            with patch("os.remove", side_effect=PermissionError("Permission denied")):
+                # Create the legacy file so the code path tries to remove it
+                legacy_path = os.path.join(str(tmp_path), LEGACY_CACHE_FILENAME)
+                with open(legacy_path, "w") as f:
+                    f.write("legacy")
+                # Must not raise
+                _remove_legacy_cache()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/common/utils/test_update_checker.py
+++ b/tests/common/utils/test_update_checker.py
@@ -149,6 +149,72 @@ class TestGetCacheDir:
 
 
 # ---------------------------------------------------------------------------
+# Lazy initialization: read-only filesystem safety
+# ---------------------------------------------------------------------------
+
+class TestReadOnlyFilesystem:
+    """Verify that importing / decorating does NOT touch the filesystem.
+
+    The cache directory should only be created on the first actual call to
+    the decorated function, so that ``CKV_SKIP_PACKAGE_UPDATE_CHECK=True``
+    can prevent the call entirely and avoid the OSError on read-only mounts.
+    """
+
+    def test_import_does_not_call_makedirs(self) -> None:
+        """Applying @cache_results must not invoke _get_cache_dir / os.makedirs."""
+        from checkov.common.util.update_checker.update_checker import cache_results, UpdateChecker, UpdateResult
+
+        makedirs_called = False
+        original_makedirs = os.makedirs
+
+        def tracking_makedirs(*args: Any, **kwargs: Any) -> None:
+            nonlocal makedirs_called
+            makedirs_called = True
+            original_makedirs(*args, **kwargs)
+
+        with patch("checkov.common.util.update_checker.update_checker.os.makedirs", side_effect=tracking_makedirs):
+            # Re-apply the decorator — simulates what happens at import time
+            @cache_results
+            def dummy_check(self: UpdateChecker, pkg: str, ver: str) -> UpdateResult | None:
+                return None
+
+        # The decorator body must NOT have called makedirs
+        assert not makedirs_called, "cache_results must not call os.makedirs at decoration time"
+
+    def test_cache_results_gracefully_handles_readonly_fs(self) -> None:
+        """When _get_cache_dir raises OSError the decorated function still works."""
+        from checkov.common.util.update_checker.update_checker import cache_results, UpdateChecker, UpdateResult
+
+        @cache_results
+        def dummy_check(self: UpdateChecker, pkg: str, ver: str) -> UpdateResult | None:
+            return UpdateResult(package=pkg, running=ver, available="99.0", release_date=None)
+
+        with patch(
+            "checkov.common.util.update_checker.update_checker._get_cache_dir",
+            side_effect=OSError("Read-only file system"),
+        ):
+            checker = UpdateChecker()
+            result = dummy_check(checker, "checkov", "1.0")
+
+        assert result is not None
+        assert result.available_version == "99.0"
+
+    def test_skip_update_check_never_triggers_cache_init(self) -> None:
+        """Simulates the real-world flow: skip_check=True means check() is never
+        called, so the cache directory is never created."""
+        from checkov.common.version_manager import check_for_update
+
+        with patch(
+            "checkov.common.util.update_checker.update_checker._get_cache_dir",
+            side_effect=OSError("Read-only file system"),
+        ):
+            # skip_check=True → returns None immediately, never calls UpdateChecker.check()
+            result = check_for_update("checkov", "3.0.0", skip_check=True)
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
 # Integration: JSON cache file is used, not pickle
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

Replaced eager initialization with a lazy _ensure_initialized() guard that defers all filesystem operations (directory creation, permacache loading) to the first actual call 

Fixes #7507

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
