### PR TITLE
fix(general): retry kustomize/helm install to survive transient GitHub failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,14 @@ RUN set -eux; \
     ; \
     \
     pip install setuptools==78.1.1 urllib3==2.2.2;  \
-    curl -sSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3; \
+    curl -fL --retry 5 --retry-all-errors --retry-delay 3 -sSo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3; \
     chmod 700 get_helm.sh; \
-    VERIFY_CHECKSUM=true ./get_helm.sh; \
+    helm_ok=0; for i in 1 2 3; do if VERIFY_CHECKSUM=true ./get_helm.sh; then helm_ok=1; break; else echo "get-helm-3 attempt $i failed, retrying..."; sleep 5; fi; done; [ "$helm_ok" = "1" ] || { echo "get-helm-3 failed after retries"; exit 1; }; \
     rm ./get_helm.sh; \
     \
-    curl -sSLo get_kustomize.sh https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh; \
+    curl -fL --retry 5 --retry-all-errors --retry-delay 3 -sSo get_kustomize.sh https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh; \
     chmod 700 get_kustomize.sh; \
-    ./get_kustomize.sh; mv /kustomize /usr/bin/kustomize; \
+    k_ok=0; for i in 1 2 3; do if ./get_kustomize.sh; then k_ok=1; break; else echo "install_kustomize.sh attempt $i failed, retrying..."; rm -f /kustomize; sleep 5; fi; done; [ "$k_ok" = "1" ] || { echo "install_kustomize.sh failed after retries"; exit 1; }; mv /kustomize /usr/bin/kustomize; \
     rm ./get_kustomize.sh; \
     \
     apt-get remove -y curl; \


### PR DESCRIPTION
Docker image build occasionally fails with:
  tar (child): ./kustomize_v*_linux_amd64.tar.gz: Cannot open: No such file or directory
  tar: Child returned status 2
Root cause: the upstream install_kustomize.sh calls the GitHub Releases
API and downloads a release asset, but its curl is silent and lacks -f
and pipefail, so a transient HTTP failure (most commonly an
unauthenticated api.github.com rate-limit on GitHub Actions runners,
which share egress IPs) is swallowed and only surfaces later at tar
when the tarball glob expands to nothing.
Mitigation:
- curl -fL --retry 5 --retry-all-errors --retry-delay 3 when fetching
  install_kustomize.sh and get-helm-3.
- 3-attempt retry loop with 5s backoff around the script invocations;
  explicit exit 1 on exhaustion so real outages still fail fast.
No version pinning, no upstream script changes, no behaviour change on
the success path.
Reference failing run:
https://github.com/bridgecrewio/checkov/actions/runs/28017232884/job/83129156448
