### PR TITLE
fix(terraform): handle empty key vault ip rules

### DIFF
--- a/checkov/terraform/checks/resource/azure/KeyVaultDisablesPublicNetworkAccess.py
+++ b/checkov/terraform/checks/resource/azure/KeyVaultDisablesPublicNetworkAccess.py
@@ -38,6 +38,14 @@ class KeyVaultDisablesPublicNetworkAccess(BaseResourceValueCheck):
                         ip_rules = ip_rules[0] if ip_rules and isinstance(ip_rules, list) else ip_rules
                         if ip_rules:
                             return CheckResult.PASSED
+                        # An explicitly empty or rendered-empty ip_rules list (e.g. [[]] or [])
+                        # combined with an explicitly resolved default_action = "Deny" also blocks
+                        # public access.
+                        if isinstance(ip_rules, list) and not ip_rules:
+                            default_action = network_acl.get("default_action")
+                            default_action = default_action[0] if isinstance(default_action, list) else default_action
+                            if default_action == "Deny":
+                                return CheckResult.PASSED
                         virtual_network_subnet_ids = network_acl.get("virtual_network_subnet_ids")
                         # Get first element in virtual_network_subnet_ids (as parser wrap it with list).
                         virtual_network_subnet_ids = virtual_network_subnet_ids[0] \

--- a/tests/terraform/checks/resource/azure/example_KeyVaultDisablesPublicNetworkAccess/main.tf
+++ b/tests/terraform/checks/resource/azure/example_KeyVaultDisablesPublicNetworkAccess/main.tf
@@ -139,6 +139,24 @@ resource "azurerm_key_vault" "pass5" {
   }
 }
 
+resource "azurerm_key_vault" "pass6" {
+  name                                   = "examplepass6"
+  location                               = azurerm_resource_group.example.location
+  resource_group_name                    = azurerm_resource_group.example.name
+  enabled_for_disk_encryption            = true
+  tenant_id                              = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days             = 90
+  purge_protection_enabled               = enabled
+  public_network_access_enabled          = true
+  sku_name                               = "standard"
+  network_acls {
+    default_action = "Deny"
+    bypass         = "None"
+    ip_rules       = []
+  }
+}
+
+
 resource "azurerm_key_vault" "fail1" {
   name                                   = "examplefail1"
   location                               = azurerm_resource_group.example.location

--- a/tests/terraform/checks/resource/azure/test_KeyVaultDisablesPublicNetworkAccess.py
+++ b/tests/terraform/checks/resource/azure/test_KeyVaultDisablesPublicNetworkAccess.py
@@ -1,9 +1,12 @@
 import os
 import unittest
 
+import hcl2
+
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.runner import Runner
 from checkov.terraform.checks.resource.azure.KeyVaultDisablesPublicNetworkAccess import check
+from checkov.common.models.enums import CheckResult
 
 
 class TestKeyVaultDisablesPublicNetworkAccess(unittest.TestCase):
@@ -22,7 +25,8 @@ class TestKeyVaultDisablesPublicNetworkAccess(unittest.TestCase):
             'azurerm_key_vault.pass2',
             'azurerm_key_vault.pass3',
             'azurerm_key_vault.pass4',
-            'azurerm_key_vault.pass5'
+            'azurerm_key_vault.pass5',
+            'azurerm_key_vault.pass6'
         }
         failing_resources = {
             'azurerm_key_vault.fail1',
@@ -45,6 +49,61 @@ class TestKeyVaultDisablesPublicNetworkAccess(unittest.TestCase):
 
         self.assertEqual(passing_resources, passed_check_resources)
         self.assertEqual(failing_resources, failed_check_resources)
+
+    def _build_conf(self, network_acls_block):
+        hcl_res = hcl2.loads(f"""
+                resource "azurerm_key_vault" "example" {{
+                  name                                    = "examplekeyvault"
+                  location                                = azurerm_resource_group.example.location
+                  resource_group_name                     = azurerm_resource_group.example.name
+                  public_network_access_enabled           = true
+                  sku_name                                = "standard"
+                  {network_acls_block}
+                }}
+                """)
+        return hcl_res['resource'][0]['azurerm_key_vault']['example']
+
+    def test_deny_empty_ip_rules_passes(self):
+        resource_conf = self._build_conf("""
+                  network_acls {
+                    default_action = "Deny"
+                    ip_rules       = []
+                  }
+                """)
+        self.assertEqual(CheckResult.PASSED, check.scan_resource_conf(conf=resource_conf))
+
+    def test_allow_empty_ip_rules_fails(self):
+        resource_conf = self._build_conf("""
+                  network_acls {
+                    default_action = "Allow"
+                    ip_rules       = []
+                  }
+                """)
+        self.assertEqual(CheckResult.FAILED, check.scan_resource_conf(conf=resource_conf))
+
+    def test_unknown_default_action_with_empty_ip_rules_fails(self):
+        resource_conf = self._build_conf("""
+                  network_acls {
+                    default_action = var.action
+                    ip_rules       = []
+                  }
+                """)
+        self.assertEqual(CheckResult.FAILED, check.scan_resource_conf(conf=resource_conf))
+
+    def test_deny_normalized_empty_ip_rules_passes(self):
+        # A rendered/normalized pipeline can present ip_rules as a bare [] list
+        # (instead of the raw HCL parser's [[]]).
+        resource_conf = {
+            "public_network_access_enabled": [True],
+            "network_acls": [
+                {
+                    "default_action": ["Deny"],
+                    "ip_rules": [],
+                }
+            ],
+        }
+        self.assertEqual(CheckResult.PASSED, check.scan_resource_conf(conf=resource_conf))
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

Fixes #7384.

`CKV_AZURE_189` incorrectly fails Azure Key Vault configurations where public network access is enabled but `network_acls` uses `default_action = "Deny"` with an explicitly empty `ip_rules` list.

Terraform can represent an empty `ip_rules` value as either a nested empty list or a normalized empty list depending on the processing path. The check previously treated the empty value as falsy and fell through to `FAILED`.

This change:
- recognizes an explicitly empty `ip_rules` list after normalization
- requires `default_action = "Deny"` for the new pass condition
- preserves existing behavior for missing, unresolved, and non-empty values
- adds regression coverage for both raw and normalized empty-list representations

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes