### PR TITLE
feat(general): fix danger node version

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e  # v4
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Install and run DangerJS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -154,7 +154,7 @@ class Checkov:
         resource_attributes_to_omit = defaultdict(set)
         for entry in self.config.mask:
             splitted_entry = entry.split(':')
-            # if we have 2 entries, this is resource & variable to mask
+            # if we have 2 entries only, this is resource & variable to mask
             splitted_entry_len = len(splitted_entry)
             if 2 == splitted_entry_len:
                 resource = splitted_entry[0]


### PR DESCRIPTION
This PR fixes danger node version to 18. Previously with node 16 it failed because new danger is not compatible with it.
