### PR TITLE
fix(serverless): report unparsable serverless files as parsing errors

### DIFF
--- a/checkov/serverless/parsers/parser.py
+++ b/checkov/serverless/parsers/parser.py
@@ -35,7 +35,9 @@ QUOTED_WORD_SYNTAX = re.compile(r"(?:('|\").*?\1)")
 FILE_LOCATION_PATTERN = re.compile(r'^file\(([^?%*:|"<>]+?)\)')
 
 
-def parse(filename: str) -> tuple[dict[str, Any], list[tuple[int, str]]] | None:
+def parse(
+    filename: str, out_parsing_errors: dict[str, str] | None = None
+) -> tuple[dict[str, Any], list[tuple[int, str]]] | None:
     template = None
     template_lines = None
 
@@ -57,6 +59,8 @@ def parse(filename: str) -> tuple[dict[str, Any], list[tuple[int, str]]] | None:
         return None
     except CfnParseError as e:
         logger.warning(f"Failed to parse file {e.filename} because it isn't valid yaml")
+        if out_parsing_errors is not None:
+            out_parsing_errors[filename] = str(e)
         return None
 
     if template is None or template_lines is None:

--- a/checkov/serverless/runner.py
+++ b/checkov/serverless/runner.py
@@ -108,7 +108,9 @@ class Runner(BaseRunner[_ServerlessDefinitions, _ServerlessContext, ServerlessGr
             if self.root_folder:
                 files_list = get_scannable_file_paths(self.root_folder, runner_filter.excluded_paths)
 
-            definitions, definitions_raw = get_files_definitions(files_list, filepath_fn)
+            parsing_errors: dict[str, str] = {}
+            definitions, definitions_raw = get_files_definitions(files_list, filepath_fn, parsing_errors)
+            report.add_parsing_errors(parsing_errors.keys())
 
             # Filter out empty files that have not been parsed successfully
             self.definitions = {k: v for k, v in definitions.items() if v}

--- a/checkov/serverless/utils.py
+++ b/checkov/serverless/utils.py
@@ -73,12 +73,15 @@ def get_scannable_file_paths(root_folder: str | None = None, excluded_paths: lis
 
 
 def get_files_definitions(
-        files: list[str], filepath_fn: Callable[[str], str] | None = None
+        files: list[str], filepath_fn: Callable[[str], str] | None = None,
+        out_parsing_errors: dict[str, str] | None = None
 ) -> tuple[dict[str, dict[str, Any]], dict[str, list[tuple[int, str]]]]:
     results = parallel_runner.run_function(_parallel_parse, files)
     definitions = {}
     definitions_raw = {}
-    for file, result in results:
+    for file, result, file_parsing_errors in results:
+        if file_parsing_errors and out_parsing_errors is not None:
+            out_parsing_errors.update(file_parsing_errors)
         if result:
             path = filepath_fn(file) if filepath_fn else file
             definitions[path], definitions_raw[path] = result
@@ -86,9 +89,14 @@ def get_files_definitions(
     return definitions, definitions_raw
 
 
-def _parallel_parse(f: str) -> tuple[str, tuple[dict[str, Any], list[tuple[int, str]]] | None]:
+def _parallel_parse(
+    f: str,
+) -> tuple[str, tuple[dict[str, Any], list[tuple[int, str]]] | None, dict[str, str]]:
     """Thin wrapper to return filename with parsed content"""
-    return f, parse(f)
+    # the parsing errors are collected per file and merged by the caller,
+    # because the parsing itself may run in a separate process
+    parsing_errors: dict[str, str] = {}
+    return f, parse(f, out_parsing_errors=parsing_errors), parsing_errors
 
 
 def get_resource_tags(entity: EntityDetails, registry: ServerlessRegistry = sls_registry) -> Optional[dict[str, str]]:

--- a/tests/serverless/runner/test_runner.py
+++ b/tests/serverless/runner/test_runner.py
@@ -1,15 +1,18 @@
 import dis
 import inspect
 import os
+import tempfile
 import unittest
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, Any
+from unittest import mock
 
 from checkov.cloudformation.checks.resource.aws import *  # noqa - prevent circular import
 from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.bridgecrew.severities import Severities, BcSeverities
 from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.common.util.consts import PARSE_ERROR_FAIL_FLAG
 from checkov.runner_filter import RunnerFilter
 from checkov.serverless.checks.function.base_function_check import BaseFunctionCheck
 from checkov.serverless.runner import Runner
@@ -143,6 +146,41 @@ class TestRunnerValid(unittest.TestCase):
         for record in all_checks:
             # no need to join with a '/' because the CFN runner adds it to the start of the file path
             self.assertEqual(record.repo_file_path, f'/{file_rel_path}')
+
+    def test_unparsable_file_is_reported_as_parsing_error(self):
+        # a single '=' is a valid YAML value, but the loader can't construct it,
+        # so the file used to be skipped without any indication in the report
+        invalid_template = (
+            "provider:\n"
+            "  name: aws\n"
+            "  tags:\n"
+            "    test: =\n"
+            "functions:\n"
+            "  hello:\n"
+            "    handler: handler.hello\n"
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            scan_file_path = os.path.join(tmp_dir, "serverless.yml")
+            with open(scan_file_path, "w") as f:
+                f.write(invalid_template)
+
+            report = Runner().run(
+                root_folder=None, files=[scan_file_path], external_checks_dir=None,
+                runner_filter=RunnerFilter(framework=['serverless'])
+            )
+
+        self.assertEqual(report.parsing_errors, [scan_file_path])
+        self.assertEqual(report.get_summary()["parsing_errors"], 1)
+        self.assertEqual(len(report.passed_checks), 0)
+        self.assertEqual(len(report.failed_checks), 0)
+
+        # the file is now part of the report, so 'CKV_PARSE_ERROR_FAIL' can act on it
+        exit_code_thresholds = {'soft_fail': False, 'soft_fail_checks': [], 'soft_fail_threshold': None,
+                                'hard_fail_checks': [], 'hard_fail_threshold': None}
+        self.assertEqual(report.get_exit_code(exit_code_thresholds), 0)
+        with mock.patch.dict(os.environ, {PARSE_ERROR_FAIL_FLAG: "true"}):
+            self.assertEqual(report.get_exit_code(exit_code_thresholds), 1)
 
     def test_wrong_check_imports(self):
         wrong_imports = ["arm", "cloudformation", "dockerfile", "helm", "kubernetes", "terraform"]


### PR DESCRIPTION
## Description

A `serverless.yml` that fails to parse is dropped from the scan without appearing anywhere in the report, so a scan that examined nothing looks the same as a clean scan.

`checkov/serverless/parsers/parser.py` catches `CfnParseError`, logs a warning and returns `None`. `serverless/utils.py::get_files_definitions` then discards that `None` without recording anything, and `serverless/runner.py` never calls `report.add_parsing_errors()` — unlike the ARM, Bicep, CloudFormation and Terraform runners.

Reproducer — a `serverless.yml` whose provider tag value is a single `=` (valid YAML, but the loader has no constructor for the `tag:yaml.org,2002:value` it resolves to):

```yaml
provider:
  name: aws
  tags:
    test: =
functions:
  hello:
    handler: handler.hello
```

Before:

```console
$ checkov --framework serverless -f serverless.yml -o json --compact
[WARNI]  Failed to parse file serverless.yml because it isn't valid yaml
{ "passed": 0, "failed": 0, "parsing_errors": 0, "resource_count": 0, ... }
$ echo $?
0
```

After:

```console
$ checkov --framework serverless -f serverless.yml -o json --compact
{
    "results": { ..., "parsing_errors": ["serverless.yml"] },
    "summary": { "passed": 0, "failed": 0, "parsing_errors": 1, ... }
}

$ CKV_PARSE_ERROR_FAIL=true checkov --framework serverless -f serverless.yml --compact
Passed checks: 0, Failed checks: 0, Skipped checks: 0, Parsing errors: 1
Error parsing file serverless.yml
$ echo $?
1
```

The warning was already logged, so this is not about visibility in a terminal — it is about the file being absent from the machine-readable report, which is what CI consumes, and about `CKV_PARSE_ERROR_FAIL` having nothing to act on.

Note serverless files are pre-filtered by `SLS_FILE_MASK` before parsing, so a parse failure here always means "a serverless file that could not be read", never "a file that belongs to another framework".

## Fix

Follows the existing convention, with an optional `out_parsing_errors` argument so no caller signature breaks:

* `parsers/parser.py::parse` records the error message for the file on `CfnParseError`.
* `_parallel_parse` returns the errors it collected rather than writing to a shared mapping, because parsing goes through `parallel_runner` and may run in a separate process; `get_files_definitions` merges them for the caller.
* `runner.py` passes a mapping down and calls `report.add_parsing_errors(...)`, matching `cloudformation/runner.py`.

This is the same gap I fixed for the Kubernetes runner in #7630; serverless was the remaining one in that family. The two PRs are independent but share a rationale, so they may be easiest to review together.

## Testing

```console
$ python -m pytest tests/serverless -q
5 failed, 48 passed
```

Baseline on an unmodified checkout is `5 failed, 47 passed` with the identical five failures — Windows-only path assertions in `test_runner.py` (`test_record_relative_path_*`) plus `test_AdminPolicyDocument::test_summary`. None are in the code touched here.

Added `test_unparsable_file_is_reported_as_parsing_error`, which asserts the file is listed in `report.parsing_errors`, that `summary["parsing_errors"] == 1`, that no checks are reported for it, and that `get_exit_code` returns `0` normally but `1` with `CKV_PARSE_ERROR_FAIL` set. It fails without the fix:

```
AssertionError: Lists differ: [] != ['...\\serverless.yml']
```

Also verified a valid `serverless.yml` is unaffected — still `3 passed, 0 parsing_errors`.

* `flake8 checkov/serverless tests/serverless/runner/test_runner.py` — clean.
* `mypy --config-file mypy.ini checkov/serverless` — 6 errors before and after; comparing the two lists with line numbers stripped shows they are identical, so no new type errors.
