### PR TITLE
fix(terraform): fix wrong windows path

### DIFF
--- a/checkov/common/runners/object_runner.py
+++ b/checkov/common/runners/object_runner.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-import platform
 
 from abc import abstractmethod
 from collections.abc import Iterable
@@ -18,6 +17,7 @@ from checkov.common.output.github_actions_record import GithubActionsRecord
 from checkov.common.output.record import Record
 from checkov.common.output.report import Report, CheckType
 from checkov.common.parallelizer.parallel_runner import parallel_runner
+from checkov.common.util.file_utils import safe_relpath
 from checkov.common.runners.base_runner import BaseRunner, filter_ignored_paths
 from checkov.common.runners.graph_manager import ObjectGraphManager
 from checkov.common.typing import _CheckResult
@@ -168,7 +168,7 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
         """Adds Python check results to given report"""
 
         for file_path in self.definitions.keys():
-            self.pbar.set_additional_data({'Current File Scanned': os.path.relpath(file_path, root_folder)})
+            self.pbar.set_additional_data({'Current File Scanned': safe_relpath(file_path, root_folder)})
             skipped_checks = collect_suppressions_for_context(self.definitions_raw[file_path])
 
             if registry.report_type == CheckType.GITLAB_CI:
@@ -188,9 +188,6 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
                     if start == -1 and end == -1:
                         logging.info(f"Skipping line in file path {file_path} in key {key}")
                         continue
-                if platform.system() == "Windows":
-                    root_folder = os.path.split(file_path)[0]
-
                 if self.check_type == CheckType.GITHUB_ACTIONS:
                     record: "Record" = GithubActionsRecord(
                         check_id=check.id,
@@ -198,7 +195,7 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
                         check_name=check.name,
                         check_result=result,
                         code_block=self.definitions_raw[file_path][start - 1:end + 1],
-                        file_path=f"/{os.path.relpath(file_path, root_folder)}",
+                        file_path=f"/{safe_relpath(file_path, root_folder)}",
                         file_line_range=[start, end + 1],
                         resource=self.get_resource(file_path, key, check.supported_entities, start, end),  # type:ignore[arg-type]  # key is str not BaseCheck
                         evaluations=None,
@@ -217,7 +214,7 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
                         check_name=check.name,
                         check_result=result,
                         code_block=self.definitions_raw[file_path][start - 1:end + 1],
-                        file_path=f"/{os.path.relpath(file_path, root_folder)}",
+                        file_path=f"/{safe_relpath(file_path, root_folder)}",
                         file_line_range=[start, end + 1],
                         resource=self.get_resource(file_path, key, check.supported_entities, start, end),  # type:ignore[arg-type]  # key is str not BaseCheck
                         evaluations=None,
@@ -240,9 +237,6 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
             for check_result in check_results:
                 entity = check_result["entity"]
                 entity_file_path: str = entity[CustomAttributes.FILE_PATH]
-
-                if platform.system() == "Windows":
-                    root_folder = os.path.split(entity_file_path)[0]
 
                 clean_check_result: _CheckResult = {
                     "result": check_result["result"],
@@ -273,7 +267,7 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
                         check_name=check.name,
                         check_result=clean_check_result,
                         code_block=code_block,
-                        file_path=f"/{os.path.relpath(entity_file_path, root_folder)}",
+                        file_path=f"/{safe_relpath(entity_file_path, root_folder)}",
                         file_line_range=[start_line, end_line + 1],
                         resource=entity[CustomAttributes.ID],
                         evaluations=None,
@@ -292,7 +286,7 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
                         check_name=check.name,
                         check_result=clean_check_result,
                         code_block=code_block,
-                        file_path=f"/{os.path.relpath(entity_file_path, root_folder)}",
+                        file_path=f"/{safe_relpath(entity_file_path, root_folder)}",
                         file_line_range=[start_line, end_line + 1],
                         resource=entity[CustomAttributes.ID],
                         evaluations=None,

--- a/checkov/common/runners/object_runner.py
+++ b/checkov/common/runners/object_runner.py
@@ -167,8 +167,9 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
     ) -> None:
         """Adds Python check results to given report"""
 
+        root_folder_str = str(root_folder) if root_folder is not None else None
         for file_path in self.definitions.keys():
-            self.pbar.set_additional_data({'Current File Scanned': safe_relpath(file_path, root_folder)})
+            self.pbar.set_additional_data({'Current File Scanned': safe_relpath(file_path, root_folder_str)})
             skipped_checks = collect_suppressions_for_context(self.definitions_raw[file_path])
 
             if registry.report_type == CheckType.GITLAB_CI:
@@ -195,7 +196,7 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
                         check_name=check.name,
                         check_result=result,
                         code_block=self.definitions_raw[file_path][start - 1:end + 1],
-                        file_path=f"/{safe_relpath(file_path, root_folder)}",
+                        file_path=f"/{safe_relpath(file_path, root_folder_str)}",
                         file_line_range=[start, end + 1],
                         resource=self.get_resource(file_path, key, check.supported_entities, start, end),  # type:ignore[arg-type]  # key is str not BaseCheck
                         evaluations=None,
@@ -214,7 +215,7 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
                         check_name=check.name,
                         check_result=result,
                         code_block=self.definitions_raw[file_path][start - 1:end + 1],
-                        file_path=f"/{safe_relpath(file_path, root_folder)}",
+                        file_path=f"/{safe_relpath(file_path, root_folder_str)}",
                         file_line_range=[start, end + 1],
                         resource=self.get_resource(file_path, key, check.supported_entities, start, end),  # type:ignore[arg-type]  # key is str not BaseCheck
                         evaluations=None,

--- a/checkov/common/runners/object_runner.py
+++ b/checkov/common/runners/object_runner.py
@@ -167,9 +167,8 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
     ) -> None:
         """Adds Python check results to given report"""
 
