### PR TITLE
fix(terraform): prevent errors with rule_no for non-int cases

### DIFF
--- a/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
+++ b/checkov/terraform/checks/resource/aws/AbsNACLUnrestrictedIngress.py
@@ -1,5 +1,14 @@
 from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.common.util.type_forcers import force_int
 from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+def _rule_no_sort_key(rule):
+    rule_no = rule.get('rule_no')
+    if isinstance(rule_no, list):
+        rule_no = rule_no[0] if rule_no else None
+    rule_no = force_int(rule_no)
+    return (0, rule_no) if rule_no is not None else (1, 0)
 
 
 class AbsNACLUnrestrictedIngress(BaseResourceCheck):
@@ -35,9 +44,9 @@ class AbsNACLUnrestrictedIngress(BaseResourceCheck):
                 if isinstance(entry, list):
                     entry = ingress[0]
                     if isinstance(entry, dict) and entry.get('rule_no'):
-                        ingress[0].sort(key=lambda x: x.get('rule_no'))
+                        ingress[0].sort(key=_rule_no_sort_key)
                 elif isinstance(ingress[0], dict) and ingress[0].get('rule_no'):
-                    ingress.sort(key=lambda x: x.get('rule_no'))
+                    ingress.sort(key=_rule_no_sort_key)
 
             for rule in ingress:
                 rule_lst = rule

--- a/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress22/main.tf
+++ b/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress22/main.tf
@@ -405,3 +405,59 @@ resource "aws_network_acl_rule" "unknown2" {
   from_port      = 80
   to_port        = 80
 }
+
+resource "aws_network_acl" "mixed_rule_no_types" {
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = "800" # string
+    action     = "deny"
+    cidr_block = "10.0.0.0/8"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 900 # int
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+}
+
+resource "aws_network_acl" "dynamic_rule_no" {
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 204
+    action     = "allow"
+    cidr_block = "10.0.5.0/24"
+    from_port  = 22
+    to_port    = 22
+  }
+
+  dynamic "ingress" {
+    for_each = { for idx, cidr in var.peered_cidr_blocks : idx => cidr }
+    content {
+      protocol   = "tcp"
+      rule_no    = 220 + tonumber(ingress.key)
+      action     = "allow"
+      cidr_block = ingress.value
+      from_port  = 22
+      to_port    = 22
+    }
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 213
+    action     = "deny"
+    cidr_block = "10.0.0.0/16"
+    from_port  = 0
+    to_port    = 0
+  }
+}

--- a/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress22/variables.tf
+++ b/tests/terraform/checks/resource/aws/example_NetworkACLUnrestrictedIngress22/variables.tf
@@ -1,0 +1,5 @@
+
+variable "peered_cidr_blocks" {
+  type    = list(string)
+  default = []
+}

--- a/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress22.py
+++ b/tests/terraform/checks/resource/aws/test_NetworkACLUnrestrictedIngress22.py
@@ -21,6 +21,7 @@ class TestNetworkACLUnrestrictedIngress22(unittest.TestCase):
             "aws_network_acl.pass",
             "aws_network_acl.pass2",
             "aws_network_acl.pass3",
+            "aws_network_acl.dynamic_rule_no",
             "aws_network_acl_rule.pass",
             "aws_network_acl_rule.pass2",
             "aws_network_acl_rule.pass3"
@@ -30,6 +31,7 @@ class TestNetworkACLUnrestrictedIngress22(unittest.TestCase):
             "aws_network_acl.fail2",
             "aws_network_acl.fail3",
             "aws_network_acl.fail4",
+            "aws_network_acl.mixed_rule_no_types",
             "aws_network_acl_rule.fail",
             "aws_network_acl_rule.fail2",
             "aws_network_acl_rule.public_ingress",


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Experiencing the same issue that Checkov throws on dynamic NACL blocks with rule_no of non integer (or integer + variable).
The fix is maintiang the sort similar to how it was suggested by the maintainer in the issue, perform relevant checks and uses `force_int()` to get the rule_no and otherwise, push the dynamic values to the end of the order.

Fixes #5893


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
