### PR TITLE
fix(terraform): include 90-day boundary in rotation check CKV_AWS_304

### DIFF
--- a/checkov/terraform/checks/resource/aws/SecretManagerSecret90days.py
+++ b/checkov/terraform/checks/resource/aws/SecretManagerSecret90days.py
@@ -22,11 +22,11 @@ class SecretManagerSecret90days(BaseResourceCheck):
             unit = rate_match.group(2)
 
             if unit.startswith('day'):
-                return value < 90
+                return value <= 90
             elif unit.startswith('hour'):
-                return value < 2160  # 90 days * 24 hours
+                return value <= 2160  # 90 days * 24 hours
             elif unit.startswith('minute'):
-                return value < 129600  # 90 days * 24 hours * 60 minutes
+                return value <= 129600  # 90 days * 24 hours * 60 minutes
         return False
 
     def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
@@ -40,7 +40,7 @@ class SecretManagerSecret90days(BaseResourceCheck):
             if days and isinstance(days, list):
                 self.evaluated_keys = ["rotation_rules/[0]/automatically_after_days"]
                 days = force_int(days[0])
-                if days is not None and days < 90:
+                if days is not None and days <= 90:
                     return CheckResult.PASSED
 
             # Check for schedule_expression

--- a/tests/terraform/checks/resource/aws/example_SecretManagerSecret90days/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SecretManagerSecret90days/main.tf
@@ -12,7 +12,7 @@ resource "aws_secretsmanager_secret_rotation" "fail" {
   rotation_lambda_arn = aws_lambda_function.example.arn
 
   rotation_rules {
-    automatically_after_days = 90
+    automatically_after_days = 91
   }
 }
 
@@ -49,6 +49,22 @@ resource "aws_secretsmanager_secret_rotation" "pass_scheduled_days" {
 
   rotation_rules {
     schedule_expression = "rate(89 days)"
+  }
+
+  depends_on = [
+    time_sleep.wait_for_lambda_permissions_for_secrets_manager,
+    module.rotation_lambda
+  ]
+}
+
+resource "aws_secretsmanager_secret_rotation" "pass_scheduled_days_90" {
+  secret_id           = aws_secretsmanager_secret.this.id
+  rotation_lambda_arn = aws_lambda_function.this.arn
+
+  rotate_immediately = true
+
+  rotation_rules {
+    schedule_expression = "rate(90 days)"
   }
 
   depends_on = [

--- a/tests/terraform/checks/resource/aws/test_SecretManagerSecret90days.py
+++ b/tests/terraform/checks/resource/aws/test_SecretManagerSecret90days.py
@@ -19,6 +19,7 @@ class TestSecretManagerSecret90days(unittest.TestCase):
             "aws_secretsmanager_secret_rotation.pass",
             "aws_secretsmanager_secret_rotation.pass_scheduled_hours",
             "aws_secretsmanager_secret_rotation.pass_scheduled_days",
+            "aws_secretsmanager_secret_rotation.pass_scheduled_days_90",
             "aws_secretsmanager_secret_rotation.pass_scheduled_cron",
         }
         failing_resources = {


### PR DESCRIPTION
Change SecretManagerSecret90days to use <= 90 instead of < 90, so that secrets rotated exactly every 90 days are considered compliant.

Updated test fixtures and assertions to cover the boundary case.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
