### PR TITLE
feat(terraform): add CKV_AWS_394 for public Secrets Manager secret policy

### DIFF
--- a/checkov/terraform/checks/resource/aws/SecretManagerSecretPolicyAnyPrincipal.py
+++ b/checkov/terraform/checks/resource/aws/SecretManagerSecretPolicyAnyPrincipal.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+from cloudsplaining.scan.resource_policy_document import ResourcePolicyDocument
+
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class SecretManagerSecretPolicyAnyPrincipal(BaseResourceCheck):
+    def __init__(self) -> None:
+        name = "Ensure Secrets Manager secret policy is not public by only allowing specific services or principals to access it"
+        id = "CKV_AWS_394"
+        supported_resources = ("aws_secretsmanager_secret_policy",)
+        categories = (CheckCategories.IAM,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:
+        conf_policy = conf.get("policy")
+        if conf_policy:
+            if isinstance(conf_policy[0], dict):
+                try:
+                    policy = ResourcePolicyDocument(policy=conf_policy[0])
+                    if policy.internet_accessible_actions:
+                        return CheckResult.FAILED
+                except (TypeError, AttributeError):
+                    return CheckResult.UNKNOWN
+            else:
+                return CheckResult.UNKNOWN
+        return CheckResult.PASSED
+
+    def get_evaluated_keys(self) -> list[str]:
+        return ["policy"]
+
+
+check = SecretManagerSecretPolicyAnyPrincipal()

--- a/tests/terraform/checks/resource/aws/example_SecretManagerSecretPolicyAnyPrincipal/main.tf
+++ b/tests/terraform/checks/resource/aws/example_SecretManagerSecretPolicyAnyPrincipal/main.tf
@@ -1,0 +1,145 @@
+# pass - denies everyone, so a wildcard principal is safe here
+resource "aws_secretsmanager_secret_policy" "sm_pass_deny" {
+  secret_arn = aws_secretsmanager_secret.test.arn
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+       {
+          "Principal": "*",
+          "Effect": "Deny",
+          "Action": [
+            "secretsmanager:GetSecretValue"
+          ],
+          "Resource": "*"
+       }
+    ]
+}
+POLICY
+}
+
+# pass - wildcard principal is scoped by a Condition
+resource "aws_secretsmanager_secret_policy" "sm_pass_condition" {
+  secret_arn = aws_secretsmanager_secret.test.arn
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+       {
+          "Sid": "AllowFromSourceAccountOnly",
+          "Principal": {
+            "AWS": [
+                "arn:aws:iam::123456789101:role/reader",
+                "*"
+            ]
+          },
+          "Effect": "Allow",
+          "Action": [
+            "secretsmanager:GetSecretValue"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "StringEquals": {
+              "aws:SourceAccount": "123456789101"
+            }
+          }
+       }
+    ]
+}
+POLICY
+}
+
+# pass - specific principal ARN, no wildcard
+resource "aws_secretsmanager_secret_policy" "sm_pass_specific" {
+  secret_arn = aws_secretsmanager_secret.test.arn
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+       {
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789101:role/reader"
+          },
+          "Effect": "Allow",
+          "Action": [
+            "secretsmanager:GetSecretValue"
+          ],
+          "Resource": "*"
+       }
+    ]
+}
+POLICY
+}
+
+# fail - wildcard string principal allowed, anyone can read the secret
+resource "aws_secretsmanager_secret_policy" "sm_fail_star" {
+  secret_arn = aws_secretsmanager_secret.test.arn
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+       {
+          "Principal": "*",
+          "Effect": "Allow",
+          "Action": [
+            "secretsmanager:GetSecretValue"
+          ],
+          "Resource": "*"
+       }
+    ]
+}
+POLICY
+}
+
+# fail - AWS wildcard principal allowed
+resource "aws_secretsmanager_secret_policy" "sm_fail_aws_star" {
+  secret_arn = aws_secretsmanager_secret.test.arn
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+       {
+          "Principal": {
+            "AWS": "*"
+          },
+          "Effect": "Allow",
+          "Action": [
+            "secretsmanager:GetSecretValue"
+          ],
+          "Resource": "*"
+       }
+    ]
+}
+POLICY
+}
+
+# fail - wildcard mixed into the principal list with no Condition to scope it
+resource "aws_secretsmanager_secret_policy" "sm_fail_list_star" {
+  secret_arn = aws_secretsmanager_secret.test.arn
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+       {
+          "Principal": {
+            "AWS": [
+                "arn:aws:iam::123456789101:role/reader",
+                "*"
+            ]
+          },
+          "Effect": "Allow",
+          "Action": [
+            "secretsmanager:GetSecretValue"
+          ],
+          "Resource": "*"
+       }
+    ]
+}
+POLICY
+}

--- a/tests/terraform/checks/resource/aws/test_SecretManagerSecretPolicyAnyPrincipal.py
+++ b/tests/terraform/checks/resource/aws/test_SecretManagerSecretPolicyAnyPrincipal.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.SecretManagerSecretPolicyAnyPrincipal import check
+from checkov.terraform.runner import Runner
+
+
+class TestSecretManagerSecretPolicyAnyPrincipal(unittest.TestCase):
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_SecretManagerSecretPolicyAnyPrincipal"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_secretsmanager_secret_policy.sm_pass_deny",
+            "aws_secretsmanager_secret_policy.sm_pass_condition",
+            "aws_secretsmanager_secret_policy.sm_pass_specific",
+        }
+        failing_resources = {
+            "aws_secretsmanager_secret_policy.sm_fail_star",
+            "aws_secretsmanager_secret_policy.sm_fail_aws_star",
+            "aws_secretsmanager_secret_policy.sm_fail_list_star",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 3)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR Information

Adds a new check, **CKV_AWS_394**, that flags an AWS Secrets Manager secret whose resource policy grants access to any principal (`Principal: "*"` / `AWS: "*"`) without a `Condition` scoping it.

### Why this matters

Checkov already detects public/wildcard-principal resource policies for a range of services: SNS (`CKV_AWS_169`), SQS (`CKV_AWS_171`), Glacier (`CKV_AWS_167`), KMS, S3, and others. `aws_secretsmanager_secret_policy` had **no** equivalent coverage, so a secret exposed to the entire internet passed silently.

This is arguably the highest-impact resource to leave uncovered: a Secrets Manager secret typically holds database credentials, API keys, and tokens. A resource policy that allows `secretsmanager:GetSecretValue` to `Principal: "*"` makes those readable by any AWS account. Checkov reported no finding on that configuration before this change.

The check reuses the same detection path as the existing SNS/Glacier checks (`cloudsplaining`'s `ResourcePolicyDocument.internet_accessible_actions`), so behavior and edge-case handling stay consistent with the rest of the codebase.

### Behavior

- **FAIL**: `Principal: "*"`, `Principal.AWS: "*"`, or a principal list containing `"*"` with an `Allow` effect and no scoping `Condition`.
- **PASS**: wildcard principal used with `Effect: Deny`; wildcard scoped by a `Condition` (e.g. `aws:SourceAccount`); a specific principal ARN.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive) - `sm_fail_*` fixtures
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive) - `sm_pass_*` fixtures

Unit test: `tests/terraform/checks/resource/aws/test_SecretManagerSecretPolicyAnyPrincipal.py` (3 passing resources, 3 failing resources).

### AI disclosure

Portions of this change were drafted with AI assistance; I reviewed, tested, and take ownership of every line.
