### PR TITLE
fix(arm): Allow min tls 1.3 for azure storage min tls

### DIFF
--- a/checkov/arm/checks/resource/StorageAccountMinimumTlsVersion.py
+++ b/checkov/arm/checks/resource/StorageAccountMinimumTlsVersion.py
@@ -9,7 +9,7 @@ from checkov.arm.base_resource_check import BaseResourceCheck
 class StorageAccountMinimumTlsVersion(BaseResourceCheck):
     def __init__(self) -> None:
         """
-            Looks for min_tls_version configuration at azurerm_storage_account to be set to TLS1_2
+            Looks for min_tls_version configuration at azurerm_storage_account to be set to TLS1_2 or TLS1_3
             https://www.terraform.io/docs/providers/azurerm/r/storage_account.html#min_tls_version
             :param conf: azurerm_storage_account configuration
             :return: <CheckResult>
@@ -24,7 +24,7 @@ class StorageAccountMinimumTlsVersion(BaseResourceCheck):
     def scan_resource_conf(self, conf: dict[str, Any]) -> CheckResult:
         if "properties" in conf and \
             "minimumTlsVersion" in conf["properties"] and \
-                conf["properties"]["minimumTlsVersion"] in ['TLS1_2']:
+                conf["properties"]["minimumTlsVersion"] in ['TLS1_2', 'TLS1_3']:
             return CheckResult.PASSED
         return CheckResult.FAILED
 

--- a/tests/arm/checks/resource/example_StorageAccountMinimumTlsVersion/exampleStorageAccountMinimumTlsVersion-passed2.json
+++ b/tests/arm/checks/resource/example_StorageAccountMinimumTlsVersion/exampleStorageAccountMinimumTlsVersion-passed2.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "storageAccountType": {
+        "type": "string",
+        "defaultValue": "Standard_LRS",
+        "allowedValues": [
+          "Standard_LRS",
+          "Standard_GRS",
+          "Standard_ZRS",
+          "Premium_LRS"
+        ],
+        "metadata": {
+          "description": "Storage Account type"
+        }
+      },
+      "location": {
+        "type": "string",
+        "defaultValue": "[resourceGroup().location]",
+        "metadata": {
+          "description": "Location for all resources."
+        }
+      }
+    },
+    "variables": {
+      "storageAccountName": "[concat('store', uniquestring(resourceGroup().id))]"
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Storage/storageAccounts",
+        "apiVersion": "2019-04-01",
+        "name": "[variables('storageAccountName')]",
+        "location": "[parameters('location')]",
+        "sku": {
+          "name": "[parameters('storageAccountType')]"
+        },
+        "kind": "StorageV2",
+        "properties": {
+          "minimumTlsVersion": "TLS1_3",
+          "supportsHttpsTrafficOnly": true,
+          "networkAcls": {
+            "defaultAction": "Deny",
+            "bypass": "AzureServices"
+          }
+        }
+      }
+    ],
+    "outputs": {
+      "storageAccountName": {
+        "type": "string",
+        "value": "[variables('storageAccountName')]"
+      }
+    }
+  }

--- a/tests/arm/checks/resource/test_StorageAccountMinimumTlsVersion.py
+++ b/tests/arm/checks/resource/test_StorageAccountMinimumTlsVersion.py
@@ -14,7 +14,7 @@ class TestStorageAccountMinimumTlsVersion(unittest.TestCase):
         test_files_dir = current_dir + "/example_StorageAccountMinimumTlsVersion"
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 3)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

- Similar to https://github.com/bridgecrewio/checkov/pull/7051 allow TLS 1.3 to be a valid value for the minimum tls version of azure storage accounts

## New/Edited policies (Delete if not relevant)

### Description
Currently it only allows TLS 1.2 and not 1.3 - this allows both

### Fix
Same as currently

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
