### PR TITLE
fix(aws): accept aws:kms:dsse as valid S3 server-side encryption

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/S3Encryption.py
+++ b/checkov/cloudformation/checks/resource/aws/S3Encryption.py
@@ -19,7 +19,7 @@ class S3Encryption(BaseResourceValueCheck):
         return 'AES256'
 
     def get_expected_values(self):
-        return [self.get_expected_value(), 'aws:kms']
+        return [self.get_expected_value(), 'aws:kms', 'aws:kms:dsse']
 
 
 check = S3Encryption()

--- a/checkov/cloudformation/graph_builder/graph_components/generic_resource_encryption.py
+++ b/checkov/cloudformation/graph_builder/graph_components/generic_resource_encryption.py
@@ -83,6 +83,7 @@ ENCRYPTION_BY_RESOURCE_TYPE: dict[str, GenericResourceEncryption] = {
         {
             "BucketEncryption.ServerSideEncryptionConfiguration.ServerSideEncryptionByDefault.SSEAlgorithm": [
                 EncryptionTypes.AWS_KMS_VALUE.value,
+                EncryptionTypes.AWS_KMS_DSSE_VALUE.value,
                 EncryptionTypes.AES256.value,
             ],
             "server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.KMSMasterKeyID": get_empty_list_str(),

--- a/checkov/common/graph/graph_builder/graph_components/attribute_names.py
+++ b/checkov/common/graph/graph_builder/graph_components/attribute_names.py
@@ -54,3 +54,4 @@ class EncryptionTypes(str, Enum):
     DEFAULT_KMS = "Default KMS"
     AES256 = "AES256"
     AWS_KMS_VALUE = "aws:kms"
+    AWS_KMS_DSSE_VALUE = "aws:kms:dsse"

--- a/checkov/terraform/checks/graph_checks/aws/S3BucketEncryption.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/S3BucketEncryption.yaml
@@ -11,6 +11,7 @@ definition:
       operator: within
       value:
         - "aws:kms"
+        - "aws:kms:dsse"
         - "AES256"
     - and:
       - cond_type: filter
@@ -48,4 +49,5 @@ definition:
         operator: within
         value:
           - "aws:kms"
+          - "aws:kms:dsse"
           - "AES256"

--- a/checkov/terraform/checks/graph_checks/aws/S3KMSEncryptedByDefault.yaml
+++ b/checkov/terraform/checks/graph_checks/aws/S3KMSEncryptedByDefault.yaml
@@ -8,8 +8,10 @@ definition:
       resource_types:
         - aws_s3_bucket
       attribute: server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm
-      operator: equals
-      value: "aws:kms"
+      operator: within
+      value:
+        - "aws:kms"
+        - "aws:kms:dsse"
     - and:
       - cond_type: filter
         attribute: resource_type
@@ -26,5 +28,7 @@ definition:
         resource_types:
           - aws_s3_bucket_server_side_encryption_configuration
         attribute: rule.apply_server_side_encryption_by_default.sse_algorithm
-        operator: equals
-        value: "aws:kms"
+        operator: within
+        value:
+          - "aws:kms"
+          - "aws:kms:dsse"

--- a/checkov/terraform/graph_builder/graph_components/generic_resource_encryption.py
+++ b/checkov/terraform/graph_builder/graph_components/generic_resource_encryption.py
@@ -111,6 +111,7 @@ ENCRYPTION_BY_RESOURCE_TYPE: Dict[str, Any] = {
         {
             "server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm": [
                 EncryptionTypes.AWS_KMS_VALUE.value,
+                EncryptionTypes.AWS_KMS_DSSE_VALUE.value,
                 EncryptionTypes.AES256.value,
             ],
             "server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.kms_master_key_id": get_empty_list_str(),

--- a/tests/cloudformation/checks/resource/aws/example_S3EncryptionDsse/DsseKms.yaml
+++ b/tests/cloudformation/checks/resource/aws/example_S3EncryptionDsse/DsseKms.yaml
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  PassDsseKms:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              KMSMasterKeyID: String
+              SSEAlgorithm: aws:kms:dsse
+  PassKms:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              KMSMasterKeyID: String
+              SSEAlgorithm: aws:kms
+  PassAes256:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+  FailUnknownAlgorithm:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms:dss

--- a/tests/cloudformation/checks/resource/aws/test_S3Encryption.py
+++ b/tests/cloudformation/checks/resource/aws/test_S3Encryption.py
@@ -21,6 +21,30 @@ class TestS3Versioning(unittest.TestCase):
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
+    def test_dsse_kms(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_S3EncryptionDsse"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            "AWS::S3::Bucket.PassDsseKms",
+            "AWS::S3::Bucket.PassKms",
+            "AWS::S3::Bucket.PassAes256",
+        }
+        failing_resources = {
+            "AWS::S3::Bucket.FailUnknownAlgorithm",
+        }
+
+        self.assertEqual(summary['passed'], 3)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+        self.assertEqual(passing_resources, {c.resource for c in report.passed_checks})
+        self.assertEqual(failing_resources, {c.resource for c in report.failed_checks})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/terraform/graph/checks/resources/S3BucketEncryption/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3BucketEncryption/expected.yaml
@@ -5,6 +5,8 @@ pass:
   - "aws_s3_bucket.bucket_good_5"
   - "aws_s3_bucket.bucket_good_6"
   - "aws_s3_bucket.default_encryption_bucket"
+  - "aws_s3_bucket.bucket_good_dsse_inline"
+  - "aws_s3_bucket.bucket_good_dsse_sse"
 fail:
   - "aws_s3_bucket.bucket_bad_2"
   - "aws_s3_bucket.bucket_bad_3"

--- a/tests/terraform/graph/checks/resources/S3BucketEncryption/main.tf
+++ b/tests/terraform/graph/checks/resources/S3BucketEncryption/main.tf
@@ -193,3 +193,31 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bad_sse_3" {
     }
   }
 }
+
+resource "aws_s3_bucket" "bucket_good_dsse_inline" {
+  bucket = "bucket_good_dsse_inline"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.mykey.arn
+        sse_algorithm     = "aws:kms:dsse"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket" "bucket_good_dsse_sse" {
+  bucket = "bucket_good_dsse_sse"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "good_sse_dsse" {
+  bucket = aws_s3_bucket.bucket_good_dsse_sse.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.mykey.arn
+      sse_algorithm     = "aws:kms:dsse"
+    }
+  }
+}

