### PR TITLE
fix(terraform_plan): apply inline skip comments when deep analysis is enabled

### DIFF
--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -272,13 +272,16 @@ class RunnerRegistry:
     def _handle_report(self, scan_report: Report, repo_root_for_plan_enrichment: list[str | Path] | None) -> None:
         if metadata_integration.check_metadata:
             RunnerRegistry.enrich_report_with_guidelines(scan_report)
-        if repo_root_for_plan_enrichment and not self.runner_filter.deep_analysis:
+        if repo_root_for_plan_enrichment:
             enriched_resources = RunnerRegistry.get_enriched_resources(
                 repo_roots=repo_root_for_plan_enrichment,
                 download_external_modules=self.runner_filter.download_external_modules,
                 external_modules_download_path=self.runner_filter.external_modules_download_path,
             )
-            scan_report = Report("terraform_plan").enrich_plan_report(scan_report, enriched_resources)
+            if not self.runner_filter.deep_analysis:
+                # deep analysis reports resources against the plan file via the merged graph,
+                # so the file path, line range and code block of the records stay as they are
+                scan_report = Report("terraform_plan").enrich_plan_report(scan_report, enriched_resources)
             scan_report = Report("terraform_plan").handle_skipped_checks(scan_report, enriched_resources)
         integration_feature_registry.run_post_runner(scan_report)
         self.scan_reports.append(scan_report)

--- a/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
+++ b/tests/common/runner_registry/test_runner_registry_plan_enrichment.py
@@ -159,6 +159,37 @@ class TestRunnerRegistryEnrichment(unittest.TestCase):
         self.assertEqual(skipped_check_ids, expected_skipped_check_ids)
 
 
+    def test_skip_check_with_deep_analysis(self):
+        allowed_checks = ["CKV_AWS_20", "CKV_AWS_28"]
+
+        repo_root = Path(__file__).parent / "plan_with_hcl_for_enrichment"
+        valid_plan_path = repo_root / "tfplan.json"
+
+        runner_registry = RunnerRegistry(
+            banner,
+            RunnerFilter(
+                checks=allowed_checks,
+                framework=["terraform_plan"],
+                deep_analysis=True,
+                repo_root_for_plan_enrichment=[str(repo_root)],
+            ),
+            tf_plan_runner(),
+        )
+
+        report = runner_registry.run(repo_root_for_plan_enrichment=[repo_root], files=[str(valid_plan_path)])[0]
+
+        failed_check_ids = {c.check_id for c in report.failed_checks}
+        skipped_check_ids = {c.check_id for c in report.skipped_checks}
+        expected_skipped_check_ids = {"CKV_AWS_20", "CKV_AWS_28"}
+
+        self.assertEqual(len(failed_check_ids), 0)
+        self.assertEqual(len(skipped_check_ids), 2)
+        self.assertEqual(skipped_check_ids, expected_skipped_check_ids)
+
+        # deep analysis keeps reporting against the plan file
+        for record in report.skipped_checks:
+            self.assertTrue(record.file_path.endswith(".json"))
+
     def test_skip_check_in_module(self):
         allowed_checks = ["CKV_AWS_19", "CKV2_AWS_6"]
         runner_registry = RunnerRegistry(


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

## Description

`RunnerRegistry._handle_report` gated the whole plan enrichment block on deep analysis being off, and that block is the only place where inline `checkov:skip` comments get applied to plan scans. Running `--repo-root-for-plan-enrichment` together with `--deep-analysis` therefore dropped every inline suppression, while the same scan without `--deep-analysis` honored them.

This change parses the enrichment repo root and applies `Report.handle_skipped_checks` in both modes. The file path, line range and code block rewriting of `Report.enrich_plan_report` stays on the non-deep path, because deep analysis reports records against the plan file through the merged graph and existing tests pin that behavior.

The new test mirrors the existing `test_skip_check` with `deep_analysis=True` and fails without the fix.

Fixes #7643 (previously reported in #6815 and #7225, both closed by the stale bot without a fix)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