-        root_folder_str = str(root_folder) if root_folder is not None else None
         for file_path in self.definitions.keys():
-            self.pbar.set_additional_data({'Current File Scanned': safe_relpath(file_path, root_folder_str)})
+            self.pbar.set_additional_data({'Current File Scanned': safe_relpath(file_path, root_folder)})
             skipped_checks = collect_suppressions_for_context(self.definitions_raw[file_path])
 
             if registry.report_type == CheckType.GITLAB_CI:
@@ -196,7 +195,7 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
                         check_name=check.name,
                         check_result=result,
                         code_block=self.definitions_raw[file_path][start - 1:end + 1],
-                        file_path=f"/{safe_relpath(file_path, root_folder_str)}",
+                        file_path=f"/{safe_relpath(file_path, root_folder)}",
                         file_line_range=[start, end + 1],
                         resource=self.get_resource(file_path, key, check.supported_entities, start, end),  # type:ignore[arg-type]  # key is str not BaseCheck
                         evaluations=None,
@@ -215,7 +214,7 @@ class Runner(BaseRunner[_ObjectDefinitions, _ObjectContext, ObjectGraphManager])
                         check_name=check.name,
                         check_result=result,
                         code_block=self.definitions_raw[file_path][start - 1:end + 1],
-                        file_path=f"/{safe_relpath(file_path, root_folder_str)}",
+                        file_path=f"/{safe_relpath(file_path, root_folder)}",
                         file_line_range=[start, end + 1],
                         resource=self.get_resource(file_path, key, check.supported_entities, start, end),  # type:ignore[arg-type]  # key is str not BaseCheck
                         evaluations=None,

--- a/checkov/common/util/file_utils.py
+++ b/checkov/common/util/file_utils.py
@@ -23,7 +23,7 @@ def convert_to_unix_path(path: str) -> str:
     return path.replace('\\', '/')
 
 
