### PR TITLE
fix(arm): don't raise IndexError on malformed resourceId()/reference() calls

### DIFF
--- a/checkov/arm/utils.py
+++ b/checkov/arm/utils.py
@@ -94,7 +94,13 @@ def extract_resource_name_from_resource_id_func(resource_id: str) -> str:
         Examples:
             resourceId('Microsoft.Network/virtualNetworks/', virtualNetworkName) -> virtualNetworkName
     '''
-    return clean_string(resource_id.split(',')[1].split(')')[0])
+    parts = resource_id.split(',')
+    if len(parts) < 2:
+        # not the expected "resourceId(type, name, ...)" shape, e.g. a
+        # single-argument resourceId() call - fall back to the raw string
+        # instead of crashing with an IndexError.
+        return clean_string(resource_id)
+    return clean_string(parts[1].split(')')[0])
 
 
 def extract_resource_name_from_reference_func(reference: str) -> str:
@@ -107,7 +113,9 @@ def extract_resource_name_from_reference_func(reference: str) -> str:
                 reference(resourceId('Microsoft.Network/publicIPAddresses', 'ipAddressName')) -> ipAddressName
     '''
     resource_name = ')'.join(reference.split('reference(', 1)[1].split(')')[:-1])
-    if 'resourceId' in resource_name:
+    if 'resourceId(' in resource_name:
+        # guard on 'resourceId(' (not just 'resourceId') so the split below is
+        # guaranteed to find a match and can't raise an IndexError
         return clean_string(
             ''.join(resource_name.split('resourceId(', 1)[1].split(')')[0]).split(',')[-1])
     else:

--- a/tests/arm/test_utils.py
+++ b/tests/arm/test_utils.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from checkov.arm.utils import get_files_definitions, extract_resource_name_from_reference_func
+from checkov.arm.utils import get_files_definitions, extract_resource_name_from_reference_func, \
+    extract_resource_name_from_resource_id_func
 
 
 def test_get_files_definitions_with_parsing_error():
@@ -29,3 +30,32 @@ def test_extract_resource_name_from_reference_func():
 
     for i, test_case in enumerate(test_cases):
         assert extract_resource_name_from_reference_func(test_case) == expected[i]
+
+
+def test_extract_resource_name_from_reference_func_resource_id_substring_without_call():
+    # 'resourceId' appears as a substring of the resource name here without
+    # being followed by '(', so this must not be treated as a nested
+    # resourceId(...) call - it used to raise an IndexError.
+    test_case = "reference('resourceIdentifier').primaryEndpoints"
+
+    assert extract_resource_name_from_reference_func(test_case) == "resourceIdentifier"
+
+
+def test_extract_resource_name_from_resource_id_func():
+    test_cases = ["resourceId('Microsoft.Network/virtualNetworks/', virtualNetworkName)",
+                  "resourceId('Microsoft.Network/virtualNetworks/subnets', 'myVNet', 'mySubnet')"]
+
+    expected = ["virtualNetworkName", "myVNet"]
+
+    for i, test_case in enumerate(test_cases):
+        assert extract_resource_name_from_resource_id_func(test_case) == expected[i]
+
+
+def test_extract_resource_name_from_resource_id_func_single_arg():
+    # a resourceId() call with no comma-separated arguments (malformed or an
+    # unsupported single-argument form) used to raise an IndexError instead
+    # of degrading gracefully.
+    test_case = "resourceId('Microsoft.Storage/storageAccounts/myStorageAccount')"
+
+    assert extract_resource_name_from_resource_id_func(test_case) == \
+        "resourceId(Microsoft.Storage/storageAccounts/myStorageAccount)"


### PR DESCRIPTION
## Description

Reported as a pipeline crash (`IndexError: list index out of range`, re-raised from `checkov/common/parallelizer/parallel_runner.py` after occurring in a worker process) that only happens when the `arm` framework is included in a scan.

## Root cause

Two functions in `checkov/arm/utils.py`, both used while building the ARM dependency graph (`checkov/arm/graph_builder/local_graph.py`), index into a `str.split(...)` result without checking there are enough parts:

1. **`extract_resource_name_from_resource_id_func`** - called from `_create_explicit_edge` for *any* `dependsOn` entry containing the substring `"resourceId("`, regardless of whether the call actually has the assumed `resourceId(type, name, ...)` shape:
   ```python
   return clean_string(resource_id.split(',')[1].split(')')[0])
   ```
   A single-argument (or otherwise malformed) `resourceId()` call has no comma to split on, so `[1]` raises `IndexError`.

2. **`extract_resource_name_from_reference_func`** has a mismatched guard: it checks `'resourceId' in resource_name` (no trailing paren) but then unconditionally does `resource_name.split('resourceId(', 1)[1]` (with the paren). Any resource/variable name that merely *contains* `"resourceId"` as a substring without being immediately followed by `"("` - e.g. `resourceIdentifier` - passes the guard but fails the split, raising `IndexError` instead of falling through to the plain-reference handling every other shape uses.

## Fix

- Add a length check before indexing in `extract_resource_name_from_resource_id_func`; fall back to the raw (cleaned) string if the split doesn't have the expected shape, rather than crashing.
- Tighten `extract_resource_name_from_reference_func`'s guard to check for `'resourceId('` (matching what the subsequent split actually looks for), so the two can never disagree.

Both changes are minimal and preserve existing behavior for every well-formed input (verified against the existing test cases).

## Testing

- Added `test_extract_resource_name_from_resource_id_func` (a new test - the function had no dedicated tests before) covering both the documented multi-argument shape and a three-argument nested-resource shape.
- Added `test_extract_resource_name_from_resource_id_func_single_arg`, reproducing the crash class from this issue with a single-argument `resourceId()` call.
- Added `test_extract_resource_name_from_reference_func_resource_id_substring_without_call`, reproducing the second crash with a resource name (`resourceIdentifier`) that contains `"resourceId"` as a substring without a call.
- Verified by reverting just the `checkov/arm/utils.py` change: both new crash-reproducing tests fail with `IndexError: list index out of range` at the exact lines described above.
- Ran the full `tests/arm/` suite (`pytest tests/arm/`): 211 passed. The only remaining issue (`tests/arm/graph_builder/checks/test_yaml_policies.py`) fails to even collect in my minimal Docker environment due to a missing `graph_framework` test-parametrization setup unrelated to this change (nothing in this PR touches graph-framework/DB-connector selection).

Fixes #7633