### PR TITLE
Fix baseline suppression for same resources in different directories

### DIFF
--- a/checkov/common/output/baseline.py
+++ b/checkov/common/output/baseline.py
@@ -85,10 +85,12 @@ class Baseline:
     def _is_check_in_baseline(self, check: Record) -> bool:
         failed_check_id = check.check_id
         failed_check_resource = check.resource
+        failed_check_path = check.file_path
         for baseline_failed_check in self.failed_checks:
-            for finding in baseline_failed_check["findings"]:
-                if finding["resource"] == failed_check_resource and failed_check_id in finding["check_ids"]:
-                    return True
+            if baseline_failed_check["file"] == failed_check_path :
+                for finding in baseline_failed_check["findings"]:
+                    if finding["resource"] == failed_check_resource and failed_check_id in finding["check_ids"]:
+                        return True
         return False
 
     def from_json(self, file_path: str) -> None:

--- a/tests/common/output/fixtures/baseline_same_resources/dev/main.tf
+++ b/tests/common/output/fixtures/baseline_same_resources/dev/main.tf
@@ -1,0 +1,11 @@
+data "aws_iam_policy_document" "route53_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "route53:ListHostedZones",
+      "route53:GetHostedZone",
+      "route53:ListTagsForResource"
+    ]
+    resources = ["*"]
+  }
+}

--- a/tests/common/output/fixtures/baseline_same_resources/prod/main.tf
+++ b/tests/common/output/fixtures/baseline_same_resources/prod/main.tf
@@ -1,0 +1,11 @@
+data "aws_iam_policy_document" "route53_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "route53:ListHostedZones",
+      "route53:GetHostedZone",
+      "route53:ListTagsForResource"
+    ]
+    resources = ["*"]
+  }
+}

--- a/tests/common/output/test_baseline.py
+++ b/tests/common/output/test_baseline.py
@@ -1,5 +1,6 @@
 import argparse
 from pathlib import Path
+import json 
 
 from checkov.common.output.baseline import Baseline
 from checkov.runner_filter import RunnerFilter
@@ -45,3 +46,31 @@ def test_to_dict():
             },
         ]
     }
+
+def test_baseline_same_resource_in_different_directories():
+    test_folder = Path(__file__).parent / "fixtures" / "baseline_same_resources"
+    check = ["CKV_AWS_356"] 
+    report = Runner().run(root_folder=str(test_folder), runner_filter=RunnerFilter(checks=check))
+    
+    baseline = Baseline()
+    baseline.add_findings_from_report(report)
+
+    baseline_dict = baseline.to_dict()
+    baseline_dict["failed_checks"] = [item for item in baseline_dict["failed_checks"] if "prod" not in item["file"]]
+
+    baseline_file_path = test_folder / ".checkov.baseline"
+    try:
+        with open(baseline_file_path, "w") as f :
+            json.dump(baseline_dict, f, indent=4)
+        baseline.from_json(str(baseline_file_path))
+
+        modified_report = Runner().run(root_folder=str(test_folder), runner_filter=RunnerFilter(checks=check))
+        baseline.compare_and_reduce_reports([modified_report])
+        failed_files = [item.file_path for item in modified_report.failed_checks]
+
+        assert any("prod" in f for f in failed_files)
+        assert not any("dev" in f for f in failed_files)
+
+    finally:
+        if baseline_file_path.exists():
+            baseline_file_path.unlink()


### PR DESCRIPTION
## Description

fixes: #7486

This fixes an issue where baseline matching only checked the resource and check ID. Because of that, resources with the same name in different directories could be treated as the same finding and get suppressed.
I added the file path to the comparison so only the matching file is suppressed.
I also added a regression test to cover this case.

### Testing
- Reproduced the issue using the provided example.
- Verified that the issue occurs without the fix.
- Verified that only the matching file is suppressed after the fix.
- Ran the new regression test and existing baseline tests successfully.