### PR TITLE
fix(ansible): respect inline checkov:skip on block tasks

### DIFF
--- a/checkov/ansible/utils.py
+++ b/checkov/ansible/utils.py
@@ -168,7 +168,7 @@ def _process_blocks(
 
     if ResourceType.BLOCK in task and isinstance(task[ResourceType.BLOCK], list):
         prefix += f"{ResourceType.BLOCK}."  # with each nested level an extra block prefix is added
-        block_name = f"{prefix}.{task.get('name') or 'unknown'}"
+        block_name = f"{prefix}{task.get('name') or 'unknown'}"
         resource_context = _create_resource_context(definition_raw=definition_raw, resource=task)
         file_path_context[block_name] = resource_context
 

--- a/tests/ansible/examples/block_skip.yml
+++ b/tests/ansible/examples/block_skip.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Verify tests
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Block with inline skip comment
+      #checkov:skip=CKV2_ANSIBLE_3:no rescue needed, natural failure is more informative
+      block:
+        - name: Run a command
+          ansible.builtin.command: echo hello
+          changed_when: false

--- a/tests/ansible/test_runner.py
+++ b/tests/ansible/test_runner.py
@@ -217,6 +217,36 @@ def test_runner_with_block(graph_connector):
         RustworkxConnector,
     ],
 )
+def test_runner_with_block_skip(graph_connector):
+    # given
+    test_file = EXAMPLES_DIR / "block_skip.yml"
+    checks = ["CKV2_ANSIBLE_3"]
+
+    # when
+    report = Runner(db_connector=graph_connector()).run(
+        root_folder="", files=[str(test_file)], runner_filter=RunnerFilter(checks=checks)
+    )
+
+    # then
+    summary = report.get_summary()
+
+    assert summary["passed"] == 0
+    assert summary["failed"] == 0
+    assert summary["skipped"] == 1
+    assert summary["parsing_errors"] == 0
+
+    skipped_check = next(iter(report.skipped_checks))
+    assert skipped_check.check_id == "CKV2_ANSIBLE_3"
+    assert skipped_check.resource == "block.Block with inline skip comment"
+
+
+@pytest.mark.parametrize(
+    "graph_connector",
+    [
+        NetworkxConnector,
+        RustworkxConnector,
+    ],
+)
 def test_runner_with_nested_blocks(graph_connector):
     # given
     test_file = EXAMPLES_DIR / "nested_blocks.yml"


### PR DESCRIPTION
## Summary
- Fixes #7501: inline `checkov:skip=CKV2_ANSIBLE_3:...` (and any other graph check) comments placed on an Ansible `block:` task were silently ignored, so the check always reported `FAILED` instead of `SKIPPED`.
- Root cause: in `checkov/ansible/utils.py`, `_process_blocks` built the suppression-context key for a block as `f"{prefix}.{name}"` where `prefix` already ends in `"."` (e.g. `"block."`), producing `"block..name"`. The graph builder (`checkov/ansible/graph_builder/local_graph.py`) creates the corresponding vertex ID as `f"{prefix}{name}"` → `"block.name"`. The mismatched keys meant the skip lookup in the suppression logic never found the resource's skip comment.
- Fix removes the extra `.`, so the context key now matches the graph vertex ID exactly, the same way `generate_task_name` already does for non-block tasks.

## Test plan
- [x] Added `tests/ansible/examples/block_skip.yml` reproducing the reported scenario (a `block:` task with an inline `checkov:skip=CKV2_ANSIBLE_3` comment).
- [x] Added `test_runner_with_block_skip` in `tests/ansible/test_runner.py` (parametrized over both graph connectors) asserting the check is now reported as `SKIPPED` with the correct resource id.
- [x] Ran the full `tests/ansible/` suite locally — all existing tests still pass (no regressions for flat tasks, blocks, or nested blocks).
- [x] Manually reproduced the original bug and confirmed the fix resolves it:
  ```
  checkov -f test_skip.yml --framework ansible --check CKV2_ANSIBLE_3 --compact
  # before: FAILED for resource: block.Block with inline skip comment
  # after:  SKIPPED for resource: block.Block with inline skip comment
  ```