### PR TITLE
feat(terraform): support private registry/mirror via TF_REGISTRY_BASE_URL

### DIFF
--- a/checkov/terraform/module_loading/loaders/registry_loader.py
+++ b/checkov/terraform/module_loading/loaders/registry_loader.py
@@ -227,9 +227,21 @@ class RegistryLoader(ModuleLoader):
             self.logger.debug(f"Service discovery response: {response.json()}")
             module_params.tf_modules_endpoint = self._normalize_module_download_url(module_params, response.json().get('modules.v1'))
         else:
-            # use terraform cloud host name and url for the public registry
-            module_params.tf_host_name = TFC_HOST_NAME
-            module_params.tf_modules_endpoint = "https://registry.terraform.io/v1/modules/"
+            # Public registry (registry.terraform.io) is used by default. A private registry or
+            # mirror that implements the module registry protocol can be targeted by setting the
+            # TF_REGISTRY_BASE_URL env var. This lets checkov resolve public-style module sources
+            # (namespace/name/provider) against the mirror without embedding the host name in each
+            # module source, and without relying on remote service discovery.
+            registry_base_url = os.getenv("TF_REGISTRY_BASE_URL")
+            if registry_base_url:
+                if not registry_base_url.endswith("/"):
+                    registry_base_url = f"{registry_base_url}/"
+                module_params.tf_modules_endpoint = registry_base_url
+                module_params.tf_host_name = urlparse(registry_base_url).netloc or module_params.tf_host_name
+            else:
+                # use terraform cloud host name and url for the public registry
+                module_params.tf_host_name = TFC_HOST_NAME
+                module_params.tf_modules_endpoint = "https://registry.terraform.io/v1/modules/"
 
         # assume module_params.tf_modules_endpoint ends with a slash as per https://developer.hashicorp.com/terraform/internals/module-registry-protocol#service-discovery
         module_params.tf_modules_versions_endpoint = urljoin(module_params.tf_modules_endpoint, "/".join((module_params.module_source, "versions")))

--- a/docs/7.Scan Examples/Terraform.md
+++ b/docs/7.Scan Examples/Terraform.md
@@ -60,6 +60,7 @@ If you have modules stored in a private repository or a private Terraform regist
 | GITHUB_PAT             | Github personal access token with read access to the private repository                          |
 | BITBUCKET_TOKEN        | Bitbucket personal access token with read access to the private repository                       |
 | TF_HOST_NAME           | (defaults to app.terraform.io) Terraform registry host name. Example: gitlab.com / example.com   |
