### PR TITLE
fix(terraform): allow aws_lb as valid EIP attachment target in CKV2_AWS_19

### DIFF
--- a/checkov/terraform/checks/graph_checks/aws/EIPAllocatedToVPCAttachedEC2.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/EIPAllocatedToVPCAttachedEC2.yaml
@@ -54,6 +54,12 @@ definition:
             - aws_transfer_server
           operator: exists
           cond_type: connection
+        - resource_types:
+            - aws_eip
+          connected_resource_types:
+            - aws_lb
+          operator: exists
+          cond_type: connection
         - cond_type: attribute
           resource_types:
           - aws_eip

--- a/tests/terraform/graph/checks/resources/EIPAllocatedToVPCAttachedEC2/expected.yaml
+++ b/tests/terraform/graph/checks/resources/EIPAllocatedToVPCAttachedEC2/expected.yaml
@@ -5,5 +5,6 @@ pass:
   - "aws_eip.eip_ok_transer_server"
   - "aws_eip.ok_eip_domain"
   - "aws_eip.ok_eip_domain_assoc"
+  - "aws_eip.ok_eip_nlb"
 fail:
   - "aws_eip.not_ok_eip"

--- a/tests/terraform/graph/checks/resources/EIPAllocatedToVPCAttachedEC2/main.tf
+++ b/tests/terraform/graph/checks/resources/EIPAllocatedToVPCAttachedEC2/main.tf
@@ -112,3 +112,18 @@ resource "aws_eip" "ok_eip_data" {
   instance = data.aws_instance.id
   vpc      = true
 }
+
+# EIP attached to a Network Load Balancer via subnet_mapping — valid attachment
+resource "aws_eip" "ok_eip_nlb" {
+  domain = "vpc"
+}
+
+resource "aws_lb" "nlb" {
+  name               = "example-nlb"
+  load_balancer_type = "network"
+
+  subnet_mapping {
+    subnet_id     = aws_subnet.public.id
+    allocation_id = aws_eip.ok_eip_nlb.id
+  }
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fixes #7532

`CKV2_AWS_19` checks that EIPs allocated to a VPC are attached to a valid resource. The check already accepts both `vpc = true` and `domain = "vpc"` as valid VPC allocation attributes, but the allowed attachment targets only included `aws_instance`, `aws_nat_gateway`, and `aws_transfer_server`.

Attaching an EIP to a Network Load Balancer via `subnet_mapping.allocation_id` is a standard AWS pattern for giving an NLB a static IP. This configuration was incorrectly flagged as a false positive. Adding `aws_lb` to the connected resource types fixes it.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective and works
- [x] New and existing tests pass locally with my changes