### PR TITLE
fix(kubernetes): correlate secret rules with resourceNames

### DIFF
--- a/checkov/kubernetes/checks/graph_checks/ReadAllSecrets.yaml
+++ b/checkov/kubernetes/checks/graph_checks/ReadAllSecrets.yaml
@@ -39,28 +39,11 @@ definition:
                 - Role
             - or:
               - cond_type: attribute
-                attribute: rules.resources
-                operator: not_intersects
-                value:
-                  - 'secrets'
-                  - '*'
-                resource_types:
-                  - ClusterRole
-                  - Role
-              - cond_type: attribute
-                attribute: rules.verbs
-                operator: not_intersects
-                value:
-                  - 'get'
-                  - 'watch'
-                  - 'list'
-                  - '*'
-                resource_types:
-                  - ClusterRole
-                  - Role
-              - cond_type: attribute
-                attribute: rules.resourceNames
-                operator: exists
+                attribute: >-
+                  $.rules[?((@.resources[*] == 'secrets' | @.resources[*] == '*') &
+                  (@.verbs[*] == 'get' | @.verbs[*] == 'watch' | @.verbs[*] == 'list' |
+                  @.verbs[*] == '*') & !@.resourceNames)]
+                operator: jsonpath_not_exists
                 resource_types:
                   - ClusterRole
                   - Role

--- a/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Failing/MixedResourceNamesClusterRole.yaml
+++ b/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Failing/MixedResourceNamesClusterRole.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mixed-secret-reader
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - "secrets"
+  verbs:
+    - "get"
+    - "watch"
+    - "list"
+- apiGroups:
+    - ""
+  resources:
+    - "secrets"
+  resourceNames:
+    - "pull-secret"
+  verbs:
+    - "get"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mixed-secrets-global
+subjects:
+- kind: ServiceAccount
+  name: sa1
+roleRef:
+  kind: ClusterRole
+  name: mixed-secret-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/kubernetes/graph/checks/resources/ReadAllSecrets/expected.yaml
+++ b/tests/kubernetes/graph/checks/resources/ReadAllSecrets/expected.yaml
@@ -3,3 +3,4 @@ pass:
   - "RoleBinding.my-namespace.my-role-binding"
 fail:
   - "ClusterRoleBinding.default.read-secrets-global"
+  - "ClusterRoleBinding.default.mixed-secrets-global"


### PR DESCRIPTION
## Summary

Fixes #7616.

`CKV2_K8S_5` previously treated `rules.resourceNames exists` as a role-wide safe condition. That meant a ClusterRole with one unrestricted secrets-read rule and a separate resourceNames-scoped secrets rule could pass, because the scoped rule satisfied the flattened attribute check.

This changes the policy to use a JSONPath condition that looks for the risky case on the same RBAC rule entry: secrets or wildcard resources, read verbs or wildcard verbs, and no `resourceNames`. The check now passes only when no such unscoped rule exists.

## Tests

- `pytest -q tests/kubernetes/graph/checks/test_yaml_policies.py -k ReadAllSecrets`
- `git diff --check`
- `checkov -f tests/kubernetes/graph/checks/resources/ReadAllSecrets/Failing/MixedResourceNamesClusterRole.yaml --framework kubernetes --check CKV2_K8S_5 --quiet`

Note: the CLI smoke scan emitted a local certificate warning while fetching Prisma guideline metadata, but still evaluated the fixture and reported the expected CKV2_K8S_5 failure.

## Risk

Narrow policy-only change with a parser-backed Kubernetes graph regression fixture. Existing safe resourceNames-scoped RoleBinding coverage remains in the same test case.