### PR TITLE
feat(github): extend CKV_GIT_3 to support github_repository_vulnerability_alerts resource

### DIFF
--- a/checkov/terraform/checks/resource/github/RepositoryEnableVulnerabilityAlerts.py
+++ b/checkov/terraform/checks/resource/github/RepositoryEnableVulnerabilityAlerts.py
@@ -10,11 +10,19 @@ class GithubRepositoryVulnerabilityAlerts(BaseResourceCheck):
     def __init__(self) -> None:
         name = "Ensure GitHub repository has vulnerability alerts enabled"
         id = "CKV_GIT_3"
-        supported_resources = ["github_repository"]
+        supported_resources = ["github_repository", "github_repository_vulnerability_alerts"]
         categories = [CheckCategories.GENERAL_SECURITY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        # New dedicated resource (GitHub provider >= 6.12.0)
+        # https://github.com/integrations/terraform-provider-github/pull/3166
+        if self.entity_type == "github_repository_vulnerability_alerts":
+            if conf.get("enabled") == [False]:
+                return CheckResult.FAILED
+            return CheckResult.PASSED
+
+        # Legacy github_repository.vulnerability_alerts attribute
         # GitHub disables the alerts when archiving the repository without an option to turn them on again.
         if conf.get("archived") == [True]:
             return CheckResult.PASSED
@@ -30,7 +38,7 @@ class GithubRepositoryVulnerabilityAlerts(BaseResourceCheck):
         return CheckResult.PASSED
 
     def get_evaluated_keys(self) -> List[str]:
-        return ["vulnerability_alerts"]
+        return ["vulnerability_alerts", "enabled"]
 
 
 check = GithubRepositoryVulnerabilityAlerts()

--- a/tests/terraform/checks/resource/github/example_RepositoryEnableVulnerabilityAlerts/main.tf
+++ b/tests/terraform/checks/resource/github/example_RepositoryEnableVulnerabilityAlerts/main.tf
@@ -89,3 +89,19 @@ resource "github_repository" "pass5" {
   }
   vulnerability_alerts = false
 }
+
+# New dedicated resource (GitHub provider >= 6.12.0)
+
+resource "github_repository_vulnerability_alerts" "pass" {
+  repository = github_repository.pass.name
+  enabled    = true
+}
+
+resource "github_repository_vulnerability_alerts" "pass2" {
+  repository = github_repository.pass2.name
+}
+
+resource "github_repository_vulnerability_alerts" "fail" {
+  repository = github_repository.fail.name
+  enabled    = false
+}

--- a/tests/terraform/checks/resource/github/test_RepositoryVulnerabilityAlerts.py
+++ b/tests/terraform/checks/resource/github/test_RepositoryVulnerabilityAlerts.py
@@ -21,17 +21,20 @@ class TestRepositoryEnableVulnerabilityAlerts(unittest.TestCase):
             "github_repository.pass3",
             "github_repository.pass4",
             "github_repository.pass5",
+            "github_repository_vulnerability_alerts.pass",
+            "github_repository_vulnerability_alerts.pass2",
         }
         failing_resources = {
             "github_repository.fail",
             "github_repository.fail2",
+            "github_repository_vulnerability_alerts.fail",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary["passed"], 5)
-        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["passed"], 7)
+        self.assertEqual(summary["failed"], 3)
         self.assertEqual(summary["skipped"], 0)
         self.assertEqual(summary["parsing_errors"], 0)
 


### PR DESCRIPTION
## Description

This PR extends the existing CKV_GIT_3 check to support the new github_repository_vulnerability_alerts resource introduced in GitHub provider v6.12.0.

### Motivation

The ulnerability_alerts attribute on github_repository is now deprecated in favor of the dedicated github_repository_vulnerability_alerts resource. Without this change, Checkov cannot evaluate configurations using the new resource type.

### Changes

- **Check**: Added github_repository_vulnerability_alerts to supported_resources
- **Logic**: Added entity_type branching in scan_resource_conf for the new resource
- **Tests**: Added test fixtures and updated test expectations

### Test Results

- New passing resources: github_repository_vulnerability_alerts.pass, github_repository_vulnerability_alerts.pass2
- New failing resource: github_repository_vulnerability_alerts.fail

### References

- [GitHub Provider v6.12.0 Release](https://github.com/integrations/terraform-provider-github/releases/tag/v6.12.0)
- [PR #3166](https://github.com/integrations/terraform-provider-github/pull/3166)

Fixes #7546