### PR TITLE
feat(terraform): add CKV_AWS_395 for IAM role max session duration

### DIFF
--- a/checkov/terraform/checks/resource/aws/IAMRoleMaxSessionDuration.py
+++ b/checkov/terraform/checks/resource/aws/IAMRoleMaxSessionDuration.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.common.util.type_forcers import force_int
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class IAMRoleMaxSessionDuration(BaseResourceCheck):
+    def __init__(self) -> None:
+        name = "Ensure IAM role max session duration does not exceed 1 hour"
+        id = "CKV_AWS_395"
+        supported_resources = ("aws_iam_role",)
+        categories = (CheckCategories.IAM,)
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        # AWS/Terraform default max_session_duration is 3600 seconds when omitted.
+        key = "max_session_duration"
+        if key not in conf:
+            return CheckResult.PASSED
+
+        duration = conf[key][0]
+        if self._is_variable_dependant(duration):
+            return CheckResult.UNKNOWN
+
+        duration_int = force_int(duration)
+        if duration_int is None:
+            return CheckResult.UNKNOWN
+
+        if duration_int <= 3600:
+            return CheckResult.PASSED
+        return CheckResult.FAILED
+
+    def get_evaluated_keys(self) -> list[str]:
+        return ["max_session_duration"]
+
+
+check = IAMRoleMaxSessionDuration()

--- a/tests/terraform/checks/resource/aws/example_IAMRoleMaxSessionDuration/main.tf
+++ b/tests/terraform/checks/resource/aws/example_IAMRoleMaxSessionDuration/main.tf
@@ -1,0 +1,43 @@
+# pass — attribute omitted (AWS default is 3600)
+resource "aws_iam_role" "pass" {
+  name               = "pass_role"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+# pass — explicit 1 hour
+resource "aws_iam_role" "pass_explicit" {
+  name                 = "pass_role_explicit"
+  assume_role_policy   = data.aws_iam_policy_document.assume.json
+  max_session_duration = 3600
+}
+
+# fail — elevated session duration (12 hours)
+resource "aws_iam_role" "fail" {
+  name                 = "fail_role"
+  assume_role_policy   = data.aws_iam_policy_document.assume.json
+  max_session_duration = 43200
+}
+
+# fail — any value above 3600
+resource "aws_iam_role" "fail_boundary" {
+  name                 = "fail_role_boundary"
+  assume_role_policy   = data.aws_iam_policy_document.assume.json
+  max_session_duration = 3601
+}
+
+# unknown — variable reference cannot be evaluated at scan time
+resource "aws_iam_role" "unknown" {
+  name                 = "unknown_role"
+  assume_role_policy   = data.aws_iam_policy_document.assume.json
+  max_session_duration = var.max_session_duration
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}

--- a/tests/terraform/checks/resource/aws/test_IAMRoleMaxSessionDuration.py
+++ b/tests/terraform/checks/resource/aws/test_IAMRoleMaxSessionDuration.py
@@ -1,0 +1,47 @@
+import unittest
+from pathlib import Path
+
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.checks.resource.aws.IAMRoleMaxSessionDuration import check
+from checkov.terraform.runner import Runner
+
+
+class TestIAMRoleMaxSessionDuration(unittest.TestCase):
+    def test(self):
+        # given
+        test_files_dir = Path(__file__).parent / "example_IAMRoleMaxSessionDuration"
+
+        # when
+        report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
+
+        # then
+        summary = report.get_summary()
+
+        passing_resources = {
+            "aws_iam_role.pass",
+            "aws_iam_role.pass_explicit",
+        }
+        failing_resources = {
+            "aws_iam_role.fail",
+            "aws_iam_role.fail_boundary",
+        }
+        # variable-dependent max_session_duration is UNKNOWN and should not be pass/fail
+        unknown_resources = {
+            "aws_iam_role.unknown",
+        }
+
+        passed_check_resources = {c.resource for c in report.passed_checks}
+        failed_check_resources = {c.resource for c in report.failed_checks}
+
+        self.assertEqual(summary["passed"], len(passing_resources))
+        self.assertEqual(summary["failed"], len(failing_resources))
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["parsing_errors"], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+        self.assertEqual(len([r for r in report.resources if r in unknown_resources]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Adds a Terraform check that fails `aws_iam_role` resources when `max_session_duration` is set above 3600 seconds (1 hour). The AWS/Terraform default of 3600 when the attribute is omitted is treated as a pass. Variable references return UNKNOWN.

Issue #7521 suggested `CKV_AWS_341`, but that ID is already used by `LaunchTemplateMetadataHop`. `CKV_AWS_394` is claimed by open PR #7595, so this PR uses free ID **CKV_AWS_395**.

Fixes #7521

## New/Edited policies

### Description
Elevated max session duration on an IAM role extends the lifetime of temporary credentials obtained via `sts:AssumeRole`, increasing the blast radius of a compromised role session. Keeping the limit at or below one hour matches common AWS/CIS session-duration guidance.

### Fix
Set `max_session_duration` to 3600 or less, or omit the attribute to keep the AWS default of 3600.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
