### PR TITLE
fix(7552): prevent branch names starting with hex chars from matching commit ID pattern

### DIFF
--- a/checkov/common/goget/github/get_git.py
+++ b/checkov/common/goget/github/get_git.py
@@ -15,7 +15,7 @@ try:
 except ImportError as e:
     git_import_error = e
 
-COMMIT_ID_PATTERN = re.compile(r"\?(ref=)(?P<commit_id>([0-9a-f]{5,40}))")
+COMMIT_ID_PATTERN = re.compile(r"\?(ref=)(?P<commit_id>([0-9a-f]{5,40}))(?:&|$)")
 TAG_PATTERN = re.compile(r'\?(ref=)(?P<tag>(.*))')  # technically should be with ?ref=tags/ but this catches both
 BRANCH_PATTERN = re.compile(r'\?(ref=heads/)(?P<branch>(.*))')
 

--- a/tests/common/goget/test_goget_github.py
+++ b/tests/common/goget/test_goget_github.py
@@ -267,5 +267,31 @@ class TestGitGetter(unittest.TestCase):
         mock_repo.clone_from.assert_called_once()
 
 
+    def test_parse_branch_name_starting_with_hex_chars(self):
+        """Branch names that start with hex characters should not be mistaken for commit IDs.
+
+        Regression test for https://github.com/bridgecrewio/checkov/issues/XXXX:
+        A ref like '1014016-chekov-branch-bug' starts with 7 valid hex characters.
+        The old COMMIT_ID_PATTERN (without an end anchor) partially matched '1014016',
+        stripped only that portion from the URL, and left '-chekov-branch-bug' dangling
+        — corrupting the repo name in the resulting git clone command.
+        """
+        url = "ssh://git@ssh.dev.azure.com/v3/Company/cat-tf-modules?ref=1014016-chekov-branch-bug"
+        getter = GitGetter(url)
+        git_url = getter.extract_git_ref(url)
+
+        self.assertEqual(
+            "ssh://git@ssh.dev.azure.com/v3/Company/cat-tf-modules",
+            git_url,
+            "URL should not have the branch name appended to the repo path",
+        )
+        self.assertIsNone(getter.commit_id, "Should not be parsed as a commit ID")
+        self.assertEqual(
+            "1014016-chekov-branch-bug",
+            getter.tag,
+            "Branch/tag name should be captured in full",
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

Fixes #7552

When a Terraform module source uses a `?ref=` value that is a branch name starting with hex characters (e.g. `1014016-chekov-branch-bug`), Checkov incorrectly identifies the hex prefix as a commit ID.

`COMMIT_ID_PATTERN` lacked an end anchor, so `re.sub` would strip only the matched hex portion (e.g. `?ref=1014016`) from the URL, leaving the remainder (`-chekov-branch-bug`) dangling — which then got appended to the repository name, producing a clone address that does not exist:

```
# Before fix — corrupted clone URL
git clone ssh://.../cat-tf-modules-chekov-branch-bug

# After fix — correct clone URL
git clone ssh://.../cat-tf-modules  (branch: 1014016-chekov-branch-bug)
```

The fix adds `(?:&|$)` to `COMMIT_ID_PATTERN` so it only matches a ref value that is purely hexadecimal with nothing following it. Branch/tag names that start with hex characters now fall through to `TAG_PATTERN` and are cloned correctly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