-def safe_relpath(file_path: str, root_folder: str | None) -> str:
+def safe_relpath(file_path: str, root_folder: str | Path | None) -> str:
     """Compute os.path.relpath(file_path, root_folder) safely on Windows.
 
     On Windows ``os.path.relpath`` raises ``ValueError`` when *file_path* and
@@ -38,6 +38,10 @@ def safe_relpath(file_path: str, root_folder: str | None) -> str:
         return os.path.relpath(file_path, root_folder)
     except ValueError:
         # Cross-drive on Windows – best-effort: return the basename only
+        logger.warning(
+            f"Could not compute relative path for '{file_path}' from root '{root_folder}' "
+            f"(cross-drive path on Windows); falling back to basename."
+        )
         return os.path.basename(file_path)
 
 

--- a/checkov/common/util/file_utils.py
+++ b/checkov/common/util/file_utils.py
@@ -23,6 +23,24 @@ def convert_to_unix_path(path: str) -> str:
     return path.replace('\\', '/')
 
 
+def safe_relpath(file_path: str, root_folder: str | None) -> str:
+    """Compute os.path.relpath(file_path, root_folder) safely on Windows.
+
+    On Windows ``os.path.relpath`` raises ``ValueError`` when *file_path* and
+    *root_folder* reside on different drives (e.g. ``C:\\`` vs ``D:\\``).
+    In that case we fall back to returning just the file basename so that the
+    caller still gets a usable (albeit shortened) relative path instead of
+    crashing.
+
+    On non-Windows platforms this is a thin wrapper around ``os.path.relpath``.
+    """
+    try:
+        return os.path.relpath(file_path, root_folder)
+    except ValueError:
+        # Cross-drive on Windows – best-effort: return the basename only
+        return os.path.basename(file_path)
+
+
 def _is_within(base: str, target: str) -> bool:
     """Return True iff target resolves inside base (both realpath'd)."""
     base_real = os.path.realpath(base)

--- a/checkov/terraform/base_runner.py
+++ b/checkov/terraform/base_runner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import platform
 from abc import abstractmethod
 from typing import Dict, Optional, Any, Set, TYPE_CHECKING, TypeVar, Generic
 
@@ -18,6 +17,7 @@ from checkov.common.output.record import Record
 from checkov.common.output.report import Report
 from checkov.common.runners.base_runner import BaseRunner
 from checkov.common.util.data_structures_utils import pickle_deepcopy
+from checkov.common.util.file_utils import safe_relpath
 from checkov.common.util.secrets import omit_secret_value_from_graph_checks
 from checkov.common.variables.context import EvaluationContext
 from checkov.runner_filter import RunnerFilter
@@ -118,7 +118,7 @@ class BaseTerraformRunner(
         full_file_path = connected_node[CustomAttributes.FILE_PATH]
         connected_node_data = {}
         connected_node_data["code_block"] = connected_entity_context.get("code_lines")
-        connected_node_data["file_path"] = f"{os.sep}{os.path.relpath(full_file_path, root_folder)}"
+        connected_node_data["file_path"] = f"{os.sep}{safe_relpath(full_file_path, root_folder)}"
         connected_node_data["file_line_range"] = [
             connected_entity_context.get("start_line"),
             connected_entity_context.get("end_line"),
@@ -157,8 +157,6 @@ class BaseTerraformRunner(
                     copy_of_check_result["entity"] = entity[CustomAttributes.CONFIG]
                     connected_node_data = self._get_connected_node_data(entity.get(CustomAttributes.CONNECTED_NODE),  # type: ignore
                                                                         root_folder)
-                    if platform.system() == "Windows":
-                        root_folder = os.path.split(full_file_path)[0]
                     resource_id = ".".join(entity_context["definition_path"])
                     resource = resource_id
                     definition_context_file_path = full_file_path
@@ -182,7 +180,7 @@ class BaseTerraformRunner(
                         check_name=check.name,
                         check_result=copy_of_check_result,
                         code_block=censored_code_lines,
-                        file_path=f"{os.sep}{os.path.relpath(full_file_path, root_folder)}",
+                        file_path=f"{os.sep}{safe_relpath(full_file_path, root_folder)}",
                         file_line_range=[
                             entity_context.get("start_line", 1),
                             entity_context.get("end_line", 1),

--- a/checkov/terraform/plan_runner.py
+++ b/checkov/terraform/plan_runner.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-import platform
 import pathlib
 from typing import Type, Optional, Any, cast
 
@@ -19,6 +18,7 @@ from checkov.terraform.graph_builder.local_graph import TerraformLocalGraph
 from checkov.common.checks_infra.registry import get_graph_checks_registry
 from checkov.common.graph.graph_builder.graph_components.attribute_names import CustomAttributes
 from checkov.common.output.record import Record
+from checkov.common.util.file_utils import safe_relpath
 from checkov.common.util.secrets import omit_secret_value_from_checks
 
 from checkov.common.bridgecrew.check_type import CheckType
@@ -209,11 +209,7 @@ class Runner(BaseTerraformRunner[_TerraformPlanDefinitions, _TerraformPlanContex
         if isinstance(full_file_path, TFDefinitionKey):
             # It might be str for terraform-plan files
             full_file_path = full_file_path.file_path
-        if platform.system() == "Windows":
-            temp = os.path.split(full_file_path)[0]
-            scanned_file = f"/{os.path.relpath(full_file_path, temp)}"
-        else:
-            scanned_file = f"/{os.path.relpath(full_file_path, root_folder)}"
+        scanned_file = f"/{safe_relpath(full_file_path, str(root_folder))}"
         return full_file_path, scanned_file
 
     def run_block(

--- a/tests/common/utils/test_file_utils.py
+++ b/tests/common/utils/test_file_utils.py
@@ -2,10 +2,12 @@ import io
 import os
 import tarfile
 import tempfile
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from checkov.common.util.file_utils import read_file_safe, get_file_size_safe, extract_tar_archive
+from checkov.common.util.file_utils import read_file_safe, get_file_size_safe, extract_tar_archive, safe_relpath
 
 def test_sanity_read_file():
     file_to_check = f"{os.path.dirname(os.path.realpath(__file__))}/resources/existing_file"
@@ -92,3 +94,28 @@ def test_extract_tar_legitimate_files_still_extracted():
         extracted = os.path.join(dest_dir, "main.tf")
         assert os.path.isfile(extracted), "Legitimate file 'main.tf' was not extracted"
         assert open(extracted).read() == "hello\n"
+
+
+def test_safe_relpath_normal() -> None:
+    """safe_relpath returns a relative path under normal conditions."""
+    result = safe_relpath("/home/user/project/main.tf", "/home/user/project")
+    assert result == "main.tf"
+
+
+def test_safe_relpath_with_path_object() -> None:
+    """safe_relpath accepts a pathlib.Path as root_folder."""
+    result = safe_relpath("/home/user/project/main.tf", Path("/home/user/project"))
+    assert result == "main.tf"
+
+
+def test_safe_relpath_cross_drive_fallback(caplog: pytest.LogCaptureFixture) -> None:
+    """safe_relpath falls back to basename and logs a warning when
+    os.path.relpath raises ValueError (simulating cross-drive on Windows)."""
+    import logging
+    file_path = "/project/main.tf"
+    with patch("checkov.common.util.file_utils.os.path.relpath", side_effect=ValueError("cross-drive")):
+        with caplog.at_level(logging.WARNING, logger="checkov.common.util.file_utils"):
+            result = safe_relpath(file_path, "/other")
+
+    assert result == os.path.basename(file_path)
+    assert any("falling back" in record.message for record in caplog.records)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

# fix: preserve subdirectory paths in graph check results on Windows

## Description

Fixes a bug where CKV2_* (graph) checks on Windows would lose intermediate subdirectory components from `file_path`, reporting `\NESTED-TEST.tf` instead of `\Nested\NESTED-TEST.tf`.

## Root Cause

A previous workaround for Windows cross-drive `os.path.relpath` failures (which raises `ValueError` when paths are on different drives) unconditionally replaced `root_folder` with the file's parent directory via `os.path.split(full_file_path)[0]`. This caused `os.path.relpath` to compute paths relative to the wrong base, stripping all intermediate directories.

## Fix

Introduced a `safe_relpath()` utility that wraps `os.path.relpath()` in a try/except, falling back to `os.path.basename()` **only** when a `ValueError` is raised (the actual cross-drive case). Removed the blanket `platform.system() == "Windows"` root folder overrides from:

- `checkov/terraform/base_runner.py` — `get_graph_checks_report()` and `_get_connected_node_data()`
- `checkov/common/runners/object_runner.py` — `add_python_check_results()` and `add_graph_check_results()`
- `checkov/terraform/plan_runner.py` — `_get_file_path()`

## Before / After

| Check Type | Before (Windows) | After (Windows) |
|---|---|---|
| CKV_AZURE_59 (Python) | `\Nested\NESTED-TEST.tf` ✅ | `\Nested\NESTED-TEST.tf` ✅ |
| CKV2_AZURE_47 (Graph) | `\NESTED-TEST.tf` ❌ | `\Nested\NESTED-TEST.tf` ✅ |


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
