### PR TITLE
fix(terraform): handle unresolved S3 policy statements

### DIFF
--- a/checkov/terraform/checks/resource/aws/S3AllowsAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/S3AllowsAnyPrincipal.py
@@ -84,9 +84,14 @@ class S3AllowsAnyPrincipal(BaseResourceCheck):
 
         if isinstance(policy_block, dict) and 'Statement' in policy_block.keys():
             statements = force_list(policy_block['Statement'])
-            if all('Effect' not in statement for statement in statements):
+            if all(not isinstance(statement, dict) or 'Effect' not in statement for statement in statements):
                 return CheckResult.UNKNOWN
+            has_unresolved_statement = False
             for statement in statements:
+                if not isinstance(statement, dict):
+                    # Unresolved statements can be serialized as strings that still contain "Effect".
+                    has_unresolved_statement = True
+                    continue
                 if 'Effect' not in statement or statement['Effect'] == 'Deny' or 'Principal' not in statement:
                     continue
                 principal = statement['Principal']
@@ -101,6 +106,8 @@ class S3AllowsAnyPrincipal(BaseResourceCheck):
                         if check_conditions(statement):
                             return CheckResult.PASSED
                         return CheckResult.FAILED
+            if has_unresolved_statement:
+                return CheckResult.UNKNOWN
         return CheckResult.PASSED
 
     def get_evaluated_keys(self) -> List[str]:

--- a/tests/terraform/checks/resource/aws/example_S3AllowsAnyPrincipal/concat_mixed.tf
+++ b/tests/terraform/checks/resource/aws/example_S3AllowsAnyPrincipal/concat_mixed.tf
@@ -1,0 +1,26 @@
+variable "extra_statements_pass" {
+  type    = list(any)
+  default = [
+    "{Effect = \"Allow\", Principal = \"*\"}",
+  ]
+}
+
+resource "aws_s3_bucket_policy" "concat_mixed_pass" {
+  bucket = "example"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Sid       = "DenyInsecureTransport"
+          Effect    = "Deny"
+          Principal = "*"
+          Action    = "s3:*"
+          Resource  = "*"
+          Condition = { Bool = { "aws:SecureTransport" = "false" } }
+        },
+      ],
+      var.extra_statements_pass,
+    )
+  })
+}

--- a/tests/terraform/checks/resource/aws/test_S3AllowsAnyPrincipal.py
+++ b/tests/terraform/checks/resource/aws/test_S3AllowsAnyPrincipal.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+from checkov.common.models.enums import CheckResult
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.checks.resource.aws.S3AllowsAnyPrincipal import check
 from checkov.terraform.runner import Runner
@@ -37,6 +38,9 @@ class TestS3AllowsAnyPrincipal(unittest.TestCase):
             "aws_s3_bucket.fail_w_condition",
             "aws_s3_bucket_policy.fail_w_condition",
         }
+        unknown_resources = {
+            "aws_s3_bucket_policy.concat_mixed_pass",
+        }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
@@ -48,6 +52,26 @@ class TestS3AllowsAnyPrincipal(unittest.TestCase):
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
+        self.assertFalse(unknown_resources & passed_check_resources)
+        self.assertFalse(unknown_resources & failed_check_resources)
+
+    def test_mixed_concat_unresolved_statement_returns_unknown(self):
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "DenyInsecureTransport",
+                    "Effect": "Deny",
+                    "Principal": "*",
+                    "Action": "s3:*",
+                    "Resource": "*",
+                    "Condition": {"Bool": {"aws:SecureTransport": "false"}},
+                },
+                "{Effect = \"Allow\", Principal = \"*\"}",
+            ],
+        }
+
+        self.assertEqual(check.scan_resource_conf({"policy": [policy]}), CheckResult.UNKNOWN)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description
Fixes #7571.

`CKV_AWS_70` assumed every `Statement` entry was a dictionary after the existing all-missing-`Effect` pre-check. Mixed `concat()`/`jsonencode()` policy statements can include unresolved statement entries serialized as strings that still contain `Effect`, which caused a `TypeError` when the check indexed `statement['Effect']`.

This change guards non-dictionary statements before indexing them and returns `UNKNOWN` when unresolved statement entries prevent a definitive pass/fail result.

## New/Edited policies (Delete if not relevant)

Not relevant; this is a bug fix for existing policy `CKV_AWS_70`.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (not applicable; no docs change needed)
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes

Local verification:

```sh
python -m pytest tests/terraform/checks/resource/aws/test_S3AllowsAnyPrincipal.py -q
python -m py_compile checkov/terraform/checks/resource/aws/S3AllowsAnyPrincipal.py tests/terraform/checks/resource/aws/test_S3AllowsAnyPrincipal.py
git diff --check
checkov -d tests/terraform/checks/resource/aws/example_S3AllowsAnyPrincipal --check CKV_AWS_70 --framework terraform --quiet
```

Note: the final Checkov command exits `1` because the existing fixture intentionally contains failing resources, but it completes without `TypeError`/traceback.
