### PR TITLE
feat(serverless): disable vars opt out

### DIFF
--- a/checkov/serverless/parsers/parser.py
+++ b/checkov/serverless/parsers/parser.py
@@ -211,17 +211,22 @@ Load data based on the type/path (see param_lookup_function parameter of process
 
     :return     None if the variable could not be resolved
     """
+    # By default, ${env:VAR} and ${file(path)} resolution stays ENABLED to preserve
+    # the original backward-compatible behavior. Setting CHECKOV_SERVERLESS_DISABLE_VARS=true
+    # disables that resolution. ${self:} resolution is unaffected.
+    disable_vars = os.environ.get("CHECKOV_SERVERLESS_DISABLE_VARS", "").lower() == "true"
+
     value = None
     if var_type is None:
         value = var_location
     elif var_type == "self":
         value = _determine_variable_value_from_dict(self_data_source, var_location, None)
     elif var_type == "env":
-        if os.environ.get("CHECKOV_SERVERLESS_RESOLVE_VARS", "").lower() != "true":
+        if disable_vars:
             return None
         value = _determine_variable_value_from_dict(dict(os.environ.items()), var_location, None)
     elif var_type.startswith("file("):
-        if os.environ.get("CHECKOV_SERVERLESS_RESOLVE_VARS", "").lower() != "true":
+        if disable_vars:
             return None
         match = FILE_LOCATION_PATTERN.match(var_type)
         if match is None:

--- a/tests/serverless/checks/aws/test_AdminPolicyDocument.py
+++ b/tests/serverless/checks/aws/test_AdminPolicyDocument.py
@@ -8,7 +8,7 @@ from checkov.runner_filter import RunnerFilter
 
 class TestAdminPolicyDocument(unittest.TestCase):
 
-    @mock.patch.dict(os.environ, {"sneaky_var": "*", "CHECKOV_SERVERLESS_RESOLVE_VARS": "true"})
+    @mock.patch.dict(os.environ, {"sneaky_var": "*"})
     def test_summary(self):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))

--- a/tests/serverless/checks/aws/test_S3PublicACLRead.py
+++ b/tests/serverless/checks/aws/test_S3PublicACLRead.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-from unittest import mock
 
 from checkov.cloudformation.checks.resource.aws.S3PublicACLRead import check
 from checkov.serverless.runner import Runner
@@ -9,7 +8,6 @@ from checkov.runner_filter import RunnerFilter
 
 class TestS3PublicACLRead(unittest.TestCase):
 
-    @mock.patch.dict(os.environ, {"CHECKOV_SERVERLESS_RESOLVE_VARS": "true"})
     def test_summary(self):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -26,7 +24,6 @@ class TestS3PublicACLRead(unittest.TestCase):
         for failed_check in report.failed_checks:
             self.assertEqual(dict(sorted(failed_check.entity_tags.items())), {"RESOURCE": "lambda", "PUBLIC": "False"})
 
-    @mock.patch.dict(os.environ, {"CHECKOV_SERVERLESS_RESOLVE_VARS": "true"})
     def test_inclusion(self):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))

--- a/tests/serverless/test_parser.py
+++ b/tests/serverless/test_parser.py
@@ -386,22 +386,13 @@ class TestParser(unittest.TestCase):
     #########################################
     # env/file variable resolution opt-out
     #
-    # Default behavior (flag unset) resolves ${env:VAR} and ${file(path)} to
-    # preserve backward compatibility. Setting CHECKOV_SERVERLESS_DISABLE_VARS=true
-    # disables that resolution.
-
-    @mock.patch.dict(os.environ, {"MY_SECRET": "s3cret"})
-    def test_env_var_resolved_by_default(self):
-        """${env:VAR} IS resolved by default when the disable flag is not set."""
-        env = os.environ.copy()
-        env.pop("CHECKOV_SERVERLESS_DISABLE_VARS", None)
-        with mock.patch.dict(os.environ, env, clear=True):
-            case = {
-                "provider": {"name": "aws"},
-                "value": "${env:MY_SECRET}"
-            }
-            result = process_variables(case, IRRELEVANT_DIR)
-            self.assertEqual(result["value"], "s3cret")
+    # Default behavior (flag unset) resolves ${env:VAR} and ${file(path)},
+    # preserving backward compatibility. That default path is already exercised
+    # by the check tests (test_AdminPolicyDocument / test_S3PublicACLRead, which
+    # rely on ${env:} and ${file()} resolution) and by the ${self:} tests above,
+    # so it is not re-tested here. These tests cover only the NEW opt-out
+    # behavior: CHECKOV_SERVERLESS_DISABLE_VARS=true disables ${env:} and
+    # ${file()} resolution while leaving ${self:} resolution intact.
 
     @mock.patch.dict(os.environ, {"MY_SECRET": "s3cret", "CHECKOV_SERVERLESS_DISABLE_VARS": "true"})
     def test_env_var_not_resolved_when_disabled(self):
@@ -413,24 +404,6 @@ class TestParser(unittest.TestCase):
         result = process_variables(case, IRRELEVANT_DIR)
         # Should remain unresolved
         self.assertEqual(result["value"], "${env:MY_SECRET}")
-
-    def test_file_var_resolved_by_default(self):
-        """${file(path)} IS resolved by default when the disable flag is not set."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            f.write('{"secret_key": "top-secret"}')
-            tmp_path = f.name
-        try:
-            env = os.environ.copy()
-            env.pop("CHECKOV_SERVERLESS_DISABLE_VARS", None)
-            with mock.patch.dict(os.environ, env, clear=True):
-                case = {
-                    "provider": {"name": "aws"},
-                    "value": "${file(" + tmp_path + "):secret_key}"
-                }
-                result = process_variables(case, IRRELEVANT_DIR)
-                self.assertEqual(result["value"], "top-secret")
-        finally:
-            os.unlink(tmp_path)
 
     @mock.patch.dict(os.environ, {"CHECKOV_SERVERLESS_DISABLE_VARS": "true"})
     def test_file_var_not_resolved_when_disabled(self):
@@ -449,19 +422,6 @@ class TestParser(unittest.TestCase):
         finally:
             os.unlink(tmp_path)
 
-    def test_self_resolution_unaffected_by_default(self):
-        """${self:} must always resolve when the disable flag is not set."""
-        env = os.environ.copy()
-        env.pop("CHECKOV_SERVERLESS_DISABLE_VARS", None)
-        with mock.patch.dict(os.environ, env, clear=True):
-            case = {
-                "provider": {"name": "aws"},
-                "source": "resolved-value",
-                "consumer": "${self:source}"
-            }
-            result = process_variables(case, IRRELEVANT_DIR)
-            self.assertEqual(result["consumer"], "resolved-value")
-
     @mock.patch.dict(os.environ, {"CHECKOV_SERVERLESS_DISABLE_VARS": "true"})
     def test_self_resolution_unaffected_when_disabled(self):
         """${self:} must always resolve even when CHECKOV_SERVERLESS_DISABLE_VARS=true."""
@@ -472,102 +432,6 @@ class TestParser(unittest.TestCase):
         }
         result = process_variables(case, IRRELEVANT_DIR)
         self.assertEqual(result["consumer"], "resolved-value")
