### PR TITLE
feat(terraform): add CKV_AWS_393 for GitHub OIDC trust on aws_iam_role

### DIFF
--- a/checkov/terraform/checks/resource/aws/GithubActionsOIDCTrustPolicyOnRole.py
+++ b/checkov/terraform/checks/resource/aws/GithubActionsOIDCTrustPolicyOnRole.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.common.util.oidc_utils import gh_abusable_claims, gh_repo_regex, gh_sub_condition
+from checkov.common.util.type_forcers import extract_policy_dict, force_list
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class GithubActionsOIDCTrustPolicyOnRole(BaseResourceCheck):
+    """
+    Resource-level mirror of CKV_AWS_358 (GithubActionsOIDCTrustPolicy).
+
+    CKV_AWS_358 only inspects `data "aws_iam_policy_document"` blocks. This
+    check applies the SAME unsafe-claim logic to `aws_iam_role` resources
+    that define their trust policy inline via `assume_role_policy`.
+
+    Logic is intentionally identical to CKV_AWS_358; only the parsing layer
+    differs (JSON statement objects vs. HCL `statement{}` blocks). Shared
+    constants (gh_sub_condition, gh_abusable_claims, gh_repo_regex) come
+    from checkov.common.util.oidc_utils.
+    """
+
+    GH_OIDC_PROVIDER_SUBSTR = "oidc-provider/token.actions.githubusercontent.com"
+
+    def __init__(self) -> None:
+        name = (
+            "Ensure AWS GitHub Actions OIDC authorization policies only allow "
+            "safe claims and claim order on IAM role"
+        )
+        id = "CKV_AWS_393"
+        supported_resources = ("aws_iam_role",)
+        categories = (CheckCategories.IAM,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        if not conf.get("assume_role_policy"):
+            return CheckResult.PASSED
+
+        try:
+            policy = extract_policy_dict(conf["assume_role_policy"][0])
+        except Exception:  # nosec
+            return CheckResult.PASSED
+
+        if not policy or "Statement" not in policy:
+            return CheckResult.PASSED
+
+        for statement in force_list(policy["Statement"]):
+            if not isinstance(statement, dict):
+                continue
+
+            if not self._has_github_oidc_federated_principal(statement):
+                # No GH-OIDC federated principal in this statement -> not our concern.
+                # (Matches CKV_AWS_358 behavior: "if not found_federated_gh_oidc: return PASSED")
+                return CheckResult.PASSED
+
+            # Federated GH-OIDC principal MUST come with a Condition.
+            condition = statement.get("Condition")
+            if not condition or not isinstance(condition, dict):
+                return CheckResult.FAILED
+
+            verdict = self._evaluate_sub_conditions(condition)
+            if verdict is not None:
+                return verdict
+
+            # Federated GH-OIDC principal present, conditions present, but none
+            # contained a recognized `:sub` constraint -> unsafe.
+            return CheckResult.FAILED
+
+        return CheckResult.PASSED
+
+    def _has_github_oidc_federated_principal(self, statement: dict[str, Any]) -> bool:
+        principal = statement.get("Principal")
+        if not isinstance(principal, dict):
+            return False
+        federated = principal.get("Federated")
+        if federated is None:
+            return False
+        for identifier in force_list(federated):
+            if isinstance(identifier, str) and self.GH_OIDC_PROVIDER_SUBSTR in identifier:
+                return True
+        return False
+
+    def _evaluate_sub_conditions(self, condition: dict[str, Any]) -> CheckResult | None:
+        """
+        Walk Condition operators looking for the `:sub` claim constraint.
+
+        Mirrors CKV_AWS_358's inner loop: returns FAILED on the first unsafe
+        value found, PASSED on the first safe value found, or None if no
+        `:sub` claim constraint exists in any operator (the caller then
+        returns FAILED, matching the data check's "Found a federated GitHub
+        user, but no restrictions" path).
+        """
+        for operator_values in condition.values():
+            if not isinstance(operator_values, dict):
+                continue
+            for variable_name, values in operator_values.items():
+                if not isinstance(variable_name, str) or not gh_sub_condition.match(variable_name):
+                    continue
+                for value in force_list(values):
+                    if not isinstance(value, str):
+                        continue
+                    verdict = self._classify_sub_value(value)
+                    if verdict is not None:
+                        return verdict
+        return None
+
+    @staticmethod
+    def _classify_sub_value(value: str) -> CheckResult | None:
+        """
+        Same four unsafe-pattern checks as CKV_AWS_358, in the same order.
+        Returns FAILED for an unsafe value, PASSED for a safe value, or
+        None if the value is malformed in a way the data check would also
+        skip (defensive; should not normally occur for string values).
+        """
+        # 1. Bare wildcard: "sub": "*"
+        if value == "*":
+            return CheckResult.FAILED
+
+        split_claims = value.split(":")
+
+        # 2. Bare claim name with no value: "sub": "invalid"
+        if len(split_claims) == 1:
+            return CheckResult.FAILED
+
+        # 3. Wildcard assertion on the first claim's value: "sub": "claim:*"
+        if split_claims[1] == "*":
+            return CheckResult.FAILED
+
+        # 4. Abusable first claim: "sub": "workflow:..." / "environment:..." / etc.
+        for abusable_claim in gh_abusable_claims:
+            if split_claims[0].startswith(abusable_claim):
+                return CheckResult.FAILED
+
+        # 5. "repo:" prefix must be followed by an org/repo-shaped value.
+        #    "repo:myOrg*" -> FAIL ; "repo:myOrg/*" -> PASS (per gh_repo_regex)
+        if split_claims[0] == "repo" and not gh_repo_regex.match(split_claims[1]):
+            return CheckResult.FAILED
+
+        return CheckResult.PASSED
+
+    def get_evaluated_keys(self) -> list[str]:
+        return ["assume_role_policy"]
+
+
+check = GithubActionsOIDCTrustPolicyOnRole()

--- a/tests/terraform/checks/resource/aws/example_GithubActionsOIDCTrustPolicyOnRole/main.tf
+++ b/tests/terraform/checks/resource/aws/example_GithubActionsOIDCTrustPolicyOnRole/main.tf
@@ -1,0 +1,302 @@
+# Fixtures mirror tests/terraform/checks/data/aws/example_GithubActionsOIDCTrustPolicy/main.tf
+# but expressed as aws_iam_role resources with inline `assume_role_policy = jsonencode({...})`.
+#
+# Each resource label matches its sibling in the data-check fixture, so the two
+# test suites are easy to compare side-by-side.
+#
+# Resource name conventions used by the unsafe-claim assertions:
+#   pass*  -> CKV_AWS_393 should return PASSED
+#   fail*  -> CKV_AWS_393 should return FAILED
+
+# pass_aud_first -- sub condition appears AFTER aud condition; safe value
+resource "aws_iam_role" "pass_aud_first" {
+  name = "pass_aud_first"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::000000000000:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.pass_aud_first.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:org/our-repo-name:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# pass1 -- non-OIDC assume_role_policy (EC2 service trust). Exercises the
+# "no GH-OIDC federated principal -> PASSED" guard. The data-check fixture
+# uses a Lambda permissions policy here; that shape is not a valid
+# assume_role_policy for an IAM role, so we use the closest legitimate
+# analogue: a role trusting an AWS service.
+resource "aws_iam_role" "pass1" {
+  name = "pass1"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ec2.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# pass2 -- repo:org/repo:* (specific repo, any branch) + aud condition
+resource "aws_iam_role" "pass2" {
+  name = "pass2"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:myOrg/myRepo:*"
+          }
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# pass3 -- fully pinned: repo:org/repo:ref:refs/heads/branch
+resource "aws_iam_role" "pass3" {
+  name = "pass3"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:sub" = "repo:myOrg/myRepo:ref:refs/heads/MyBranch"
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# fail1 -- federated GH OIDC principal but NO condition at all -> FAIL
+resource "aws_iam_role" "fail1" {
+  name = "fail1"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+      }
+    ]
+  })
+}
+
+# fail2 -- sub condition value is a bare claim name ("invalid") with no claim:value pair -> FAIL
+resource "aws_iam_role" "fail2" {
+  name = "fail2"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:sub" = "invalid"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# fail-wildcard -- sub value is the bare wildcard "*" -> FAIL
+resource "aws_iam_role" "fail-wildcard" {
+  name = "fail-wildcard"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:sub" = "*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# fail-abusable -- abusable first claim ("workflow:...") -> FAIL
+resource "aws_iam_role" "fail-abusable" {
+  name = "fail-abusable"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:sub" = "workflow:github-actions:repo:myOrg/myRepo:ref:refs/heads/MyBranch"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# fail-wildcard-assertion -- "repo:*" (wildcard as the only repo scoping) -> FAIL
+resource "aws_iam_role" "fail-wildcard-assertion" {
+  name = "fail-wildcard-assertion"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:sub" = "repo:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# fail-misused-repo -- "repo:myOrg*" lacks the "/" required by gh_repo_regex -> FAIL
+resource "aws_iam_role" "fail-misused-repo" {
+  name = "fail-misused-repo"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:sub" = "repo:myOrg*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# pass-org-only -- "repo:myOrg/*" (any repo in org, any branch). Considered SAFE
+# by CKV_AWS_358's design (see test_GithubActionsOIDCTrustPolicy.py's
+# "pass-org-only"). Mirrored here to preserve parity.
+resource "aws_iam_role" "pass-org-only" {
+  name = "pass-org-only"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:sub" = "repo:myOrg/*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# pass-gh-org -- variable name uses the .../github-org:sub form, so the
+# gh_sub_condition regex still matches and the value is fully pinned -> PASS
+resource "aws_iam_role" "pass-gh-org" {
+  name = "pass-gh-org"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com/github-org:sub" = "repo:myOrg/myRepo:ref:refs/heads/MyBranch"
+            "token.actions.githubusercontent.com:aud"            = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# pass-fm-customer -- XSUP-69131 regression marker. Freddie Mac's exact value
+# `repo:freddiemac/*`. Asserted as PASSED here to lock in parity with
+# CKV_AWS_358's existing "pass-org-only" semantics. If this fixture's verdict
+# ever flips to FAILED, it means someone tightened the policy -- which is a
+# deliberate global behavior change and should not happen silently.
+resource "aws_iam_role" "pass-fm-customer" {
+  name = "pass-fm-customer"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:freddiemac/*"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/tests/terraform/checks/resource/aws/test_GithubActionsOIDCTrustPolicyOnRole.py
+++ b/tests/terraform/checks/resource/aws/test_GithubActionsOIDCTrustPolicyOnRole.py
@@ -1,0 +1,65 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.GithubActionsOIDCTrustPolicyOnRole import check
+from checkov.terraform.runner import Runner
+
+
+class TestGithubActionsOIDCTrustPolicyOnRole(unittest.TestCase):
+    """
+    Resource-level mirror of CKV_AWS_358 (data-source-only).
+
+    This test asserts behavioral parity with
+    tests/terraform/checks/data/aws/test_GithubActionsOIDCTrustPolicy.py
+    when the same trust policy is expressed as an inline
+    `aws_iam_role.assume_role_policy = jsonencode({...})` instead of a
+    `data "aws_iam_policy_document"` block.
+
+    Extra fixture `pass-fm-customer` locks in the XSUP-69131 regression
+    marker: Freddie Mac's `repo:freddiemac/*` value is intentionally
+    treated as PASSED, matching CKV_AWS_358's `pass-org-only` semantics.
+    """
+
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_GithubActionsOIDCTrustPolicyOnRole"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_iam_role.pass1",
+            "aws_iam_role.pass2",
+            "aws_iam_role.pass3",
+            "aws_iam_role.pass_aud_first",
+            "aws_iam_role.pass-org-only",
+            "aws_iam_role.pass-gh-org",
+            "aws_iam_role.pass-fm-customer",
+        }
+        failing_resources = {
+            "aws_iam_role.fail1",
+            "aws_iam_role.fail2",
+            "aws_iam_role.fail-wildcard",
+            "aws_iam_role.fail-abusable",
+            "aws_iam_role.fail-wildcard-assertion",
+            "aws_iam_role.fail-misused-repo",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/terraform/image_referencer/test_plan_runner_aws_resources.py
+++ b/tests/terraform/image_referencer/test_plan_runner_aws_resources.py
@@ -151,7 +151,7 @@ def test_codebuild_resources(mocker: MockerFixture, graph_framework):
     sca_image_report = next(report for report in reports if report.check_type == CheckType.SCA_IMAGE)
 
     assert len(tf_report.resources) == 3
-    assert len(tf_report.passed_checks) == 9
+    assert len(tf_report.passed_checks) == 10
     assert len(tf_report.failed_checks) == 2
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0

--- a/tests/terraform/image_referencer/test_runner_aws_resources.py
+++ b/tests/terraform/image_referencer/test_runner_aws_resources.py
@@ -151,7 +151,7 @@ def test_codebuild_resources(mocker: MockerFixture, graph_framework):
     sca_image_report = next(report for report in reports if report.check_type == CheckType.SCA_IMAGE)
 
     assert len(tf_report.resources) == 3
-    assert len(tf_report.passed_checks) == 8
+    assert len(tf_report.passed_checks) == 9
     assert len(tf_report.failed_checks) == 2
     assert len(tf_report.skipped_checks) == 0
     assert len(tf_report.parsing_errors) == 0


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

CKV_AWS_358 ("Ensure AWS GitHub Actions OIDC authorization policies only allow safe claims and claim order") is a BaseDataCheck and only inspects data "aws_iam_policy_document" blocks. When users define the trust policy inline on an aws_iam_role resource via assume_role_policy = jsonencode({...}) — a very common Terraform pattern — the rule never runs against the resource, so unsafe GitHub Actions OIDC sub claims slip through silently.

This PR adds CKV_AWS_393, a resource-level mirror of CKV_AWS_358 that applies the identical unsafe-claim logic to aws_iam_role resources. Together, the two checks now cover both Terraform styles for writing the same trust policy.

- New BaseResourceCheck in checkov/terraform/checks/resource/aws/GithubActionsOIDCTrustPolicyOnRole.py.
- Reuses gh_sub_condition, gh_abusable_claims, and gh_repo_regex from checkov.common.util.oidc_utils — no logic duplication.
- CKV_AWS_358's code, tests, and verdicts are untouched.
- Test fixtures mirror CKV_AWS_358's 1:1 (6 pass + 6 fail cases).

Fixes # [XSUP-69131](https://jira-dc.paloaltonetworks.com/browse/XSUP-69131)

## New/Edited policies (Delete if not relevant)

### Description
**CKV_AWS_393** — "Ensure AWS GitHub Actions OIDC authorization policies only allow safe claims and claim order on IAM role"
Applies to aws_iam_role resources whose assume_role_policy trusts a GitHub Actions OIDC federated principal (ARN containing oidc-provider/token.actions.githubusercontent.com). A statement is a violation when any of the following is true:
- No Condition block exists.
- The Condition block contains no :sub claim constraint.
- The :sub value is "*", or shaped like "repo:*", or a bare claim with no value.
- The first claim is an abusable one (workflow, environment, ref, context, head_ref, base_ref) — these can be set by the workflow author and shouldn't be the primary authorization key.
- The first claim is "repo:" but the value isn't in <org>/<something> shape (guards against typos like "repo:myOrg*").
Same conditions as CKV_AWS_358, just applied to the resource form.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
