### PR TITLE
Validate unknown check IDs passed to --check

### DIFF
--- a/checkov/main.py
+++ b/checkov/main.py
@@ -350,7 +350,11 @@ class Checkov:
                 report_sast_imports=bool(convert_str_to_bool(os.getenv('CKV_ENABLE_UPLOAD_SAST_IMPORTS', False))),
                 report_sast_reachability=bool(convert_str_to_bool(os.getenv('CKV_ENABLE_UPLOAD_SAST_REACHABILITY', False)))
             )
-
+            
+            invalid_checks = runner_filter.validate_checks() 
+            if invalid_checks:
+                self.parser.error(f"Invalid Checks: {', '.join(invalid_checks)}" )
+             
             source_env_val = os.getenv('BC_SOURCE', 'cli')
             source = source_type if source_type else get_source_type(source_env_val)
             if source == SourceTypes[BCSourceType.DISABLED]:

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -325,9 +325,14 @@ class RunnerFilter(object):
         pattern_list = [extract_checks] if isinstance(extract_checks, str) else list(extract_checks)
         # local import to avoid a circular import 
         from checkov.common.checks.base_check_registry import BaseCheckRegistry
-        all_checks = BaseCheckRegistry.get_all_registered_checks()
+        from checkov.common.checks_infra.registry import get_all_graph_checks_registries
+
+        all_checks = list(BaseCheckRegistry.get_all_registered_checks())
         invalid_checks = []
-        
+
+        for registry in get_all_graph_checks_registries():
+            registry.load_checks()
+            all_checks.extend(registry.checks)
         for pattern in pattern_list:
             for registered_check in all_checks:
                 if (fnmatch.fnmatch(registered_check.id, pattern) or (registered_check.bc_id and fnmatch.fnmatch(registered_check.bc_id, pattern))):

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -317,7 +317,26 @@ class RunnerFilter(object):
         return any(
             (fnmatch.fnmatch(check_id, pattern) or (bc_check_id and fnmatch.fnmatch(bc_check_id, pattern))) for pattern
             in pattern_list)
+    
+    def validate_checks(self):
+        extract_checks = self.checks
+        if not extract_checks:
+            return
+        pattern_list = [extract_checks] if isinstance(extract_checks, str) else list(extract_checks)
+        # local import to avoid a circular import 
+        from checkov.common.checks.base_check_registry import BaseCheckRegistry
+        all_checks = BaseCheckRegistry.get_all_registered_checks()
+        invalid_checks = []
+        
+        for pattern in pattern_list:
+            for registered_check in all_checks:
+                if (fnmatch.fnmatch(registered_check.id, pattern) or (registered_check.bc_id and fnmatch.fnmatch(registered_check.bc_id, pattern))):
+                    break
+            else :
+                invalid_checks.append(pattern)
 
+        return invalid_checks 
+            
     def within_threshold(self, severity: Severity) -> bool:
         above_min = (not self.check_threshold) or self.check_threshold.level <= severity.level
         below_max = self.skip_check_threshold and self.skip_check_threshold.level >= severity.level

--- a/tests/test_runner_filter.py
+++ b/tests/test_runner_filter.py
@@ -67,11 +67,13 @@ def test_runner_filter_constructor_framework(
     # then
     assert set(runner_filter.framework) == expected_frameworks
 
+@patch("checkov.common.checks_infra.registry.get_all_graph_checks_registries")
 @patch('checkov.common.checks.base_check_registry.BaseCheckRegistry.get_all_registered_checks')
-def test_validate_checks(test_registry):
+def test_validate_checks(test_registry, graph_test_registry):
     runner_filter = RunnerFilter(
-        checks= ['CKV_T_1', 'CKV_FAKE', 'CKV_T_2', 'CKV_T*', 'CKV_BC_T_1', 'CKV_BC_T_4', 'CKV_BC_FAKE']
+        checks= ['CKV_T_1', 'CKV_FAKE', 'CKV2_T_2', 'CKV_T*', 'CKV_BC_T_1', 'CKV2_BC_T_2', 'CKV2_BC_FAKE', 'CKV2_T*']
     )
+    # Basechecks
     check1 = MagicMock()
     check1.id = 'CKV_T_1'
     check1.bc_id = 'CKV_BC_T_1'
@@ -80,17 +82,22 @@ def test_validate_checks(test_registry):
     check2.id = 'CKV_T_2'
     check2.bc_id = 'CKV_BC_T_2'
 
+    # graph checks 
     check3 = MagicMock()
-    check3.id = 'CKV_T_3'
-    check3.bc_id = 'CKV_BC_T_3'
+    check3.id = 'CKV2_T_1'
+    check3.bc_id = 'CKV2_BC_T_1'
 
     check4 = MagicMock()
-    check4.id = 'CKV_T_4'
-    check4.bc_id = 'CKV_BC_T_4'
+    check4.id = 'CKV2_T_2'
+    check4.bc_id = 'CKV2_BC_T_2'
 
-    test_registry.return_value = [check1, check2, check3, check4]
+    test_registry.return_value = [check1, check2]
+    
+    graph_test_registry.checks = [check3, check4]
+    graph_test_registry.return_value = [graph_test_registry]
     
     invalid = runner_filter.validate_checks()
-    assert invalid == ['CKV_FAKE', 'CKV_BC_FAKE']
+    assert invalid == ['CKV_FAKE', 'CKV2_BC_FAKE']
 
     test_registry.assert_called_once()
+    graph_test_registry.assert_called_once() 

--- a/tests/test_runner_filter.py
+++ b/tests/test_runner_filter.py
@@ -1,4 +1,5 @@
 from typing import Optional, List, Set
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -65,3 +66,31 @@ def test_runner_filter_constructor_framework(
 
     # then
     assert set(runner_filter.framework) == expected_frameworks
+
+@patch('checkov.common.checks.base_check_registry.BaseCheckRegistry.get_all_registered_checks')
+def test_validate_checks(test_registry):
+    runner_filter = RunnerFilter(
+        checks= ['CKV_T_1', 'CKV_FAKE', 'CKV_T_2', 'CKV_T*', 'CKV_BC_T_1', 'CKV_BC_T_4', 'CKV_BC_FAKE']
+    )
+    check1 = MagicMock()
+    check1.id = 'CKV_T_1'
+    check1.bc_id = 'CKV_BC_T_1'
+
+    check2 = MagicMock()
+    check2.id = 'CKV_T_2'
+    check2.bc_id = 'CKV_BC_T_2'
+
+    check3 = MagicMock()
+    check3.id = 'CKV_T_3'
+    check3.bc_id = 'CKV_BC_T_3'
+
+    check4 = MagicMock()
+    check4.id = 'CKV_T_4'
+    check4.bc_id = 'CKV_BC_T_4'
+
+    test_registry.return_value = [check1, check2, check3, check4]
+    
+    invalid = runner_filter.validate_checks()
+    assert invalid == ['CKV_FAKE', 'CKV_BC_FAKE']
+
+    test_registry.assert_called_once()


### PR DESCRIPTION
Fixes #7614
I added validation for check IDs passed with --check.
If a check ID is not found in the registry, checkov now shows an error instead of ignoring it.
I also added tests for valid, invalid, wildcard, and BC ID cases.