### PR TITLE
fix(dockerfile): support custom-prefix Dockerfile names like AdtDockerfile

### DIFF
--- a/checkov/common/util/dockerfile.py
+++ b/checkov/common/util/dockerfile.py
@@ -1,6 +1,6 @@
 import re
 
-DOCKERFILE_MASK = re.compile(r"^(?:.+\.)?[Dd]ockerfile(?:\..+)?$(?<!\.[Dd]ockerignore)")
+DOCKERFILE_MASK = re.compile(r"^(?:(?:.+\.)?[Dd]|.+D)ockerfile(?:\..+)?$(?<!\.[Dd]ockerignore)")
 
 
 def is_dockerfile(file: str) -> bool:

--- a/tests/dockerfile/test_utils.py
+++ b/tests/dockerfile/test_utils.py
@@ -12,6 +12,9 @@ VALID_DOCKERFILE_NAMES = [
     "Dockerfile.Product1",
     "dev.Dockerfile",
     "team1.product.dockerfile",
+    "AdtDockerfile",
+    "MyServiceDockerfile",
+    "AdtDockerfile.prod",
 ]
 INVALID_DOCKERFILE_NAMES = [
     "package.json",


### PR DESCRIPTION
## Summary

- `DOCKERFILE_MASK` in `checkov/common/util/dockerfile.py` only matched `Dockerfile`/`dockerfile` at the start of the filename or after a dot separator (e.g. `dev.Dockerfile`).
- Files with a CamelCase or word prefix *without* a dot separator — such as `AdtDockerfile` or `MyServiceDockerfile` — were silently skipped, leaving those images unscanned.
- The regex is updated to add a second alternative that allows any non-dot prefix followed by an uppercase `D`, so `AdtDockerfile` and similar variants are now recognised.
- Lowercase-only prefix variants (e.g. `ddockerfile`) remain invalid to avoid ambiguity, preserving all existing test expectations.

Closes #7541

## Test plan

- [ ] All previously-valid names still pass `is_dockerfile()`: `Dockerfile`, `dockerfile`, `Dockerfile.prod`, `dev.Dockerfile`, `team1.product.dockerfile`, etc.
- [ ] All previously-invalid names still fail: `.dockerfile`, `ddockerfile`, `docker-file`, `dockerfile1`, `Dockerfile.env.dockerignore`, etc.
- [ ] New valid names now pass: `AdtDockerfile`, `MyServiceDockerfile`, `AdtDockerfile.prod`
- [ ] Run `pytest tests/dockerfile/test_utils.py::test_is_dockerfile`