### PR TITLE
fix(terraform): CKV_AWS_304 correctly evaluates cron() schedule expressions instead of unconditionally passing

### DIFF
--- a/checkov/terraform/checks/resource/aws/SecretManagerSecret90days.py
+++ b/checkov/terraform/checks/resource/aws/SecretManagerSecret90days.py
@@ -29,6 +29,55 @@ class SecretManagerSecret90days(BaseResourceCheck):
                 return value <= 129600  # 90 days * 24 hours * 60 minutes
         return False
 
+    def _check_cron_expression(self, expression: str) -> bool:
+        """
+        Parse AWS EventBridge cron format: cron(minutes hours day-of-month month day-of-week year)
+        Returns True (PASS) only if the rotation is guaranteed to run at least every 90 days.
+        Fails safe — if parsing fails or is ambiguous, returns False (FAIL).
+        """
+        inner = expression[5:-1]  # strip cron( and )
+        parts = inner.split()
+        if len(parts) != 6:
+            return False  # malformed cron → fail safe
+
+        month_field = parts[3]
+
+        # Wildcard means runs every month (worst case ~31 days apart) → PASS
+        if month_field in ('*', '?'):
+            return True
+
+        # Step syntax e.g. */3 means every 3 months → check gap
+        if month_field.startswith('*/'):
+            try:
+                step = int(month_field[2:])
+                return (step * 31) <= 90
+            except ValueError:
+                return False
+
+        # Expand month list/range e.g. "1,4,7,10" or "1-3"
+        try:
+            months: list[int] = []
+            for part in month_field.split(','):
+                if '-' in part:
+                    start, end = part.split('-', 1)
+                    months.extend(range(int(start), int(end) + 1))
+                else:
+                    months.append(int(part))
+
+            months = sorted(set(months))
+            if not months:
+                return False
+
+            # Calculate the maximum gap between consecutive months (including wrap-around)
+            gaps = [months[i + 1] - months[i] for i in range(len(months) - 1)]
+            gaps.append(12 - months[-1] + months[0])  # wrap Jan→Dec gap
+            max_gap_months = max(gaps)
+
+            # Worst case: 31 days per month
+            return (max_gap_months * 31) <= 90
+        except (ValueError, IndexError):
+            return False  # parse failure → fail safe
+
     def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
         self.evaluated_keys = ["rotation_rules"]
         rules = conf.get("rotation_rules")
@@ -52,8 +101,7 @@ class SecretManagerSecret90days(BaseResourceCheck):
                 if expression.startswith('rate('):
                     return CheckResult.PASSED if self._check_rate_expression(expression) else CheckResult.FAILED
                 elif expression.startswith('cron('):
-                    # TODO: Handle failing cron expressions
-                    return CheckResult.PASSED
+                    return CheckResult.PASSED if self._check_cron_expression(expression) else CheckResult.FAILED
 
         return CheckResult.FAILED
 

--- a/tests/terraform/checks/resource/aws/example_SecretManagerSecret90days/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SecretManagerSecret90days/main.tf
@@ -106,21 +106,14 @@ resource "aws_secretsmanager_secret_rotation" "pass_scheduled_cron" {
 }
 
 
-# Fail example with cron to be tackled later
-# resource "aws_secretsmanager_secret_rotation" "fail_scheduled_cron" {
-#   secret_id           = aws_secretsmanager_secret.this.id
-#   rotation_lambda_arn = aws_lambda_function.this.arn
-#
-#   rotate_immediately = true
-#
-#   rotation_rules {
-#     schedule_expression = "cron(0 12 * 2 ? *)"
-#   }
-#
-#   depends_on = [
-#     time_sleep.wait_for_lambda_permissions_for_secrets_manager,
-#     module.rotation_lambda
-#   ]
-# }
+resource "aws_secretsmanager_secret_rotation" "fail_scheduled_cron" {
+  secret_id           = aws_secretsmanager_secret.this.id
+  rotation_lambda_arn = aws_lambda_function.this.arn
 
+  rotate_immediately = true
+
+  rotation_rules {
+    schedule_expression = "cron(0 12 * 2 ? *)"
+  }
+}
 

--- a/tests/terraform/checks/resource/aws/test_SecretManagerSecret90days.py
+++ b/tests/terraform/checks/resource/aws/test_SecretManagerSecret90days.py
@@ -26,7 +26,7 @@ class TestSecretManagerSecret90days(unittest.TestCase):
             "aws_secretsmanager_secret_rotation.fail",
             "aws_secretsmanager_secret_rotation.fail_2",
             "aws_secretsmanager_secret_rotation.fail_scheduled_days",
-            #"aws_secretsmanager_secret_rotation.fail_scheduled_cron", # Will handle later
+            "aws_secretsmanager_secret_rotation.fail_scheduled_cron", 
         }
 
         passed_check_resources = {c.resource for c in report.passed_checks}


### PR DESCRIPTION
## Description

`CKV_AWS_304` ("Ensure Secrets Manager secrets should be rotated within 90 days") 
previously returned `PASSED` for **all** `cron()` schedule expressions due to an 
unimplemented TODO — meaning a secret rotating once a year (e.g., `cron(0 12 1 1 ? *)`) 
was silently reported as compliant.

This PR implements `_check_cron_expression()` which parses the AWS EventBridge cron 
month field and calculates the maximum possible gap between rotations. If that gap can 
exceed 90 days, the check returns `FAILED`. The method fails safe — malformed or 
unparseable expressions return `FAILED` rather than `PASSED`.

Also uncomments the `fail_scheduled_cron` test fixture that was left commented out 
with `# Will handle later`, and updates the test to include it in expected failures.

Fixes # (issue)

## New/Edited policies

### Description

`aws_secretsmanager_secret_rotation` resources that use a `schedule_expression` with 
`cron()` syntax could configure rotation intervals far exceeding 90 days (e.g., once 
per year, once per quarter) and still pass the check. This violates the intent of 
CKV_AWS_304 and the CIS AWS Foundations Benchmark requirement for regular secret rotation.

AWS EventBridge cron docs: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html

### Fix

Use `automatically_after_days` set to 90 or fewer, or use a `schedule_expression` 
with either a `rate()` expression within 90 days, or a `cron()` expression whose 
month field guarantees rotation at least every 90 days (e.g., monthly `*` or 
every-2-months `*/2`).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
