### PR TITLE
feat(kubernetes): add CKV_K8S_50 automount service account token check

### DIFF
--- a/checkov/terraform/checks/resource/kubernetes/AutomountServiceAccountToken.py
+++ b/checkov/terraform/checks/resource/kubernetes/AutomountServiceAccountToken.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class AutomountServiceAccountToken(BaseResourceCheck):
+    def __init__(self) -> None:
+        name = "Ensure pods are not automatically mounting service account tokens"
+        id = "CKV_K8S_50"
+        supported_resources = ['kubernetes_pod', 'kubernetes_pod_v1',
+                               'kubernetes_deployment', 'kubernetes_deployment_v1']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        if "spec" not in conf:
+            return CheckResult.FAILED
+        spec = conf['spec'][0]
+        if not spec:
+            return CheckResult.UNKNOWN
+
+        # Handle deployment templates
+        template = spec.get("template")
+        if template and isinstance(template, list):
+            template = template[0]
+            template_spec = template.get("spec")
+            if template_spec and isinstance(template_spec, list):
+                spec = template_spec[0]
+
+        # Check if automount_service_account_token is explicitly set to False
+        automount = spec.get("automount_service_account_token")
+        if automount is not None:
+            if isinstance(automount, list):
+                automount = automount[0]
+            if automount is False:
+                return CheckResult.PASSED
+
+        return CheckResult.FAILED
+
+
+check = AutomountServiceAccountToken()

--- a/tests/terraform/checks/resource/kubernetes/example_AutomountServiceAccountToken/main.tf
+++ b/tests/terraform/checks/resource/kubernetes/example_AutomountServiceAccountToken/main.tf
@@ -1,0 +1,95 @@
+# PASS: automount_service_account_token explicitly set to false
+resource "kubernetes_pod" "pass" {
+  metadata {
+    name = "pass"
+  }
+  spec {
+    automount_service_account_token = false
+    container {
+      name  = "test"
+      image = "nginx"
+    }
+  }
+}
+
+# PASS: deployment with automount_service_account_token = false
+resource "kubernetes_deployment" "pass" {
+  metadata {
+    name = "pass"
+  }
+  spec {
+    selector {
+      match_labels = {
+        app = "test"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "test"
+        }
+      }
+      spec {
+        automount_service_account_token = false
+        container {
+          name  = "test"
+          image = "nginx"
+        }
+      }
+    }
+  }
+}
+
+# FAIL: automount_service_account_token set to true
+resource "kubernetes_pod" "fail" {
+  metadata {
+    name = "fail"
+  }
+  spec {
+    automount_service_account_token = true
+    container {
+      name  = "test"
+      image = "nginx"
+    }
+  }
+}
+
+# FAIL: automount_service_account_token not set (defaults to true)
+resource "kubernetes_pod" "fail2" {
+  metadata {
+    name = "fail2"
+  }
+  spec {
+    container {
+      name  = "test"
+      image = "nginx"
+    }
+  }
+}
+
+# FAIL: deployment without automount_service_account_token
+resource "kubernetes_deployment" "fail" {
+  metadata {
+    name = "fail"
+  }
+  spec {
+    selector {
+      match_labels = {
+        app = "test"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "test"
+        }
+      }
+      spec {
+        container {
+          name  = "test"
+          image = "nginx"
+        }
+      }
+    }
+  }
+}

--- a/tests/terraform/checks/resource/kubernetes/test_AutomountServiceAccountToken.py
+++ b/tests/terraform/checks/resource/kubernetes/test_AutomountServiceAccountToken.py
@@ -1,0 +1,44 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.kubernetes.AutomountServiceAccountToken import check
+from checkov.terraform.runner import Runner
+
+
+class TestAutomountServiceAccountToken(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_AutomountServiceAccountToken"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "kubernetes_pod.pass",
+            "kubernetes_deployment.pass",
+        }
+
+        failing_resources = {
+            "kubernetes_pod.fail",
+            "kubernetes_pod.fail2",
+            "kubernetes_deployment.fail",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["failed"], 3)
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What is this?

Added a new Kubernetes security check (**CKV_K8S_50**) that warns when pods automatically mount service account tokens.

## Why?

Kubernetes automatically gives every pod a login token by default. If an attacker breaks into your pod, they can use that token to access the cluster API and move laterally. Setting `automount_service_account_token = false` prevents this.

This is **CIS Kubernetes Benchmark 5.1.1**.

## Example

```hcl
# GOOD - no token mounted
resource "kubernetes_pod" "safe" {
  spec {
    automount_service_account_token = false
    container {
      name  = "app"
      image = "nginx"
    }
  }
}

# BAD - token mounted (default)
resource "kubernetes_pod" "risky" {
  spec {
    container {
      name  = "app"
      image = "nginx"
    }
  }
}
```

## What changed

- Added `checkov/terraform/checks/resource/kubernetes/AutomountServiceAccountToken.py`
- Added unit tests with pass/fail cases
- Test results: 2 passed, 3 failed as expected ✅