-
-
-    #########################################
-    # Security: env/file variable resolution opt-in (BCE-58125)
-
-    def test_env_var_not_resolved_by_default(self):
-        """${env:VAR} must NOT resolve when CHECKOV_SERVERLESS_RESOLVE_VARS is not set."""
-        with mock.patch.dict(os.environ, {"MY_SECRET": "s3cret"}, clear=False):
-            # Ensure opt-in is NOT set
-            env = os.environ.copy()
-            env.pop("CHECKOV_SERVERLESS_RESOLVE_VARS", None)
-            with mock.patch.dict(os.environ, env, clear=True):
-                case = {
-                    "provider": {"name": "aws"},
-                    "value": "${env:MY_SECRET}"
-                }
-                result = process_variables(case, IRRELEVANT_DIR)
-                # Should remain unresolved
-                self.assertEqual(result["value"], "${env:MY_SECRET}")
-
-    @mock.patch.dict(os.environ, {"MY_SECRET": "s3cret", "CHECKOV_SERVERLESS_RESOLVE_VARS": "true"})
-    def test_env_var_resolved_when_opted_in(self):
-        """${env:VAR} must resolve when CHECKOV_SERVERLESS_RESOLVE_VARS=true."""
-        case = {
-            "provider": {"name": "aws"},
-            "value": "${env:MY_SECRET}"
-        }
-        result = process_variables(case, IRRELEVANT_DIR)
-        self.assertEqual(result["value"], "s3cret")
-
-    def test_file_var_not_resolved_by_default(self):
-        """${file(path)} must NOT resolve when CHECKOV_SERVERLESS_RESOLVE_VARS is not set."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            f.write('{"secret_key": "top-secret"}')
-            tmp_path = f.name
-        try:
-            env = os.environ.copy()
-            env.pop("CHECKOV_SERVERLESS_RESOLVE_VARS", None)
-            with mock.patch.dict(os.environ, env, clear=True):
-                case = {
-                    "provider": {"name": "aws"},
-                    "value": "${file(" + tmp_path + "):secret_key}"
-                }
-                result = process_variables(case, IRRELEVANT_DIR)
-                # Should remain unresolved
-                self.assertEqual(result["value"], "${file(" + tmp_path + "):secret_key}")
-        finally:
-            os.unlink(tmp_path)
-
-    @mock.patch.dict(os.environ, {"CHECKOV_SERVERLESS_RESOLVE_VARS": "true"})
-    def test_file_var_resolved_when_opted_in(self):
-        """${file(path)} must resolve when CHECKOV_SERVERLESS_RESOLVE_VARS=true."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            f.write('{"secret_key": "top-secret"}')
-            tmp_path = f.name
-        try:
-            case = {
-                "provider": {"name": "aws"},
-                "value": "${file(" + tmp_path + "):secret_key}"
-            }
-            result = process_variables(case, IRRELEVANT_DIR)
-            self.assertEqual(result["value"], "top-secret")
-        finally:
-            os.unlink(tmp_path)
-
-    def test_self_resolution_unaffected_by_opt_in(self):
-        """${self:} must always resolve regardless of CHECKOV_SERVERLESS_RESOLVE_VARS."""
-        env = os.environ.copy()
-        env.pop("CHECKOV_SERVERLESS_RESOLVE_VARS", None)
-        with mock.patch.dict(os.environ, env, clear=True):
-            case = {
-                "provider": {"name": "aws"},
-                "source": "resolved-value",
-                "consumer": "${self:source}"
-            }
-            result = process_variables(case, IRRELEVANT_DIR)
-            self.assertEqual(result["consumer"], "resolved-value")
-
-    def test_env_var_with_fallback_not_resolved_by_default(self):
-        """${env:VAR, 'default'} should remain unresolved when env resolution is disabled.
-
-        When the opt-in is not set, the env branch returns None early (before
-        the fallback logic), so the entire expression stays as a literal string.
-        This is intentional: fallbacks could themselves be file() references that
-        would leak host data.
-        """
-        env = os.environ.copy()
-        env.pop("CHECKOV_SERVERLESS_RESOLVE_VARS", None)
-        with mock.patch.dict(os.environ, env, clear=True):
-            case = {
-                "provider": {"name": "aws"},
-                "value": "${env:MISSING_VAR, 'fallback-value'}"
-            }
-            result = process_variables(case, IRRELEVANT_DIR)
-            # The entire expression stays unresolved — no fallback processing
-            self.assertEqual(result["value"], "${env:MISSING_VAR, 'fallback-value'}")
 
 
 if __name__ == '__main__':

