### PR TITLE
fix(sca): Align ImageScanner.run_image_scan with execute_scan

### DIFF
--- a/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
+++ b/checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import subprocess  # nosec
 from pathlib import Path
-from typing import Union, Dict, Any
+from typing import Union, Dict, Any, List
 import asyncio
 from urllib.parse import quote_plus
 
@@ -20,10 +20,21 @@ from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.util.file_utils import decompress_file_gzip_base64
 from checkov.common.util.http_utils import request_wrapper, aiohttp_client_session_wrapper
 from checkov.common.bridgecrew.platform_key import bridgecrew_dir
+from checkov.common.sca.commons import validate_image_id
 
 TWISTCLI_FILE_NAME = 'twistcli'
 DOCKER_IMAGE_SCAN_RESULT_FILE_NAME = 'docker-image-scan-results.json'
 CHECKOV_SEC_IN_WEEK = 604800
+_REDACT_FLAGS = ("--token",)
+
+
+def redact_token_args(command_args: List[str]) -> List[str]:
+    """Return a copy of command_args with the value following any flag in _REDACT_FLAGS replaced by '***'."""
+    redacted: List[str] = list(command_args)
+    for i, arg in enumerate(redacted[:-1]):
+        if arg in _REDACT_FLAGS:
+            redacted[i + 1] = "***"
+    return redacted
 
 
 def generate_image_name() -> str:
@@ -80,9 +91,21 @@ class ImageScanner:
             logging.info('twistcli file removed')
 
     def run_image_scan(self, docker_image_id: str) -> Dict[str, Any]:
-        command = f"./{self.twistcli_path} images scan --address {docker_image_scanning_integration.get_proxy_address()} --token {docker_image_scanning_integration.get_bc_api_key()} --details --output-file \"{DOCKER_IMAGE_SCAN_RESULT_FILE_NAME}\" {docker_image_id}"
-        logging.debug(f"TwistCLI: {command}")
-        command_args = command.split(' ')
+        if not validate_image_id(docker_image_id):
+            logging.error(f"Invalid docker image id format: {docker_image_id}")
+            self.cleanup_scan()
+            raise ValueError(f"Invalid docker image id format: {docker_image_id}")
+
+        command_args = [
+            str(self.twistcli_path),
+            "images", "scan",
+            "--address", docker_image_scanning_integration.get_proxy_address(),
+            "--token", docker_image_scanning_integration.get_bc_api_key(),
+            "--details",
+            "--output-file", DOCKER_IMAGE_SCAN_RESULT_FILE_NAME,
+            docker_image_id,
+        ]
+        logging.debug(f"TwistCLI: {redact_token_args(command_args)}")
         try:
             subprocess.run(command_args, check=True, shell=False)  # nosec B603
         except Exception as exc:

--- a/checkov/sca_image/runner.py
+++ b/checkov/sca_image/runner.py
@@ -10,7 +10,8 @@ from typing import Optional, Union, Dict, Any
 
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.bridgecrew.platform_key import bridgecrew_dir
-from checkov.common.bridgecrew.vulnerability_scanning.image_scanner import image_scanner, TWISTCLI_FILE_NAME
+from checkov.common.bridgecrew.vulnerability_scanning.image_scanner import image_scanner, TWISTCLI_FILE_NAME, \
+    redact_token_args
 from checkov.common.bridgecrew.vulnerability_scanning.integrations.docker_image_scanning import \
     docker_image_scanning_integration
 from checkov.common.images.image_referencer import ImageReferencer, Image
@@ -107,7 +108,7 @@ class Runner(PackageRunner):
         except UnicodeDecodeError:
             logging.error("error was caught when trying to decode the \'stdout\' from twistcli.\n"
                           f"file content is:\n{image_scanner.dockerfile_content}.\n"
-                          f"twistcli command args are \'{command_args}\'", exc_info=True)
+                          f"twistcli command args are \'{redact_token_args(command_args)}\'", exc_info=True)
 
         exit_code = await process.wait()
 

--- a/tests/common/bridgecrew/vulnerability_scanning/integrations/test_docker_image_scanning.py
+++ b/tests/common/bridgecrew/vulnerability_scanning/integrations/test_docker_image_scanning.py
@@ -1,3 +1,5 @@
+import json
+import logging
 import os
 from pathlib import Path
 from unittest import mock
@@ -6,7 +8,12 @@ import pytest
 from aioresponses import aioresponses
 from pytest_mock import MockerFixture
 
-from checkov.common.bridgecrew.vulnerability_scanning.image_scanner import ImageScanner, CHECKOV_SEC_IN_WEEK
+from checkov.common.bridgecrew.vulnerability_scanning.image_scanner import (
+    ImageScanner,
+    CHECKOV_SEC_IN_WEEK,
+    DOCKER_IMAGE_SCAN_RESULT_FILE_NAME,
+    redact_token_args,
+)
 from checkov.common.bridgecrew.vulnerability_scanning.integrations.docker_image_scanning import (
     docker_image_scanning_integration,
 )
@@ -217,3 +224,56 @@ def test_cleanup_twistcli_not_exists(tmp_path: Path):
 
     # then
     assert not twistcli_path.exists()
+
+
+def test_redact_token_args():
+    args = ["twistcli", "images", "scan", "--address", "https://addr", "--token", "super-secret", "--details", "img"]
+    redacted = redact_token_args(args)
+
+    assert redacted[redacted.index("--token") + 1] == "***"
+    assert "super-secret" not in redacted
+    # original list must not be mutated
+    assert args[args.index("--token") + 1] == "super-secret"
+
+
+def test_run_image_scan_builds_list_args(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+):
+    # given
+    scanner = ImageScanner()
+    scanner.twistcli_path = tmp_path / "twistcli"
+    image_id = "alpine:3.19"
+    api_key = "abcd1234-abcd-1234-abcd-1234abcd1234"
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / DOCKER_IMAGE_SCAN_RESULT_FILE_NAME).write_text(json.dumps({"results": [{}]}))
+
+    mocker.patch.object(docker_image_scanning_integration, "get_proxy_address", return_value="https://proxy.example")
+    mocker.patch.object(docker_image_scanning_integration, "get_bc_api_key", return_value=api_key)
+    run_mock = mocker.patch("checkov.common.bridgecrew.vulnerability_scanning.image_scanner.subprocess.run")
+
+    # when
+    with caplog.at_level(logging.DEBUG):
+        scanner.run_image_scan(image_id)
+
+    # then
+    called_args = run_mock.call_args.args[0]
+    assert isinstance(called_args, list)
+    assert called_args.count(image_id) == 1
+    assert called_args[-1] == image_id
+    assert called_args[called_args.index("--output-file") + 1] == DOCKER_IMAGE_SCAN_RESULT_FILE_NAME
+    assert api_key not in caplog.text
+    assert "***" in caplog.text
+
+
+def test_run_image_scan_rejects_invalid_image_id(tmp_path: Path, mocker: MockerFixture):
+    # given
+    scanner = ImageScanner()
+    scanner.twistcli_path = tmp_path / "twistcli"
+    run_mock = mocker.patch("checkov.common.bridgecrew.vulnerability_scanning.image_scanner.subprocess.run")
+
+    # when / then
+    with pytest.raises(ValueError):
+        scanner.run_image_scan("alpine:3.19 --extra flag")
+
+    run_mock.assert_not_called()


### PR DESCRIPTION
- build twistcli args as an explicit list (consistent with sca_image runner)

- reuse validate_image_id() before invoking twistcli

- redact --token value in twistcli debug/error logs

- add unit tests for arg construction, validation and redaction

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
