### PR TITLE
fix(terraform): pin security-group module to 5.3.1 in linked-module test

### DIFF
--- a/tests/terraform/graph/resources/modules/registry_security_group_inner_module/main.tf
+++ b/tests/terraform/graph/resources/modules/registry_security_group_inner_module/main.tf
@@ -1,5 +1,6 @@
 module "web_server_sg" {
-  source = "terraform-aws-modules/security-group/aws//modules/http-80"
+  source  = "terraform-aws-modules/security-group/aws//modules/http-80"
+  version = "5.3.1"
 
   name        = "web-server"
   description = "Security group for web-server with HTTP ports open within VPC"


### PR DESCRIPTION
## What

Pin the `terraform-aws-modules/security-group/aws//modules/http-80` module to version `5.3.1` in the test fixture used by `test_build_graph_with_linked_registry_modules`.

## Why

The fixture had no `version` constraint, so it always downloaded **latest**. The upstream module published **v6.0.0** on 2026-06-03, a major release that **removed the `aws_security_group.this_name_prefix` resource**.

The test asserts that `aws_security_group.this_name_prefix` exists in the built graph:

```python
resource_security_group_this_name_prefix = self.get_vertex_by_name_and_type(
    local_graph, BlockType.RESOURCE, "aws_security_group.this_name_prefix")
```

With v6.0.0 that resource is gone, so the vertex lookup returns an empty list and the test fails with `IndexError: list index out of range`. This is not a Checkov bug or an AWS outage — it is an unpinned dependency on a mutable "latest" upstream module.

## Fix

Pin the fixture to `5.3.1` (the last release that still contains both `aws_security_group.this` and `aws_security_group.this_name_prefix`), making the test deterministic and immune to future upstream major-version bumps.

## Verification

```
tests/terraform/graph/graph_builder/test_graph_builder.py::TestGraphBuilder::test_build_graph_with_linked_registry_modules PASSED
1 passed
```
