### PR TITLE
fix(terraform): prevent crash in S3AllowsAnyPrincipal with unparsed v…

### DIFF
--- a/checkov/terraform/checks/resource/aws/S3AllowsAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/S3AllowsAnyPrincipal.py
@@ -87,6 +87,8 @@ class S3AllowsAnyPrincipal(BaseResourceCheck):
             if all('Effect' not in statement for statement in statements):
                 return CheckResult.UNKNOWN
             for statement in statements:
+                if not isinstance(statement, dict):
+                    continue
                 if 'Effect' not in statement or statement['Effect'] == 'Deny' or 'Principal' not in statement:
                     continue
                 principal = statement['Principal']

--- a/tests/terraform/checks/resource/aws/example_S3AllowsAnyPrincipal/main.tf
+++ b/tests/terraform/checks/resource/aws/example_S3AllowsAnyPrincipal/main.tf
@@ -518,3 +518,27 @@ resource "aws_s3_bucket_policy" "logs" {
     )
   })
 }
+# Test for Issue 7571: Unparsed variables in concat should not crash the parser
+variable "additional_policy_statements" {
+  default = []
+}
+
+resource "aws_s3_bucket_policy" "mixed_concat_crash" {
+  bucket = "bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Sid       = "DenyInsecureTransport"
+          Effect    = "Deny"
+          Principal = "*"
+          Action    = "s3:*"
+          Resource  = ["arn:aws:s3:::bucket/*"]
+        }
+      ],
+      var.additional_policy_statements
+    )
+  })
+}

--- a/tests/terraform/checks/resource/aws/test_S3AllowsAnyPrincipal.py
+++ b/tests/terraform/checks/resource/aws/test_S3AllowsAnyPrincipal.py
@@ -28,6 +28,7 @@ class TestS3AllowsAnyPrincipal(unittest.TestCase):
             "aws_s3_bucket.pass_w_condition5",
             "aws_s3_bucket.pass_w_condition6",
             "aws_s3_bucket_policy.vpce_account_condition",
+            "aws_s3_bucket_policy.mixed_concat_crash",
         }
         failing_resources = {
             "aws_s3_bucket.fail",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

This PR fixes a parser crash in the `CKV_AWS_70` (`S3AllowsAnyPrincipal`) check when it encounters an unparsed Terraform variable within a `concat` statement for an S3 Bucket Policy.

A `TypeError` was previously thrown when the parser expected a dictionary but received a string (the unparsed variable placeholder). I added an `isinstance` guard inside the loop to safely skip non-dictionary elements, along with a corresponding Terraform test fixture to prevent regression.

Fixes #7571

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes