### PR TITLE
fix(helm): do not discard charts on non-fatal helm template stderr warnings

### DIFF
--- a/checkov/helm/runner.py
+++ b/checkov/helm/runner.py
@@ -362,10 +362,18 @@ class Runner(BaseRunner[_KubernetesDefinitions, _KubernetesContext, "KubernetesG
             o, e = proc.communicate()
             if threading.current_thread() is threading.main_thread():
                 signal.alarm(0)
-            if e:
+            # `helm template` writes non-fatal warnings to stderr while still exiting 0 and
+            # rendering valid manifests to stdout — e.g. OCI dependency "Pulled:"/"Digest:"
+            # messages from --dependency-update and coalesce.go "Ignoring non-table value"
+            # warnings. The real failure signal is a non-zero exit code, so only bail on that;
+            # otherwise a single benign warning would discard the entire rendered chart.
+            if proc.returncode:
                 logging.warning(
                     f"Failed processing helm chart {chart_name} at dir: {chart_dir}. Working dir: {target_dir}. Failure details: {str(e, 'utf-8')}")
                 return None, None
+            if e:
+                logging.debug(
+                    f"Non-fatal warnings while templating helm chart {chart_name} at dir: {chart_dir}. Working dir: {target_dir}. Details: {str(e, 'utf-8')}")
             logging.debug(
                 f"Ran helm command to template chart output. Chart: {chart_name}. dir: {target_dir}. Output: {str(o, 'utf-8')}. Errors: {str(e, 'utf-8')}")
             logging.info(f'Done helm run for: {chart_dir}')

--- a/tests/helm/test_runner.py
+++ b/tests/helm/test_runner.py
@@ -67,13 +67,14 @@ class TestRunnerValid(unittest.TestCase):
 
         runner = Runner()
         filter = RunnerFilter(framework=['helm'], use_enforcement_rules=False)
-        # this is not quite a true test, because the checks don't have severities. However, this shows that the check registry
-        # passes the report type properly to RunnerFilter.should_run_check, and we have tests for that method
+        # `helm template` for this chart exits 0 and renders valid manifests while emitting
+        # non-fatal coalesce.go "Not a table" warnings to stderr; the chart must still be
+        # scanned rather than discarded on account of those warnings.
         report = runner.run(
             root_folder=scan_dir_path, runner_filter=filter
         )
 
-        self.assertEqual(len(report.failed_checks), 0)
+        self.assertGreater(len(report.failed_checks), 0)
 
     @unittest.skipIf(not helm_exists(), "helm not installed")
     def test_get_binary_output_from_directory_equals_to_get_binary_result(self):
@@ -82,7 +83,8 @@ class TestRunnerValid(unittest.TestCase):
 
         runner_filter = RunnerFilter(framework=['helm'], use_enforcement_rules=False)
 
-        chart_meta = Runner.parse_helm_chart_details(scan_dir_path)
+        # parse_helm_chart_details returns (path, meta); get_binary_output expects the meta dict.
+        _, chart_meta = Runner.parse_helm_chart_details(scan_dir_path)
         chart_item = (scan_dir_path, chart_meta)
         regular_result = Runner.get_binary_output(chart_item, target_dir='./tmp', helm_command="helm",
                                                   runner_filter=runner_filter)
@@ -332,6 +334,7 @@ class TestHelmDependencyRemoteRepos(unittest.TestCase):
         dep_list_proc = mock.MagicMock()
         dep_list_proc.communicate.return_value = (b"", b"")
         template_proc = mock.MagicMock()
+        template_proc.returncode = 0
         template_proc.communicate.return_value = (fake_output, b"")
         env = {"CHECKOV_HELM_ALLOWED_REMOTE_REPOS": "http://192.0.2.1"}
         with mock.patch.dict(os.environ, env):
@@ -352,6 +355,41 @@ class TestHelmDependencyRemoteRepos(unittest.TestCase):
                 Runner.get_binary_output(chart_item, "./tmp", "helm", RunnerFilter())
         call_args = mock_popen.call_args[0][0]
         self.assertEqual(call_args[-1], self._REMOTE_DEP_DIR)
+
+    def test_stderr_warnings_do_not_discard_output(self):
+        """helm warnings on stderr with a 0 exit code must NOT discard the rendered chart."""
+        chart_item = self._make_chart_item()
+        fake_output = b"apiVersion: v1\nkind: ConfigMap\n"
+        # Mirrors the real litellm case: OCI pull messages + a coalesce.go warning on stderr,
+        # while helm still exits 0 and renders valid manifests on stdout.
+        warning_stderr = (
+            b"Pulled: ghcr.io/berriai/litellm-helm:0.1.832\n"
+            b"Digest: sha256:9dfea2195c0b2adde8c83eac7c5e9b16f80282cbba3d14d5e81746686e7d73af\n"
+            b"coalesce.go:319: warning: destination for litellm-helm.ingress.tls is a table. "
+            b"Ignoring non-table value ([])\n"
+        )
+        mock_proc = mock.MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate.return_value = (fake_output, warning_stderr)
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CHECKOV_HELM_ALLOWED_REMOTE_REPOS", None)
+            with mock.patch("subprocess.Popen", return_value=mock_proc):
+                result, returned_item = Runner.get_binary_output(chart_item, "./tmp", "helm", RunnerFilter())
+        self.assertEqual(result, fake_output)
+        self.assertEqual(returned_item, chart_item)
+
+    def test_nonzero_exit_code_discards_output(self):
+        """A real helm failure (non-zero exit code) must still discard the chart."""
+        chart_item = self._make_chart_item()
+        mock_proc = mock.MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = (b"", b"Error: template: parse error")
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CHECKOV_HELM_ALLOWED_REMOTE_REPOS", None)
+            with mock.patch("subprocess.Popen", return_value=mock_proc):
+                result, returned_item = Runner.get_binary_output(chart_item, "./tmp", "helm", RunnerFilter())
+        self.assertIsNone(result)
+        self.assertIsNone(returned_item)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

`checkov`'s Helm runner (`checkov/helm/runner.py`, `Runner.get_binary_output`) treats **any** output on `helm template`'s stderr as a fatal error and discards the entire rendered chart — even when `helm` exits 0 and emits only non-fatal warnings, e.g. OCI dependency-update messages (`Pulled:` / `Digest:`) or `coalesce.go ... Ignoring non-table value` warnings.

The buggy branch keyed the failure off the mere presence of stderr:

```python
o, e = proc.communicate()
...
if e:   # any stderr content is treated as a failure
    logging.warning(f"Failed processing helm chart {chart_name} ...")
    return None, None
```

**Effect:** the chart is not processed at all — it contributes no passed and no failed checks and is absent from the report. It is not reported as "clean/passing"; it simply never gets scanned. Because the overall run still exits 0 (other resources report normally), the skip is invisible — in CI the pipeline goes green while an entire chart was silently left unscanned.

**Fix:** decide failure based on the process **exit code** (`proc.returncode`) instead of the presence of stderr. Non-fatal warnings are now logged at debug and the rendered output is kept; only a non-zero exit code discards the chart. This mirrors how the sibling `helm dependency list` branch already tolerates warnings on stderr.

### Tests
- Added `test_stderr_warnings_do_not_discard_output` — reproduces the real case (OCI
  `Pulled:`/`Digest:` + `coalesce.go` warning on stderr, exit 0) and asserts the rendered output
  is kept.
- Added `test_nonzero_exit_code_discards_output` — a genuine failure (non-zero exit) still
  discards the chart.
- Adjusted 3 existing tests that relied on the old behavior:
  - `test_runner_invalid_chart` — the `schema-registry` fixture actually renders valid manifests
    (only emits `coalesce.go` warnings), so it now asserts findings are produced.
  - `test_get_binary_output_from_directory_equals_to_get_binary_result` — fixed a latent bug in
    the test (it passed the `(path, meta)` tuple as `chart_meta`); both sides only matched before
    because both returned `None`.
  - `test_build_proceeds_when_all_repos_in_allowlist` — its mock now sets `returncode = 0` so the
    success path is exercised.

Verified end-to-end on a real umbrella chart that pulls the `litellm-helm` OCI subchart: before the fix it produced 0 records (silently skipped on the `litellm-helm.ingress.tls` coalesce warning); after the fix the same chart scans normally.

Fixes #7605

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
