### PR TITLE
fix(cloudformation): handle unresolvable WebACL Rules in CKV_AWS_192

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/WAFACLCVE202144228.py
+++ b/checkov/cloudformation/checks/resource/aws/WAFACLCVE202144228.py
@@ -17,7 +17,12 @@ class WAFACLCVE202144228(BaseResourceCheck):
         properties = conf.get("Properties")
         if properties:
             rules = properties.get("Rules") or []
+            if not isinstance(rules, list):
+                # can't be resolved, e.g. a `Fn::If` expression
+                return CheckResult.UNKNOWN
             for idx_rule, rule in enumerate(rules):
+                if not isinstance(rule, dict):
+                    continue
                 self.evaluated_keys = [f"Properties/Rules/[{idx_rule}]/Statement"]
                 statement = rule.get("Statement")
                 if statement:

--- a/tests/cloudformation/checks/resource/aws/example_WAFACLCVE202144228/UNKNOWN.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_WAFACLCVE202144228/UNKNOWN.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Conditions:
+  ExtraProtection: !Equals [!Ref 'AWS::Region', us-east-1]
+Resources:
+  ConditionalRules:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Name: 'example-webacl'
+      DefaultAction:
+        Allow: { }
+      Scope: REGIONAL
+      VisibilityConfig:
+        SampledRequestsEnabled: false
+        MetricName: ExampleWebACLMetric
+        CloudWatchMetricsEnabled: false
+      Rules: !If
+        - ExtraProtection
+        - - Name: rule-1
+            Priority: 1
+            Statement:
+              ManagedRuleGroupStatement:
+                VendorName: AWS
+                Name: AWSManagedRulesKnownBadInputsRuleSet
+            OverrideAction:
+              None: { }
+            VisibilityConfig:
+              CloudWatchMetricsEnabled: false
+              MetricName: AWSManagedRulesKnownBadInputsRuleSet
+              SampledRequestsEnabled: false
+        - []

--- a/tests/cloudformation/checks/resource/aws/test_WAFACLCVE202144228.py
+++ b/tests/cloudformation/checks/resource/aws/test_WAFACLCVE202144228.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from checkov.cloudformation.checks.resource.aws.WAFACLCVE202144228 import check
 from checkov.cloudformation.runner import Runner
+from checkov.common.models.enums import CheckResult
 from checkov.runner_filter import RunnerFilter
 
 
@@ -38,6 +39,39 @@ class TestWAFACLCVE202144228(unittest.TestCase):
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
+
+    def test_conditional_rules(self):
+        # a `Fn::If` in `Rules` can't be resolved statically
+        resource_conf = {
+            "Type": "AWS::WAFv2::WebACL",
+            "Properties": {
+                "DefaultAction": {"Allow": {}},
+                "Scope": "REGIONAL",
+                "Rules": {
+                    "Fn::If": [
+                        "SomeCondition",
+                        [
+                            {
+                                "Name": "rule-1",
+                                "Priority": 1,
+                                "Statement": {
+                                    "ManagedRuleGroupStatement": {
+                                        "VendorName": "AWS",
+                                        "Name": "AWSManagedRulesKnownBadInputsRuleSet",
+                                    }
+                                },
+                                "OverrideAction": {"None": {}},
+                            }
+                        ],
+                        [],
+                    ]
+                },
+            },
+        }
+
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+
+        self.assertEqual(CheckResult.UNKNOWN, scan_result)
 
 
 if __name__ == "__main__":

--- a/tests/cloudformation/checks/resource/aws/test_WAFACLCVE202144228.py
+++ b/tests/cloudformation/checks/resource/aws/test_WAFACLCVE202144228.py
@@ -1,9 +1,9 @@
+import logging
 import unittest
 from pathlib import Path
 
 from checkov.cloudformation.checks.resource.aws.WAFACLCVE202144228 import check
 from checkov.cloudformation.runner import Runner
-from checkov.common.models.enums import CheckResult
 from checkov.runner_filter import RunnerFilter
 
 
@@ -41,37 +41,20 @@ class TestWAFACLCVE202144228(unittest.TestCase):
         self.assertEqual(failing_resources, failed_check_resources)
 
     def test_conditional_rules(self):
-        # a `Fn::If` in `Rules` can't be resolved statically
-        resource_conf = {
-            "Type": "AWS::WAFv2::WebACL",
-            "Properties": {
-                "DefaultAction": {"Allow": {}},
-                "Scope": "REGIONAL",
-                "Rules": {
-                    "Fn::If": [
-                        "SomeCondition",
-                        [
-                            {
-                                "Name": "rule-1",
-                                "Priority": 1,
-                                "Statement": {
-                                    "ManagedRuleGroupStatement": {
-                                        "VendorName": "AWS",
-                                        "Name": "AWSManagedRulesKnownBadInputsRuleSet",
-                                    }
-                                },
-                                "OverrideAction": {"None": {}},
-                            }
-                        ],
-                        [],
-                    ]
-                },
-            },
-        }
+        # given
+        test_files_dir = Path(__file__).parent / "example_WAFACLCVE202144228"
 
-        scan_result = check.scan_resource_conf(conf=resource_conf)
+        # when
+        # a `Fn::If` in `Rules` (UNKNOWN.yaml) can't be resolved statically and
+        # must yield UNKNOWN instead of crashing the check; a crash is also
+        # downgraded to UNKNOWN by the check registry, so it is only observable
+        # as an ERROR log
+        with self.assertNoLogs(level=logging.ERROR):
+            report = Runner().run(root_folder=str(test_files_dir), runner_filter=RunnerFilter(checks=[check.id]))
 
-        self.assertEqual(CheckResult.UNKNOWN, scan_result)
+        # then
+        reported_resources = {c.resource for c in report.passed_checks + report.failed_checks}
+        self.assertNotIn("AWS::WAFv2::WebACL.ConditionalRules", reported_resources)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

`CKV_AWS_192` (`WAFACLCVE202144228`) crashes with `AttributeError: 'str' object has no attribute 'get'` when an `AWS::WAFv2::WebACL` declares its `Rules` via an intrinsic function, e.g. `Fn::If` selecting between rule lists: the parsed value is a dict, so the check iterates its string keys. The check registry downgrades the crash to `UNKNOWN`, so the report is unaffected, but every scan of such a template logs a `Failed to run check` ERROR traceback.

This PR makes the check return `UNKNOWN` explicitly when `Rules` is not a list (the approach used by e.g. `LambdaEnvironmentEncryptionSettings`) and skip non-dict rule elements.

Note on the test: since the registry already downgrades the crash to `UNKNOWN`, the report is identical with and without the fix — the crash is only observable as an ERROR log. The regression test therefore wraps a runner-based scan of the new `Fn::If` example template in `assertNoLogs(level=logging.ERROR)`; it fails with the original `AttributeError` before the fix and passes after.

Fixes #7620

*Written with AI assistance (Claude Code), human-reviewed.*

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
