### PR TITLE
fix(terraform): CKV_GCP_125 should not crash on non-OIDC providers

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GithubActionsOIDCTrustPolicy.py
+++ b/checkov/terraform/checks/resource/gcp/GithubActionsOIDCTrustPolicy.py
@@ -30,7 +30,7 @@ class GithubActionsOIDCTrustPolicy(BaseResourceCheck):
         try:
             # Check issuer URI
             # If it's not OIDC or GitHub Actions URI, then pass
-            issuer_oidc = conf.get("oidc")[0]
+            issuer_oidc = conf.get("oidc", [None])[0]
             if not issuer_oidc:
                 return CheckResult.PASSED
             else:

--- a/tests/terraform/checks/resource/gcp/example_GithubActionsOIDCTrustPolicy/main.tf
+++ b/tests/terraform/checks/resource/gcp/example_GithubActionsOIDCTrustPolicy/main.tf
@@ -54,6 +54,19 @@ resource "google_iam_workload_identity_pool_provider" "pass_org_only" {
   }
 }
 
+# pass5 - Non-OIDC (AWS-federated) provider should pass, not crash
+resource "google_iam_workload_identity_pool_provider" "pass_non_oidc" {
+  workload_identity_pool_id          = "example-pool"
+  workload_identity_pool_provider_id = "example-provider-aws"
+  attribute_mapping                 = {
+    "google.subject" = "assertion.arn"
+  }
+  attribute_condition               = "assertion.arn.startsWith(\"arn:aws:sts::123456789012:assumed-role/foo-\")"
+  aws {
+    account_id = "123456789012"
+  }
+}
+
 # fail1 - Missing attribute condition
 resource "google_iam_workload_identity_pool_provider" "fail1" {
   workload_identity_pool_id          = "example-pool"

--- a/tests/terraform/checks/resource/gcp/test_GithubActionsOIDCTrustPolicy.py
+++ b/tests/terraform/checks/resource/gcp/test_GithubActionsOIDCTrustPolicy.py
@@ -18,6 +18,7 @@ class TestGithubActionsOIDCTrustPolicy(unittest.TestCase):
             "google_iam_workload_identity_pool_provider.pass2",
             "google_iam_workload_identity_pool_provider.pass3",
             "google_iam_workload_identity_pool_provider.pass_org_only",
+            "google_iam_workload_identity_pool_provider.pass_non_oidc",
         }
         failing_resources = {
             "google_iam_workload_identity_pool_provider.fail1",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Simple bug: `CKV_GCP_125` ("Ensure GCP GitHub Actions OIDC trust policy is configured securely") crashes on any `google_iam_workload_identity_pool_provider` resource that doesn't use an `oidc {}` block (for example, one that uses an `aws` block instead).  I believe this was unintentional, as a comment in the relevant code explicitly says "If it's not OIDC or GitHub Actions URI, then pass", but instead it crashes trying to index a None

```python
# If it's not OIDC or GitHub Actions URI, then pass
issuer_oidc = conf.get("oidc")[0]
if not issuer_oidc:
    return CheckResult.PASSED
```


Related to #6981, though it doesn't resolve that issue's broader ask (the check being too generic/hard to satisfy overall). It does fix the specific false-positive reported in [that issue's comments](https://github.com/bridgecrewio/checkov/issues/6981#issuecomment-2870539282).

## New/Edited policies (Delete if not relevant)

### Description
No change to what constitutes a violation. CKV_GCP_125 is scoped to GitHub Actions OIDC trust policies. Providers that don't use an `oidc` block should be out of scope for this check.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas -> **not relevant, trivial fix**
- [ ] I have made corresponding changes to the documentation -> **doesn't seem like a change that warrants documentation, let me know if I'm wrong**
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
