### PR TITLE
fix(secrets): reduce CKV_AWS_45 false positives on 40-char env values

### DIFF
--- a/checkov/common/util/secrets.py
+++ b/checkov/common/util/secrets.py
@@ -50,7 +50,9 @@ _secrets_regexes = {
     ],
 
     'aws': [
-        "(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])",  # AWS secret access key
+        # Require mixed upper/lower/digit so 40-char resource names/URLs do not FP as secret keys
+        # (see https://github.com/bridgecrewio/checkov/issues/7542).
+        "(?<![A-Za-z0-9/+=])(?=[A-Za-z0-9/+=]*[A-Z])(?=[A-Za-z0-9/+=]*[a-z])(?=[A-Za-z0-9/+=]*[0-9])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])",  # AWS secret access key
         "(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}",  # AWS access key ID
         "(\"|')?(AWS|aws|Aws)?_?(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)(\"|')?\\s*(:|=>|=)\\s*(\"|')?[A-Za-z0-9/\\+=]{40}(\"|')?",
         "(\"|')?(AWS|aws|Aws)?_?(ACCOUNT|account|Account)_?(ID|id|Id)?(\"|')?\\s*(:|=>|=)\\s*(\"|')?[0-9]{4}\\-?[0-9]{4}\\-?[0-9]{4}(\"|')?"

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -70,3 +70,28 @@ class TestSecrets(unittest.TestCase):
         secret = get_secrets_from_string(s)
 
         assert secret == ["AKIAIOSFODNN7EXAMPLE"]
+
+    # Regression for https://github.com/bridgecrewio/checkov/issues/7542
+    def test_aws_secret_key_pattern_ignores_non_mixed_40_char_values(self):
+        # Legitimate Lambda env values from the issue report (and similar resource names)
+        # must not be treated as AWS secret access keys just because of length.
+        false_positives = [
+            "mdp/feature-logging/FdaCompositePipeline",  # 40-char namespace-like value
+            "https://www.fda.gov/media/76860/download",  # 40-char URL
+            "mdp-test-new-destroy-147997161038-uploads-bucket",  # 48-char bucket name
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",  # 40 identical chars
+            "abcdefghijklmnopqrstuvwxyzabcdefghijklmn",  # 40 lower-only
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMN",  # 40 upper-only
+            "abcdefghijklmnopqrstuvwxyz0123456789abcd",  # lower+digit, no upper
+        ]
+        for value in false_positives:
+            self.assertFalse(
+                string_has_secrets(value, AWS),
+                msg=f"unexpected AWS secret match for {value!r}",
+            )
+
+        # Real AWS secret access keys mix upper, lower, and digits within 40 base64 chars
+        real_secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"  # checkov:skip=CKV_SECRET_6 test secret
+        self.assertTrue(string_has_secrets(real_secret, AWS))
+        self.assertTrue(get_secrets_from_string(real_secret, AWS))
+


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

CKV_AWS_45 (and any other AWS secret scan that uses the shared bare-40-character pattern in `checkov/common/util/secrets.py`) can fail Lambda environment values that are not secrets. The first AWS regex matched any 40-character base64-ish run with no structure check, so resource names, URLs, and other environment strings that merely land on that length could trip CI.

This change tightens only that bare secret-access-key pattern so a 40-character candidate must contain at least one upper-case letter, one lower-case letter, and one digit — the structural mix of a real AWS secret access key. Keyword-keyed AWS patterns and access-key-id patterns are unchanged.

Fixes #7542

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
