### PR TITLE
fix(kubernetes): report unparsable YAML files as parsing errors

### DIFF
--- a/checkov/kubernetes/kubernetes_utils.py
+++ b/checkov/kubernetes/kubernetes_utils.py
@@ -41,7 +41,7 @@ def should_include_path(full_path: str, ignore_hidden_dir: bool) -> bool:
 
 
 def get_folder_definitions(
-        root_folder: str, excluded_paths: list[str] | None
+        root_folder: str, excluded_paths: list[str] | None, out_parsing_errors: dict[str, str] | None = None
 ) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[tuple[int, str]]]]:
     files_list = []
     for root, d_names, f_names in os.walk(root_folder):
@@ -55,24 +55,33 @@ def get_folder_definitions(
                 if should_include_path(full_path, env_vars_config.IGNORE_HIDDEN_DIRECTORIES):
                     # skip temp directories
                     files_list.append(full_path)
-    return get_files_definitions(files_list)
+    return get_files_definitions(files_list, out_parsing_errors)
 
 
-def get_files_definitions(files: list[str]) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[tuple[int, str]]]]:
+def get_files_definitions(
+    files: list[str], out_parsing_errors: dict[str, str] | None = None
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[tuple[int, str]]]]:
     definitions = {}
     definitions_raw = {}
     results = parallel_runner.run_function(_parse_file, files)
     for result in results:
         if result:
-            path, parse_result = result
+            path, parse_result, file_parsing_errors = result
+            if file_parsing_errors and out_parsing_errors is not None:
+                out_parsing_errors.update(file_parsing_errors)
             if parse_result:
                 definitions[path], definitions_raw[path] = parse_result
     return definitions, definitions_raw
 
 
-def _parse_file(filename: str) -> tuple[str, tuple[list[dict[str, Any]], list[tuple[int, str]]] | None] | None:
+def _parse_file(
+    filename: str,
+) -> tuple[str, tuple[list[dict[str, Any]], list[tuple[int, str]]] | None, dict[str, str]] | None:
+    # the parsing errors are collected per file and merged by the caller,
+    # because the parsing itself may run in a separate process
+    parsing_errors: dict[str, str] = {}
     try:
-        return filename, parse(filename)
+        return filename, parse(filename, out_parsing_errors=parsing_errors), parsing_errors
     except (TypeError, ValueError):
         logging.warning(f"Kubernetes skipping {filename} as it is not a valid Kubernetes template", exc_info=True)
 
@@ -117,15 +126,21 @@ def create_definitions(
     root_folder: str | None,
     files: list[str] | None = None,
     runner_filter: RunnerFilter | None = None,
+    out_parsing_errors: dict[str, str] | None = None,
 ) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[tuple[int, str]]]]:
     runner_filter = runner_filter or RunnerFilter()
     definitions: dict[str, list[dict[str, Any]]] = {}
     definitions_raw: dict[str, list[tuple[int, str]]] = {}
     if files:
-        definitions, definitions_raw = get_files_definitions(files)
+        definitions, definitions_raw = get_files_definitions(files, out_parsing_errors)
 
     if root_folder:
-        definitions, definitions_raw = get_folder_definitions(root_folder, runner_filter.excluded_paths)
+        definitions, definitions_raw = get_folder_definitions(
+            root_folder, runner_filter.excluded_paths, out_parsing_errors
+        )
+
+    if out_parsing_errors:
+        logging.warning(f"[kubernetes] found errors while parsing definitions: {list(out_parsing_errors.keys())}")
 
     return definitions, definitions_raw
 

--- a/checkov/kubernetes/parser/parser.py
+++ b/checkov/kubernetes/parser/parser.py
@@ -14,7 +14,9 @@ logger = logging.getLogger(__name__)
 add_resource_code_filter_to_logger(logger)
 
 
-def parse(filename: str) -> tuple[list[dict[str, Any]], list[tuple[int, str]]] | None:
+def parse(
+    filename: str, out_parsing_errors: dict[str, str] | None = None
+) -> tuple[list[dict[str, Any]], list[tuple[int, str]]] | None:
     template = None
     template_lines: "list[tuple[int, str]]" = []
     valid_templates = []
