### PR TITLE
fix(terraform): CKV_AZURE_249 should flag pull_request OIDC subjects

### DIFF
--- a/checkov/terraform/checks/resource/azure/GithubActionsOIDCTrustPolicy.py
+++ b/checkov/terraform/checks/resource/azure/GithubActionsOIDCTrustPolicy.py
@@ -6,6 +6,12 @@ from checkov.common.util.oidc_utils import gh_abusable_claims, gh_repo_regex
 
 
 class AzureGithubActionsOIDCTrustPolicy(BaseResourceCheck):
+    # Subjects of the form "repo:<org>/<repo>:pull_request" trust tokens minted by
+    # pull_request-triggered workflows, which run proposed changes rather than the
+    # protected default branch. Only the event segment (index 2) is matched, so an
+    # environment or ref that happens to be named "pull_request" is unaffected.
+    GH_PULL_REQUEST_EVENT = "pull_request"
+
     def __init__(self) -> None:
         name = "Ensure Azure GitHub Actions OIDC trust policy is configured securely"
         id = "CKV_AZURE_249"
@@ -39,6 +45,10 @@ class AzureGithubActionsOIDCTrustPolicy(BaseResourceCheck):
             if not gh_repo_regex.match(claim_parts[1]):
                 return False
 
+            # Reject pull_request-triggered subjects
+            if len(claim_parts) > 2 and claim_parts[2] == self.GH_PULL_REQUEST_EVENT:
+                return False
+
         return True
 
     def scan_resource_conf(self, conf: Dict[str, List[Any]]) -> CheckResult:
@@ -65,6 +75,14 @@ class AzureGithubActionsOIDCTrustPolicy(BaseResourceCheck):
 
             # Third check -> repo format
             if split_condition[0] == "repo" and not gh_repo_regex.match(split_condition[1]):
+                return CheckResult.FAILED
+
+            # Fourth check -> pull_request event
+            if (
+                split_condition[0] == "repo"
+                and len(split_condition) > 2
+                and split_condition[2] == self.GH_PULL_REQUEST_EVENT
+            ):
                 return CheckResult.FAILED
 
             return CheckResult.PASSED

--- a/tests/terraform/checks/resource/azure/example_GithubActionsOIDCTrustPolicy/main.tf
+++ b/tests/terraform/checks/resource/azure/example_GithubActionsOIDCTrustPolicy/main.tf
@@ -35,6 +35,26 @@ resource "azuread_application_federated_identity_credential" "pass_special_chars
   subject             = "repo:${var.github_organisation_target}/${github_repository.project.name}:environment:${var.environment}"
 }
 
+# pass_environment_named_pull_request - "pull_request" here is an environment NAME,
+# not the pull_request event, so it must still pass
+resource "azuread_application_federated_identity_credential" "pass_environment_named_pull_request" {
+  application_object_id = "example-app-id"
+  display_name         = "github-actions-oidc"
+  audiences           = ["api://AzureADTokenExchange"]
+  issuer              = "https://token.actions.githubusercontent.com"
+  subject             = "repo:myOrg/myRepo:environment:pull_request"
+}
+
+# fail_pull_request - trusts pull_request-triggered workflows, which run proposed
+# (unreviewed, potentially fork) code
+resource "azuread_application_federated_identity_credential" "fail_pull_request" {
+  application_object_id = "example-app-id"
+  display_name         = "github-actions-oidc"
+  audiences           = ["api://AzureADTokenExchange"]
+  issuer              = "https://token.actions.githubusercontent.com"
+  subject             = "repo:myOrg/myRepo:pull_request"
+}
+
 # fail1 - Missing subject
 resource "azuread_application_federated_identity_credential" "fail1" {
   application_object_id = "example-app-id"

--- a/tests/terraform/checks/resource/azure/test_GithubActionsOIDCTrustPolicy.py
+++ b/tests/terraform/checks/resource/azure/test_GithubActionsOIDCTrustPolicy.py
@@ -19,12 +19,14 @@ class TestAzureGithubActionsOIDCTrustPolicy(unittest.TestCase):
             "azuread_application_federated_identity_credential.pass2",
             "azuread_application_federated_identity_credential.pass4",
             "azuread_application_federated_identity_credential.pass_special_chars",
+            "azuread_application_federated_identity_credential.pass_environment_named_pull_request",
         }
         failing_resources = {
             "azuread_application_federated_identity_credential.fail1",
             "azuread_application_federated_identity_credential.fail2",
             "azuread_application_federated_identity_credential.fail3",
             "azuread_application_federated_identity_credential.fail5",
+            "azuread_application_federated_identity_credential.fail_pull_request",
         }
 
         passed_check_resources = set([c.resource for c in report.passed_checks])


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

