### PR TITLE
\fix(general): add request timeout to aiohttp_client_session_wrapper to prevent indefinite CI hangs

### DIFF
--- a/checkov/common/util/http_utils.py
+++ b/checkov/common/util/http_utils.py
@@ -302,7 +302,8 @@ async def aiohttp_client_session_wrapper(
                 f"[http_utils](aiohttp_client_session_wrapper) reporting attempt {i + 1} out of {request_max_tries}")
             try:
                 async with session.request(
-                        method=method, url=url, headers=headers, json=payload, proxy=proxy_url, proxy_auth=proxy_auth
+                        method=method, url=url, headers=headers, json=payload, proxy=proxy_url, proxy_auth=proxy_auth,
+			timeout=aiohttp.ClientTimeout(connect=REQUEST_CONNECT_TIMEOUT, sock_read=REQUEST_READ_TIMEOUT),
                 ) as response:
                     content = await response.text()
                 if response.ok:


### PR DESCRIPTION
## Description

`request_wrapper` (synchronous) correctly sets `timeout=DEFAULT_TIMEOUT` — configurable via
`CHECKOV_REQUEST_CONNECT_TIMEOUT` (default 3.1s) and `CHECKOV_REQUEST_READ_TIMEOUT` (default 30s).

`aiohttp_client_session_wrapper` (async) called `session.request()` with no `timeout=` parameter.
aiohttp's built-in default does not protect against hung server connections that never close —
meaning CI pipelines could freeze indefinitely after scanning completes, with no error message
and the retry loop never firing.

This PR adds `aiohttp.ClientTimeout(connect=REQUEST_CONNECT_TIMEOUT, sock_read=REQUEST_READ_TIMEOUT)`
to the async `session.request()` call, reusing the same env-configurable constants already defined
at the top of `http_utils.py`, aligning async behavior with the synchronous request path.

**Affected callers:**
- `checkov/common/sca/output.py` — SCA report uploads
- `checkov/common/bridgecrew/vulnerability_scanning/integrations/twistcli.py` — container scan uploads
- `checkov/common/bridgecrew/vulnerability_scanning/image_scanner.py` — image scan downloads

Fixes # (issue)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes