### PR TITLE
fix(terraform): handle null container_properties in aws_batch_job_def…

### DIFF
--- a/checkov/terraform/plan_parser.py
+++ b/checkov/terraform/plan_parser.py
@@ -161,12 +161,13 @@ def jsonify(obj: dict[str, Any], resource_type: str) -> dict[str, Any] | None:
     """Tries to create a dict from a string of a supported resource type attribute"""
 
     jsonify_key = RESOURCE_TYPES_JSONIFY[resource_type]
-    if jsonify_key in obj:
+    attr_value = obj.get(jsonify_key)
+    if attr_value:
         try:
-            return cast("dict[str, Any]", json.loads(obj[jsonify_key]))
-        except json.JSONDecodeError:
+            return cast("dict[str, Any]", json.loads(attr_value))
+        except (json.JSONDecodeError, TypeError):
             logging.debug(
-                f"Attribute {jsonify_key} of resource type {resource_type} is not json encoded {obj[jsonify_key]}"
+                f"Attribute {jsonify_key} of resource type {resource_type} is not json encoded {attr_value}"
             )
 
     return None

--- a/tests/terraform/parser/resources/plan_batch_job_null_container_properties/tfplan.json
+++ b/tests/terraform/parser/resources/plan_batch_job_null_container_properties/tfplan.json
@@ -1,0 +1,92 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.5.7",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_batch_job_definition.eks_job",
+          "mode": "managed",
+          "type": "aws_batch_job_definition",
+          "name": "eks_job",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "name": "eks-job-def",
+            "type": "container",
+            "container_properties": null,
+            "eks_properties": [
+              {
+                "pod_properties": [
+                  {
+                    "containers": [
+                      { "image": "busybox" }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_batch_job_definition.eks_job",
+      "mode": "managed",
+      "type": "aws_batch_job_definition",
+      "name": "eks_job",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "name": "eks-job-def",
+          "type": "container",
+          "container_properties": null,
+          "eks_properties": [
+            {
+              "pod_properties": [
+                {
+                  "containers": [
+                    { "image": "busybox" }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_batch_job_definition.eks_job",
+          "mode": "managed",
+          "type": "aws_batch_job_definition",
+          "name": "eks_job",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": { "constant_value": "eks-job-def" },
+            "type": { "constant_value": "container" },
+            "eks_properties": [
+              {
+                "pod_properties": [
+                  {
+                    "containers": [
+                      { "image": { "constant_value": "busybox" } }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}

--- a/tests/terraform/parser/test_plan_parser.py
+++ b/tests/terraform/parser/test_plan_parser.py
@@ -97,6 +97,18 @@ class TestPlanFileParser(unittest.TestCase):
             resource_attributes = next(iter(resource_definition.values()))
             self.assertTrue(resource_attributes['provisioner'])
 
+    def test_aws_batch_job_definition_null_container_properties(self):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        valid_plan_path = current_dir + "/resources/plan_batch_job_null_container_properties/tfplan.json"
+
+        tf_definition, _ = parse_tf_plan(valid_plan_path, {})
+
+        file_resource_definition = tf_definition['resource'][0]
+        resource_definition = next(iter(file_resource_definition.values()))
+        resource_attributes = next(iter(resource_definition.values()))
+        self.assertIsNone(resource_attributes['container_properties'][0])
+        self.assertTrue(resource_attributes['eks_properties'])
+
     def test_module_with_connected_resources(self):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         valid_plan_path = current_dir + "/resources/plan_module_with_connected_resources/tfplan.json"


### PR DESCRIPTION

Terraform's compiled plan JSON sets unused schema attributes explicitly to null rather than omitting them. When an aws_batch_job_definition resource uses eks_properties instead of container_properties, the plan JSON still contains container_properties: null, which caused jsonify() to call json.loads(None) and raise an unhandled TypeError, crashing the scan.

Guard against falsy/None values before calling json.loads, and catch TypeError defensively in addition to JSONDecodeError.

Fixes #7587

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    We use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the other types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Each prefix should be accompanied by a scope that specifies the targeted framework. If uncertain, use 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
