### PR TITLE
fix(kubernetes): prevent CKV2_K8S_5 per-rule secrets bypass in ClusterRole

### DIFF
--- a/checkov/kubernetes/checks/graph_checks/ReadAllSecrets.yaml
+++ b/checkov/kubernetes/checks/graph_checks/ReadAllSecrets.yaml
@@ -39,28 +39,11 @@ definition:
                 - Role
             - or:
               - cond_type: attribute
-                attribute: rules.resources
-                operator: not_intersects
-                value:
-                  - 'secrets'
-                  - '*'
-                resource_types:
-                  - ClusterRole
-                  - Role
-              - cond_type: attribute
-                attribute: rules.verbs
-                operator: not_intersects
-                value:
-                  - 'get'
-                  - 'watch'
-                  - 'list'
-                  - '*'
-                resource_types:
-                  - ClusterRole
-                  - Role
-              - cond_type: attribute
-                attribute: rules.resourceNames
-                operator: exists
+                attribute: >-
+                  $.rules[?((@.resources[*] == 'secrets' | @.resources[*] == '*') &
+                  (@.verbs[*] == 'get' | @.verbs[*] == 'watch' | @.verbs[*] == 'list' |
+                  @.verbs[*] == '*') & !@.resourceNames)]
+                operator: jsonpath_not_exists
                 resource_types:
                   - ClusterRole
                   - Role

--- a/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Failing/MixedResourceNamesClusterRole.yaml
+++ b/tests/kubernetes/graph/checks/resources/ReadAllSecrets/Failing/MixedResourceNamesClusterRole.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mixed-secret-reader
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - "secrets"
+  verbs:
+    - "get"
+    - "watch"
+    - "list"
+- apiGroups:
+    - ""
+  resources:
+    - "secrets"
+  resourceNames:
+    - "pull-secret"
+  verbs:
+    - "get"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mixed-secrets-global
+subjects:
+- kind: ServiceAccount
+  name: sa1
+roleRef:
+  kind: ClusterRole
+  name: mixed-secret-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/kubernetes/graph/checks/resources/ReadAllSecrets/expected.yaml
+++ b/tests/kubernetes/graph/checks/resources/ReadAllSecrets/expected.yaml
@@ -3,3 +3,4 @@ pass:
   - "RoleBinding.my-namespace.my-role-binding"
 fail:
   - "ClusterRoleBinding.default.read-secrets-global"
+  - "ClusterRoleBinding.default.mixed-secrets-global"


### PR DESCRIPTION
### Context

Fixes #7616

CKV2_K8S_5 is intended to fail when a ServiceAccount or Node is bound to a Role or ClusterRole that grants get, list, watch, or wildcard verbs on secrets without a resourceNames restriction.

The current YAML check treats `rules.resourceNames exists` as a role-wide safe condition. If a ClusterRole has one unrestricted secrets rule and a separate scoped rule with resourceNames, the presence of the second rule satisfies the flattened attribute check and the check incorrectly passes.

This is a common real-world operator pattern. Controllers often need resourceNames-scoped access to a pull secret plus broad create and manage access to secrets they generate dynamically. The broad rule cannot use resourceNames, so the combination creates a meaningful blind spot.

This is related to #7110 and #6765, same underlying per-rule correlation limitation.

### Description

Replace the three separate attribute checks for resources, verbs, and resourceNames with a single JSONPath condition that looks for the risky pattern on the same RBAC rule entry.

The check now fails when any rule matches:
- resources includes secrets or wildcard
- verbs includes get, watch, list, or wildcard
- resourceNames is absent

It passes only when no such unscoped rule exists, which correctly handles mixed rules where one rule is scoped and another is not.

Change is in `checkov/kubernetes/checks/graph_checks/ReadAllSecrets.yaml`.

Add test fixture `MixedResourceNamesClusterRole.yaml` with one unrestricted secrets rule plus one scoped rule, and update `expected.yaml` to expect failure for `ClusterRoleBinding.default.mixed-secrets-global`.

### Steps to review

- Verify check YAML at `checkov/kubernetes/checks/graph_checks/ReadAllSecrets.yaml`
- Review new fixture `tests/kubernetes/graph/checks/resources/ReadAllSecrets/Failing/MixedResourceNamesClusterRole.yaml`
- Run locally: `pytest tests/kubernetes/graph/checks/test_yaml_policies.py -k ReadAllSecrets -o addopts='' -v`
- Run CLI smoke: `checkov -f tests/kubernetes/graph/checks/resources/ReadAllSecrets/Failing/MixedResourceNamesClusterRole.yaml --framework kubernetes --check CKV2_K8S_5`
- Confirm existing passing fixtures still pass: `RoleResourceName.yaml` and `Passing/ClusterRole.yaml`

### Checklist

- [x] This fix is listed in open issues #7616
- [x] I have reviewed open PRs and confirmed no existing merged fix that fully addresses per-rule correlation, PR #7625 is open draft with same approach
- [x] Code is covered by tests: added failing fixture for mixed rules, updated expected.yaml, existing passing fixtures retained
- [x] Documentation follows project style: YAML only, no extra metadata needed

#### New checks

- No new checks, fix to existing CKV2_K8S_5

### Real-world impact

An unrestricted secrets read bound to a ServiceAccount allows read of all secrets in namespace or cluster. When operators combine a scoped pull secret grant with a broad secret management grant in same ClusterRole, the old check missed it. This fix closes that false negative, improving RBAC least-privilege detection for operator workloads.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of Apache 2.0 license.
