### PR TITLE
fix(terraform): add aws:VpceAccount to recognized condition keys in check CKV_AWS_70

### DIFF
--- a/checkov/terraform/checks/resource/aws/S3AllowsAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/S3AllowsAnyPrincipal.py
@@ -44,6 +44,7 @@ def check_conditions(statement) -> bool:
                 # 'aws:PrincipalServiceName', 'aws:PrincipalServiceNamesList', 'aws:PrincipalType', 'aws:userid',
                 # 'aws:username'
                 if any(source in condition[condition_type] for source in ['aws:sourceVpce', 'aws:SourceVpc',
+                                                                          'aws:VpceAccount',
                                                                           'aws:PrincipalOrgPaths', 'aws:userid',
                                                                           'aws:PrincipalArn',
                                                                           'aws:PrincipalAccount',

--- a/tests/terraform/checks/resource/aws/example_S3AllowsAnyPrincipal/main.tf
+++ b/tests/terraform/checks/resource/aws/example_S3AllowsAnyPrincipal/main.tf
@@ -485,6 +485,27 @@ resource "aws_s3_bucket" "pass_w_condition6" {
 POLICY
 }
 
+resource "aws_s3_bucket_policy" "vpce_account_condition" {
+  bucket = "example"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowVpceAccount"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "arn:aws:s3:::example/*"
+        Condition = {
+          StringEquals = {
+            "aws:VpceAccount" = "123456789012"
+          }
+        }
+      }
+    ]
+  })
+}
+
 # Handle error
 resource "aws_s3_bucket_policy" "logs" {
   bucket = aws_s3_bucket.logs.id

--- a/tests/terraform/checks/resource/aws/test_S3AllowsAnyPrincipal.py
+++ b/tests/terraform/checks/resource/aws/test_S3AllowsAnyPrincipal.py
@@ -27,6 +27,7 @@ class TestS3AllowsAnyPrincipal(unittest.TestCase):
             "aws_s3_bucket.pass_w_condition4",
             "aws_s3_bucket.pass_w_condition5",
             "aws_s3_bucket.pass_w_condition6",
+            "aws_s3_bucket_policy.vpce_account_condition",
         }
         failing_resources = {
             "aws_s3_bucket.fail",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Customer is experiencing a false positive with Checkov policy CKV_AWS_70 ("Ensure S3 bucket does not allow an action with any Principal").
The policy currently fails whenever an AWS resource policy uses the aws:VpceAccount condition key to restrict access. 
In this PR the condition aws:VpceAccount is being added to the conditions list in policy CKV_AWS_70.

Fixes PCSUP-30968

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
