### PR TITLE
fix(terraform): support GitHub immutable OIDC subject IDs in gh_repo_regex

### DIFF
--- a/checkov/common/util/oidc_utils.py
+++ b/checkov/common/util/oidc_utils.py
@@ -5,10 +5,11 @@ This file provides utility functions for handling OIDC-related operations, parti
 Constants:
     gh_repo_regex (re.Pattern): A regular expression pattern that matches GitHub repository paths.
         # Matches patterns like: "owner/repo", "${var}/repo", "org.name/repo"
+        # Also matches GitHub immutable OIDC subjects: "owner@123456/repo@456789"
         # Allows for variable substitution syntax ${} and organization names with dots
 
     gh_abusable_claims (list): A list of GitHub OIDC claims that could potentially be abused in security contexts.
 """
-gh_repo_regex = re.compile(r"(\$\{)?[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*(\})?/[^/]+")
+gh_repo_regex = re.compile(r"(\$\{)?[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*(@[0-9]+)?(\})?/[^/]+")
 gh_abusable_claims = ["workflow", "environment", "ref", "context", "head_ref", "base_ref"]
 gh_sub_condition = re.compile(r"^token\.actions\.githubusercontent\.com(?:/[a-zA-Z0-9_-]+)?:sub$")

--- a/tests/terraform/checks/data/aws/example_GithubActionsOIDCTrustPolicy/main.tf
+++ b/tests/terraform/checks/data/aws/example_GithubActionsOIDCTrustPolicy/main.tf
@@ -262,3 +262,30 @@ data "aws_iam_policy_document" "pass-gh-org" {
     }
   }
 }
+
+# pass_immutable - GitHub immutable OIDC subject (owner@id/repo@id numeric suffixes)
+data "aws_iam_policy_document" "pass_immutable" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    action = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+    principals {
+      identifiers = ["arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"]
+      type        = "Federated"
+    }
+    condition {
+      test     = "StringEquals"
+      values   = ["repo:octo-org@123456/octo-repo@456789:ref:refs/heads/main"]
+      variable = "token.actions.githubusercontent.com:sub"
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["sts.amazonaws.com"]
+      variable = "token.actions.githubusercontent.com:aud"
+    }
+  }
+}

--- a/tests/terraform/checks/data/aws/example_GithubActionsOIDCTrustPolicy/tfplan.json
+++ b/tests/terraform/checks/data/aws/example_GithubActionsOIDCTrustPolicy/tfplan.json
@@ -513,6 +513,88 @@
                   }
                 ]
               }
+            },
+            {
+              "address": "module.poc.data.aws_iam_policy_document.pass_immutable",
+              "mode": "data",
+              "type": "aws_iam_policy_document",
+              "name": "pass_immutable",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 0,
+              "values": {
+                "override_json": null,
+                "override_policy_documents": null,
+                "policy_id": null,
+                "source_json": null,
+                "source_policy_documents": null,
+                "statement": [
+                  {
+                    "actions": [
+                      "sts:AssumeRoleWithWebIdentity"
+                    ],
+                    "condition": [
+                      {
+                        "test": "StringEquals",
+                        "values": [
+                          "sts.amazonaws.com"
+                        ],
+                        "variable": "token.actions.githubusercontent.com:aud"
+                      },
+                      {
+                        "test": "StringEquals",
+                        "values": [
+                          "repo:octo-org@123456/octo-repo@456789:ref:refs/heads/main"
+                        ],
+                        "variable": "token.actions.githubusercontent.com:sub"
+                      }
+                    ],
+                    "effect": "Allow",
+                    "not_actions": null,
+                    "not_principals": [],
+                    "not_resources": null,
+                    "principals": [
+                      {
+                        "identifiers": [
+                          "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+                        ],
+                        "type": "Federated"
+                      }
+                    ],
+                    "resources": null,
+                    "sid": null
+                  }
+                ],
+                "version": null
+              },
+              "sensitive_values": {
+                "statement": [
+                  {
+                    "actions": [
+                      false
+                    ],
+                    "condition": [
+                      {
+                        "values": [
+                          false
+                        ]
+                      },
+                      {
+                        "values": [
+                          false
+                        ]
+                      }
+                    ],
+                    "not_principals": [],
+                    "principals": [
+                      {
+                        "identifiers": [
+                          false
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           ],
           "address": "module.poc"

--- a/tests/terraform/checks/data/aws/test_GithubActionsOIDCTrustPolicy.py
+++ b/tests/terraform/checks/data/aws/test_GithubActionsOIDCTrustPolicy.py
@@ -22,6 +22,7 @@ class TestGithubActionsOIDCTrustPolicy(unittest.TestCase):
             "aws_iam_policy_document.pass-org-only",
             "aws_iam_policy_document.pass_aud_first",
             "aws_iam_policy_document.pass-gh-org",
+            "aws_iam_policy_document.pass_immutable",
         }
         failing_resources = {
             "aws_iam_policy_document.fail1",
@@ -56,6 +57,7 @@ class TestGithubActionsOIDCTrustPolicy(unittest.TestCase):
             'module.poc.data.aws_iam_policy_document.r4["p2"]',
             'module.poc.data.aws_iam_policy_document.r3["p1"]',
             'module.poc.data.aws_iam_policy_document.r3["p2"]',
+            'module.poc.data.aws_iam_policy_document.pass_immutable',
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])

--- a/tests/terraform/checks/resource/aws/example_GithubActionsOIDCTrustPolicyOnRole/main.tf
+++ b/tests/terraform/checks/resource/aws/example_GithubActionsOIDCTrustPolicyOnRole/main.tf
@@ -227,6 +227,29 @@ resource "aws_iam_role" "fail-misused-repo" {
   })
 }
 
+# pass_immutable -- GitHub immutable OIDC subject (owner@id/repo@id numeric suffixes) -> PASS
+resource "aws_iam_role" "pass_immutable" {
+  name = "pass_immutable"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::123456123456:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:sub" = "repo:octo-org@123456/octo-repo@456789:ref:refs/heads/main"
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
 # pass-org-only -- "repo:myOrg/*" (any repo in org, any branch). Considered SAFE
 # by CKV_AWS_358's design (see test_GithubActionsOIDCTrustPolicy.py's
 # "pass-org-only"). Mirrored here to preserve parity.

--- a/tests/terraform/checks/resource/aws/test_GithubActionsOIDCTrustPolicyOnRole.py
+++ b/tests/terraform/checks/resource/aws/test_GithubActionsOIDCTrustPolicyOnRole.py
@@ -39,6 +39,7 @@ class TestGithubActionsOIDCTrustPolicyOnRole(unittest.TestCase):
             "aws_iam_role.pass-org-only",
             "aws_iam_role.pass-gh-org",
             "aws_iam_role.pass-fm-customer",
+            "aws_iam_role.pass_immutable",
         }
         failing_resources = {
             "aws_iam_role.fail1",

--- a/tests/terraform/checks/resource/azure/example_GithubActionsOIDCTrustPolicy/main.tf
+++ b/tests/terraform/checks/resource/azure/example_GithubActionsOIDCTrustPolicy/main.tf
@@ -35,6 +35,15 @@ resource "azuread_application_federated_identity_credential" "pass_special_chars
   subject             = "repo:${var.github_organisation_target}/${github_repository.project.name}:environment:${var.environment}"
 }
 
+# pass_immutable - GitHub immutable OIDC subject (owner@id/repo@id numeric suffixes)
+resource "azuread_application_federated_identity_credential" "pass_immutable" {
+  application_object_id = "example-app-id"
+  display_name         = "github-actions-oidc"
+  audiences           = ["api://AzureADTokenExchange"]
+  issuer              = "https://token.actions.githubusercontent.com"
+  subject             = "repo:octo-org@123456/octo-repo@456789:ref:refs/heads/main"
+}
+
 # fail1 - Missing subject
 resource "azuread_application_federated_identity_credential" "fail1" {
   application_object_id = "example-app-id"

--- a/tests/terraform/checks/resource/azure/test_GithubActionsOIDCTrustPolicy.py
+++ b/tests/terraform/checks/resource/azure/test_GithubActionsOIDCTrustPolicy.py
@@ -19,6 +19,7 @@ class TestAzureGithubActionsOIDCTrustPolicy(unittest.TestCase):
             "azuread_application_federated_identity_credential.pass2",
             "azuread_application_federated_identity_credential.pass4",
             "azuread_application_federated_identity_credential.pass_special_chars",
+            "azuread_application_federated_identity_credential.pass_immutable",
         }
         failing_resources = {
             "azuread_application_federated_identity_credential.fail1",

--- a/tests/terraform/checks/resource/gcp/example_GithubActionsOIDCTrustPolicy/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GithubActionsOIDCTrustPolicy/main.tf
@@ -54,6 +54,19 @@ resource "google_iam_workload_identity_pool_provider" "pass_org_only" {
   }
 }
 
+# pass_immutable - GitHub immutable OIDC subject (owner@id/repo@id numeric suffixes)
+resource "google_iam_workload_identity_pool_provider" "pass_immutable" {
+  workload_identity_pool_id          = "example-pool"
+  workload_identity_pool_provider_id = "example-provider-immutable"
+  attribute_mapping                 = {
+    "google.subject"       = "assertion.sub"
+  }
+  attribute_condition               = "assertion.sub == 'repo:octo-org@123456/octo-repo@456789:ref:refs/heads/main'"
+  oidc {
+    issuer_uri                       = "https://token.actions.githubusercontent.com"
+  }
+}
+
 # fail1 - Missing attribute condition
 resource "google_iam_workload_identity_pool_provider" "fail1" {
   workload_identity_pool_id          = "example-pool"

--- a/tests/terraform/checks/resource/gcp/test_GithubActionsOIDCTrustPolicy.py
+++ b/tests/terraform/checks/resource/gcp/test_GithubActionsOIDCTrustPolicy.py
@@ -18,6 +18,7 @@ class TestGithubActionsOIDCTrustPolicy(unittest.TestCase):
             "google_iam_workload_identity_pool_provider.pass2",
             "google_iam_workload_identity_pool_provider.pass3",
             "google_iam_workload_identity_pool_provider.pass_org_only",
+            "google_iam_workload_identity_pool_provider.pass_immutable",
         }
         failing_resources = {
             "google_iam_workload_identity_pool_provider.fail1",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

GitHub is rolling out **immutable OIDC subject claims**, where the `repo:` segment embeds numeric owner and repository IDs so the identity survives renames — `repo:octo-org@123456/octo-repo@456789:ref:refs/heads/main` instead of the classic `repo:octo-org/octo-repo:...`. Per the [GitHub changelog](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/), this format becomes the default for **newly created and renamed repositories on 2026-07-15**.

The shared helper `gh_repo_regex` in `checkov/common/util/oidc_utils.py` validates the `owner/repo` segment of a `repo:` subject claim, but its character classes contain no `@`, so it rejects the immutable owner segment:

```python
# before
gh_repo_regex = re.compile(r"(\$\{)?[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*(\})?/[^/]+")
# after
gh_repo_regex = re.compile(r"(\$\{)?[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*(@[0-9]+)?(\})?/[^/]+")
```

`re.match` on `octo-org@123456/octo-repo@456789` stops at the first `@` and returns `None`, so a correctly-pinned immutable subject is treated as an invalid repo format and the check **fails**. The single added token `(@[0-9]+)?` accepts an optional numeric ID on the owner side; the repo side (`[^/]+`) already accepts `@456789`.

This helper is the single validation point reached — on the `split[0] == "repo"` branch — by all four GitHub-OIDC checks, so one line fixes every consumer:

| Check | Consumer |
|---|---|
| `CKV_AZURE_249` | `azuread_application_federated_identity_credential` |
| `CKV_AWS_358` | `data.aws_iam_policy_document` (HCL + terraform_plan) |
| `CKV_AWS_393` | `aws_iam_role.assume_role_policy` |
| `CKV_GCP_125` | `google_iam_workload_identity_pool_provider` |

Without the fix, every new or renamed repository authenticating via GitHub Actions OIDC would trigger a false positive across AWS, Azure, and GCP trust policies from 2026-07-15 onward.

The change is inert on existing inputs: exact `owner/repo`, org-only `owner/*`, and `${var}`-interpolated subjects all still match, and `owner*` (missing `/`) still correctly fails.

### Tests

Added a `pass_immutable` fixture with subject `repo:octo-org@123456/octo-repo@456789:ref:refs/heads/main` to each of the four suites (HCL for all four, plus a GitHub-OIDC data source in `tfplan.json` to exercise the `CKV_AWS_358` plan path). Reverting the regex alone, with the fixtures in place, fails all five new/updated assertions — so they are genuine regression guards, not just added coverage.

References:
- GitHub changelog — immutable subject claims for GitHub Actions OIDC tokens: https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/
- GitHub OIDC security hardening / subject claim format: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes

---

**Open question (intentionally out of scope here):** `gh_repo_regex` also matches the org-wide `repo:myOrg/*` value, so an org-wide subject currently PASSES `CKV_AWS_358` / `CKV_AWS_393`. The inline comment in `GithubActionsOIDCTrustPolicyOnRole.py` marks that as deliberate (`"repo:myOrg/*" -> PASS`), so I've left it untouched. Is the org-wide-wildcard pass intended long-term — any repository the org can create is allowed to assume the role — or would tightening it to require a concrete repository segment be worth a separate issue?
