### PR TITLE
fix(terraform): handle null values and alternative blocks in plan parser for aws_batch_job_definition

### DIFF
--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -25,7 +25,7 @@ TF_PLAN_RESOURCE_AFTER_UNKNOWN = 'after_unknown'
 COUNT_PATTERN = re.compile(r"\[?\d+\]?$")
 
 RESOURCE_TYPES_JSONIFY = {
-    "aws_batch_job_definition": "container_properties",
+    "aws_batch_job_definition": ("container_properties", "ecs_properties", "eks_properties", "node_properties"),
     "aws_ecs_task_definition": "container_definitions",
     "aws_iam_policy": "policy",
     "aws_iam_role": "assume_role_policy",
@@ -158,16 +158,20 @@ def _hclify(
 
 
 def jsonify(obj: dict[str, Any], resource_type: str) -> dict[str, Any] | None:
-    """Tries to create a dict from a string of a supported resource type attribute"""
+    """Tries to create a dict from a string of a supported resource type attribute"""  
 
-    jsonify_key = RESOURCE_TYPES_JSONIFY[resource_type]
-    if jsonify_key in obj:
-        try:
-            return cast("dict[str, Any]", json.loads(obj[jsonify_key]))
-        except json.JSONDecodeError:
-            logging.debug(
-                f"Attribute {jsonify_key} of resource type {resource_type} is not json encoded {obj[jsonify_key]}"
-            )
+    mapping = RESOURCE_TYPES_JSONIFY[resource_type]
+    jsonify_keys = [mapping] if isinstance(mapping, str) else mapping
+    for jsonify_key in jsonify_keys:
+        if jsonify_key in obj and obj[jsonify_key]:             
+            if isinstance(obj[jsonify_key], (dict, list)):
+                return obj[jsonify_key]            
+            try:
+                return cast("dict[str, Any]", json.loads(obj[jsonify_key]))
+            except json.JSONDecodeError:
+                logging.debug(
+                    f"Attribute {jsonify_key} of resource type {resource_type} is not json encoded {obj[jsonify_key]}"
+                )
 
     return None
 


### PR DESCRIPTION
## Description

This PR resolves an unhandled `TypeError` crash in the Terraform plan parser and expands policy scanning coverage for `aws_batch_job_definition` configurations.

### The Problem
Currently, `RESOURCE_TYPES_JSONIFY` maps `"aws_batch_job_definition"` strictly to a single string attribute: `"container_properties"`. 
1. If a user deploys a batch job utilizing alternative configuration blocks (such as `ecs_properties`, `eks_properties`, or `node_properties`), Terraform sets the unused `"container_properties"` key to `null` inside the generated plan JSON.
2. Checkov's `jsonify()` function evaluates `if jsonify_key in obj`, which returns `True` because the key physically exists in the dictionary with a `null` value.
3. Checkov passes `null` (Python `None`) directly into `json.loads()`, causing an immediate framework crash: `TypeError: the JSON object must be str, bytes or bytearray, not NoneType`.
4. Downstream check engines completely miss evaluating the configurations present in the active alternative block.

### The Solution
1. Refactored `RESOURCE_TYPES_JSONIFY` to allow a tuple of valid strings for a resource type to support multi-variant configurations.
2. Updated `jsonify()` to dynamically evaluate single string mappings or iterate through tuples seamlessly.
3. Implemented safe value validation (`if jsonify_key in obj and obj[jsonify_key]`) to gracefully filter out `null`, `None`, or empty arrays before parsing.
4. The loop successfully extracts the active alternative configuration block and passes it smoothly to downstream policies without dropping execution.

Fixes [#7587](https://github.com/bridgecrewio/checkov/issues/7587)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally with my changes