### PR TITLE
fix(CKV2_AWS_19): allow EIPs attached to Network Load Balancers to pass

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/EIPAllocatedToVPCAttachedEC2.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/EIPAllocatedToVPCAttachedEC2.yaml
@@ -54,6 +54,13 @@ definition:
             - aws_transfer_server
           operator: exists
           cond_type: connection
+        - resource_types:
+            - aws_eip
+          connected_resource_types:
+            - aws_lb
+            - aws_alb
+          operator: exists
+          cond_type: connection
         - cond_type: attribute
           resource_types:
           - aws_eip

--- a/tests/terraform/graph/checks/resources/EIPAllocatedToVPCAttachedEC2/expected.yaml
+++ b/tests/terraform/graph/checks/resources/EIPAllocatedToVPCAttachedEC2/expected.yaml
@@ -5,5 +5,6 @@ pass:
   - "aws_eip.eip_ok_transer_server"
   - "aws_eip.ok_eip_domain"
   - "aws_eip.ok_eip_domain_assoc"
+  - "aws_eip.ok_eip_nlb"
 fail:
   - "aws_eip.not_ok_eip"

--- a/tests/terraform/graph/checks/resources/EIPAllocatedToVPCAttachedEC2/main.tf
+++ b/tests/terraform/graph/checks/resources/EIPAllocatedToVPCAttachedEC2/main.tf
@@ -112,3 +112,20 @@ resource "aws_eip" "ok_eip_data" {
   instance = data.aws_instance.id
   vpc      = true
 }
+
+# via aws_lb (Network Load Balancer with subnet_mapping)
+
+resource "aws_eip" "ok_eip_nlb" {
+  domain = "vpc"
+}
+
+resource "aws_lb" "nlb" {
+  name               = "my-nlb"
+  internal           = false
+  load_balancer_type = "network"
+
+  subnet_mapping {
+    subnet_id     = "subnet-12345"
+    allocation_id = aws_eip.ok_eip_nlb.id
+  }
+}


### PR DESCRIPTION
## Summary

- CKV2_AWS_19 was producing a false positive for `aws_eip` resources with `domain = "vpc"` when the EIP is used in the `subnet_mapping.allocation_id` of an `aws_lb` (Network Load Balancer).
- The check already validates VPC membership correctly (via `vpc = true` or `domain = "vpc"`), but the connection check only allowed `aws_instance`, `aws_nat_gateway`, `aws_transfer_server`, and `aws_eip_association` — not NLBs.
- Add `aws_lb` and `aws_alb` as valid connected resource types in the YAML definition so EIPs legitimately assigned to NLBs are no longer flagged.

Closes #7532

## Test plan

- [ ] Added `aws_eip.ok_eip_nlb` test resource in `tests/terraform/graph/checks/resources/EIPAllocatedToVPCAttachedEC2/main.tf` — an EIP with `domain = "vpc"` referenced by an `aws_lb` via `subnet_mapping.allocation_id`
- [ ] Updated `expected.yaml` to include `aws_eip.ok_eip_nlb` in the `pass` list
- [ ] Existing test `test_EIPAllocatedToVPCAttachedEC2` passes locally with the new test case