### PR TITLE
fix(cloudformation): CKV_AWS_61 should catch string AWS principal

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/IAMRoleAllowAssumeFromAccount.py
+++ b/checkov/cloudformation/checks/resource/aws/IAMRoleAllowAssumeFromAccount.py
@@ -39,17 +39,33 @@ class IAMRoleAllowAssumeFromAccount(BaseResourceCheck):
         else:
             return CheckResult.UNKNOWN
 
-        if 'Statement' in assume_role_block.keys():
-            if isinstance(assume_role_block['Statement'], list) and 'Principal' in \
-                    assume_role_block['Statement'][0]:
-                if 'AWS' in assume_role_block['Statement'][0]['Principal']:
-                    if isinstance(assume_role_block['Statement'][0]['Principal']['AWS'], list) \
-                            and isinstance(assume_role_block['Statement'][0]['Principal']['AWS'][0], str):
-                        if re.match(ACCOUNT_ACCESS, assume_role_block['Statement'][0]['Principal']['AWS'][0]):
-                            self.evaluated_keys = ['Properties/AssumeRolePolicyDocument/Statement']
-                            return CheckResult.FAILED
-
+        if not isinstance(assume_role_block, dict) or 'Statement' not in assume_role_block:
             return CheckResult.PASSED
+
+        statements = assume_role_block['Statement']
+        if not isinstance(statements, list):
+            statements = [statements]
+
+        for statement in statements:
+            if not isinstance(statement, dict) or statement.get('Effect') == 'Deny':
+                continue
+            principal = statement.get('Principal')
+            if not isinstance(principal, dict) or 'AWS' not in principal:
+                continue
+
+            aws_principals = principal['AWS']
+            # Can be a string or a list of strings
+            if isinstance(aws_principals, str):
+                aws_principals = [aws_principals]
+            if not isinstance(aws_principals, list):
+                continue
+
+            for aws_principal in aws_principals:
+                if isinstance(aws_principal, str) and re.match(ACCOUNT_ACCESS, aws_principal):
+                    self.evaluated_keys = ['Properties/AssumeRolePolicyDocument/Statement']
+                    return CheckResult.FAILED
+
+        return CheckResult.PASSED
 
 
 check = IAMRoleAllowAssumeFromAccount()

--- a/tests/cloudformation/checks/resource/aws/example_IAMRoleAllowAssumeFromAccount/example_IAMRoleAllowAssumeFromAccount-FAILED-2.yml
+++ b/tests/cloudformation/checks/resource/aws/example_IAMRoleAllowAssumeFromAccount/example_IAMRoleAllowAssumeFromAccount-FAILED-2.yml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+Resources:
+  ExecutionRole:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Principal:
+                AWS: arn:aws:iam::123456789101:root
+            Action:
+            - "sts:AssumeRole"

--- a/tests/cloudformation/checks/resource/aws/test_IAMRoleAllowAssumeFromAccount.py
+++ b/tests/cloudformation/checks/resource/aws/test_IAMRoleAllowAssumeFromAccount.py
@@ -17,7 +17,7 @@ class TestIAMRoleAllowAssumeFromAccount(unittest.TestCase):
         summary = report.get_summary()
 
         self.assertEqual(summary['passed'], 5)
-        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 

--- a/tests/cloudformation/parser/test_cfn_yaml.py
+++ b/tests/cloudformation/parser/test_cfn_yaml.py
@@ -153,7 +153,7 @@ class TestCfnYaml(unittest.TestCase):
         report = Runner().run(None, files=[f'{current_dir}/{f}' for f in test_files], runner_filter=RunnerFilter())
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 6)
+        self.assertEqual(summary['passed'], 7)
         self.assertEqual(summary['failed'], 0)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 2)


### PR DESCRIPTION
## Summary
- Fixes #7430: `CKV_AWS_61` ("Ensure AWS IAM policy does not allow assume role permission across all services") is implemented for both Terraform and CloudFormation, but the CloudFormation variant misses the exact case from the issue: an `AWS::IAM::Role` whose `AssumeRolePolicyDocument` grants `sts:AssumeRole` to a `Principal.AWS` given as a **plain string** account ID/ARN (e.g. `arn:aws:iam::123456789012:root`) instead of a list. The check silently passes instead of failing.
- Root cause in `checkov/cloudformation/checks/resource/aws/IAMRoleAllowAssumeFromAccount.py`: the old logic (a) required `Principal.AWS` to be a `list` via `isinstance(..., list) and isinstance(...[0], str)`, with no branch for a bare string, and (b) only ever inspected `Statement[0]`, ignoring any other statements in the policy.
- The Terraform check for the same `CKV_AWS_61` (`checkov/terraform/checks/resource/aws/IAMRoleAllowAssumeFromAccount.py`) already explicitly supports both shapes ("Can be a string or an array of strings") and loops over all statements — this PR brings the CloudFormation check in line with that, and additionally skips `Effect: Deny` statements for parity.
- Side effect (verified intentional, not a regression): a role with an empty `AssumeRolePolicyDocument: {}` (no `Statement` key) previously fell through an implicit `return None` due to the old nested-if structure, so it wasn't counted in any pass/fail/skip bucket. It now explicitly resolves to `PASSED`, matching how the Terraform check already treats the same "no Statement" edge case. Updated `tests/cloudformation/parser/test_cfn_yaml.py::test_parsing_error` accordingly (passed count 6 → 7, using the existing `cfn_bad_iam.yaml` fixture's `rIamRole`, which has `AssumeRolePolicyDocument: {}`).

## Test plan
- [x] Reproduced the exact issue template (string `Principal.AWS` with an account ARN) and confirmed it now fails as expected:
  ```
  checkov --quiet -c CKV_AWS_61 -f main.yaml
  # before: Passed checks: 1, Failed checks: 0
  # after:  Passed checks: 0, Failed checks: 1
  ```
- [x] Added `example_IAMRoleAllowAssumeFromAccount-FAILED-2.yml` (string `Principal.AWS`, matches the issue's reproduction) and updated `test_IAMRoleAllowAssumeFromAccount.py`'s summary assertion (failed 1 → 2).
- [x] Ran the full `tests/cloudformation/` suite locally: 282 passed (up from 281 passed + 1 failed before fixing the now-updated `test_parsing_error` assertion), 4 skipped, same 4 pre-existing unrelated `test_yaml_policies.py` collection errors present on `main` too.