### PR TITLE
fix(azure): guard against dict dotnet version crashing CKV_AZURE_80

### DIFF
--- a/checkov/terraform/checks/resource/azure/AppServiceDotnetFrameworkVersion.py
+++ b/checkov/terraform/checks/resource/azure/AppServiceDotnetFrameworkVersion.py
@@ -23,6 +23,8 @@ class AppServiceDotnetFrameworkVersion(BaseResourceCheck):
             site_config = conf.get('site_config')[0]
             if site_config.get('dotnet_framework_version') and isinstance(site_config.get('dotnet_framework_version'), list):
                 version = site_config.get('dotnet_framework_version')[0]
+                if not isinstance(version, str):
+                    return CheckResult.UNKNOWN
                 if version in supported_versions:
                     return CheckResult.PASSED
                 self.evaluated_keys = ['site_config/[0]/dotnet_framework_version']
@@ -31,6 +33,8 @@ class AppServiceDotnetFrameworkVersion(BaseResourceCheck):
                 stack = site_config.get('application_stack')[0]
                 if stack.get('dotnet_version') and isinstance(stack.get('dotnet_version'), list):
                     version = stack.get('dotnet_version')[0]
+                    if not isinstance(version, str):
+                        return CheckResult.UNKNOWN
                     if version in supported_versions:
                         return CheckResult.PASSED
                     self.evaluated_keys = ['site_config/[0]/application_stack/[0]/dotnet_version']

--- a/tests/terraform/checks/resource/azure/test_AppServiceDotnetFrameworkVersion.py
+++ b/tests/terraform/checks/resource/azure/test_AppServiceDotnetFrameworkVersion.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+from checkov.common.models.enums import CheckResult
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.runner import Runner
 from checkov.terraform.checks.resource.azure.AppServiceDotnetFrameworkVersion import check
@@ -43,6 +44,31 @@ class TestAppServiceDotnetFrameworkVersion(unittest.TestCase):
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
+
+
+    def test_dict_version_does_not_crash(self):
+        # Regression test: when dotnet_version resolves to a dict (unresolved Terraform
+        # reference) instead of a string, the check must return UNKNOWN rather than raising
+        # TypeError: unhashable type: 'dict'.
+        conf = {
+            'site_config': [{
+                'application_stack': [{
+                    'dotnet_version': [{'__startline__': 1, '__endline__': 2}]
+                }]
+            }]
+        }
+        result = check.scan_resource_conf(conf)
+        self.assertEqual(result, CheckResult.UNKNOWN)
+
+    def test_dict_framework_version_does_not_crash(self):
+        # Regression test: same crash via dotnet_framework_version path.
+        conf = {
+            'site_config': [{
+                'dotnet_framework_version': [{'__startline__': 1, '__endline__': 2}]
+            }]
+        }
+        result = check.scan_resource_conf(conf)
+        self.assertEqual(result, CheckResult.UNKNOWN)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Fixes #7523

`CKV_AZURE_80` crashes with `TypeError: unhashable type: 'dict'` when `dotnet_framework_version` or `dotnet_version` inside `site_config.application_stack` resolves to a dict rather than a string. This happens when the attribute value is an unresolved Terraform variable or local reference that the parser cannot fully evaluate.

The `version in supported_versions` membership check requires `version` to be hashable. When it is a dict, it raises `TypeError`. The fix adds an `isinstance(version, str)` guard before the set membership check and returns `UNKNOWN` when the value is not a string, consistent with how the check handles missing version configuration.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective and works
- [x] New and existing tests pass locally with my changes