`CKV_AZURE_249` currently passes a federated identity credential whose subject is `repo:<org>/<repo>:pull_request`.

That subject matches tokens minted by **`pull_request`-triggered workflow runs** — runs that execute a *proposed* change rather than the protected default branch. GitHub's security-hardening guidance treats the `pull_request` subject as a distinct, broader trust surface for exactly this reason: the code that runs during a pull request has not necessarily been reviewed or merged, and on public repositories it can originate from a fork.

Since an Azure FIC subject is an exact string match, a credential written this way trusts every pull-request run of that repository. The check inspects the subject closely enough to reject wildcards and abusable leading claims, so this seemed like a gap in the same family rather than an intentional allowance.

### Change

One additional comparison in `scan_resource_conf`, after the existing repo-format check:

```python
# Fourth check -> pull_request event
if (
    split_condition[0] == "repo"
    and len(split_condition) > 2
    and split_condition[2] == self.GH_PULL_REQUEST_EVENT
):
    return CheckResult.FAILED
```

It matches only the **event segment** (index 2) of a `repo:` subject, so it is deliberately narrow:

| Subject | Before | After |
|---|---|---|
| `repo:myOrg/myRepo:pull_request` | PASSED | **FAILED** |
| `repo:myOrg/myRepo:environment:pull_request` | PASSED | PASSED (environment *named* `pull_request`) |
| `repo:myOrg/pull_request:ref:refs/heads/x` | PASSED | PASSED (repo *named* `pull_request`) |
| `repo:myOrg/myRepo:ref:refs/heads/main` | PASSED | PASSED |
| `repo:myOrg/myRepo:environment:Production` | PASSED | PASSED |
| `repo:*`, `*`, `workflow:...` | FAILED | FAILED |

No other check or shared helper is touched, so `CKV_AWS_358` / `CKV_AWS_393` / `CKV_GCP_125` are unaffected (their suites pass unchanged).

### Tests

Two fixtures: `fail_pull_request` (the flagged subject) and `pass_environment_named_pull_request`, which pins the precision boundary so a later broadened match would fail the suite.

References:
- GitHub — security hardening with OpenID Connect (subject claim / `pull_request`): https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
- Microsoft Entra — workload identity federation considerations (FIC subject is an exact match): https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-considerations

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes

---

Two things I noticed while working in this file and left alone, in case they are of interest:

1. `validate_subject_claim` appears to be unused — `scan_resource_conf` re-implements the same sequence inline, and I could not find a caller. I mirrored the new condition into both so they do not drift further, but would removing it (or having `scan_resource_conf` call it) be preferable?

2. The check registers only `azuread_application_federated_identity_credential`. The AzureAD provider added `azuread_application_flexible_federated_identity_credential` in 3.7, where matching moves to a `claims_matching_expression` and the `matches` operator honours `*` — so `claims['sub'] matches 'repo:org/*'` there really does admit the whole org, unlike a classic FIC subject where `*` is an inert literal. Is flexible FIC out of scope by design, or would a follow-up covering that resource be welcome?

---

Note on overlap: #7610 (immutable OIDC subject IDs) adds a fixture to the same two Azure test files, so whichever of the two lands first will leave the other with a small fixture-level conflict. The changes are independent — that one widens `gh_repo_regex`, this one adds an event-segment comparison — and I am happy to rebase whichever comes second.
