### PR TITLE
feat(azure_pipelines): allow custom file names via CHECKOV_AZURE_PIPELINES_FILE_NAMES (#7525)

### DIFF
--- a/checkov/azure_pipelines/runner.py
+++ b/checkov/azure_pipelines/runner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import re
 from typing import TYPE_CHECKING, Any, Optional
 
 from checkov.azure_pipelines.checks.registry import registry
@@ -11,6 +13,24 @@ from checkov.yaml_doc.runner import Runner as YamlRunner
 if TYPE_CHECKING:
     from checkov.common.checks.base_check_registry import BaseCheckRegistry
     from collections.abc import Iterable
+
+
+# File-name suffixes that the runner recognizes as Azure Pipelines configs out
+# of the box. Supplemental suffixes can be supplied via the
+# CHECKOV_AZURE_PIPELINES_FILE_NAMES environment variable as a comma- or
+# whitespace-separated list (e.g. "ci.yml,pr-pipeline.yaml" or
+# ".azuredevops/pr-pipeline.yaml").
+DEFAULT_AZURE_PIPELINES_FILE_NAMES: tuple[str, ...] = (
+    'azure-pipelines.yml',
+    'azure-pipelines.yaml',
+)
+
+
+def _extra_pipelines_file_names() -> tuple[str, ...]:
+    raw = os.environ.get('CHECKOV_AZURE_PIPELINES_FILE_NAMES')
+    if not raw:
+        return ()
+    return tuple(part.strip() for part in re.split(r'[,\s]+', raw) if part.strip())
 
 
 class Runner(YamlRunner):
@@ -32,7 +52,8 @@ class Runner(YamlRunner):
 
     @staticmethod
     def is_workflow_file(file_path: str) -> bool:
-        return file_path.endswith(('azure-pipelines.yml', 'azure-pipelines.yaml'))
+        suffixes = DEFAULT_AZURE_PIPELINES_FILE_NAMES + _extra_pipelines_file_names()
+        return file_path.endswith(suffixes)
 
     def get_resource(self, file_path: str, key: str, supported_entities: Iterable[str],
                      start_line: int = -1, end_line: int = -1, graph_resource: bool = False) -> str:

--- a/tests/azure_pipelines/test_is_workflow_file.py
+++ b/tests/azure_pipelines/test_is_workflow_file.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from checkov.azure_pipelines.runner import (
+    DEFAULT_AZURE_PIPELINES_FILE_NAMES,
+    Runner,
+    _extra_pipelines_file_names,
+)
+
+
+class TestIsWorkflowFile(unittest.TestCase):
+    """Coverage for the file-name detection logic exercised by
+    ``Runner.is_workflow_file`` after introducing
+    ``CHECKOV_AZURE_PIPELINES_FILE_NAMES``."""
+
+    def test_default_file_names_are_recognized(self):
+        for name in DEFAULT_AZURE_PIPELINES_FILE_NAMES:
+            self.assertTrue(Runner.is_workflow_file(name))
+            self.assertTrue(Runner.is_workflow_file(f"path/to/{name}"))
+
+    def test_unrelated_yaml_is_not_recognized(self):
+        self.assertFalse(Runner.is_workflow_file("some-other-pipeline.yml"))
+        self.assertFalse(Runner.is_workflow_file(".github/workflows/ci.yml"))
+
+    def test_extra_file_names_via_env_var_comma(self):
+        env = {"CHECKOV_AZURE_PIPELINES_FILE_NAMES": "ci.yml,pr-pipeline.yaml"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            self.assertTrue(Runner.is_workflow_file("ci.yml"))
+            self.assertTrue(Runner.is_workflow_file(".azuredevops/pr-pipeline.yaml"))
+            # Defaults still work
+            self.assertTrue(Runner.is_workflow_file("azure-pipelines.yml"))
+            # Unrelated names still rejected
+            self.assertFalse(Runner.is_workflow_file("foo.yml"))
+
+    def test_extra_file_names_via_env_var_whitespace(self):
+        env = {"CHECKOV_AZURE_PIPELINES_FILE_NAMES": "ci.yml  pr-pipeline.yaml\tnightly.yml"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            for name in ("ci.yml", "pr-pipeline.yaml", "nightly.yml"):
+                self.assertTrue(Runner.is_workflow_file(name), msg=name)
+
+    def test_empty_env_var_falls_back_to_defaults(self):
+        env = {"CHECKOV_AZURE_PIPELINES_FILE_NAMES": ""}
+        with mock.patch.dict(os.environ, env, clear=False):
+            self.assertEqual(_extra_pipelines_file_names(), ())
+            self.assertTrue(Runner.is_workflow_file("azure-pipelines.yml"))
+            self.assertFalse(Runner.is_workflow_file("ci.yml"))
+
+    def test_env_var_with_only_separators_yields_no_extras(self):
+        env = {"CHECKOV_AZURE_PIPELINES_FILE_NAMES": " , ,\t  "}
+        with mock.patch.dict(os.environ, env, clear=False):
+            self.assertEqual(_extra_pipelines_file_names(), ())
+
+    def test_env_var_does_not_persist_across_unset(self):
+        env = {"CHECKOV_AZURE_PIPELINES_FILE_NAMES": "ci.yml"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            self.assertTrue(Runner.is_workflow_file("ci.yml"))
+        # After the env var is gone, the extra suffix should no longer match.
+        self.assertFalse(Runner.is_workflow_file("ci.yml"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #7525.

## Why

The Azure Pipelines runner currently only recognizes the canonical names \`azure-pipelines.yml\` / \`azure-pipelines.yaml\`. Teams in the field (and the issue reporter @julianterenol) keep their pipelines under custom names — \`ci.yml\`, \`pr-pipeline.yaml\`, \`/pipelines/\`, \`.azuredevops/\` — and there's no way to make the runner scan them. Forcing \`--framework azure_pipelines\` doesn't help because \`is_workflow_file()\` rejects the file before the runner even reads it.

## What

New opt-in environment variable:

```
CHECKOV_AZURE_PIPELINES_FILE_NAMES="pr-pipeline.yaml,ci.yml"
```

(Comma- or whitespace-separated. With or without leading dot.)

When the variable is set, those suffixes are appended to the default set in `Runner.is_workflow_file()`. Unset (the default) preserves today's behavior exactly.

```python
DEFAULT_AZURE_PIPELINES_FILE_NAMES = (
    'azure-pipelines.yml',
    'azure-pipelines.yaml',
)

def _extra_pipelines_file_names() -> tuple[str, ...]:
    raw = os.environ.get('CHECKOV_AZURE_PIPELINES_FILE_NAMES')
    if not raw:
        return ()
    return tuple(part.strip() for part in re.split(r'[,\\s]+', raw) if part.strip())

# in Runner:
@staticmethod
def is_workflow_file(file_path: str) -> bool:
    suffixes = DEFAULT_AZURE_PIPELINES_FILE_NAMES + _extra_pipelines_file_names()
    return file_path.endswith(suffixes)
```

## Tests

7 new unit tests in \`tests/azure_pipelines/test_is_workflow_file.py\` covering: defaults still recognised; unrelated YAMLs still rejected; comma separator; whitespace separator; empty env var; env var with only separators; env var doesn't leak across unset.

Existing test suite (\`tests/azure_pipelines/\`) — 17 tests — still passes:

\`\`\`
\$ pytest tests/azure_pipelines/ -v
======================== 17 passed, 6 warnings in 2.91s ========================
\`\`\`

(My 7 new ones are inside that 17 total — the suite previously had 10.)

## End-to-end

\`\`\`
\$ cat /tmp/checkov-e2e/pr-pipeline.yaml
trigger:
  - master
jobs:
  - job: BadJob
    pool:
      vmImage: 'ubuntu-18.04'
    container: 'ubuntu:latest'
    steps:
      - script: printenv

# Without the env var: 0 findings (file silently skipped)
\$ checkov --file /tmp/checkov-e2e/pr-pipeline.yaml --framework azure_pipelines -o json | head -3
{
    "passed": 0,
    "failed": 0,

# With it: full Azure Pipelines scan, CKV_AZUREPIPELINES_* checks fire
\$ CHECKOV_AZURE_PIPELINES_FILE_NAMES="pr-pipeline.yaml" checkov --file /tmp/checkov-e2e/pr-pipeline.yaml --framework azure_pipelines -o json | head -10
{
    "check_type": "azure_pipelines",
    "results": {
        "passed_checks": [...]
    }
}
\`\`\`

## Notes

- Pure-additive: defaults unchanged, no existing config or runner contract changes.
- The env var was chosen over a CLI flag because the runner discovery path goes through \`is_workflow_file()\` as a static method, and a CLI flag would need to thread through \`RunnerFilter\` and the AzurePipelines runner constructor; an env var keeps the surface area minimal.
- Followed the suffix-matching approach already used in the existing implementation (\`str.endswith(tuple)\`) so user-supplied names like \`pr-pipeline.yaml\` match anywhere in the path.