@@ -50,9 +52,11 @@ def parse(filename: str) -> tuple[list[dict[str, Any]], list[tuple[int, str]]] |
     except UnicodeDecodeError:
         logger.error('Cannot read file contents: %s', filename)
         return None
-    except YAMLError:
+    except YAMLError as e:
         if filename.endswith(".yaml") or filename.endswith(".yml"):
             logger.debug('Cannot read file contents: %s - is it a yaml?', filename)
+            if out_parsing_errors is not None:
+                out_parsing_errors[filename] = str(e)
         return None
 
     return valid_templates, template_lines

--- a/checkov/kubernetes/runner.py
+++ b/checkov/kubernetes/runner.py
@@ -95,7 +95,10 @@ class Runner(ImageReferencerMixin[None], BaseRunner[_KubernetesDefinitions, _Kub
         report = Report(self.check_type)
         if self.context is None or self.definitions is None:
             if files or root_folder:
-                self.definitions, self.definitions_raw = create_definitions(root_folder, files, runner_filter)
+                parsing_errors: dict[str, str] = {}
+                self.definitions, self.definitions_raw = create_definitions(root_folder, files, runner_filter,
+                                                                            parsing_errors)
+                report.add_parsing_errors(parsing_errors.keys())
             else:
                 return report
             if external_checks_dir:

--- a/tests/kubernetes/runner/test_runner.py
+++ b/tests/kubernetes/runner/test_runner.py
@@ -1,9 +1,11 @@
 import dis
 import inspect
 import os
+import tempfile
 import unittest
 from collections import defaultdict
 from pathlib import Path
+from unittest import mock
 
 from parameterized import parameterized_class
 
@@ -13,6 +15,7 @@ from checkov.common.checks_infra.registry import get_graph_checks_registry
 from checkov.common.graph.db_connectors.networkx.networkx_db_connector import NetworkxConnector
 from checkov.common.graph.db_connectors.rustworkx.rustworkx_db_connector import RustworkxConnector
 from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.common.util.consts import PARSE_ERROR_FAIL_FLAG
 from checkov.kubernetes.checks.resource.base_spec_check import BaseK8Check
 from checkov.runner_filter import RunnerFilter
 from checkov.kubernetes.runner import Runner
@@ -177,6 +180,44 @@ class TestRunnerValid(unittest.TestCase):
             self.assertGreater(len(report.failed_checks) + len(report.passed_checks), 0)
         except Exception:
             self.assertTrue(False, "Could not run K8 runner on configuration")
+
+    def test_unparsable_file_is_reported_as_parsing_error(self):
+        # a single '=' is a valid YAML value, but the safe loader can't construct it,
+        # so the file used to be skipped without any indication in the report
+        invalid_template = (
+            "apiVersion: v1\n"
+            "kind: Service\n"
+            "metadata:\n"
+            "  name: test\n"
+            "  labels:\n"
+            "    test: =\n"
+            "spec:\n"
+            "  selector:\n"
+            "    app: test\n"
+            "  ports:\n"
+            "  - port: 8080\n"
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            scan_file_path = os.path.join(tmp_dir, "service.yaml")
+            with open(scan_file_path, "w") as f:
+                f.write(invalid_template)
+
+            runner = Runner(db_connector=self.db_connector())
+            report = runner.run(root_folder=None, external_checks_dir=None, files=[scan_file_path],
+                                runner_filter=RunnerFilter(framework=['kubernetes']))
+
+        self.assertEqual(report.parsing_errors, [scan_file_path])
+        self.assertEqual(report.get_summary()["parsing_errors"], 1)
+        self.assertEqual(len(report.passed_checks), 0)
+        self.assertEqual(len(report.failed_checks), 0)
+
+        # the file is now part of the report, so 'CKV_PARSE_ERROR_FAIL' can act on it
+        exit_code_thresholds = {'soft_fail': False, 'soft_fail_checks': [], 'soft_fail_threshold': None,
+                                'hard_fail_checks': [], 'hard_fail_threshold': None}
+        self.assertEqual(report.get_exit_code(exit_code_thresholds), 0)
+        with mock.patch.dict(os.environ, {PARSE_ERROR_FAIL_FLAG: "true"}):
+            self.assertEqual(report.get_exit_code(exit_code_thresholds), 1)
 
     def test_record_includes_severity(self):
         custom_check_id = "CKV_MY_CUSTOM_CHECK"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

A Kubernetes manifest that cannot be loaded is currently dropped from the scan without appearing anywhere in the report, so a scan that examined nothing looks exactly like a clean scan.

Reproducer from the issue — a `Service` with a single `=` as a label value. It is valid YAML, but `SafeLoader` has no constructor for the `tag:yaml.org,2002:value` tag that `=` resolves to, so loading raises a `ConstructorError`:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: test
  labels:
    test: =
spec:
  selector:
    app: test
  ports:
  - port: 8080
```

Before this change (the same file without the label fails `CKV_K8S_21`):

```console
$ checkov --framework kubernetes -f unsafe.yaml -o json --compact
{ "passed": 0, "failed": 0, "skipped": 0, "parsing_errors": 0, "resource_count": 0, ... }
$ echo $?
0
```

After this change:

```console
$ checkov --framework kubernetes -f unsafe.yaml -o json --compact
[WARNI]  [kubernetes] found errors while parsing definitions: ['unsafe.yaml']
{
    "results": { ..., "parsing_errors": ["unsafe.yaml"] },
    "summary": { "passed": 0, "failed": 0, "skipped": 0, "parsing_errors": 1, "resource_count": 0, ... }
}

$ CKV_PARSE_ERROR_FAIL=true checkov --framework kubernetes -f unsafe.yaml --compact
Passed checks: 0, Failed checks: 0, Skipped checks: 0, Parsing errors: 1
Error parsing file unsafe.yaml
$ echo $?
1
```

### Root cause

`checkov/kubernetes/parser/parser.py` catches `YAMLError`, logs it at `debug` level and returns `None`. `kubernetes_utils.get_files_definitions` then discards that `None` without recording anything, and the Kubernetes runner — unlike the ARM, Bicep, CloudFormation and Terraform runners — never calls `report.add_parsing_errors()`. The result is that `parsing_errors` stays `0` and the skipped file is invisible in every output format.

### Fix

Collect the YAML error while parsing and report it, following the existing convention in the other frameworks:

* `parse()` takes an optional `out_parsing_errors` mapping and records the error message for the file.
* `_parse_file` returns the errors it collected instead of writing to a shared mapping, because parsing runs through `parallel_runner` and may happen in a separate process. `get_files_definitions` merges them for the caller.
* `get_folder_definitions` / `get_files_definitions` / `create_definitions` accept an optional `out_parsing_errors` argument, so existing callers are unaffected, and `create_definitions` logs an aggregated warning like the ARM and Bicep utils do.
* `Runner.run` passes a mapping down and calls `report.add_parsing_errors(...)`, matching `cloudformation/runner.py`.

Because the file is now part of the report, the existing `CKV_PARSE_ERROR_FAIL` flag makes such a scan exit non-zero, which is what the issue asks for. The default exit code is deliberately left unchanged to avoid breaking existing pipelines.

This also covers Helm and Kustomize, since those runners scan their rendered output through the Kubernetes runner.

Fixes #7453

## Testing

```console
$ python -m pytest tests/kubernetes -q
9 failed, 251 passed, 4 errors
```

The 9 failures and 4 errors are identical to those on an unmodified checkout (verified by stashing the change and re-running): they are Windows-specific path-separator assertions, a UTF-8 BOM test, and a pre-existing collection error in `test_yaml_policies.py`. The 2 additional passes are the new test under both graph connectors.

* `tests/kubernetes/runner/test_runner.py::test_unparsable_file_is_reported_as_parsing_error` — asserts the file is listed in `report.parsing_errors`, that `summary["parsing_errors"] == 1`, that no checks are reported for it, and that `get_exit_code` returns `0` normally but `1` with `CKV_PARSE_ERROR_FAIL` set. It fails without the fix (`Lists differ: [] != ['.../service.yaml']`).
* `python -m pytest tests/helm tests/kustomize -q` → `3 failed, 26 passed, 19 skipped`; the 3 failures are `signal.SIGALRM` not existing on Windows and are unrelated.
* `python -m flake8 checkov/kubernetes/ tests/kubernetes/runner/test_runner.py` → clean.
* `python -m mypy --config-file mypy.ini checkov/kubernetes/` → 11 errors, the same 11 as on an unmodified checkout.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
