### PR TITLE
fix(terraform): guard against unhashable dict in CKV_AZURE_80

### DIFF
--- a/checkov/terraform/checks/resource/azure/AppServiceDotnetFrameworkVersion.py
+++ b/checkov/terraform/checks/resource/azure/AppServiceDotnetFrameworkVersion.py
@@ -23,6 +23,8 @@ class AppServiceDotnetFrameworkVersion(BaseResourceCheck):
             site_config = conf.get('site_config')[0]
             if site_config.get('dotnet_framework_version') and isinstance(site_config.get('dotnet_framework_version'), list):
                 version = site_config.get('dotnet_framework_version')[0]
+                if not isinstance(version, str):
+                    return CheckResult.UNKNOWN
                 if version in supported_versions:
                     return CheckResult.PASSED
                 self.evaluated_keys = ['site_config/[0]/dotnet_framework_version']
@@ -31,6 +33,8 @@ class AppServiceDotnetFrameworkVersion(BaseResourceCheck):
                 stack = site_config.get('application_stack')[0]
                 if stack.get('dotnet_version') and isinstance(stack.get('dotnet_version'), list):
                     version = stack.get('dotnet_version')[0]
+                    if not isinstance(version, str):
+                        return CheckResult.UNKNOWN
                     if version in supported_versions:
                         return CheckResult.PASSED
                     self.evaluated_keys = ['site_config/[0]/application_stack/[0]/dotnet_version']

--- a/tests/terraform/checks/resource/azure/example_AppServiceDotnetFrameworkVersion/main.tf
+++ b/tests/terraform/checks/resource/azure/example_AppServiceDotnetFrameworkVersion/main.tf
@@ -334,6 +334,33 @@ resource "azurerm_windows_web_app" "fail2" {
   }
 }
 
+# UNKNOWN - dotnet_version is a non-string value (triggers CKV_AZURE_80 crash guard)
+resource "azurerm_windows_web_app" "unknown" {
+  #checkov:skip=CKV_AZURE_16: AD might not be required
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.rg_name
+  service_plan_id     = var.service_plan_id
+
+  https_only = true
+
+  site_config {
+    application_stack {
+      dotnet_version = {}
+    }
+  }
+
+  client_certificate_enabled = true
+
+  auth_settings {
+    enabled = true
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
 # IGNORE - no dotnet version specified
 resource "azurerm_windows_web_app" "ignore" {
   #checkov:skip=CKV_AZURE_16: AD might not be required


### PR DESCRIPTION
## Summary

- `CKV_AZURE_80` (`AppServiceDotnetFrameworkVersion`) crashes with `TypeError: unhashable type: 'dict'` when the HCL parser produces a list containing a dict (e.g. `[{}]`) for `dotnet_version` or `dotnet_framework_version` — triggered by configurations like `dotnet_version = {}`.
- The bug was introduced when the equality check (`== "v8.0"`) was refactored to a set membership test (`version in supported_versions`): sets require hashable keys, but dicts are not hashable.
- Added `if not isinstance(version, str): return CheckResult.UNKNOWN` guards in both the `dotnet_framework_version` and `application_stack.dotnet_version` branches, consistent with the check's existing convention for indeterminate configurations.

## Test plan

- [ ] Added `azurerm_windows_web_app.unknown` fixture with `dotnet_version = {}` to reproduce the crash scenario
- [ ] Existing test suite (`test_AppServiceDotnetFrameworkVersion.py`) passes without modification — the new fixture resource produces `UNKNOWN` and does not affect the pass/fail counts
- [ ] Manually verified: `scan_resource_conf` with `dotnet_version = [{}]` now returns `CheckResult.UNKNOWN` instead of raising `TypeError`
- [ ] Valid versions (`v8.0`, `v9.0`, `v10.0`) still return `PASSED`; unsupported versions still return `FAILED`

Closes #7523