### PR TITLE
fix(kubernetes): scope NetworkPolicyEdgeBuilder connections to same namespace

### DIFF
--- a/checkov/kubernetes/graph_builder/graph_components/edge_builders/NetworkPolicyEdgeBuilder.py
+++ b/checkov/kubernetes/graph_builder/graph_components/edge_builders/NetworkPolicyEdgeBuilder.py
@@ -29,12 +29,19 @@ class NetworkPolicyEdgeBuilder(K8SEdgeBuilder):
         """
 
         connections: list[int] = []
+        network_policy = vertex
+        network_policy_namespace = (network_policy.attributes.get("metadata") or {}).get("namespace") or "default"
+
         for potential_pod_index, potential_vertex in enumerate(vertices):
             if potential_vertex.id == vertex.id or potential_vertex.attributes.get("kind") != "Pod":
                 continue
 
-            network_policy = vertex
             pod = potential_vertex
+            pod_namespace = (pod.attributes.get("metadata") or {}).get("namespace") or "default"
+
+            # NetworkPolicies are namespace-scoped and only apply to pods in the same namespace
+            if pod_namespace != network_policy_namespace:
+                continue
 
             pod_spec = network_policy.attributes.get("spec", {})
             if pod_spec is None:
@@ -54,7 +61,7 @@ class NetworkPolicyEdgeBuilder(K8SEdgeBuilder):
                 shared_labels = [k for k in match_labels if k in pod_labels and match_labels[k] == pod_labels[k]]
                 if len(shared_labels) == len(match_labels):
                     connections.append(potential_pod_index)
-            # the network policy has a podSelector property with no labels and should apply for all pods
+            # the network policy has a podSelector property with no labels and should apply for all pods in the namespace
             else:
                 connections.append(potential_pod_index)
 

--- a/tests/kubernetes/graph/resources/Keyword/network-policy-namespace-scoping.yaml
+++ b/tests/kubernetes/graph/resources/Keyword/network-policy-namespace-scoping.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-in-namespace-a
+  namespace: namespace-a
+  labels:
+    app: myapp
+spec:
+  containers:
+  - name: app
+    image: nginx:1.7.9
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-in-namespace-b
+  namespace: namespace-b
+  labels:
+    app: myapp
+spec:
+  containers:
+  - name: app
+    image: nginx:1.7.9
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-in-namespace-a
+  namespace: namespace-a
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: label-policy-in-namespace-a
+  namespace: namespace-a
+spec:
+  podSelector:
+    matchLabels:
+      app: myapp
+  policyTypes:
+  - Ingress

--- a/tests/kubernetes/graph/test_local_graph.py
+++ b/tests/kubernetes/graph/test_local_graph.py
@@ -147,6 +147,23 @@ class TestKubernetesLocalGraph(TestGraph):
         self.assertEqual(5, len(local_graph.vertices))
         self.assertEqual(4, len(local_graph.edges))
 
+    def test_NetworkPolicyEdgeBuilder_respects_namespace_scoping(self) -> None:
+        relative_file_path = "resources/Keyword/network-policy-namespace-scoping.yaml"
+        definitions = {}
+        file = os.path.realpath(os.path.join(TEST_DIRNAME, relative_file_path))
+        (definitions[relative_file_path], definitions_raw) = parse(file)
+        graph_flags = K8sGraphFlags(create_complex_vertices=True, create_edges=True)
+
+        local_graph = KubernetesLocalGraph(definitions)
+        local_graph.edge_builders = [NetworkPolicyEdgeBuilder]
+        local_graph.build_graph(render_variables=False, graph_flags=graph_flags)
+        # 2 pods + 2 network policies = 4 vertices
+        self.assertEqual(4, len(local_graph.vertices))
+        # Only pod-in-namespace-a should be connected; pod-in-namespace-b is in a different namespace
+        # allow-all-in-namespace-a -> pod-in-namespace-a (empty podSelector, same namespace)
+        # label-policy-in-namespace-a -> pod-in-namespace-a (matchLabels match, same namespace)
+        self.assertEqual(2, len(local_graph.edges))
+
     def test_extracting_pod_from_container_types(self) -> None:
         relative_file_path = "resources/statefulstate_nested_resource.yaml"
         definitions = {}


### PR DESCRIPTION
## Summary

Fixes false-positive PASS results in `CKV2_K8S_6` (Require all pods to have a NetworkPolicy) caused by `NetworkPolicyEdgeBuilder` ignoring namespace scoping.

Kubernetes NetworkPolicies are namespace-scoped: a policy in `namespace-a` does not protect pods in `namespace-b`. Before this fix, the edge builder connected a `NetworkPolicy` with an empty `podSelector: {}` to **every Pod in the entire graph**, regardless of namespace. This meant a single wildcard NetworkPolicy in any namespace caused pods in all other namespaces to incorrectly pass the check.

**Root cause**: In `NetworkPolicyEdgeBuilder.find_connections()`, both the empty-podSelector wildcard branch and the `matchLabels` branch appended pod connections without comparing namespaces.

**Fix**: Extract the namespace from the NetworkPolicy and Pod vertex attributes (falling back to `"default"` when unset, matching the Kubernetes API default), and skip the connection when namespaces differ.

Closes #7474

## Test plan

- [x] Existing test `test_LabelSelectorEdgeBuilder_on_templates_with_network_policy` continues to pass (all resources in the same `default` namespace — behaviour unchanged)
- [x] New test `test_NetworkPolicyEdgeBuilder_respects_namespace_scoping` verifies that a NetworkPolicy in `namespace-a` with an empty `podSelector` and a label-based selector only connects to pods in `namespace-a`, not pods in `namespace-b`
- [x] All 15 tests in `tests/kubernetes/graph/test_local_graph.py` pass