--- a/tests/serverless/test_parser.py
+++ b/tests/serverless/test_parser.py
@@ -383,6 +383,96 @@ class TestParser(unittest.TestCase):
         self.assertEqual(("self", "foo", None, None),
                          _parse_var("self: foo"))       # eat whitespace
 
+    #########################################
+    # env/file variable resolution opt-out
+    #
+    # Default behavior (flag unset) resolves ${env:VAR} and ${file(path)} to
+    # preserve backward compatibility. Setting CHECKOV_SERVERLESS_DISABLE_VARS=true
+    # disables that resolution.
+
+    @mock.patch.dict(os.environ, {"MY_SECRET": "s3cret"})
+    def test_env_var_resolved_by_default(self):
+        """${env:VAR} IS resolved by default when the disable flag is not set."""
+        env = os.environ.copy()
+        env.pop("CHECKOV_SERVERLESS_DISABLE_VARS", None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            case = {
+                "provider": {"name": "aws"},
+                "value": "${env:MY_SECRET}"
+            }
+            result = process_variables(case, IRRELEVANT_DIR)
+            self.assertEqual(result["value"], "s3cret")
+
+    @mock.patch.dict(os.environ, {"MY_SECRET": "s3cret", "CHECKOV_SERVERLESS_DISABLE_VARS": "true"})
+    def test_env_var_not_resolved_when_disabled(self):
+        """${env:VAR} must NOT resolve when CHECKOV_SERVERLESS_DISABLE_VARS=true."""
+        case = {
+            "provider": {"name": "aws"},
+            "value": "${env:MY_SECRET}"
+        }
+        result = process_variables(case, IRRELEVANT_DIR)
+        # Should remain unresolved
+        self.assertEqual(result["value"], "${env:MY_SECRET}")
+
+    def test_file_var_resolved_by_default(self):
+        """${file(path)} IS resolved by default when the disable flag is not set."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write('{"secret_key": "top-secret"}')
+            tmp_path = f.name
+        try:
+            env = os.environ.copy()
+            env.pop("CHECKOV_SERVERLESS_DISABLE_VARS", None)
+            with mock.patch.dict(os.environ, env, clear=True):
+                case = {
+                    "provider": {"name": "aws"},
+                    "value": "${file(" + tmp_path + "):secret_key}"
+                }
+                result = process_variables(case, IRRELEVANT_DIR)
+                self.assertEqual(result["value"], "top-secret")
+        finally:
+            os.unlink(tmp_path)
+
+    @mock.patch.dict(os.environ, {"CHECKOV_SERVERLESS_DISABLE_VARS": "true"})
+    def test_file_var_not_resolved_when_disabled(self):
+        """${file(path)} must NOT resolve when CHECKOV_SERVERLESS_DISABLE_VARS=true."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write('{"secret_key": "top-secret"}')
+            tmp_path = f.name
+        try:
+            case = {
+                "provider": {"name": "aws"},
+                "value": "${file(" + tmp_path + "):secret_key}"
+            }
+            result = process_variables(case, IRRELEVANT_DIR)
+            # Should remain unresolved
+            self.assertEqual(result["value"], "${file(" + tmp_path + "):secret_key}")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_self_resolution_unaffected_by_default(self):
+        """${self:} must always resolve when the disable flag is not set."""
+        env = os.environ.copy()
+        env.pop("CHECKOV_SERVERLESS_DISABLE_VARS", None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            case = {
+                "provider": {"name": "aws"},
+                "source": "resolved-value",
+                "consumer": "${self:source}"
+            }
+            result = process_variables(case, IRRELEVANT_DIR)
+            self.assertEqual(result["consumer"], "resolved-value")
+
+    @mock.patch.dict(os.environ, {"CHECKOV_SERVERLESS_DISABLE_VARS": "true"})
+    def test_self_resolution_unaffected_when_disabled(self):
+        """${self:} must always resolve even when CHECKOV_SERVERLESS_DISABLE_VARS=true."""
+        case = {
+            "provider": {"name": "aws"},
+            "source": "resolved-value",
+            "consumer": "${self:source}"
+        }
+        result = process_variables(case, IRRELEVANT_DIR)
+        self.assertEqual(result["consumer"], "resolved-value")
+
 
     #########################################
     # Security: env/file variable resolution opt-in (BCE-58125)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

This PR inverts the serverless variable-resolution gating introduced in #7554.

Previously (#7554), ${env:VAR} and ${file(path)} resolution in the serverless parser was disabled by default and could only be turned on via an opt-in flag (CHECKOV_SERVERLESS_RESOLVE_VARS=true). That changed the default behavior and broke backward compatibility for users who relied on env/file resolution during scans.

This PR replaces that opt-in model with an opt-out model:

Default (flag unset): env/file variable resolution stays ENABLED, preserving the original, backward-compatible behavior.
CHECKOV_SERVERLESS_DISABLE_VARS=true: disables ${env:VAR} and ${file(path)} resolution, for environments where reading host environment variables / files during a scan is undesirable (information-exposure hardening, CWE-200).
${self:} resolution is unaffected in all cases.

What changed
[checkov/serverless/parsers/parser.py](vscode-webview://0f4qspjlfkqqfulnrjo0jboautdnfjhsrpusvejneevbspbqje1k/checkov/checkov/serverless/parsers/parser.py) _load_var_data():
Removed the old opt-in flag CHECKOV_SERVERLESS_RESOLVE_VARS and its gating.
Added a single disable_vars = os.environ.get("CHECKOV_SERVERLESS_DISABLE_VARS", "").lower() == "true" check.
env branch and file(...) branch now return None only when disable_vars is true; otherwise they resolve as before.
Tests
[tests/serverless/test_parser.py](vscode-webview://0f4qspjlfkqqfulnrjo0jboautdnfjhsrpusvejneevbspbqje1k/checkov/tests/serverless/test_parser.py): added 3 focused tests for the opt-out path:
test_env_var_not_resolved_when_disabled
test_file_var_not_resolved_when_disabled
test_self_resolution_unaffected_when_disabled
The default-ON behavior is already covered by the existing serverless check fixtures (test_AdminPolicyDocument.py, test_S3PublicACLRead.py) and existing test_self_* tests, so no redundant default-resolution tests were added.
Removed the now-obsolete RESOLVE_VARS env-mocks from the two check tests, since resolution is the default again.

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
