### PR TITLE
fix(terraform_plan): handle computed log_bucket in CKV_GCP_62 and CKV_GCP_63

### DIFF
--- a/checkov/terraform/checks/resource/gcp/CloudStorageLogging.py
+++ b/checkov/terraform/checks/resource/gcp/CloudStorageLogging.py
@@ -15,8 +15,12 @@ class CloudStorageLogging(BaseResourceCheck):
     def scan_resource_conf(self, conf):
         # check for logging
         if 'logging' in conf:
-            if conf['logging'][0]:
-                log_bucket_name = conf['logging'][0]['log_bucket']
+            logging_block = conf['logging'][0]
+            if logging_block:
+                if 'log_bucket' not in logging_block:
+                    # log_bucket is a computed/unknown value (e.g. at terraform plan time)
+                    return CheckResult.UNKNOWN
+                log_bucket_name = logging_block['log_bucket']
                 if log_bucket_name:
                     return CheckResult.PASSED
                 else:

--- a/checkov/terraform/checks/resource/gcp/CloudStorageSelfLogging.py
+++ b/checkov/terraform/checks/resource/gcp/CloudStorageSelfLogging.py
@@ -17,8 +17,12 @@ class CloudStorageSelfLogging(BaseResourceCheck):
         # check for logging
         if "logging" in conf:
             self.evaluated_keys = ["logging"]
-            if conf["logging"][0]:
-                log_bucket_name = conf["logging"][0]["log_bucket"]
+            logging_block = conf["logging"][0]
+            if logging_block:
+                if "log_bucket" not in logging_block:
+                    # log_bucket is a computed/unknown value (e.g. at terraform plan time)
+                    return CheckResult.UNKNOWN
+                log_bucket_name = logging_block["log_bucket"]
                 self.evaluated_keys = ["logging/[0]/log_bucket", "name"]
                 if log_bucket_name != bucket_name:
                     return CheckResult.PASSED

--- a/tests/terraform/checks/resource/gcp/example_CloudStorageSelfLogging/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_CloudStorageSelfLogging/main.tf
@@ -19,3 +19,14 @@ resource "google_storage_bucket" "fail" {
     log_bucket = "example.com"
   }
 }
+
+# unknown - log_bucket is a computed value, absent from plan JSON
+
+resource "google_storage_bucket" "unknown" {
+  name     = "my-bucket"
+  location = "EU"
+
+  logging {
+    log_object_prefix = "my-prefix/"
+  }
+}

--- a/tests/terraform/checks/resource/gcp/test_CloudStorageLogging.py
+++ b/tests/terraform/checks/resource/gcp/test_CloudStorageLogging.py
@@ -35,5 +35,14 @@ class TestCloudStorageLogging(unittest.TestCase):
         scan_result = check.scan_resource_conf(conf=resource_conf)
         self.assertEqual(CheckResult.PASSED, scan_result)
 
+    def test_computed_log_bucket(self):
+        # When log_bucket references a computed value it is absent from the plan JSON
+        resource_conf = {
+            "name": ["my-bucket"],
+            "logging": [{"log_object_prefix": "my-prefix/"}],
+        }
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_CloudStorageSelfLogging.py
+++ b/tests/terraform/checks/resource/gcp/test_CloudStorageSelfLogging.py
@@ -36,6 +36,16 @@ class TestCloudStorageSelfLogging(unittest.TestCase):
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
 
+    def test_computed_log_bucket(self):
+        # When log_bucket is a computed value it is absent from the plan JSON; expect UNKNOWN
+        from checkov.common.models.enums import CheckResult
+        resource_conf = {
+            "name": ["my-bucket"],
+            "logging": [{"log_object_prefix": ["my-prefix/"]}],
+        }
+        result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.UNKNOWN, result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- `CKV_GCP_62` (CloudStorageLogging) and `CKV_GCP_63` (CloudStorageSelfLogging) both perform a direct dict key access on `logging_block['log_bucket']`.
- When `log_bucket` references a computed value (e.g. `"other-bucket-${random_id.log_bucket.hex}"`), Terraform plan JSON omits the key from the `logging` block entirely because its value is unknown at plan time.
- This caused a `KeyError` that was silently caught by the exception handler in `base_check_registry.py` and converted to `CheckResult.UNKNOWN`, meaning the check was effectively skipped for such resources with no explanation.
- This PR guards the access with an explicit `'log_bucket' not in logging_block` check and returns `CheckResult.UNKNOWN` intentionally, making the behavior transparent.

Closes #7473

## Test plan

- [ ] `test_CloudStorageLogging::test_computed_log_bucket` — verifies that a config with `logging` present but `log_bucket` missing returns `UNKNOWN`
- [ ] `test_CloudStorageSelfLogging::test_computed_log_bucket` — same for the self-logging check
- [ ] `test_CloudStorageSelfLogging::test` — full runner test still passes (1 pass, 1 fail, 0 skipped; the new `unknown` fixture is not counted in summary)
- [ ] `test_CloudStorageLogging::test_failure` / `test_success` — existing tests unchanged