--- a/tests/terraform/graph/checks/resources/S3KMSEncryptedByDefault/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3KMSEncryptedByDefault/expected.yaml
@@ -2,6 +2,8 @@ pass:
   - "aws_s3_bucket.bucket_good_1"
   - "aws_s3_bucket.bucket_good_3"
   - "aws_s3_bucket.bucket_good_6"
+  - "aws_s3_bucket.bucket_good_dsse_inline"
+  - "aws_s3_bucket.bucket_good_dsse_sse"
 fail:
   - "aws_s3_bucket.bucket_bad_1"
   - "aws_s3_bucket.bucket_bad_2"

--- a/tests/terraform/graph/checks/resources/S3KMSEncryptedByDefault/main.tf
+++ b/tests/terraform/graph/checks/resources/S3KMSEncryptedByDefault/main.tf
@@ -163,3 +163,31 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bad_sse_3" {
     }
   }
 }
+
+resource "aws_s3_bucket" "bucket_good_dsse_inline" {
+  bucket = "bucket_good_dsse_inline"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.mykey.arn
+        sse_algorithm     = "aws:kms:dsse"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket" "bucket_good_dsse_sse" {
+  bucket = "bucket_good_dsse_sse"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "good_sse_dsse" {
+  bucket = aws_s3_bucket.bucket_good_dsse_sse.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.mykey.arn
+      sse_algorithm     = "aws:kms:dsse"
+    }
+  }
+}


### PR DESCRIPTION
## Description

S3 supports dual-layer server-side encryption with AWS KMS keys (DSSE-KMS), which reports an `SSEAlgorithm` of `aws:kms:dsse`. None of checkov's S3 encryption logic recognises that value, so a bucket using the *strongest* option AWS offers is currently reported as unencrypted.

This adds `aws:kms:dsse` alongside the existing `aws:kms` / `AES256` values everywhere checkov decides whether an S3 bucket is encrypted:

| Location | Change |
| --- | --- |
| `checkov/cloudformation/checks/resource/aws/S3Encryption.py` (CKV_AWS_19) | added to `get_expected_values()` |
| `checkov/terraform/checks/graph_checks/aws/S3BucketEncryption.yaml` (CKV_AWS_19) | added to both `within` lists |
| `checkov/terraform/checks/graph_checks/aws/S3KMSEncryptedByDefault.yaml` (CKV_AWS_145) | `equals: "aws:kms"` → `within: ["aws:kms", "aws:kms:dsse"]` |
| `checkov/{terraform,cloudformation}/graph_builder/graph_components/generic_resource_encryption.py` | added to the S3 `encryption_` attribute mapping so the graph attribute agrees with the checks |
| `checkov/common/graph/graph_builder/graph_components/attribute_names.py` | new `EncryptionTypes.AWS_KMS_DSSE_VALUE` constant |

DSSE-KMS is KMS-backed, so passing CKV_AWS_145 ("encrypted with KMS by default") is the intended semantics, not a loosening of it.

## Tests

- `tests/cloudformation/checks/resource/aws/test_S3Encryption.py::test_dsse_kms` — new test over a new `example_S3EncryptionDsse/` template covering DSSE-KMS, SSE-KMS, SSE-S3 (pass) and a near-miss `aws:kms:dss` (fail), so the check is not merely accepting any `aws:kms*` prefix. The existing `S3Templates/` fixture is shared by 8 other test modules, so a separate directory avoids perturbing their counts.
- Both terraform graph-check fixtures gain a DSSE-KMS bucket in each of the two supported shapes: the inline `server_side_encryption_configuration` block and a separate `aws_s3_bucket_server_side_encryption_configuration` resource.

Verified non-vacuous: with the test/fixture changes applied but the `checkov/` source changes reverted, all three tests fail (`test_dsse_kms`, `test_S3BucketEncryption`, `test_S3KMSEncryptedByDefault`).

Regression run: `tests/terraform/graph/checks/test_yaml_policies.py` and `tests/cloudformation/checks/resource/aws/` — 326 passed. `flake8` and `mypy` clean on the changed files.

## Note on prior art

@evan-schiewe proposed the CKV_AWS_19 terraform half of this in #7415 back in January and was closed by the stale bot on 2026-07-25 without ever being reviewed on its merits. This supersedes it and covers the CloudFormation check, CKV_AWS_145, and the graph-builder encryption attribute as well, all of which had the same gap.
