### PR TITLE
fix(kubernetes): CKV_K8S_40 should pass when hostUsers is false

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/RootContainersHighUID.py
+++ b/checkov/kubernetes/checks/resource/k8s/RootContainersHighUID.py
@@ -21,6 +21,12 @@ class RootContainersHighUID(BaseK8sRootContainerCheck):
 
         # Collect results
         if spec and isinstance(spec, dict):
+            # With a private user namespace (hostUsers: false) container UIDs are
+            # remapped to unprivileged host UIDs, so the high-UID host-collision
+            # concern this check guards against no longer applies.
+            if spec.get("hostUsers") is False:
+                return CheckResult.PASSED
+
             results: dict[str, Any] = {"pod": {}, "container": []}
             results["pod"]["runAsUser"] = self.check_runAsUser(spec, 10000)
 

--- a/tests/kubernetes/checks/example_RootContainersHighUID/rootContainersHighUIDFAILED.yaml
+++ b/tests/kubernetes/checks/example_RootContainersHighUID/rootContainersHighUIDFAILED.yaml
@@ -88,3 +88,16 @@ spec:
   - name: main2
     image: alpine
     command: ["/bin/sleep", "999999"]
+---
+# hostUsers: true keeps the host user namespace, so the high-UID check still
+# applies and a missing runAsUser must FAIL (guards the hostUsers exemption)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod5
+spec:
+  hostUsers: true
+  containers:
+  - name: main
+    image: alpine
+    command: ["/bin/sleep", "999999"]

--- a/tests/kubernetes/checks/example_RootContainersHighUID/rootContainersHighUIDPASSED.yaml
+++ b/tests/kubernetes/checks/example_RootContainersHighUID/rootContainersHighUIDPASSED.yaml
@@ -38,3 +38,16 @@ spec:
     command: ["/bin/sleep", "999999"]
     securityContext:
       runAsUser: 12000
+---
+# runAsUser not set, but hostUsers: false enables a private user namespace,
+# so host UID collisions cannot occur (PASSED)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod4
+spec:
+  hostUsers: false
+  containers:
+  - name: main
+    image: alpine
+    command: ["/bin/sleep", "999999"]

--- a/tests/kubernetes/checks/test_RootContainersHighUID.py
+++ b/tests/kubernetes/checks/test_RootContainersHighUID.py
@@ -16,8 +16,8 @@ class TestRootContainersHighUID(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 3)
-        self.assertEqual(summary['failed'], 6)
+        self.assertEqual(summary['passed'], 4)
+        self.assertEqual(summary['failed'], 7)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
## Description

`CKV_K8S_40` ("Containers should run as a high UID to avoid host conflict") enforces `runAsUser >= 10000` so that, if a container process runs as root, its UID will not collide with a privileged UID on the host.

When a pod sets `spec.hostUsers: false` it runs in a **private user namespace** ([enabled by default since Kubernetes 1.33](https://kubernetes.io/blog/2025/04/25/userns-enabled-by-default/)). Container UIDs are then remapped to unprivileged, non-overlapping host UIDs, so the host-collision risk this check guards against can no longer occur. In that case the high-UID requirement is moot and the check should `PASS`.

This PR makes `RootContainersHighUID.scan_spec_conf` return `PASSED` early when `spec.hostUsers is False`.

Fixes #7527

## Behaviour

- `hostUsers: false` -> `PASSED` (private user namespace; UID collision impossible)
- `hostUsers: true` or unset -> unchanged (high-UID check still applies)

The guard uses an explicit `is False` check, so only the namespaced case is exempted; an unset or `true` value keeps the original behaviour.

## Tests

Extended `tests/kubernetes/checks/test_RootContainersHighUID.py` example manifests:
- added a `hostUsers: false` pod with no `runAsUser` -> expected `PASSED` (proves the fix)
- added an explicit `hostUsers: true` pod with no `runAsUser` -> expected `FAILED` (guards against over-broadening the exemption)

Expected summary counts updated to `passed=4`, `failed=7`. Test passes locally.
