### PR TITLE
[fast-lane] feat: add CKV_AWS_394 - Ensure DynamoDB table has deletion protection enabled

### DIFF
--- a/checkov/terraform/checks/resource/aws/DynamoDBTableDeletionProtection.py
+++ b/checkov/terraform/checks/resource/aws/DynamoDBTableDeletionProtection.py
@@ -1,0 +1,18 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class DynamoDBTableDeletionProtection(BaseResourceValueCheck):
+
+    def __init__(self):
+        name = "Ensure that DynamoDB table has deletion protection enabled"
+        id = "CKV_AWS_394"
+        supported_resources = ['aws_dynamodb_table']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'deletion_protection_enabled'
+
+
+check = DynamoDBTableDeletionProtection()

--- a/tests/terraform/checks/resource/aws/test_DynamoDBTableDeletionProtection.py
+++ b/tests/terraform/checks/resource/aws/test_DynamoDBTableDeletionProtection.py
@@ -1,0 +1,84 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.aws.DynamoDBTableDeletionProtection import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestDynamoDBTableDeletionProtection(unittest.TestCase):
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+                resource "aws_dynamodb_table" "pass" {
+                    name           = "GameScores"
+                    billing_mode   = "PAY_PER_REQUEST"
+                    hash_key       = "UserId"
+                    range_key      = "GameTitle"
+                    deletion_protection_enabled = true
+
+                    attribute {
+                        name = "UserId"
+                        type = "S"
+                    }
+
+                    attribute {
+                        name = "GameTitle"
+                        type = "S"
+                    }
+                }
+                """)
+        resource_conf = hcl_res['resource'][0]['aws_dynamodb_table']['pass']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+                resource "aws_dynamodb_table" "fail" {
+                    name           = "GameScores"
+                    billing_mode   = "PAY_PER_REQUEST"
+                    hash_key       = "UserId"
+                    range_key      = "GameTitle"
+                    deletion_protection_enabled = false
+
+                    attribute {
+                        name = "UserId"
+                        type = "S"
+                    }
+
+                    attribute {
+                        name = "GameTitle"
+                        type = "S"
+                    }
+                }
+                """)
+        resource_conf = hcl_res['resource'][0]['aws_dynamodb_table']['fail']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_missing_attribute(self):
+        hcl_res = hcl2.loads("""
+                resource "aws_dynamodb_table" "fail_missing" {
+                    name           = "GameScores"
+                    billing_mode   = "PAY_PER_REQUEST"
+                    hash_key       = "UserId"
+                    range_key      = "GameTitle"
+
+                    attribute {
+                        name = "UserId"
+                        type = "S"
+                    }
+
+                    attribute {
+                        name = "GameTitle"
+                        type = "S"
+                    }
+                }
+                """)
+        resource_conf = hcl_res['resource'][0]['aws_dynamodb_table']['fail_missing']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

This PR adds `CKV_AWS_394` — a check that ensures `aws_dynamodb_table` resources have `deletion_protection_enabled` set to `true`.

DynamoDB already has checkov coverage for encryption (`CKV_AWS_119`), point-in-time recovery (`CKV_AWS_28`, `CKV_AWS_165`), and replica CMK usage (`CKV_AWS_271`), but there was no check for deletion protection. Since DynamoDB tables often hold critical application state, accidental or unauthorized deletion without this flag enabled can result in irreversible data loss. AWS has supported `deletion_protection_enabled` on `aws_dynamodb_table` since Terraform AWS provider v4.55.

The check follows the `BaseResourceValueCheck` pattern (same structure as `RDSDeletionProtection` / `CKV_AWS_139`).

## Tests

Three scenarios covered using `hcl2.loads()` per the contribution guidelines:

- `deletion_protection_enabled = true` → PASS
- `deletion_protection_enabled = false` → FAIL
- Attribute missing entirely → FAIL

All tests pass locally and flake8 reports no errors.

## Checklist
- [x] New check follows `BaseResourceValueCheck` pattern  
- [x] Unit tests included (3 scenarios: pass, fail, missing attribute)
- [x] Tests use `hcl2.loads()` per contribution guidelines
- [x] flake8 passes with no errors