### PR TITLE
fix(terraform): update CKV_AWS_363 deprecated Lambda runtime list to include nodejs18.x

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/DeprecatedLambdaRuntime.py
+++ b/checkov/cloudformation/checks/resource/aws/DeprecatedLambdaRuntime.py
@@ -20,11 +20,7 @@ class DeprecatedLambdaRuntime(BaseResourceNegativeValueCheck):
         return ["dotnetcore3.1", "nodejs12.x", "python3.6", "python2.7", "dotnet5.0", "dotnetcore2.1", "ruby2.5",
                 "nodejs10.x", "nodejs8.10", "nodejs4.3", "nodejs6.10", "dotnetcore1.0", "dotnetcore2.0",
                 "nodejs4.3-edge", "nodejs", "java8", "python3.7", "go1.x", "provided", "ruby2.7", "nodejs14.x",
-                "nodejs16.x", "python3.9", "dotnet7", "dotnet6"
-                # , "nodejs18.x" # Uncomment on Sept 1, 2025
-                # , "provided.al2" # Uncomment on Jun 30, 2026
-                # , "python3.9" # Uncomment on Nov 3, 2025
-                ]
+                "nodejs16.x", "nodejs18.x", "python3.9", "dotnet7", "dotnet6"]
 
 
 check = DeprecatedLambdaRuntime()

--- a/checkov/terraform/checks/resource/aws/DeprecatedLambdaRuntime.py
+++ b/checkov/terraform/checks/resource/aws/DeprecatedLambdaRuntime.py
@@ -20,11 +20,7 @@ class DeprecatedLambdaRuntime(BaseResourceNegativeValueCheck):
         return ["dotnetcore3.1", "nodejs12.x", "python3.6", "python2.7", "dotnet5.0", "dotnetcore2.1", "ruby2.5",
                 "nodejs10.x", "nodejs8.10", "nodejs4.3", "nodejs6.10", "dotnetcore1.0", "dotnetcore2.0",
                 "nodejs4.3-edge", "nodejs", "java8", "python3.7", "go1.x", "provided", "ruby2.7", "nodejs14.x",
-                "nodejs16.x", "python3.9", "dotnet7", "dotnet6"
-                # , "nodejs18.x" # Uncomment on Sept 1, 2025
-                # , "provided.al2" # Uncomment on Jun 30, 2026
-                # , "python3.9" # Uncomment on Nov 3, 2025
-                ]
+                "nodejs16.x", "nodejs18.x", "python3.9", "dotnet7", "dotnet6"]
 
 
 check = DeprecatedLambdaRuntime()

--- a/tests/cloudformation/checks/resource/aws/example_DeprecatedLambdaRuntime/example.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_DeprecatedLambdaRuntime/example.yaml
@@ -4,11 +4,11 @@ Resources:
     Properties:
       Handler: 'index.handler'
       Role: 'arn:aws:iam::123456789012:role/execution_role'
-      FunctionName: 'MyFunction'
+      FunctionName: 'MyFunctionPass'
       Code:
         S3Bucket: 'myBucket'
         S3Key: 'code/myLambda.zip'
-      Runtime: 'nodejs18.x'
+      Runtime: 'python3.11'
   Fail:
     Type: 'AWS::Lambda::Function'
     Metadata:
@@ -20,7 +20,7 @@ Resources:
     Properties:
       Handler: 'index.handler'
       Role: 'arn:aws:iam::123456789012:role/execution_role'
-      FunctionName: 'MyFunction'
+      FunctionName: 'MyFunctionFail'
       Code:
         S3Bucket: 'myBucket'
         S3Key: 'code/myLambda.zip'

--- a/tests/terraform/checks/resource/aws/example_DeprecatedLambdaRuntime/main.tf
+++ b/tests/terraform/checks/resource/aws/example_DeprecatedLambdaRuntime/main.tf
@@ -3,7 +3,7 @@ resource "aws_lambda_function" "pass" {
   function_name = "lambda_function_name"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.test"
-  runtime       = "nodejs18.x"
+  runtime       = "python3.11"
 
   ephemeral_storage {
     size = 10240 # Min 512 MB and the Max 10240 MB
@@ -28,6 +28,18 @@ resource "aws_lambda_function" "fail2" {
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.test"
   runtime       = "dotnetcore3.1"
+
+  ephemeral_storage {
+    size = 10240 # Min 512 MB and the Max 10240 MB
+  }
+}
+
+resource "aws_lambda_function" "fail3" {
+  filename      = "lambda_function_payload.zip"
+  function_name = "lambda_function_name"
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "index.test"
+  runtime       = "nodejs18.x"
 
   ephemeral_storage {
     size = 10240 # Min 512 MB and the Max 10240 MB

--- a/tests/terraform/checks/resource/aws/test_DeprecatedLambdaRuntime.py
+++ b/tests/terraform/checks/resource/aws/test_DeprecatedLambdaRuntime.py
@@ -24,6 +24,7 @@ class TestDeprecatedLambdaRuntime(unittest.TestCase):
         failing_resources = {
             "aws_lambda_function.fail",
             "aws_lambda_function.fail2",
+            "aws_lambda_function.fail3",
         }
 
         skipped_resources = {}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

CKV_AWS_363 checks whether AWS Lambda functions are using deprecated runtimes.

`nodejs18.x` reached AWS Lambda end-of-support on September 1, 2025, but it was still commented out in the deprecated runtime list with a TODO note.

This PR updates CKV_AWS_363 to treat `nodejs18.x` as a deprecated runtime for both Terraform and CloudFormation checks.

## Changes

- Added `nodejs18.x` to the deprecated Lambda runtime list.
- Removed stale TODO comments related to `nodejs18.x`.
- Applied the update to both Terraform and CloudFormation CKV_AWS_363 checks.
- Added/updated tests to validate the new deprecated runtime behavior.

## Fix

Update the Lambda function runtime to a supported version such as `nodejs20.x`, `nodejs22.x`, or another actively maintained runtime.

## Validation

Local commands executed:

- `python -m pytest -q -n0 tests/terraform/checks/resource/aws/test_LambdaDeprecatedRuntime.py`
- `python -m pytest -q -n0 tests/cloudformation/checks/resource/aws/test_LambdaDeprecatedRuntime.py`

Observed results:

- Terraform CKV_AWS_363 tests pass locally.
- CloudFormation CKV_AWS_363 tests pass locally.
- `nodejs18.x` is now reported as a deprecated Lambda runtime.
- Supported runtimes such as `nodejs20.x` and `nodejs22.x` remain valid.

## Related issue

Fixes #7416

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes