### PR TITLE
Fix/baseline file match

### DIFF
--- a/checkov/common/output/baseline.py
+++ b/checkov/common/output/baseline.py
@@ -85,10 +85,12 @@ class Baseline:
     def _is_check_in_baseline(self, check: Record) -> bool:
         failed_check_id = check.check_id
         failed_check_resource = check.resource
+        failed_check_path = check.file_path
         for baseline_failed_check in self.failed_checks:
-            for finding in baseline_failed_check["findings"]:
-                if finding["resource"] == failed_check_resource and failed_check_id in finding["check_ids"]:
-                    return True
+            if baseline_failed_check["file"] == failed_check_path :
+                for finding in baseline_failed_check["findings"]:
+                    if finding["resource"] == failed_check_resource and failed_check_id in finding["check_ids"]:
+                        return True
         return False
 
     def from_json(self, file_path: str) -> None:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -350,7 +350,11 @@ class Checkov:
                 report_sast_imports=bool(convert_str_to_bool(os.getenv('CKV_ENABLE_UPLOAD_SAST_IMPORTS', False))),
                 report_sast_reachability=bool(convert_str_to_bool(os.getenv('CKV_ENABLE_UPLOAD_SAST_REACHABILITY', False)))
             )
-
+            
+            invalid_checks = runner_filter.validate_checks() 
+            if invalid_checks:
+                self.parser.error(f"Invalid Checks: {', '.join(invalid_checks)}" )
+             
             source_env_val = os.getenv('BC_SOURCE', 'cli')
             source = source_type if source_type else get_source_type(source_env_val)
             if source == SourceTypes[BCSourceType.DISABLED]:

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -325,9 +325,14 @@ class RunnerFilter(object):
         pattern_list = [extract_checks] if isinstance(extract_checks, str) else list(extract_checks)
         # local import to avoid a circular import 
         from checkov.common.checks.base_check_registry import BaseCheckRegistry
-        all_checks = BaseCheckRegistry.get_all_registered_checks()
+        from checkov.common.checks_infra.registry import get_all_graph_checks_registries
+
+        all_checks = list(BaseCheckRegistry.get_all_registered_checks())
         invalid_checks = []
-        
+
+        for registry in get_all_graph_checks_registries():
+            registry.load_checks()
+            all_checks.extend(registry.checks)
         for pattern in pattern_list:
             for registered_check in all_checks:
                 if (fnmatch.fnmatch(registered_check.id, pattern) or (registered_check.bc_id and fnmatch.fnmatch(registered_check.bc_id, pattern))):

--- a/checkov/runner_filter.py
+++ b/checkov/runner_filter.py
@@ -317,7 +317,26 @@ class RunnerFilter(object):
         return any(
             (fnmatch.fnmatch(check_id, pattern) or (bc_check_id and fnmatch.fnmatch(bc_check_id, pattern))) for pattern
             in pattern_list)
+    
+    def validate_checks(self):
+        extract_checks = self.checks
+        if not extract_checks:
+            return
+        pattern_list = [extract_checks] if isinstance(extract_checks, str) else list(extract_checks)
+        # local import to avoid a circular import 
+        from checkov.common.checks.base_check_registry import BaseCheckRegistry
+        all_checks = BaseCheckRegistry.get_all_registered_checks()
+        invalid_checks = []
+        
+        for pattern in pattern_list:
+            for registered_check in all_checks:
+                if (fnmatch.fnmatch(registered_check.id, pattern) or (registered_check.bc_id and fnmatch.fnmatch(registered_check.bc_id, pattern))):
+                    break
+            else :
+                invalid_checks.append(pattern)
 
+        return invalid_checks 
+            
     def within_threshold(self, severity: Severity) -> bool:
         above_min = (not self.check_threshold) or self.check_threshold.level <= severity.level
         below_max = self.skip_check_threshold and self.skip_check_threshold.level >= severity.level

--- a/tests/common/output/fixtures/baseline_same_resources/dev/main.tf
+++ b/tests/common/output/fixtures/baseline_same_resources/dev/main.tf
@@ -1,0 +1,11 @@
+data "aws_iam_policy_document" "route53_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "route53:ListHostedZones",
+      "route53:GetHostedZone",
+      "route53:ListTagsForResource"
+    ]
+    resources = ["*"]
+  }
+}

--- a/tests/common/output/fixtures/baseline_same_resources/prod/main.tf
+++ b/tests/common/output/fixtures/baseline_same_resources/prod/main.tf
@@ -1,0 +1,11 @@
+data "aws_iam_policy_document" "route53_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "route53:ListHostedZones",
+      "route53:GetHostedZone",
+      "route53:ListTagsForResource"
+    ]
+    resources = ["*"]
+  }
+}

--- a/tests/common/output/test_baseline.py
+++ b/tests/common/output/test_baseline.py
@@ -1,5 +1,6 @@
 import argparse
 from pathlib import Path
+import json 
 
 from checkov.common.output.baseline import Baseline
 from checkov.runner_filter import RunnerFilter
@@ -45,3 +46,31 @@ def test_to_dict():
             },
         ]
     }
+
+def test_baseline_same_resource_in_different_directories():
+    test_folder = Path(__file__).parent / "fixtures" / "baseline_same_resources"
+    check = ["CKV_AWS_356"] 
+    report = Runner().run(root_folder=str(test_folder), runner_filter=RunnerFilter(checks=check))
+    
+    baseline = Baseline()
+    baseline.add_findings_from_report(report)
+
+    baseline_dict = baseline.to_dict()
+    baseline_dict["failed_checks"] = [item for item in baseline_dict["failed_checks"] if "prod" not in item["file"]]
+
+    baseline_file_path = test_folder / ".checkov.baseline"
+    try:
+        with open(baseline_file_path, "w") as f :
+            json.dump(baseline_dict, f, indent=4)
+        baseline.from_json(str(baseline_file_path))
+
+        modified_report = Runner().run(root_folder=str(test_folder), runner_filter=RunnerFilter(checks=check))
+        baseline.compare_and_reduce_reports([modified_report])
+        failed_files = [item.file_path for item in modified_report.failed_checks]
+
+        assert any("prod" in f for f in failed_files)
+        assert not any("dev" in f for f in failed_files)
+
+    finally:
+        if baseline_file_path.exists():
+            baseline_file_path.unlink()

--- a/tests/test_runner_filter.py
+++ b/tests/test_runner_filter.py
@@ -67,11 +67,13 @@ def test_runner_filter_constructor_framework(
     # then
     assert set(runner_filter.framework) == expected_frameworks
 
+@patch("checkov.common.checks_infra.registry.get_all_graph_checks_registries")
 @patch('checkov.common.checks.base_check_registry.BaseCheckRegistry.get_all_registered_checks')
-def test_validate_checks(test_registry):
+def test_validate_checks(test_registry, graph_test_registry):
     runner_filter = RunnerFilter(
-        checks= ['CKV_T_1', 'CKV_FAKE', 'CKV_T_2', 'CKV_T*', 'CKV_BC_T_1', 'CKV_BC_T_4', 'CKV_BC_FAKE']
+        checks= ['CKV_T_1', 'CKV_FAKE', 'CKV2_T_2', 'CKV_T*', 'CKV_BC_T_1', 'CKV2_BC_T_2', 'CKV2_BC_FAKE', 'CKV2_T*']
     )
+    # Basechecks
     check1 = MagicMock()
     check1.id = 'CKV_T_1'
     check1.bc_id = 'CKV_BC_T_1'
@@ -80,17 +82,22 @@ def test_validate_checks(test_registry):
     check2.id = 'CKV_T_2'
     check2.bc_id = 'CKV_BC_T_2'
 
+    # graph checks 
     check3 = MagicMock()
-    check3.id = 'CKV_T_3'
-    check3.bc_id = 'CKV_BC_T_3'
+    check3.id = 'CKV2_T_1'
+    check3.bc_id = 'CKV2_BC_T_1'
 
     check4 = MagicMock()
-    check4.id = 'CKV_T_4'
-    check4.bc_id = 'CKV_BC_T_4'
+    check4.id = 'CKV2_T_2'
+    check4.bc_id = 'CKV2_BC_T_2'
 
-    test_registry.return_value = [check1, check2, check3, check4]
+    test_registry.return_value = [check1, check2]
+    
+    graph_test_registry.checks = [check3, check4]
+    graph_test_registry.return_value = [graph_test_registry]
     
     invalid = runner_filter.validate_checks()
-    assert invalid == ['CKV_FAKE', 'CKV_BC_FAKE']
+    assert invalid == ['CKV_FAKE', 'CKV2_BC_FAKE']
 
     test_registry.assert_called_once()
+    graph_test_registry.assert_called_once() 

--- a/tests/test_runner_filter.py
+++ b/tests/test_runner_filter.py
@@ -1,4 +1,5 @@
 from typing import Optional, List, Set
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -65,3 +66,31 @@ def test_runner_filter_constructor_framework(
 
     # then
     assert set(runner_filter.framework) == expected_frameworks
+
+@patch('checkov.common.checks.base_check_registry.BaseCheckRegistry.get_all_registered_checks')
+def test_validate_checks(test_registry):
+    runner_filter = RunnerFilter(
+        checks= ['CKV_T_1', 'CKV_FAKE', 'CKV_T_2', 'CKV_T*', 'CKV_BC_T_1', 'CKV_BC_T_4', 'CKV_BC_FAKE']
+    )
+    check1 = MagicMock()
+    check1.id = 'CKV_T_1'
+    check1.bc_id = 'CKV_BC_T_1'
+
+    check2 = MagicMock()
+    check2.id = 'CKV_T_2'
+    check2.bc_id = 'CKV_BC_T_2'
+
+    check3 = MagicMock()
+    check3.id = 'CKV_T_3'
+    check3.bc_id = 'CKV_BC_T_3'
+
+    check4 = MagicMock()
+    check4.id = 'CKV_T_4'
+    check4.bc_id = 'CKV_BC_T_4'
+
+    test_registry.return_value = [check1, check2, check3, check4]
+    
+    invalid = runner_filter.validate_checks()
+    assert invalid == ['CKV_FAKE', 'CKV_BC_FAKE']
+
+    test_registry.assert_called_once()


### PR DESCRIPTION
 ## Description

fixes: #7486

This fixes an issue where baseline matching only checked the resource and check ID. Because of that, resources with the same name in different directories could be treated as the same finding and get suppressed.
 I added the file path to the comparison so only the matching file is suppressed. 
I also added a regression test to cover this case.

### Testing 

-  Reproduced the issue using the provided example.
-  Verified that the issue occurs without the fix.
-  Verified that only the matching file is suppressed after the fix.
-  Ran the new regression test and existing baseline tests successfully.