### PR TITLE
fix(kustomize): surface non-zero build failures as parsing errors

### DIFF
--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -432,6 +432,8 @@ class Runner(BaseRunner[_KubernetesDefinitions, _KubernetesContext, "KubernetesG
         self.kustomizeFileMappings: "dict[str, str]" = {}
         self.templateRendererCommand: str | None = None
         self.target_folder_path = ''
+        # Paths where kustomize/kubectl build failed; surfaced as report.parsing_errors (#7599)
+        self.kustomize_build_errors: "list[str]" = []
 
         self.checkov_allow_kustomize_file_edits = convert_str_to_bool(os.getenv("CHECKOV_ALLOW_KUSTOMIZE_FILE_EDITS",
                                                                                 False))
@@ -637,12 +639,25 @@ class Runner(BaseRunner[_KubernetesDefinitions, _KubernetesContext, "KubernetesG
 
         full_command = f'{template_renderer_command} {template_render_command_options}'
         proc = subprocess.Popen(full_command.split(' '), cwd=filePath, stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # nosec
-        output, _ = proc.communicate()
+        output, err = proc.communicate()
 
         if self.checkov_allow_kustomize_file_edits and add_origin_annotations_return_code == 0:
             # If the return code is not 0, we didn't add the new buildmetadata field, so we shouldn't remove it
             remove_origin_annotaions = 'kustomize edit remove buildmetadata originAnnotations'
             subprocess.run(remove_origin_annotaions.split(' '), cwd=filePath)  # nosec
+
+        if proc.returncode != 0:
+            stderr_text = (err or b"").decode("utf-8", errors="replace").strip()
+            logging.error(
+                "Error: Kustomize build failed for %s (command: %s, exit code: %s).\n%s",
+                filePath,
+                full_command,
+                proc.returncode,
+                stderr_text or "(no stderr)",
+            )
+            if filePath not in self.kustomize_build_errors:
+                self.kustomize_build_errors.append(filePath)
+            return None
 
         logging.info(
             f"Ran kubectl to build Kustomize output. DIR: {filePath}. TYPE: {source_type}.")
@@ -727,11 +742,18 @@ class Runner(BaseRunner[_KubernetesDefinitions, _KubernetesContext, "KubernetesG
         kustomize_processed_folder_and_meta: dict[str, dict[str, Any]],
         template_renderer_command: str,
         target_folder_path: str,
-    ) -> None:
+    ) -> str | None:
+        """
+        Returns the file_path when kustomize/kubectl build fails (non-zero exit), else None.
+        Parallel runners only return this value to the parent process (#7599).
+        """
         output, _ = self.get_binary_output(file_path, kustomize_processed_folder_and_meta, template_renderer_command)
         if not output:
-            return
+            if file_path in self.kustomize_build_errors:
+                return file_path
+            return None
         Runner._parse_output(output, file_path, kustomize_processed_folder_and_meta, target_folder_path, shared_kustomize_file_mappings)
+        return None
 
     def run_kustomize_to_k8s(
         self, root_folder: str | None, files: list[str] | None, runner_filter: RunnerFilter
@@ -755,13 +777,15 @@ class Runner(BaseRunner[_KubernetesDefinitions, _KubernetesContext, "KubernetesG
 
             shared_kustomize_file_mappings: dict[str, str] = {}
             for file_path in self.kustomizeProcessedFolderAndMeta:
-                self._run_kustomize_parser(
+                failed_path = self._run_kustomize_parser(
                     file_path=file_path,
                     shared_kustomize_file_mappings=shared_kustomize_file_mappings,
                     kustomize_processed_folder_and_meta=self.kustomizeProcessedFolderAndMeta,
                     template_renderer_command=self.templateRendererCommand,
                     target_folder_path=self.target_folder_path,
                 )
+                if failed_path and failed_path not in self.kustomize_build_errors:
+                    self.kustomize_build_errors.append(failed_path)
             self.kustomizeFileMappings = shared_kustomize_file_mappings
             return
 
@@ -780,7 +804,9 @@ class Runner(BaseRunner[_KubernetesDefinitions, _KubernetesContext, "KubernetesG
             )
             for filePath in self.kustomizeProcessedFolderAndMeta
         ]
-        list(parallel_runner.run_function(self._run_kustomize_parser, items))
+        for failed_path in parallel_runner.run_function(self._run_kustomize_parser, items):
+            if failed_path and failed_path not in self.kustomize_build_errors:
+                self.kustomize_build_errors.append(failed_path)
 
         self.kustomizeFileMappings = dict(shared_kustomize_file_mappings)
 
@@ -801,6 +827,8 @@ class Runner(BaseRunner[_KubernetesDefinitions, _KubernetesContext, "KubernetesG
 
         if not self.kustomizeProcessedFolderAndMeta:
             # nothing to process
+            if self.kustomize_build_errors:
+                report.add_parsing_errors(self.kustomize_build_errors)
             return report
 
         target_dir = ""
@@ -825,6 +853,13 @@ class Runner(BaseRunner[_KubernetesDefinitions, _KubernetesContext, "KubernetesG
                 logging.debug(
                     f"Error running k8s scan on Scan dir: {target_dir}. Saved context dir: {save_error_dir}")
                 shutil.move(target_dir, save_error_dir)
+
+        if self.kustomize_build_errors:
+            if isinstance(report, list):
+                if report:
+                    report[0].add_parsing_errors(self.kustomize_build_errors)
+            else:
+                report.add_parsing_errors(self.kustomize_build_errors)
 
         return report
 

--- a/tests/kustomize/test_runner.py
+++ b/tests/kustomize/test_runner.py
@@ -251,6 +251,7 @@ class TestRemoteBaseAllowlist(unittest.TestCase):
         runner = self._make_runner()
         fake_output = b"apiVersion: v1\nkind: ConfigMap\n"
         mock_proc = mock.MagicMock()
+        mock_proc.returncode = 0
         mock_proc.communicate.return_value = (fake_output, b"")
         with mock.patch.dict(os.environ, {}, clear=False):
             os.environ.pop("CHECKOV_KUSTOMIZE_ALLOWED_REMOTE_PREFIXES", None)
@@ -274,6 +275,7 @@ class TestRemoteBaseAllowlist(unittest.TestCase):
         runner = self._make_runner()
         fake_output = b"apiVersion: v1\nkind: ConfigMap\n"
         mock_proc = mock.MagicMock()
+        mock_proc.returncode = 0
         mock_proc.communicate.return_value = (fake_output, b"")
         env = {"CHECKOV_KUSTOMIZE_ALLOWED_REMOTE_PREFIXES": "http://192.0.2.1/,git::https://example.com/"}
         with mock.patch.dict(os.environ, env):
@@ -288,6 +290,7 @@ class TestRemoteBaseAllowlist(unittest.TestCase):
         local_dir = str(Path(__file__).parent / "runner/resources/example/base")
         fake_output = b"apiVersion: v1\nkind: ConfigMap\n"
         mock_proc = mock.MagicMock()
+        mock_proc.returncode = 0
         mock_proc.communicate.return_value = (fake_output, b"")
         with mock.patch.dict(os.environ, {}, clear=False):
             os.environ.pop("CHECKOV_KUSTOMIZE_ALLOWED_REMOTE_PREFIXES", None)
@@ -295,6 +298,41 @@ class TestRemoteBaseAllowlist(unittest.TestCase):
                 result = runner._get_kubectl_output(local_dir, "kustomize", "base")
         mock_popen.assert_called_once()
         self.assertEqual(result, fake_output)
+
+    def test_get_kubectl_output_surfaces_build_failure(self):
+        """Non-zero kustomize/kubectl exit must not look like a successful empty scan (#7599)."""
+        runner = self._make_runner()
+        local_dir = str(Path(__file__).parent / "runner/resources/example/base")
+        stderr = b"Error: accumulating resources: no such file or directory"
+        mock_proc = mock.MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = (b"", stderr)
+        with mock.patch("checkov.kustomize.runner.subprocess.Popen", return_value=mock_proc) as mock_popen:
+            with self.assertLogs(level="ERROR") as logs:
+                result = runner._get_kubectl_output(local_dir, "kustomize", "base")
+        mock_popen.assert_called_once()
+        self.assertIsNone(result)
+        self.assertIn(local_dir, runner.kustomize_build_errors)
+        self.assertTrue(any("Kustomize build failed" in line for line in logs.output))
+        self.assertTrue(any("accumulating resources" in line for line in logs.output))
+
+    def test_run_adds_parsing_errors_when_kustomize_build_fails(self):
+        """Failed builds should appear in report.parsing_errors so CI can see them (#7599)."""
+        runner = self._make_runner()
+        scan_dir = Path(__file__).parent / "runner/resources/example/base"
+        mock_proc = mock.MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = (b"", b"Error: missing resource")
+        # Force sequential path so the mocked failure stays in-process (parallel fork would hide list mutations)
+        with mock.patch("checkov.kustomize.runner.platform.system", return_value="Windows"):
+            with mock.patch("checkov.kustomize.runner.subprocess.Popen", return_value=mock_proc):
+                report = runner.run(root_folder=str(scan_dir), runner_filter=RunnerFilter(framework=["kustomize"]))
+        if isinstance(report, list):
+            report = report[0]
+        self.assertGreaterEqual(len(report.parsing_errors), 1)
+        self.assertTrue(any(str(scan_dir) in path or path.endswith("base") for path in report.parsing_errors))
+        self.assertEqual(len(report.failed_checks), 0)
+        self.assertEqual(len(report.passed_checks), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

When `kustomize`/`kubectl kustomize` exits non-zero, Checkov previously discarded stderr and continued as if the build had produced an empty successful scan. That made CI look green while no Kubernetes checks ran.

This change:

- treats a non-zero build exit as a failure
- logs an ERROR with the build command, exit code, and stderr
- records the failed directory and attaches it to `report.parsing_errors`
- returns the failed path from parallel parser workers so parent processes still see the failure

## Related Issue

Fixes #7599

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/bridgecrewio/checkov/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix works
- [x] Local: `python -m pytest tests/kustomize/test_runner.py -q -o addopts=''` → 14 passed, 7 skipped

## Notes

`report.parsing_errors` is the existing Checkov surface for parse/build failures. Process exit code still follows `CKV_PARSE_ERROR_FAIL` (same as other frameworks). Operators who want hard CI fail on parse errors should set that env var.

## Tests

```
python -m pytest tests/kustomize/test_runner.py -q -o addopts=''
# 14 passed, 7 skipped
```
