### PR TITLE
fix(general): Strip unnecessary control bytes from CLI code block

### DIFF
--- a/checkov/common/output/record.py
+++ b/checkov/common/output/record.py
@@ -26,6 +26,12 @@ SCA_PACKAGE_SCAN_CHECK_NAME = "SCA package scan"
 SCA_LICENSE_CHECK_NAME = "SCA license"
 PLACEHOLDER_LINE = "...\n"
 
+# C0 control characters (excluding \t and \n) plus DEL. These are removed from
+# source lines before they are written to the CLI code-block output so that any
+# ANSI/OSC escape sequences embedded in scanned files don't affect terminal
+# rendering (e.g. colour resets, clear-screen, OSC 8 hyperlinks).
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+
 
 class Record:
     def __init__(
@@ -124,6 +130,7 @@ class Record:
                    f'Please use IDE of your choice to review the file.'
 
         for line_num, line in code_block:
+            line = _CONTROL_CHARS_RE.sub("", line)
             spaces = " " * (last_line_number_len - len(str(line_num)))
             if line.lstrip().startswith("#"):
                 code_output.append(f"\t\t{color_codes[0]}{line_num}{spaces} | {line}")

--- a/tests/common/output/test_record.py
+++ b/tests/common/output/test_record.py
@@ -39,3 +39,22 @@ def test_from_reduced_json(json_reduced_check):
             ],
         ]
     assert record.bc_check_id == 'BC_REPO_GITHUB_ACTION_1'
+
+
+def test_code_line_string_strips_control_chars():
+    """Embedded ANSI/OSC escape sequences in source lines should not be passed
+    through to the CLI code-block output; tab and newline must be preserved."""
+    code_block = [
+        (1, 'resource "x" "y" {\n'),
+        (2, '\tdescription = "\x1b[2J\x1b]8;;http://example/\x07link\x1b]8;;\x07"\n'),
+        (3, '}\n'),
+    ]
+
+    out = Record._code_line_string(code_block, colorized=False)
+
+    assert "\x1b" not in out
+    assert "\x07" not in out
+    # printable content, tab indentation and newlines are kept
+    assert "link" in out
+    assert "\tdescription" in out
+    assert out.count("\n") == 3


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