+| TF_REGISTRY_BASE_URL   | (defaults to https://registry.terraform.io/v1/modules/) Base URL of a registry/mirror that implements the module registry protocol. Redirects public-style sources (namespace/name/provider) to the mirror without embedding the host in each source. |
 | TFC_TOKEN\*            | (deprecated, use TF_REGISTRY_TOKEN) Terraform Cloud token which can access the private registry  |
 | TF_REGISTRY_TOKEN      | Private registry access token (supports Terraform Cloud / Enterprise and third-party registries) |
 | BITBUCKET_USERNAME     | Bitbucket username (can only be used with a BITBUCKET_APP_PASSWORD)                              |
@@ -95,6 +96,16 @@ checkov -d . --download-external-modules true
 
 ```shell
 export TF_HOST_NAME=gitlab.com
+checkov -d . --download-external-modules true
+```
+
+- Private registry / mirror scan (module registry protocol) using a base URL override
+
+```shell
+# Resolve public-style sources (e.g. Azure/naming/azurerm) against a private mirror
+# without embedding the host in each module source or relying on service discovery.
+export TF_REGISTRY_BASE_URL=https://artifactory.example.com/artifactory/api/terraform/v1/modules/
+export TF_REGISTRY_TOKEN=xxxxxx
 checkov -d . --download-external-modules true
 ```
 

--- a/tests/terraform/module_loading/loaders/test_registry_loader.py
+++ b/tests/terraform/module_loading/loaders/test_registry_loader.py
@@ -89,6 +89,38 @@ def test_determine_tf_api_endpoints_tfe(discovery_response):
     assert module_params.tf_modules_endpoint == "https://example.registry.com/api/registry/v1/modules/"
     assert module_params.tf_modules_versions_endpoint == "https://example.registry.com/api/registry/v1/modules/terraform-aws-modules/example/versions"
 
+def test_determine_tf_api_endpoints_registry_base_url():
+    # given a public-style source and a custom registry base URL (a private mirror that speaks
+    # the module registry protocol), the module is resolved against the mirror without discovery
+    loader = RegistryLoader()
+    module_params = ModuleParams("", "", "terraform-aws-modules/example", "", "", "")
+    with mock.patch.dict("os.environ", {"TF_REGISTRY_BASE_URL": "https://mirror.example.com/artifactory/api/terraform/v1/modules/"}):
+        loader.discover(module_params)
+
+        # when
+        loader._determine_tf_api_endpoints(module_params)
+
+    # then
+    assert module_params.tf_host_name == "mirror.example.com"
+    assert module_params.module_source == "terraform-aws-modules/example"
+    assert module_params.tf_modules_endpoint == "https://mirror.example.com/artifactory/api/terraform/v1/modules/"
+    assert module_params.tf_modules_versions_endpoint == "https://mirror.example.com/artifactory/api/terraform/v1/modules/terraform-aws-modules/example/versions"
+
+def test_determine_tf_api_endpoints_registry_base_url_normalizes_trailing_slash():
+    # given a base URL without a trailing slash, it is normalized so path joins stay under the base
+    loader = RegistryLoader()
+    module_params = ModuleParams("", "", "terraform-aws-modules/example", "", "", "")
+    with mock.patch.dict("os.environ", {"TF_REGISTRY_BASE_URL": "https://mirror.example.com/v1/modules"}):
+        loader.discover(module_params)
+
+        # when
+        loader._determine_tf_api_endpoints(module_params)
+
+    # then
+    assert module_params.tf_host_name == "mirror.example.com"
+    assert module_params.tf_modules_endpoint == "https://mirror.example.com/v1/modules/"
+    assert module_params.tf_modules_versions_endpoint == "https://mirror.example.com/v1/modules/terraform-aws-modules/example/versions"
+
 @responses.activate
 def test_load_module():
     # given


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Adds an optional `TF_REGISTRY_BASE_URL` environment variable that overrides the hardcoded public module-registry endpoint used by the registry loader.

Today, module sources written in the public "shorthand" form `namespace/name/provider` (e.g. `Azure/naming/azurerm`, `terraform-aws-modules/vpc/aws`) are **always** resolved against the hardcoded `https://registry.terraform.io/v1/modules/` endpoint in `RegistryLoader._determine_tf_api_endpoints`. The existing `TF_HOST_NAME` variable only helps when the host is embedded in the module source string (e.g. `tfe.example.com/ns/name/provider`), because that path is gated by `module_source.startswith(tf_host_name)`.

This is a problem for users who run Checkov behind a private registry / mirror (Terraform Enterprise, GitLab, JFrog Artifactory, `boring-registry`, an air-gapped proxy, etc.) that serves the [module registry protocol](https://developer.hashicorp.com/terraform/internals/module-registry-protocol). Their shorthand sources cannot be redirected without rewriting every module source to embed a host.

With this change, setting `TF_REGISTRY_BASE_URL` points those shorthand sources at the mirror:

```shell
export TF_REGISTRY_BASE_URL=https://artifactory.example.com/artifactory/api/terraform/v1/modules/
export TF_REGISTRY_TOKEN=xxxxxx   # optional, existing var
checkov -d . --download-external-modules true
```

### Notes
- **No behavior change when unset** — the default remains `https://registry.terraform.io/v1/modules/`.
- Kept intentionally minimal and consistent with the existing `TF_HOST_NAME` / `TF_REGISTRY_TOKEN` vars (read via `os.getenv` in the same loader, no new config plumbing).
- A trailing slash is added if missing so path joins stay under the base URL; `tf_host_name` is derived from the base URL so relative `X-Terraform-Get` download URLs normalize correctly.
- The `TF_HOST_NAME` service-discovery path (Branch A) is untouched.

Relates to #6805 (and #4007).

## Tests

Added unit tests in `tests/terraform/module_loading/loaders/test_registry_loader.py`:
- resolves a shorthand source against `TF_REGISTRY_BASE_URL` (endpoint, host, and versions URL);
- normalizes a base URL provided without a trailing slash.

Existing module-loading tests continue to pass (`83 passed`). `flake8` clean on the changed loader.
