### PR TITLE
fix(terraform_plan): prevent TypeError crash on null container_properties and support alternative resource attributes (#7587)

### DIFF
--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -25,7 +25,7 @@ TF_PLAN_RESOURCE_AFTER_UNKNOWN = 'after_unknown'
 COUNT_PATTERN = re.compile(r"\[?\d+\]?$")
 
 RESOURCE_TYPES_JSONIFY = {
-    "aws_batch_job_definition": "container_properties",
+    "aws_batch_job_definition": ("container_properties", "ecs_properties", "eks_properties", "node_properties"),
     "aws_ecs_task_definition": "container_definitions",
     "aws_iam_policy": "policy",
     "aws_iam_role": "assume_role_policy",
@@ -150,24 +150,32 @@ def _hclify(
 
     if resource_type and resource_type in RESOURCE_TYPES_JSONIFY:
         # values shouldn't be encapsulated in lists
-        dict_value = jsonify(obj=obj, resource_type=resource_type)
-        if dict_value is not None:
-            ret_dict[RESOURCE_TYPES_JSONIFY[resource_type]] = force_list(dict_value)
+        result = jsonify(obj=obj, resource_type=resource_type)
+        if result is not None:
+            dict_value, matched_key = result
+            ret_dict[matched_key] = force_list(dict_value)
 
     return ret_dict
 
 
-def jsonify(obj: dict[str, Any], resource_type: str) -> dict[str, Any] | None:
-    """Tries to create a dict from a string of a supported resource type attribute"""
+def jsonify(obj: dict[str, Any], resource_type: str) -> tuple[dict[str, Any], str] | None:
+    """Tries to create a dict from a string or dict of a supported resource type attribute"""
 
-    jsonify_key = RESOURCE_TYPES_JSONIFY[resource_type]
-    if jsonify_key in obj:
-        try:
-            return cast("dict[str, Any]", json.loads(obj[jsonify_key]))
-        except json.JSONDecodeError:
-            logging.debug(
-                f"Attribute {jsonify_key} of resource type {resource_type} is not json encoded {obj[jsonify_key]}"
-            )
+    raw_keys = RESOURCE_TYPES_JSONIFY[resource_type]
+    jsonify_keys = (raw_keys,) if isinstance(raw_keys, str) else raw_keys
+
+    for jsonify_key in jsonify_keys:
+        if jsonify_key in obj and obj[jsonify_key] is not None:
+            val = obj[jsonify_key]
+            if isinstance(val, dict):
+                return val, jsonify_key
+            if isinstance(val, (str, bytes, bytearray)):
+                try:
+                    return cast("dict[str, Any]", json.loads(val)), jsonify_key
+                except json.JSONDecodeError:
+                    logging.debug(
+                        f"Attribute {jsonify_key} of resource type {resource_type} is not json encoded {val}"
+                    )
 
     return None
 

--- a/tests/terraform/parser/test_plan_parser.py
+++ b/tests/terraform/parser/test_plan_parser.py
@@ -62,6 +62,24 @@ class TestPlanFileParser(unittest.TestCase):
         # TODO: this should also verify the flattening but at least shows it parses now.
         assert True
 
+    def test_aws_batch_job_definition_null_container_properties(self):
+        from checkov.terraform.plan_parser import _hclify
+        resource = {
+            "address": "aws_batch_job_definition.fargate_job",
+            "mode": "managed",
+            "type": "aws_batch_job_definition",
+            "name": "fargate_job",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "values": {
+                "container_properties": None,
+                "deregister_on_new_revision": True,
+                "ecs_properties": '{"taskProperties": "containers"}'
+            }
+        }
+        res_conf = _hclify(obj=resource["values"], conf=None, resource_type="aws_batch_job_definition")
+        self.assertIn("ecs_properties", res_conf)
+        self.assertEqual(res_conf["ecs_properties"], [{"taskProperties": "containers"}])
+
     # Check Plan Booleans are treated similar to normal Terraform Parser
     # https://github.com/bridgecrewio/checkov/issues/1764
     def test_simple_type_booleans_clean(self):


### PR DESCRIPTION
### Summary
Fixes #7587 by handling `null` values in Terraform plan JSON resource attributes safely without throwing unhandled `TypeError: the JSON object must be str, bytes or bytearray, not NoneType`.

### Problem & Root Cause
When scanning compiled Terraform plan JSON files containing resource definitions with alternative configuration blocks (such as `aws_batch_job_definition` using `ecs_properties`), unused schema attributes (such as `container_properties`) are explicitly compiled as `null` in the JSON plan dictionary (`"container_properties": null`).
Previously, `plan_parser.py` checked `"container_properties" in obj`, which evaluated to `True` for `null` entries, causing `json.loads(None)` to raise an unhandled `TypeError` crash.

### Key Changes
1. **Safely Handle Null / Truthy Attributes:** Updated `jsonify()` in `checkov/terraform/plan_parser.py` to verify `obj[jsonify_key] is not None` before attempting parsing.
2. **Support Alternative Configuration Blocks:** Updated `RESOURCE_TYPES_JSONIFY` so attributes can be declared as tuples of candidate keys (`("container_properties", "ecs_properties", "eks_properties", "node_properties")`), dynamically discovering whichever active variant block is present on the resource.
3. **Unit Tests:** Added regression unit test `test_aws_batch_job_definition_null_container_properties` in `tests/terraform/parser/test_plan_parser.py` verifying seamless execution without errors.
