### PR TITLE
fix(terraform): CKV_AZURE_190 override singular get_expected_value

### DIFF
--- a/checkov/terraform/checks/resource/azure/StorageBlobRestrictPublicAccess.py
+++ b/checkov/terraform/checks/resource/azure/StorageBlobRestrictPublicAccess.py
@@ -22,8 +22,8 @@ class StorageBlobRestrictPublicAccess(BaseResourceValueCheck):
     def get_inspected_key(self) -> str:
         return "allow_nested_items_to_be_public"
 
-    def get_expected_values(self) -> list[Any]:
-        return [False]
+    def get_expected_value(self) -> Any:
+        return False
 
 
 check = StorageBlobRestrictPublicAccess()

--- a/tests/terraform/checks/resource/azure/test_StorageBlobRestrictPublicAccess.py
+++ b/tests/terraform/checks/resource/azure/test_StorageBlobRestrictPublicAccess.py
@@ -38,6 +38,10 @@ class TestStorageBlobRestrictPublicAccess(unittest.TestCase):
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
 
+    def test_expected_value_api_contract(self):
+        self.assertEqual(check.get_expected_value(), False)
+        self.assertEqual(check.get_expected_values(), [False])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

`StorageBlobRestrictPublicAccess` (CKV_AZURE_190) overrides `get_expected_values()` (plural) returning `[False]`, but inherits `get_expected_value()` (singular) from `BaseResourceValueCheck`, which returns `True` by default.
Per the base class docstring, `get_expected_values()` (plural) should be overridden only when a check accepts multiple values; single-value checks should override `get_expected_value()` (singular). Because of the mismatch, consumers that call the singular form (e.g. fix-suggestion generators) receive `True` — the value the rule flags as non-compliant — instead of `False`.
This PR overrides `get_expected_value()` to return `False` and lets `get_expected_values()` inherit `[False]` from the base class, so both methods stay consistent. Adds a regression test asserting both return values.
Detection behavior is unchanged.

Fixes [XSUP-71484](https://jira-dc.paloaltonetworks.com/browse/XSUP-71484)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
