### PR TITLE
fix(cloudformation): accept SqsManagedSseEnabled for CKV_AWS_27

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/SQSQueueEncryption.py
+++ b/checkov/cloudformation/checks/resource/aws/SQSQueueEncryption.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckCategories, CheckResult
 from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.models.consts import ANY_VALUE
 
@@ -18,6 +18,19 @@ class SQSQueueEncryption(BaseResourceValueCheck):
 
     def get_expected_value(self) -> Any:
         return ANY_VALUE
+
+    def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:
+        # SQS-managed SSE is a valid alternative to a customer KMS key, so a queue
+        # that enables it should pass even when KmsMasterKeyId is absent.
+        properties = conf.get("Properties")
+        if isinstance(properties, dict):
+            sqs_managed_sse = properties.get("SqsManagedSseEnabled")
+            # The parser yields a real bool for `true`/`false`, but a quoted value
+            # like "false" comes through as a (truthy) string, so check both forms.
+            if sqs_managed_sse is True or (isinstance(sqs_managed_sse, str) and sqs_managed_sse.lower() == "true"):
+                return CheckResult.PASSED
+
+        return super().scan_resource_conf(conf)
 
 
 check = SQSQueueEncryption()

--- a/tests/cloudformation/checks/resource/aws/example_SQSQueueEncryption/test_SQSQueueEncryption-FAILED3.yml
+++ b/tests/cloudformation/checks/resource/aws/example_SQSQueueEncryption/test_SQSQueueEncryption-FAILED3.yml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MySseDisabledQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      RedrivePolicy:
+        deadLetterTargetArn: "example_arn"
+        maxReceiveCount: 5
+      SqsManagedSseEnabled: "false"

--- a/tests/cloudformation/checks/resource/aws/example_SQSQueueEncryption/test_SQSQueueEncryption-PASSED2.yml
+++ b/tests/cloudformation/checks/resource/aws/example_SQSQueueEncryption/test_SQSQueueEncryption-PASSED2.yml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MySseManagedQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      RedrivePolicy:
+        deadLetterTargetArn: "example_arn"
+        maxReceiveCount: 5
+      SqsManagedSseEnabled: true

--- a/tests/cloudformation/checks/resource/aws/test_SQSQueueEncryption.py
+++ b/tests/cloudformation/checks/resource/aws/test_SQSQueueEncryption.py
@@ -16,8 +16,8 @@ class TestSQSQueueEncryption(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 3)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fixes #7381

CKV_AWS_27 for CloudFormation only inspects `Properties/KmsMasterKeyId`, so an `AWS::SQS::Queue` that relies on native SQS-managed SSE (`SqsManagedSseEnabled: true`) is reported as FAILED even though the queue is encrypted. The Terraform check for the same ID already accepts `sqs_managed_sse_enabled`, so this just brings the CloudFormation side to parity.

The fix overrides `scan_resource_conf` to return PASSED when SQS-managed SSE is enabled, and otherwise falls back to the existing `KmsMasterKeyId` logic (same pattern as CKV_AWS_161 / `RDSIAMAuthentication`).

One thing to call out on the typing: the CFN parser yields a real bool for `true`/`false`, but a quoted value like `"false"` comes through as a (truthy) string node. That's the case James raised on the earlier attempt (#5870), which otherwise looked good. I picked that approach up and handled it explicitly, so `SqsManagedSseEnabled: "false"` still FAILS rather than slipping through on truthiness. I kept the change scoped to the false positive and didn't touch the no-property default behavior.

Tests: added a PASSED fixture (`SqsManagedSseEnabled: true`) and a FAILED fixture (`SqsManagedSseEnabled: "false"`), and bumped the expected counts. The existing KMS-key and empty-key cases are unchanged.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my feature, policy, or fix is effective and works
